### PR TITLE
Minor revisions to data types docs

### DIFF
--- a/bool.md
+++ b/bool.md
@@ -9,7 +9,7 @@ The `BOOL` [data type](data-types.html) stores a Boolean value of `false` or `tr
 
 ## Synonyms
 
-In CockroachDB, `BOOLEAN` is a synonym of `BOOL` and is implemented identically. 
+In CockroachDB, `BOOLEAN` is a synonym of `BOOL`. 
 
 ## Format
 

--- a/bytes.md
+++ b/bytes.md
@@ -5,11 +5,11 @@ toc: true
 
 ## Description
 
-The `BYTES` [data type](data-types.html) stores binary strings of variable, unlimited length.
+The `BYTES` [data type](data-types.html) stores binary strings of variable length.
 
 ## Synonyms
 
-In CockroachDB, the following are synonyms of `BYTES` and are implemented identically: 
+In CockroachDB, the following are synonyms of `BYTES`: 
 
 - `BYTEA` 
 - `BLOB` 

--- a/decimal.md
+++ b/decimal.md
@@ -9,7 +9,7 @@ The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers wit
 
 ## Synonyms
 
-In CockroachDB, the following are synonyms of `DECIMAL` and are implemented identically:
+In CockroachDB, the following are synonyms of `DECIMAL`:
 
 - `DEC` 
 - `NUMERIC` 
@@ -23,6 +23,8 @@ Precision (the maximum count of digits in a whole number, both to the left and r
 When declaring a decimal, format it as `DECIMAL '1.2345'`. This casts the value as a string, which preserves the number's exact precision.
 
 Alternately, you can cast a float as a decimal: `CAST(1.2345 AS DECIMAL)`. However, note that precision will be limited to 17 digits in total (both to the left and right of the decimal point). 
+
+{{site.data.alerts.callout_info}}In an upcoming version, CockroachDB will support declaring a decimal as a literal instead needing to cast from a string or float.{{site.data.alerts.end}}
 
 ## Examples
 

--- a/decimal.md
+++ b/decimal.md
@@ -24,7 +24,7 @@ When declaring a decimal, format it as `DECIMAL '1.2345'`. This casts the value 
 
 Alternately, you can cast a float as a decimal: `CAST(1.2345 AS DECIMAL)`. However, note that precision will be limited to 17 digits in total (both to the left and right of the decimal point). 
 
-{{site.data.alerts.callout_info}}In an upcoming version, CockroachDB will support declaring a decimal as a literal instead needing to cast from a string or float.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}A future version of CockroachDB will support declaring a decimal as a literal instead of needing to cast from a string or float.{{site.data.alerts.end}}
 
 ## Examples
 

--- a/float.md
+++ b/float.md
@@ -9,7 +9,7 @@ The `FLOAT` [data type](data-types.html) stores inexact, floating-point numbers 
 
 ## Synonyms
 
-In CockroachDB, the following are synonyms of `FLOAT` and are implemented identically:
+In CockroachDB, the following are synonyms of `FLOAT`:
 
 - `REAL` 
 - `DOUBLE PRECISION` 

--- a/int.md
+++ b/int.md
@@ -9,7 +9,7 @@ The `INT` [data type](data-types.html) stores 64-bit signed integers, that is, w
 
 ## Synonyms 
 
-In CockroachDB, the following are synonyms of `INT` and are implemented identically: 
+In CockroachDB, the following are synonyms of `INT`: 
 
 - `SMALLINT` 
 - `INTEGER` 

--- a/string.md
+++ b/string.md
@@ -5,11 +5,11 @@ toc: true
 
 ## Description
 
-The `STRING` [data type](data-types.html) stores strings of variable, unlimited length. 
+The `STRING` [data type](data-types.html) stores strings of variable length. 
 
 ## Synonyms 
 
-In CockroachDB, the following are synonyms of `STRING` and are implemented identically: 
+In CockroachDB, the following are synonyms of `STRING`: 
 
 - `CHAR` 
 - `CHAR(n)` 
@@ -19,7 +19,7 @@ In CockroachDB, the following are synonyms of `STRING` and are implemented ident
 
 ## Length
 
-Length is always variable and unlimited for a `STRING` value. If you specify a fixed length by declaring `CHAR(n)` or `VARCHAR(n)` on a column, it will not be enforced.
+Length is always variable for a `STRING` value. If you specify a fixed length by declaring `CHAR(n)` or `VARCHAR(n)` on a column, it will not be enforced.
 
 ## Format
 

--- a/string.md
+++ b/string.md
@@ -19,7 +19,9 @@ In CockroachDB, the following are synonyms of `STRING`:
 
 ## Length
 
-Length is always variable for a `STRING` value. If you specify a fixed length by declaring `CHAR(n)` or `VARCHAR(n)` on a column, it will not be enforced.
+At this time, length is always variable for a `STRING` value. If you specify a fixed length by declaring `CHAR(n)` or `VARCHAR(n)` on a column, it will not be enforced.
+
+{{site.data.alerts.callout_info}}A future version of CockroachDB will support enforcing length limits on strings.{{site.data.alerts.end}}
 
 ## Format
 


### PR DESCRIPTION
Pete,

Revised based on your comments in PR #131:

- Removed mention of "unlimited" for `string` and `bytes`.
- Removed redundant language when specifying synonyms.
- Added note that we'll support declaring a decimal as a literal (rather than casting from string or float) in a future version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/160)
<!-- Reviewable:end -->
