### PR TITLE
updates to insecure and secure startup

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -132,8 +132,15 @@ entries:
           product: all
           version: all
 
-        - title: Deploy a Multi-Node Cluster
-          url: /deploy-a-multinode-cluster.html
+        - title: On-Premise Deployment
+          url: /deploy-on-premises.html
+          audience: all
+          platform: all
+          product: all
+          version: all
+
+        - title: Cloud Deployment
+          url: /deploy-in-cloud.html
           audience: all
           platform: all
           product: all

--- a/cloud-deployment.md
+++ b/cloud-deployment.md
@@ -1,0 +1,4 @@
+---
+title: Cloud Deployment
+toc: false
+---

--- a/deploy-a-multinode-cluster.md
+++ b/deploy-a-multinode-cluster.md
@@ -1,4 +1,0 @@
----
-title: Deploy a Multi-Node Cluster
-toc: false
----

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -96,7 +96,7 @@ $(document).ready(function(){
 
 <ul>
 <li>A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). On Mac OS X, Xcode should suffice. </li>
-<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code>$GOPATH</code> and <code>$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</li>
+<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.6. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code>$GOPATH</code> and <code>$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</li>
 <li>Git 1.8+ </li>
 </ul></li>
 <li><p>Get the CockroachDB code:</p>
@@ -160,7 +160,7 @@ $(document).ready(function(){
 
 <ul>
 <li>A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). </li>
-<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.5. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code>$GOPATH</code> and <code>$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</li>
+<li>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.6. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code>$GOPATH</code> and <code>$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</li>
 <li>Git 1.8+ </li>
 </ul></li>
 <li><p>Get the CockroachDB code:</p>
@@ -256,7 +256,7 @@ $(document).ready(function(){
 
 1.  Make sure you have the following prerequisites:
     - A C++ compiler that supports C++11 (GCC 4.9+ and clang 3.6+ are known to work). On Mac OS X, Xcode should suffice. 
-    - A [Go environment](http://golang.org/doc/code.html) with a 64-bit version of Go 1.5. You can download the [Go binary](https://golang.org/dl/) directly from the official site. Be sure to set the `$GOPATH` and `$PATH` environment variables as described [here](https://golang.org/doc/code.html#GOPATH). 
+    - A [Go environment](http://golang.org/doc/code.html) with a 64-bit version of Go 1.6. You can download the [Go binary](https://golang.org/dl/) directly from the official site. Be sure to set the `$GOPATH` and `$PATH` environment variables as described [here](https://golang.org/doc/code.html#GOPATH). 
     - Git 1.8+ 
 
 2.  Get the CockroachDB code:

--- a/on-premise-deployment.md
+++ b/on-premise-deployment.md
@@ -1,0 +1,4 @@
+---
+title: On-Premise Deployment
+toc: false
+---

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -3,7 +3,7 @@ title: Start a Local Cluster
 toc: false
 ---
 
-Once you've [installed CockroachDB locally](install-cockroachdb.html), it's easy to start a single- or multi-node cluster locally and talk to it via the built-in SQL client. Your cluster can be insecure or secure:
+Once you've [installed CockroachDB](install-cockroachdb.html), it's easy to start a single- or multi-node cluster locally and talk to it via the built-in SQL client. Your cluster can be insecure or secure:
 
 - [Insecure](#insecure)  
 This is the fastest way to start up a cluster and learn CockroachDB, but there's no client/server authentication or encryption, so it's suitable only for limited testing and development.
@@ -19,11 +19,19 @@ Starting up a cluster with authenticated, encrypted client/server communication 
 
    ~~~ shell
    $ ./cockroach start --insecure
+
+   build:     alpha.v1-362-g723805f @ 2016/02/24 16:03:23 (go1.6)
+   admin:     http://ROACHs-MacBook-Pro.local:26257
+   sql:       postgresql://root@ROACHs-MacBook-Pro.local:26257?sslmode=disable
+   logs:      cockroach-data/logs
+   store[0]:  cockroach-data
    ~~~
 
    - The `--insecure` flag sets client/server communication to insecure on the default port, 26257. To bind to different port, set `--port=<port>`.
 
-   - Node storage defaults to the `cockroach-data` directory. To store to a different directory, set `--stores=<filepath>`. 
+   - Node storage defaults to the `cockroach-data` directory. To store to a different location, set `--stores=<filepath>`. 
+
+   - The output gives you a helpful summary of the CockroachDB version, the URL for the admin UI, the SQL URL for your client code, and the storage locations for node data and logs. 
 
 2. For each additional node, repeat step 1 with a few extra flags:
 
@@ -37,15 +45,18 @@ Starting up a cluster with authenticated, encrypted client/server communication 
   
    - The `--join` flag connects the new node to the cluster. Set this flag to `localhost` and the port of the first node.
 
-2. In a new shell, start the built-in SQL client:
+3. In a new shell, start the built-in SQL client:
 
    ~~~ shell
    $ ./cockroach sql --insecure
+   # Welcome to the cockroach SQL interface.
+   # All statements must be terminated by a semicolon.
+   # To exit: CTRL + D.
    ~~~
 
-3. [Run some queries](basic-sql-statements.html).
+4. [Run some queries](basic-sql-statements.html).
 
-4. [Check out the Admin UI](explore-the-admin-ui.html) by pointing your browser to `http://<your local host>:26257`. You can find the complete address in the the `admin` field in the response after starting a node.
+5. [Check out the Admin UI](explore-the-admin-ui.html) by pointing your browser to `http://<local host>:26257`. You can find the complete address in the startup output as well (see step 1).
 
 ## Secure
 
@@ -65,13 +76,21 @@ Starting up a cluster with authenticated, encrypted client/server communication 
  
    ~~~ shell
    $ ./cockroach start
+
+   build:     alpha.v1-362-g723805f @ 2016/02/24 16:03:23 (go1.6)
+   admin:     https://ROACHs-MacBook-Pro.local:26257
+   sql:       postgresql://root@ROACHs-MacBook-Pro.local:26257?sslcert=%2FUsers%2F...
+   logs:      cockroach-data/logs
+   store[0]:  cockroach-data
    ~~~
 
    - Secure communication uses the certificates in the `certs` directory and defaults to port 26257. To bind to a different port, set `--port=<port>`.
 
-   - Node storage defaults to the `cockroach-data` directory. To store to a different directory, set `--stores=<filepath>`.
+   - Node storage defaults to the `cockroach-data` directory. To store to a different location, set `--stores=<filepath>`.
 
-3. For each additional node, repeat step 1 with a few extra flags:
+   - The output gives you a helpful summary of the CockroachDB version, the URL for the admin UI, the SQL URL for your client code, and the storage locations for node data and logs. 
+
+3. For each additional node, repeat step 2 with a few extra flags:
 
    ~~~ shell
    $ ./cockroach start --stores=<filepath> --port=26258 --join=localhost:26257
@@ -87,11 +106,14 @@ Starting up a cluster with authenticated, encrypted client/server communication 
 
    ~~~ shell
    $ ./cockroach sql
+   # Welcome to the cockroach SQL interface.
+   # All statements must be terminated by a semicolon.
+   # To exit: CTRL + D.
    ~~~
 
-4. [Run some queries](basic-sql-statements.html).
+5. [Run some queries](basic-sql-statements.html).
 
-5. [Check out the Admin UI](explore-the-admin-ui.html) by pointing your browser to `https://<your local host>:26257`. You can find the complete address in the the `admin` field in the response after starting a node. Note that your browser will consider the cockroach-created certificate invalid, so you'll need to click through a warning message to get the UI.
+6. [Check out the Admin UI](explore-the-admin-ui.html) by pointing your browser to `https://<local host>:26257`. You can find the complete address in the startup output as well (see step 2). Note that your browser will consider the cockroach-created certificate invalid; you'll need to click through a warning message to get to the UI.
 
 ## What's Next?
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -21,21 +21,19 @@ Starting up a cluster with authenticated, encrypted client/server communication 
    $ ./cockroach start --insecure
    ~~~
 
-   - The `--insecure` flag sets node and client communication to insecure. 
+   - The `--insecure` flag sets client/server communication to insecure on the default port, 26257. To bind to different port, set `--port=<port>`.
 
-   - Node and client traffic default to ports 26257 and 15432. To bind to different ports, set `--port=<node port>` and `--pgport=<client port>`. 
-
-   - Node storage defaults to the `cockroach-data` directory. To have CockroachDB create and store to a different directory, set `--stores=<filepath>`. 
+   - Node storage defaults to the `cockroach-data` directory. To store to a different directory, set `--stores=<filepath>`. 
 
 2. For each additional node, repeat step 1 with a few extra flags:
 
    ~~~ shell
-   $ ./cockroach start --insecure --stores=<filepath> --port=26258 --pgport=15433 --join=localhost:26257
+   $ ./cockroach start --insecure --stores=<filepath> --port=26258 --join=localhost:26257
    ~~~
 
-   - Set the `--stores` flag to a storage location not in use by other nodes.
+   - Set the `--stores` flag to a storage location not in use by other nodes. To use multiple stores for the node, comma-separate the filepaths.
 
-   - Set the `--port` and `--pgport` flags to ports not in use by other nodes.
+   - Set the `--port` flag to a port not in use by other nodes.
   
    - The `--join` flag connects the new node to the cluster. Set this flag to `localhost` and the port of the first node.
 
@@ -59,7 +57,9 @@ Starting up a cluster with authenticated, encrypted client/server communication 
    $ ./cockroach cert create-client root
    ~~~
 
-   These commands create certificates in the `certs` directory. The first two commands create the files for the cluster: `ca.cert`, `ca.key`, `node.server.crt`, `node.server.key`, `node.client.crt`, and `node.client.key`. The last command creates the files for the SQL client: `root.client.crt` and `root.client.key`.
+   - The first two commands create a default `certs` directory and add the certificate authority files and files for the node: `ca.cert`, `ca.key`,`node.server.crt`, `node.server.key`, `node.client.crt`, and `node.client.key`. 
+   
+   - The last command adds the files for the SQL client: `root.client.crt` and `root.client.key`.
 
 2. Start a secure node:
  
@@ -67,21 +67,19 @@ Starting up a cluster with authenticated, encrypted client/server communication 
    $ ./cockroach start
    ~~~
 
-   - Node and client communication look for certificates in the default `certs` directory. If certificates are stored elsewhere, set `--certs=<path to directory>`.
+   - Secure communication uses the certificates in the `certs` directory and defaults to port 26257. To bind to a different port, set `--port=<port>`.
 
-   - Node and client traffic default to ports 26257 and 15432. To bind to different ports, set `--port=<node port>` and `--pgport=<client port>`. 
-
-   - Node storage defaults to the `cockroach-data` directory. To have CockroachDB create and store to a different directory, set `--stores=<filepath>`.
+   - Node storage defaults to the `cockroach-data` directory. To store to a different directory, set `--stores=<filepath>`.
 
 3. For each additional node, repeat step 1 with a few extra flags:
 
    ~~~ shell
-   $ ./cockroach start --stores=<filepath> --port=26258 --pgport=15433 --join=localhost:26257
+   $ ./cockroach start --stores=<filepath> --port=26258 --join=localhost:26257
    ~~~
 
-   - Set the `--stores` flag to a storage location not in use by other nodes.
+   - Set the `--stores` flag to a storage location not in use by other nodes. To use multiple stores for the node, comma-separate the filepaths.
 
-   - Set the `--port` and `--pgport` flags to ports not in use by other nodes.
+   - Set the `--port` flag to a port not in use by other nodes.
   
    - The `--join` flag connects the new node to the cluster. Set this flag to `localhost` and the port of the first node.
 


### PR DESCRIPTION
Updated start-a-local-cluster.md to account for:

- removal of `--dev` flag
- default storage location
- attribute optional when passing `--stores` flag

@petermattis, @mberhault, please let me know if I missed anything, or if you want me to cut back or expand any explanations. I'll also be sure all of this gets into the `cockroach` CLI docs. 

I'll work on this file again once @mberhault's done with his changes to certs, @BramGruneir's done with his changes to `--store`, and @tamird's done with his changes to ports.

Fixes #47 