### PR TITLE
removed --init step and added step for adding new nodes

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -60,7 +60,7 @@ $(document).ready(function(){
 </div>
 
 <div id="macinstall">
-<p>There are four ways to install CockroachDB locally on Mac OS X:</p>
+<p>There are four ways to install CockroachDB on Mac OS X:</p>
 
 <ul>
 <li><a href="#download-the-binary">Download the Binary</a></li>
@@ -131,11 +131,11 @@ $ make build
 
 <h2 id="what-39-s-next">What&#39;s Next?</h2>
 
-<p>The quickest way to try out the database is to <a href="start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
+<p>The quickest way to try out the database is to <a href="start-a-local-cluster.html">start a local cluster</a> and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="linuxinstall" style="display: none;">
-<p>There are three ways to install CockroachDB locally on Linux:</p>
+<p>There are three ways to install CockroachDB on Linux:</p>
 
 <ul>    
 <li><a href="#download-the-binary-linux">Download the Binary</a></li>
@@ -198,7 +198,7 @@ $ make build
 
 <h2 id="what-39-s-next">What&#39;s Next?</h2>
 
-<p>The quickest way to try out the database is to <a href="start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
+<p>The quickest way to try out the database is to <a href="start-a-local-cluster.html">start a local cluster</a> and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="windowsinstall" style="display: none;">
@@ -223,7 +223,7 @@ $ make build
 
 <h2 id="what-39-s-next">What&#39;s Next?</h2>
 
-<p>The quickest way to try out the database is to <a href="start-a-local-cluster.html">start a single-node cluster</a> and talk to it via the built-in SQL client.</p>
+<p>The quickest way to try out the database is to <a href="start-a-local-cluster.html">start a local cluster</a> and talk to it via the built-in SQL client.</p>
 </div>
 
 <!-- Below is some of the page's content in Markdown. To get correct html, it's easiest to let Jeyll translate the Markdown and then use that html above.

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -3,9 +3,9 @@ title: Start a Local Cluster
 toc: false
 ---
 
-Once you've [installed CockroachDB locally](install-cockroachdb.html), the quickest way to try out the database is to start a single node cluster and talk to it via the built-in SQL client. You can also add more nodes to simulate a multi-node scenario. 
+Once you've [installed CockroachDB locally](install-cockroachdb.html), the quickest way to try out the database is to start a single node cluster and talk to it via the built-in SQL client. You can then easily add more nodes to simulate a multi-node scenario. 
 
-There are two modes in which you can do this:
+There are two modes in which you can start a local cluster:
 
 - [Dev Mode (Insecure)](#dev-mode-insecure)  
 Data is stored in-memory and client/server communication is completely insecure. This mode is great for learning CockroachDB, but since there's no authentication or encryption and nothing is stored persistently, it's suitable only for limited testing and development.  
@@ -22,7 +22,7 @@ Data is stored on-disk and client/server communication is secure. Setup involves
     ```bash
     $ ./cockroach start --dev
     ```
-    The `--dev` flag defaults storage to in-memory, communication to insecure, and the client (SQL) and server (CockroachDB) ports to 15432 and 26257 respectively.
+    The `--dev` flag defaults storage to in-memory, communication to insecure, and the CockroachDB and SQL client ports to 26257 and 15432 respectively.
 
 2. In a new shell, start the built-in SQL client in dev mode:
 
@@ -40,10 +40,12 @@ Data is stored on-disk and client/server communication is secure. Setup involves
 5. To simulate a multi-node cluster, add each new node as follows:
     
     ```bash
-    $ ./cockroach start --dev pgport=15433 --port=26258 --join=localhost:26257
+    $ ./cockroach start --dev --port=26258 --pgport=15433 --join=<your local host>:26257
     ```
 
-    where `--pgport` and `--port` are set to ports not in use by other nodes and `--join` connects the new node to the cluster via your local host and the port of the first node, `26257`.
+    The `--port` and `--pgport` flags bind the ports for CockroachDB and SQL client traffic. Set these flags to ports not in use by other nodes. 
+
+    The `--join` flag connects the new node to the cluster. Set this flag to your local host and the port of the first node, `26257`. You can find your local host by running `hostname` in your shell.
 
 ## Secure Mode
 
@@ -61,7 +63,7 @@ Data is stored on-disk and client/server communication is secure. Setup involves
     ```bash
     $ ./cockroach start --stores=ssd=data/node1
     ```
-    where `ssd` can be any arbitrary string describing the store (e.g., `ssd` for flash, `hdd` for spinny disk) and `dev/data` is the filepath to the storage location. For the filepath, the parent directory must exist and the store directory, if it already exists, must not contain any CockroachDB data.
+    The `--stores` flag defines the store type and the filepath to the storage location. The store type can be any arbitrary string describing the store (e.g., `ssd` for flash, `hdd` for spinny disk). For the filepath, the parent directory must exist and the store directory, if it already exists, should not contain any CockroachDB data.
     
 3. In a new shell, start the built-in SQL client:
 
@@ -79,10 +81,14 @@ Data is stored on-disk and client/server communication is secure. Setup involves
 6. To simulate a multi-node cluster, add each new node as follows:
     
     ```bash
-    $ ./cockroach start --stores=ssd=data/node2 pgport=15433 --port=26258 --join=localhost:26257
+    $ ./cockroach start --stores=ssd=data/node2 --port=26258 --pgport=15433 --join=<your local host>:26257
     ```
 
-    where `--stores` is set to a unique storage location, `--pgport` and `--port` are set to ports not in use by other nodes, and `--join` connects the new node to the cluster via your local host and the port of the first node, `26257`.
+    Set the `--stores` flag to a storage location not in use by other nodes.
+
+    The `--port` and `--pgport` flags bind the ports for CockroachDB and SQL client traffic. Set these flags to ports not in use by other nodes. 
+
+    The `--join` flag connects the new node to the cluster. Set this flag to your local host and the port of the first node, `26257`. You can find your local host by running `hostname` in your shell.
 
 ## What's Next?
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -3,15 +3,13 @@ title: Start a Local Cluster
 toc: false
 ---
 
-Once you've [installed CockroachDB locally](install-cockroachdb.html), the quickest way to try out the database is to start a single node cluster and talk to it via the built-in SQL client. You can then easily add more nodes to simulate a multi-node scenario. 
-
-There are two modes in which you can start a local cluster:
+Once you've [installed CockroachDB locally](install-cockroachdb.html), the quickest way to try out the database is to start a local cluster and talk to it via the built-in SQL client. There are two modes in which you can do this: 
 
 - [Dev Mode (Insecure)](#dev-mode-insecure)  
-Data is stored in-memory and client/server communication is completely insecure. This mode is great for learning CockroachDB, but since there's no authentication or encryption and nothing is stored persistently, it's suitable only for limited testing and development.  
+In dev mode, you start up a single-node cluster where data is stored in-memory and client/server communication is completely insecure. This mode is great for learning CockroachDB, but since there's no authentication or encryption and nothing is stored persistently, it's suitable only for limited testing and development.  
 
-- [Secure Mode](#secure-mode)  
-Data is stored on-disk and client/server communication is secure. Setup involves creating certificates and passing certain command line options, but it's still simple. This mode is suitable for standing up a persistent test cluster to develop an application or test CockroachDB.
+- [Standard Mode (Secure)](#secure-mode-secure)  
+In standard mode, you start up a single-node or multi-node cluster where data is stored on-disk and client/server communication is secure. Setup involves creating certificates and passing additional command line options, but it's still simple. This mode is suitable for standing up a persistent test cluster to develop an application or test CockroachDB. 
 
 {{site.data.alerts.callout_info}} For production deployments, see <a href="deploy-a-multinode-cluster.html">Deploy a Multi-Node Cluster</a>.{{site.data.alerts.end}}
 
@@ -37,17 +35,7 @@ Data is stored on-disk and client/server communication is secure. Setup involves
 
 4. Check out the Admin UI by pointing your browser to `http://<your local host>:26257`. You can find your local host by running `hostname` in your shell.    
 
-5. To simulate a multi-node cluster, add each new node as follows:
-    
-    ```bash
-    $ ./cockroach start --dev --port=26258 --pgport=15433 --join=<your local host>:26257
-    ```
-
-    The `--port` and `--pgport` flags bind the ports for CockroachDB and SQL client traffic. Set these flags to ports not in use by other nodes. 
-
-    The `--join` flag connects the new node to the cluster. Set this flag to your local host and the port of the first node, `26257`. You can find your local host by running `hostname` in your shell.
-
-## Secure Mode
+## Standard Mode (Secure)
 
 1. From the directory containing the `cockroach` binary, create security certificates:
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -72,11 +72,11 @@ Data is stored on-disk and client/server communication is secure. Setup involves
     # To exit: CTRL + D.
     ```
 
-5. [Run some queries](basic-sql-commands.html).
+4. [Run some queries](basic-sql-commands.html).
 
-6. Check out the Admin UI by pointing your browser to `https://<your local host>:26257`. You can find your local host by running `hostname` in your shell. Note that your browser will consider the cockroach-created certificate invalid, so you'll need to click through a warning message to get the UI. 
+5. Check out the Admin UI by pointing your browser to `https://<your local host>:26257`. You can find your local host by running `hostname` in your shell. Note that your browser will consider the cockroach-created certificate invalid, so you'll need to click through a warning message to get the UI. 
 
-7. To simulate a multi-node cluster, add each new node as follows:
+6. To simulate a multi-node cluster, add each new node as follows:
     
     ```bash
     $ ./cockroach start --stores=ssd=data/node2 pgport=15433 --port=26258 --join=localhost:26257

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -3,26 +3,28 @@ title: Start a Local Cluster
 toc: false
 ---
 
-Once you've [installed CockroachDB locally](install-cockroachdb.html), the quickest way to try out the database is to start a single-node cluster and talk to the node via the built-in SQL client. There are two ways to do this:
+Once you've [installed CockroachDB locally](install-cockroachdb.html), the quickest way to try out the database is to start a single node cluster and talk to it via the built-in SQL client. You can also add more nodes to simulate a multi-node scenario. 
 
-- [Development Mode (Insecure)](#development-mode)  
+There are two modes in which you can do this:
+
+- [Dev Mode (Insecure)](#dev-mode-insecure)  
 Data is stored in-memory and client/server communication is completely insecure. This mode is great for learning CockroachDB, but since there's no authentication or encryption and nothing is stored persistently, it's suitable only for limited testing and development.  
 
-- [Standard Mode (Secure)](#standard-mode)  
+- [Secure Mode](#secure-mode)  
 Data is stored on-disk and client/server communication is secure. Setup involves creating certificates and passing certain command line options, but it's still simple. This mode is suitable for standing up a persistent test cluster to develop an application or test CockroachDB.
 
 {{site.data.alerts.callout_info}} For production deployments, see <a href="deploy-a-multinode-cluster.html">Deploy a Multi-Node Cluster</a>.{{site.data.alerts.end}}
 
-## Development Mode
+## Dev Mode (Insecure)
 
-1. From the directory containing the `cockroach` binary, start the cluster:
+1. From the directory containing the `cockroach` binary, start a single-node cluster:
     
     ```bash
     $ ./cockroach start --dev
     ```
-    The `--dev` flag defaults storage to in-memory and client/server communication to insecure. 
+    The `--dev` flag defaults storage to in-memory, communication to insecure, and the client (SQL) and server (CockroachDB) ports to 15432 and 26257 respectively.
 
-2. In a new shell, start the built-in SQL client in development mode:
+2. In a new shell, start the built-in SQL client in dev mode:
 
     ```bash
     $ ./cockroach sql --dev
@@ -32,34 +34,36 @@ Data is stored on-disk and client/server communication is secure. Setup involves
     ```
 
 3. [Run some queries](basic-sql-commands.html).
+
 4. Check out the Admin UI by pointing your browser to `http://<your local host>:26257`. You can find your local host by running `hostname` in your shell.    
 
-## Standard Mode
-
-1. From the directory containing the `cockroach` binary, initialize the cluster:
-
+5. To simulate a multi-node cluster, add each new node as follows:
+    
     ```bash
-    $ ./cockroach init --stores=ssd=dev/data
+    $ ./cockroach start --dev pgport=15433 --port=26258 --join=localhost:26257
     ```
-    where `ssd` can be any arbitrary string describing the store (e.g., `ssd` for flash, `hdd` for spinny disk) and `dev/data` is the filepath to the storage location. For the filepath, the parent directory must exist and the store directory, if it already exists, must not contain any CockroachDB data.
 
-2. Create security certificates:
+    where `--pgport` and `--port` are set to ports not in use by other nodes and `--join` connects the new node to the cluster via your local host and the port of the first node, `26257`.
+
+## Secure Mode
+
+1. From the directory containing the `cockroach` binary, create security certificates:
 
     ```bash
     $ ./cockroach cert create-ca
     $ ./cockroach cert create-node localhost $(hostname) 
     $ ./cockroach cert create-client root
     ```
-    These commands create security certificates in the `certs` directory. The first two commands create the files for the cluster: `ca.cert`, `ca.key`, `node.server.crt`, `node.server.key`, `node.client.crt`, and `node.client.key`. The last command creates the files for the SQL client: `root.client.crt` and `root.client.key`.  
+    These commands create certificates in the `certs` directory. The first two commands create the files for the cluster: `ca.cert`, `ca.key`, `node.server.crt`, `node.server.key`, `node.client.crt`, and `node.client.key`. The last command creates the files for the SQL client: `root.client.crt` and `root.client.key`.  
 
-3. Start the cluster:
+2. Start a single-node cluster:
 
     ```bash
-    $ ./cockroach start --stores=ssd=dev/data --gossip=self
+    $ ./cockroach start --stores=ssd=data/node1
     ```
-    In the `--gossip` flag, `self` is equivalent to `localhost:26257`, the default host and port for CockroachDB. 
-
-4. In a new shell, start the built-in SQL client:
+    where `ssd` can be any arbitrary string describing the store (e.g., `ssd` for flash, `hdd` for spinny disk) and `dev/data` is the filepath to the storage location. For the filepath, the parent directory must exist and the store directory, if it already exists, must not contain any CockroachDB data.
+    
+3. In a new shell, start the built-in SQL client:
 
     ```bash
     $ ./cockroach sql
@@ -71,6 +75,14 @@ Data is stored on-disk and client/server communication is secure. Setup involves
 5. [Run some queries](basic-sql-commands.html).
 
 6. Check out the Admin UI by pointing your browser to `https://<your local host>:26257`. You can find your local host by running `hostname` in your shell. Note that your browser will consider the cockroach-created certificate invalid, so you'll need to click through a warning message to get the UI. 
+
+7. To simulate a multi-node cluster, add each new node as follows:
+    
+    ```bash
+    $ ./cockroach start --stores=ssd=data/node2 pgport=15433 --port=26258 --join=localhost:26257
+    ```
+
+    where `--stores` is set to a unique storage location, `--pgport` and `--port` are set to ports not in use by other nodes, and `--join` connects the new node to the cluster via your local host and the port of the first node, `26257`.
 
 ## What's Next?
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -8,7 +8,7 @@ Once you've [installed CockroachDB locally](install-cockroachdb.html), the quick
 - [Dev Mode (Insecure)](#dev-mode-insecure)  
 In dev mode, you start up a single-node cluster where data is stored in-memory and client/server communication is completely insecure. This mode is great for learning CockroachDB, but since there's no authentication or encryption and nothing is stored persistently, it's suitable only for limited testing and development.  
 
-- [Standard Mode (Secure)](#secure-mode-secure)  
+- [Standard Mode (Secure)](#standard-mode-secure)  
 In standard mode, you start up a single-node or multi-node cluster where data is stored on-disk and client/server communication is secure. Setup involves creating certificates and passing additional command line options, but it's still simple. This mode is suitable for standing up a persistent test cluster to develop an application or test CockroachDB. 
 
 {{site.data.alerts.callout_info}} For production deployments, see <a href="deploy-a-multinode-cluster.html">Deploy a Multi-Node Cluster</a>.{{site.data.alerts.end}}
@@ -49,7 +49,7 @@ In standard mode, you start up a single-node or multi-node cluster where data is
 2. Start a single-node cluster:
 
     ```bash
-    $ ./cockroach start --stores=ssd=data/node1
+    $ ./cockroach start --stores=ssd=dev/node1
     ```
     The `--stores` flag defines the store type and the filepath to the storage location. The store type can be any arbitrary string describing the store (e.g., `ssd` for flash, `hdd` for spinny disk). For the filepath, the parent directory must exist and the store directory, if it already exists, should not contain any CockroachDB data.
     
@@ -69,14 +69,14 @@ In standard mode, you start up a single-node or multi-node cluster where data is
 6. To simulate a multi-node cluster, add each new node as follows:
     
     ```bash
-    $ ./cockroach start --stores=ssd=data/node2 --port=26258 --pgport=15433 --join=<your local host>:26257
+    $ ./cockroach start --stores=ssd=dev/node2 --port=26258 --pgport=15433 --join=<your local host>:26257
     ```
 
     Set the `--stores` flag to a storage location not in use by other nodes.
 
-    The `--port` and `--pgport` flags bind the ports for CockroachDB and SQL client traffic. Set these flags to ports not in use by other nodes. 
+    The `--port` and `--pgport` flags bind the ports for CockroachDB and SQL client traffic. Set these flags to ports not in use by other nodes (the first node uses the default ports, 26257 and 15432). 
 
-    The `--join` flag connects the new node to the cluster. Set this flag to your local host and the port of the first node, `26257`. You can find your local host by running `hostname` in your shell.
+    The `--join` flag connects the new node to the cluster. Set this flag to your local host and the port of the first node, 26257. You can find your local host by running `hostname` in your shell.
 
 ## What's Next?
 


### PR DESCRIPTION
Fixes #30 

- Removed `--init` step from **Secure Mode** instructions.
- Added step on adding nodes to both the **Dev Mode** and **Secure Mode** instructions. 
- Tweaked the intro to mention adding additional nodes.

@spencerkimball, @mberhault, please let me know what you think. Instead of adding a third section for a "multi-node local cluster", I just added a step to each of the existing procedures. Happy to try another approach, if you prefer. 

@spencerkimball: I've used `localhost` in the secure example, even though it's currently a problem: [#4118](https://github.com/cockroachdb/cockroach/issues/4118) and [#3358](https://github.com/cockroachdb/cockroach/issues/3358).

In case you'd rather review an html version: http://cockroach-draft-docs.s3-website-us-east-1.amazonaws.com/start-a-local-cluster.html