### PR TITLE
Add CSE inline search

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -50,11 +50,8 @@
         <ul id="mysidebar" class="nav" style="display: none">
             <li>
                 <div class="search">
-                    <form action="https://google.com/search" method="GET">
-                        <span class="fa fa-search"></span>
-                        <input type="hidden" name="sitesearch" value="cockroachlabs.com/docs">
-                        <input type="text" name="q" id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}">
-                    </form>
+                    <span class="fa fa-search"></span>
+                    <input type="text" id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}">
                 </div>
             </li>
             {% for entry in sidebar %}

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1408,3 +1408,17 @@ dd {
 
 a.accordion-toggle {
   font-style: normal; }
+
+.search-item {
+	margin-top: 30px;
+}
+.search-title {
+	font-size: 20px;
+}
+.search-link {
+	color: #999988;
+	font-size: 14px;
+}
+.search-snippet {
+	font-size: 14px;
+}

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -66,6 +66,33 @@
                 $sidebar.css('margin-top', 40);
             }
         });
+
+        var gsearch = document.getElementById('search-input');
+        gsearch.addEventListener('keydown', function (e) {
+            if (e.keyCode != 13) {
+                return;
+            }
+            var obj = {
+                q: gsearch.value,
+                cx: '',
+                key: ''
+            };
+            $.getJSON('https://www.googleapis.com/customsearch/v1', obj, function (data) {
+                var div = $('<div/>');
+                if (data.items) {
+                    data.items.forEach(function(item) {
+                        var h = $('<div/>', {class: 'search-title'});
+                        h.append($('<a/>', {href: item.link}).html(item.htmlTitle));
+                        var r = $('<div/>', {class: 'search-item'});
+                        r.append(h);
+                        r.append($('<div/>', {class: 'search-link'}).html(item.formattedUrl));
+                        r.append($('<div/>', {class: 'search-snippet'}).html(item.htmlSnippet));
+                        div.append(r);
+                    });
+                }
+                $('.post-content').html(div);
+            });
+        });
     });
 })(jQuery);
 

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -74,8 +74,8 @@
             }
             var obj = {
                 q: gsearch.value,
-                cx: '',
-                key: ''
+                cx: '014222686769097698638:i_krv_mjv4w',
+                key: 'AIzaSyCMGfdDaSfjqv5zYoS0mTJnOT3e9MURWkU'
             };
             $.getJSON('https://www.googleapis.com/customsearch/v1', obj, function (data) {
                 var div = $('<div/>');
@@ -95,6 +95,4 @@
         });
     });
 })(jQuery);
-
-
 


### PR DESCRIPTION
This adds search inline. See screenshot. We need an API key and custom search ID to make this work. I used some from my account. See fields in the JS where you fill that in.

This works by just changing the main page contents to the search results. It currently doesn't support paging. It also doesn't change the URL. That means if you reload you'll get the old page data. It also means the back button doesn't work (i.e., won't take you to how it looked before you hit search). We can add support for all of those features, they just each take time.

I did this with custom code because it looked like dealing with all the styling issues from using google's native stuff was going to cause some bad problems.

![search](https://cloud.githubusercontent.com/assets/41181/13522416/6861d0ac-e1bd-11e5-8e15-13b5c366e252.png)
