### PR TITLE
Jseldess/adding google analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ destination: ../cockroach_site
 topnav_title: CockroachDB
 homepage_title: CockroachDB Documentation
 site_title: Cockroach Labs
-google_analytics: 
+google_analytics: UA-63775601-1
 
 # variables
 sidebar_tagline: 
@@ -37,7 +37,7 @@ theme_file: theme-blue.css
 redcarpet:
   extensions: ["no_intra_emphasis", "fenced_code_blocks", "tables", "with_toc_data"]
 
-highlighter: rouge
+highlighter: pygments
 
 collections:
   tooltips:


### PR DESCRIPTION
Added our Google Analytics ID to the `_config.yml` file. The theme auto-inserts the ID into `_includes/google_analytics.html`, which in turn gets included in `_layouts/default.html`.

I'd now like to sync the current draft site up to dreamhost in a /docs directory so that we can validate the pageviews of cockroachlabs.com/docs/xxx get picked up in our stats. 

@mberhault: Can you remind me how to ssh to the dreamhost site and sync the content properly? 

cc: @jess-edwards

Fixes: #11 