### PR TITLE
removing bit

### DIFF
--- a/int.md
+++ b/int.md
@@ -15,7 +15,6 @@ In CockroachDB, the following are synonyms of `INT` and are implemented identica
 - `INTEGER` 
 - `INT64` 
 - `BIGINT`
-- `BIT`
 
 ## Format
 


### PR DESCRIPTION
Removing mention of `BIT` data type. 

Issue open to implement `INT(n)` and `BIT(n)`: https://github.com/cockroachdb/cockroach/issues/5514