### PR TITLE
Fix broken markdown tables and restore HTML tables

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,6 +26,7 @@
                         adjustMinHeight();
                     }
                 });
+                $sidebar.show();
 
                 adjustMinHeight();
 
@@ -44,10 +45,9 @@
 
         </script>
 
-
         {% include custom/conditions.html %}
 
-        <ul id="mysidebar" class="nav">
+        <ul id="mysidebar" class="nav" style="display: none">
             <li>
                 <form action="https://google.com/search" method="GET">
                     <input type="hidden" name="sitesearch" value="cockroachlabs.com/docs">
@@ -58,7 +58,7 @@
             {% for subcategory in entry.subcategories %}
             {% if subcategory.audience contains audience and subcategory.product contains product and subcategory.platform contains platform and subcategory.version contains version and subcategory.web != false %}
             <li><a href="#">{{ subcategory.title }}</a>
-                {% if subcategory.class == "series" %}<ul class="series">{% else %}<ul>{% endif %}
+                <ul>
                     {% for item in subcategory.items %}
                     {% if item.audience contains audience and item.product contains product and item.platform contains platform and item.version contains version and item.web != false %}
                     {% if item.external_url %}


### PR DESCRIPTION
## Summary

Fixes broken markdown tables in the Mintlify docs set (`cockroachlabs-preview-main/`), part of DOC-17764. This PR handles tables that should remain inline (not snippets).

### Fixes applied

- **Separator `+` → `|`**: 260 fixes across 175 files. Markdown separator rows used `+` instead of `|` for column delimiters.
- **Blank lines in tables**: Removed blank lines left behind by stripped `{% if %}` Liquid conditionals that broke table continuity (ui-databases-page v23.1/v24.2).
- **ARM rows missing OS column**: Fixed ~490 release download table rows missing the Operating System cell.
- **Release download tables → HTML**: Converted 245 download tables across 10 release files from broken markdown back to `<table>` with `rowspan`, matching the Jekyll source structure.
- **Performance-recipes tables → HTML**: Restored HTML `<table>` with `<ul><li>` from Jekyll source across 12 versioned files. Links converted from Jekyll syntax to Mintlify `/docs/` paths.
- **Cloud-only content removed from self-hosted pages**: During Jekyll-to-Mintlify conversion, some versions had both branches of `{% if page.cloud != true %}` conditionals dumped into self-hosted pages. Removed 81 cloud-only items (navigation instructions, duplicate Regions rows, concatenated CPU Time descriptions) from 19 files across v23.1, v24.2, v25.1, v25.3, v26.2, v26.3.

### Not in scope (handled by separate PR)

Tables that should be replaced with snippets (cluster settings, session vars, metrics, SQL functions, logging, CLI flags, third-party tools) — per DOC-17764 Google Doc.

## Test plan

- [ ] Verify separator rows render as proper tables (spot-check `docs/stable/foreign-key.mdx`)
- [ ] Verify release download tables render with correct OS grouping (spot-check `docs/releases/v25.4.mdx`)
- [ ] Verify performance-recipes tables render with bullet lists inside cells (spot-check `docs/stable/performance-recipes.mdx`)
- [ ] Verify self-hosted UI pages no longer show cloud navigation instructions (spot-check `docs/v23.1/ui-statements-page.mdx`)
- [ ] Verify cloud pages under `docs/cockroachcloud/` still have correct cloud content