### PR TITLE
draft of install instructions for osx, linux, and windows

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -84,6 +84,10 @@ $ make build
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
 </code></pre></div></li>
 </ol>
+
+<h2 id="what-39-s-next">What&#39;s Next?</h2>
+
+<p>The quickest way to try out the database is to <a href="/start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
 </div>
 
 <!-- Install instructions for Linux -->
@@ -158,6 +162,10 @@ $ make build
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
 </code></pre></div></li>
 </ol>
+
+<h2 id="what-39-s-next">What&#39;s Next?</h2>
+
+<p>The quickest way to try out the database is to <a href="/start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
 </div>
 
 <!-- Install instructions for Windows -->
@@ -179,6 +187,10 @@ $ make build
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
 </code></pre></div></li>
 </ol>
+
+<h2 id="what-39-s-next">What&#39;s Next?</h2>
+
+<p>The quickest way to try out the database is to <a href="/start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
 </div>
 
 <!-- Below is some of the page's content in Markdown. To get correct html, it's easiest to let Jeyll translate the Markdown and then use that html above.

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -52,7 +52,7 @@ $(document).ready(function(){
 <ol>
 <li><p><a href="http://brew.sh/">Install Homebrew</a>.</p></li>
 <li><p>Run this single brew command to install dependencies, get the CockroachDB code, and build the CockroachDB binary:</p>
-<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="nv">$ </span>brew install https://raw.githubusercontent.com/cockroachdb/cockroach/master/build/cockroach.rb<span class="o">)</span>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="nv">$ </span>brew install https://raw.githubusercontent.com/cockroachdb/cockroach/master/build/cockroach.rb<span class="o"></span>
 </code></pre></div></li>
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p></li>
 </ol>

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -64,7 +64,7 @@ $(document).ready(function(){
 
 <ul>
 <li>A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). On Mac OS X, Xcode should suffice. </li>
-<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. On OS X, you can also use <a href="http://brew.sh">homebrew</a>: <code>brew install go</code>. </li>
+<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code>$GOPATH</code> and <code>$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</li>
 <li>Git 1.8+ </li>
 </ul></li>
 <li><p>Get the CockroachDB code:</p>
@@ -91,8 +91,9 @@ $ make build
 </code></pre></div></li>
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p>
 
-<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background by adding <code>&amp;</code> to the end of the command:</p>
-<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
+<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background and quiet the logs by adding <code>&gt; /dev/null 2&gt;&amp;1  &amp;</code> to the end of the command:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &gt; /dev/null 2&gt;&amp;1  &amp;
+<span class="gp">$ </span>./cockroach sql --dev
 </code></pre></div></li>
 </ol>
 
@@ -128,7 +129,7 @@ $ make build
 
 <ul>
 <li>A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). </li>
-<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. </li>
+<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code>$GOPATH</code> and <code>$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</li>
 <li>Git 1.8+ </li>
 </ul></li>
 <li><p>Get the CockroachDB code:</p>
@@ -158,8 +159,9 @@ $ make build
 </code></pre></div></li>
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p>
 
-<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background by adding <code>&amp;</code> to the end of the command:</p>
-<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
+<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background and quiet the logs by adding <code>&gt; /dev/null 2&gt;&amp;1  &amp;</code> to the end of the command:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &gt; /dev/null 2&gt;&amp;1  &amp;
+<span class="gp">$ </span>./cockroach sql --dev
 </code></pre></div></li>
 </ol>
 
@@ -183,8 +185,9 @@ $ make build
 </code></pre></div></li>
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p>
 
-<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background by adding <code>&amp;</code> to the end of the command:</p>
-<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
+<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background and quiet the logs by adding <code>&gt; /dev/null 2&gt;&amp;1  &amp;</code> to the end of the command:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &gt; /dev/null 2&gt;&amp;1  &amp;
+<span class="gp">$ </span>./cockroach sql --dev
 </code></pre></div></li>
 </ol>
 
@@ -192,6 +195,7 @@ $ make build
 
 <p>The quickest way to try out the database is to <a href="/start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
 </div>  
+
 
 <!-- Below is some of the page's content in Markdown. To get correct html, it's easiest to let Jeyll translate the Markdown and then use that html above.
 
@@ -223,7 +227,7 @@ $ make build
 
 1.  Make sure you have the following prerequisites:
     - A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). On Mac OS X, Xcode should suffice. 
-    - A [Go environment](http://golang.org/doc/code.html) with a 64-bit version of Go 1.5. You can download the [Go binary](https://golang.org/dl/) directly from the official site. On OS X, you can also use [homebrew](http://brew.sh): `brew install go`. 
+    - A [Go environment](http://golang.org/doc/code.html) with a 64-bit version of Go 1.5. You can download the [Go binary](https://golang.org/dl/) directly from the official site. Be sure to set the `$GOPATH` and `$PATH` environment variables as described [here](https://golang.org/doc/code.html#GOPATH). 
     - Git 1.8+ 
 
 2.  Get the CockroachDB code:
@@ -263,11 +267,12 @@ $ make build
 
 5. [Start a local cluster](/start-a-local-cluster.html).  
 
-    When following the [start a local cluster](/start-a-local-cluster.html) instructions, be sure to run the commands from within your Docker container. Also, it's simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you'll have to start the cluster in the background by adding `&` to the end of the command:
+    When following the [start a local cluster](/start-a-local-cluster.html) instructions, be sure to run the commands from within your Docker container. Also, it's simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you'll have to start the cluster in the background and quiet the logsby adding `> /dev/null 2>&1  &` to the end of the command:
 
     ```bash
-    $ ./cockroach start --dev &
-    ```   
+    $ ./cockroach start --dev > /dev/null 2>&1  &
+    $ ./cockroach sql --dev
+    ```
 
 ## Use Docker (Linux)
 
@@ -294,9 +299,10 @@ $ make build
 
 5. [Start a local cluster](/start-a-local-cluster.html).  
 
-    When following the [start a local cluster](/start-a-local-cluster.html) instructions, be sure to run the commands from within your Docker container. Also, it's simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you'll have to start the cluster in the background by adding `&` to the end of the command:
+    When following the [start a local cluster](/start-a-local-cluster.html) instructions, be sure to run the commands from within your Docker container. Also, it's simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you'll have to start the cluster in the background and quiet the logs by adding `> /dev/null 2>&1  &` to the end of the command:
 
     ```bash
-    $ ./cockroach start --dev &
+    $ ./cockroach start --dev > /dev/null 2>&1  &
+    $ ./cockroach sql --dev
     ```
 -->

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -22,31 +22,18 @@ $(document).ready(function(){
 });
 </script>
 
-<!--<script>
-$(document).ready(function(){
-$(".osbutton").click(function(){ $(".install").hide();});
-    $("#mac").click(function(){
-        $("#macinstall").show();
-    });
-    $("#linux").click(function(){
-        $("#linuxinstall").show();
-    });
-    $("#windows").click(function(){
-        $("#windowsinstall").show();
-    });
-});
-</script>-->
-
-<button id="mac">Mac</button>
+<button id="mac">Mac OS X</button>
 <button id="linux">Linux</button>
 <button id="windows">Windows</button>
 
+<!-- Install instructions for Mac OS X -->
 <div id=macinstall>
-<p>There are currently two ways to install CockroachDB locally on OSX:</p>
+<p>There are three ways to install CockroachDB locally on Mac OS X:</p>
 
 <ul>
 <li><a href="#download-the-binary">Download the Binary</a></li>
 <li><a href="#build-from-source">Build from Source</a></li>
+<li><a href="#use-docker">Use Docker</a></li>
 </ul>
 
 <h2 id="download-the-binary">Download the Binary</h2>
@@ -79,21 +66,47 @@ $ make build
 <p>The first time you run <code>make</code>, it can take awhile to download and install various dependencies.</p></li>
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>. </p></li>
 </ol>
+
+<h2 id="use-docker">Use Docker</h2>
+
+<ol>
+<li><p><a href="https://docs.docker.com/mac/step_one/">Install Docker</a>, as described in Docker&#39;s installation instructions for OS X.   </p></li>
+<li><p>Open <strong>Launchpad</strong> and start the <strong>Docker Quickstart Terminal</strong>. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM.</p></li>
+<li><p>In the shell, pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/">Docker Hub</a>:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker pull cockroachdb/cockroach
+</code></pre></div></li>
+<li><p>Start a new Docker container and load the CockroachDB image into it:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker run -t -i cockroachdb/cockroach shell
+</code></pre></div></li>
+<li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p>
+
+<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background by adding <code>&amp;</code> to the end of the command:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
+</code></pre></div></li>
+</ol>
 </div>
 
+<!-- Install instructions for Linux -->
 <div id=linuxinstall style="display: none;">
-<p>There are currently two ways to install CockroachDB locally on Linux:</p>
+<p>There are three ways to install CockroachDB locally on Linux:</p>
 
+<<<<<<< 45e9905fde39ac92302be7264bcffd41ce75b059
 <ul>    
 <li><a href="#download-the-binary-linux">Download the Binary</a></li>
 <li><a href="#build-from-source-linux">Build from Source</a></li>
 <li><a href="#use-docker-linux">Use Docker</a></li>
+=======
+<ul>
+<li><a href="#download-the-binary">Download the Binary</a></li>
+<li><a href="#build-from-source">Build from Source</a></li>
+<li><a href="use-docker">Use Docker</a></li>
+>>>>>>> draft of install instructions for osx, linux, and windows
 </ul>
 
 <h2 id="download-the-binary-linux">Download the Binary</h2>
 
 <ol>
-<li><p>Download the <a href="http://cockroachlabs.com/download/osx">CockroachDB binary for OS X</a>.</p></li>
+<li><p>Download the <a href="http://cockroachlabs.com/download/osx">CockroachDB binary for Linux</a>.</p></li>
 <li><p>Make the binary executible:</p>
 <div class="highlight"><pre><code class="language-" data-lang="">$ chmod +x &lt;binary file name&gt;
 </code></pre></div></li>
@@ -106,8 +119,8 @@ $ make build
 <li><p>Make sure you have the following prerequisites:</p>
 
 <ul>
-<li>A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). On Mac OS X, Xcode should suffice. </li>
-<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. On OS X, you can also use <a href="http://brew.sh">homebrew</a>: <code>brew install go</code>. </li>
+<li>A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). </li>
+<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. </li>
 <li>Git 1.8+ </li>
 </ul></li>
 <li><p>Get the CockroachDB code:</p>
@@ -121,7 +134,11 @@ $ make build
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>. </p></li>
 </ol>
 
+<<<<<<< 45e9905fde39ac92302be7264bcffd41ce75b059
 <h2 id="use-docker-linux">Use Docker</h2>
+=======
+<h2 id="use-docker">Use Docker</h2>
+>>>>>>> draft of install instructions for osx, linux, and windows
 
 <ol>
 <li><p><a href="https://docs.docker.com/engine/installation/ubuntulinux/">Install Docker</a>, as described in Docker&#39;s installation instructions for Linux.   </p></li>
@@ -143,24 +160,29 @@ $ make build
 </ol>
 </div>
 
+<!-- Install instructions for Windows -->
 <div id=windowsinstall style="display: none;">
-<p>At this time, the only way to run CockroachDB on Windows is to use Docker. 
+<p>At this time, it's possible to run CockroachDB on Windows only from within a Docker container, which is a stripped-to-basics version of a Linux operating system. 
 
 <ol>
-<li><p><a href="https://docs.docker.com/mac/step_one/">Install Docker</a>, as described in Docker&#39;s installation instructions for OS X.   </p></li>
-<li><p>To start CockroachDB, run this command in your terminal:</p>
+<li><p><a href="https://docs.docker.com/engine/installation/windows/">Install Docker</a>, as described in Docker&#39;s installation instructions for Windows.   </p></li>
+<li><p>Start the <strong>Docker Quickstart Terminal</strong> application. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM. </p></li>
+<li><p>In the shell, pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/">Docker Hub</a>:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker pull cockroachdb/cockroach
+</code></pre></div></li>
+<li><p>Start a new Docker container and load the CockroachDB image into it:</p>
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker run -t -i cockroachdb/cockroach shell
-</code></pre></div>
-<p>The first time you do this, Docker pulls the official CockroachDB image from Docker Hub. From that point on, the image remains on your local system. You can run <code>docker images</code> to list all of your local images.</p>
-<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker images
+</code></pre></div></li>
+<li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p>
 
-REPOSITORY              TAG         IMAGE ID            CREATED             VIRTUAL SIZE
-cockroachdb/cockroach   latest      e707dfaf8703        2 days ago          278.2 MB
-hello-world             latest      0a6ba66e537a        9 weeks ago         960 B
+<p>When following the <a href="/start-a-local-cluster.html">start a local cluster</a> instructions, be sure to run the commands from within your Docker container. Also, it&#39;s simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you&#39;ll have to start the cluster in the background by adding <code>&amp;</code> to the end of the command:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>./cockroach start --dev &amp;
 </code></pre></div></li>
 </ol>
 </div>
-<!--
+
+<!-- Below is some of the page's content in Markdown. To get correct html, it's easiest to let Jeyll translate the Markdown and then use that html above.
+
 There are currently two ways to install CockroachDB locally on OSX:
 
 - [Download the Binary](#download-the-binary)
@@ -202,25 +224,60 @@ There are currently two ways to install CockroachDB locally on OSX:
 
 4. [Start a local cluster](/start-a-local-cluster.html). 
 
-## Use Docker
-
-Deploying CockroachDB in Docker is quick and easy. Once you've installed Docker, just run Cockroach in the default Docker container.  
+## Use Docker (Mac)
 
 1. 	[Install Docker](https://docs.docker.com/mac/step_one/), as described in Docker's installation instructions for OS X.   
 
-2.	To start CockroachDB, run this command in your terminal:
+2.	Open **Launchpad** and start the **Docker Quickstart Terminal**. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM. 
 
-	```bash
-	$ docker run -t -i cockroachdb/cockroach shell
-	```
+3.  In the shell, pull the official CockroachDB image from [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach/):
 
-	The first time you do this, Docker pulls the official CockroachDB image from Docker Hub. From that point on, the image remains on your local system. You can run `docker images` to list all of your local images.
+    ```bash
+    $ docker pull cockroachdb/cockroach
+    ```
 
-	```bash
-	$ docker images
+4.  Start a new Docker container and load the CockroachDB image into it:
 
-	REPOSITORY              TAG			IMAGE ID            CREATED             VIRTUAL SIZE
-	cockroachdb/cockroach   latest 		e707dfaf8703        2 days ago			278.2 MB
-	hello-world             latest      0a6ba66e537a        9 weeks ago         960 B
-	```
+    ```bash
+    $ docker run -t -i cockroachdb/cockroach shell
+    ```
+
+5. [Start a local cluster](/start-a-local-cluster.html).  
+
+    When following the [start a local cluster](/start-a-local-cluster.html) instructions, be sure to run the commands from within your Docker container. Also, it's simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you'll have to start the cluster in the background by adding `&` to the end of the command:
+
+    ```bash
+    $ ./cockroach start --dev &
+    ```   
+
+## Use Docker (Linux)
+
+1.  [Install Docker](https://docs.docker.com/engine/installation/ubuntulinux/), as described in Docker's installation instructions for Linux.   
+
+2.  If you don't already have the Docker daemon running in the background, run:  
+    
+    ```bash
+    $ sudo docker -d &
+    ```
+    {{site.data.alerts.callout_info}} On Linux, Docker needs sudo privileges in order to work.{{site.data.alerts.end}}
+
+3. Pull the official CockroachDB image from [Docker Hub](https://hub.docker.com/r/cockroachdb/cockroach/):
+
+    ```bash
+    $ sudo docker pull cockroachdb/cockroach
+    ```
+
+4.  Start a new Docker container and load the CockroachDB image into it:
+
+    ```bash
+    $ sudo docker run -t -i cockroachdb/cockroach shell
+    ```
+
+5. [Start a local cluster](/start-a-local-cluster.html).  
+
+    When following the [start a local cluster](/start-a-local-cluster.html) instructions, be sure to run the commands from within your Docker container. Also, it's simplest to start the built-in SQL client from within the same container as the CockroachDB cluster, but to do so, you'll have to start the cluster in the background by adding `&` to the end of the command:
+
+    ```bash
+    $ ./cockroach start --dev &
+    ```
 -->

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -105,17 +105,10 @@ $ make build
 <div id=linuxinstall style="display: none;">
 <p>There are three ways to install CockroachDB locally on Linux:</p>
 
-<<<<<<< 45e9905fde39ac92302be7264bcffd41ce75b059
 <ul>    
 <li><a href="#download-the-binary-linux">Download the Binary</a></li>
 <li><a href="#build-from-source-linux">Build from Source</a></li>
 <li><a href="#use-docker-linux">Use Docker</a></li>
-=======
-<ul>
-<li><a href="#download-the-binary">Download the Binary</a></li>
-<li><a href="#build-from-source">Build from Source</a></li>
-<li><a href="use-docker">Use Docker</a></li>
->>>>>>> draft of install instructions for osx, linux, and windows
 </ul>
 
 <h2 id="download-the-binary-linux">Download the Binary</h2>
@@ -149,11 +142,7 @@ $ make build
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>. </p></li>
 </ol>
 
-<<<<<<< 45e9905fde39ac92302be7264bcffd41ce75b059
 <h2 id="use-docker-linux">Use Docker</h2>
-=======
-<h2 id="use-docker">Use Docker</h2>
->>>>>>> draft of install instructions for osx, linux, and windows
 
 <ol>
 <li><p><a href="https://docs.docker.com/engine/installation/ubuntulinux/">Install Docker</a>.   </p></li>

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -28,10 +28,11 @@ $(document).ready(function(){
 
 <!-- Install instructions for Mac OS X -->
 <div id=macinstall>
-<p>There are three ways to install CockroachDB locally on Mac OS X:</p>
+<p>There are four ways to install CockroachDB locally on Mac OS X:</p>
 
 <ul>
 <li><a href="#download-the-binary">Download the Binary</a></li>
+<li><a href="#use-homebrew">Use Homebrew</a></li>
 <li><a href="#build-from-source">Build from Source</a></li>
 <li><a href="#use-docker">Use Docker</a></li>
 </ul>
@@ -44,6 +45,16 @@ $(document).ready(function(){
 <div class="highlight"><pre><code class="language-" data-lang="">$ chmod +x &lt;binary file name&gt;
 </code></pre></div></li>
 <li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>. </p></li>
+</ol>
+
+<h2 id="use-homebrew">Use Homebrew</h2>
+
+<ol>
+<li><p><a href="http://brew.sh/">Install Homebrew</a>.</p></li>
+<li><p>Run this single brew command to install dependencies, get the CockroachDB code, and build the CockroachDB binary:</p>
+<div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="nv">$ </span>brew install https://raw.githubusercontent.com/cockroachdb/cockroach/master/build/cockroach.rb<span class="o">)</span>
+</code></pre></div></li>
+<li><p><a href="/start-a-local-cluster.html">Start a local cluster</a>.  </p></li>
 </ol>
 
 <h2 id="build-from-source">Build from Source</h2>
@@ -70,7 +81,7 @@ $ make build
 <h2 id="use-docker">Use Docker</h2>
 
 <ol>
-<li><p><a href="https://docs.docker.com/mac/step_one/">Install Docker</a>, as described in Docker&#39;s installation instructions for OS X.   </p></li>
+<li><p><a href="https://docs.docker.com/mac/step_one/">Install Docker</a>.   </p></li>
 <li><p>Open <strong>Launchpad</strong> and start the <strong>Docker Quickstart Terminal</strong>. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM.</p></li>
 <li><p>In the shell, pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/">Docker Hub</a>:</p>
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker pull cockroachdb/cockroach
@@ -145,7 +156,7 @@ $ make build
 >>>>>>> draft of install instructions for osx, linux, and windows
 
 <ol>
-<li><p><a href="https://docs.docker.com/engine/installation/ubuntulinux/">Install Docker</a>, as described in Docker&#39;s installation instructions for Linux.   </p></li>
+<li><p><a href="https://docs.docker.com/engine/installation/ubuntulinux/">Install Docker</a>.   </p></li>
 <li><p>If you don&#39;t already have the Docker daemon running in the background, run:  </p>
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>sudo docker -d &amp;
 </code></pre></div>
@@ -173,7 +184,7 @@ $ make build
 <p>At this time, it's possible to run CockroachDB on Windows only from within a Docker container, which is a stripped-to-basics version of a Linux operating system. 
 
 <ol>
-<li><p><a href="https://docs.docker.com/engine/installation/windows/">Install Docker</a>, as described in Docker&#39;s installation instructions for Windows.   </p></li>
+<li><p><a href="https://docs.docker.com/engine/installation/windows/">Install Docker</a>.   </p></li>
 <li><p>Start the <strong>Docker Quickstart Terminal</strong> application. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM. </p></li>
 <li><p>In the shell, pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/">Docker Hub</a>:</p>
 <div class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">$ </span>docker pull cockroachdb/cockroach
@@ -191,14 +202,9 @@ $ make build
 <h2 id="what-39-s-next">What&#39;s Next?</h2>
 
 <p>The quickest way to try out the database is to <a href="/start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
-</div>
+</div>  
 
 <!-- Below is some of the page's content in Markdown. To get correct html, it's easiest to let Jeyll translate the Markdown and then use that html above.
-
-There are currently two ways to install CockroachDB locally on OSX:
-
-- [Download the Binary](#download-the-binary)
-- [Build from Source](#build-from-source)
 
 ## Download the Binary
 
@@ -211,6 +217,18 @@ There are currently two ways to install CockroachDB locally on OSX:
     ```
 
 3. [Start a local cluster](/start-a-local-cluster.html). 
+
+## Use Homebrew
+
+1. [Install Homebrew](http://brew.sh/).
+
+2. Run this single brew command to install dependencies, get the CockroachDB code, and build the CockroachDB binary:
+
+    ```bash
+    $ brew install https://raw.githubusercontent.com/cockroachdb/cockroach/master/build/cockroach.rb)
+    ``` 
+
+3. [Start a local cluster](/start-a-local-cluster.html).
 
 ## Build from Source
 
@@ -238,7 +256,7 @@ There are currently two ways to install CockroachDB locally on OSX:
 
 ## Use Docker (Mac)
 
-1. 	[Install Docker](https://docs.docker.com/mac/step_one/), as described in Docker's installation instructions for OS X.   
+1. 	[Install Docker](https://docs.docker.com/mac/step_one/).   
 
 2.	Open **Launchpad** and start the **Docker Quickstart Terminal**. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM. 
 
@@ -264,7 +282,7 @@ There are currently two ways to install CockroachDB locally on OSX:
 
 ## Use Docker (Linux)
 
-1.  [Install Docker](https://docs.docker.com/engine/installation/ubuntulinux/), as described in Docker's installation instructions for Linux.   
+1.  [Install Docker](https://docs.docker.com/engine/installation/ubuntulinux/).   
 
 2.  If you don't already have the Docker daemon running in the background, run:  
     


### PR DESCRIPTION
Completed writing up install instructions for OS X, Linux, and Windows (issue #3). "Live" version of this draft can be seen here: http://cockroach-draft-docs.s3-website-us-east-1.amazonaws.com/install-cockroachdb.html

I've assigned this to Marc, but I'd love for others to review as well, ideally performing the steps to find anything I've missed or gotten wrong. cc: @mjibson, @bdarnell, @spencerkimball, @petermattis, @andreimatei.

Some notes:
- OS tabs at the top work but still need to be styled. I might try that myself but will probably ask DivisionOf to help. 
- Links for downloading os x and linux binaries are just dummies. I'll update those once we have the binaries and know where we'll host them.
- I'm pretty confident about the mac instructions, since I'm on mac, but I'm speculating a bit for linux (using what I found online). And as long as the general docker instructions are correct, Windows should be ok, I think. @mberhault, for linux in particular, please check closely and let me know what to change. 
- For all Docker instructions, I'm just assuming they should run the sql client in the same container as the server, but if the output streams are spammy, this will be sort of difficult. So after talking this over with Ben, I created an issue to maybe add a new flag to limit the output to information that really matters: https://github.com/cockroachdb/cockroach/issues/3921