### PR TITLE
Add `www.` to URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ gems:
   - jekyll-sitemap
 
 baseurl: "/docs"
-url: http://cockroachlabs.com
+url: http://www.cockroachlabs.com
 
 theme_file: theme-blue.css
 highlighter: rouge


### PR DESCRIPTION
It's better for SEO to either always or never use "www.", and we currently use it.