### PR TITLE
using variables for version and build

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -1,6 +1,5 @@
-
-
-# placed here for translation purposes
 search_placeholder_text: Search
 search_no_results_text: No results found.
 copyright_line: "&copy;2016 Cockroach Labs. All rights reserved."
+version: beta-20160329
+build: beta-20160329 @ 2016/03/30 02:43:57 (go1.6)

--- a/install-cockroachdb-in-md.md
+++ b/install-cockroachdb-in-md.md
@@ -5,14 +5,14 @@ toc: false
 
 ## Get the Binary - Mac and Linux
 
-<!-- For Linux, just change the download link in step 1 to  https://binaries.cockroachdb.com/cockroach-beta-20160329.linux-amd64.tgz -->
+<!-- For Linux, just change the download link in step 1 to  https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.linux-amd64.tgz -->
 
-1. Download the latest [CockroachDB tarball for OS X](https://binaries.cockroachdb.com/cockroach-beta-20160329.darwin-10.9-amd64.tgz).  
+1. Download the latest [CockroachDB tarball for OS X](https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.darwin-10.9-amd64.tgz).
 
 2. Extract the binary:
    
    ~~~ shell
-   $ tar xfz <tarball file name>
+   $ tar xfz cockroach-{{site.data.strings.version}}.darwin-10.9.amd64.tgz
    ~~~ 
 
 ## Use Homebrew - Mac

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -92,12 +92,12 @@ $(document).ready(function(){
 
   <ol>
     <li>
-      <p>Download the latest <a href="https://binaries.cockroachdb.com/cockroach-beta-20160329.darwin-10.9-amd64.tgz">CockroachDB tarball for OS X</a>.</p>
+      <p>Download the latest <a href="https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.darwin-10.9-amd64.tgz">CockroachDB tarball for OS X</a>.</p>
     </li>
     <li>
       <p>Extract the binary:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>tar xfz cockroach-beta-20160329.darwin-10.9-amd64.tgz</code></pre>
+      <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>tar xfz cockroach-{{site.data.strings.version}}.darwin-10.9-amd64.tgz</code></pre>
       </div>
     </li>
     <li>
@@ -256,12 +256,12 @@ $(document).ready(function(){
 
   <ol>
     <li>
-      <p>Download the latest <a href="https://binaries.cockroachdb.com/cockroach-beta-20160329.linux-amd64.tgz">CockroachDB tarball for Linux</a>.</p>
+      <p>Download the latest <a href="https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.linux-amd64.tgz">CockroachDB tarball for Linux</a>.</p>
     </li>
     <li>
       <p>Extract the binary:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>tar xfz cockroach-beta-20160329.linux-amd64.tgz</code></pre>
+      <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>tar xfz cockroach-{{site.data.strings.version}}.linux-amd64.tgz</code></pre>
       </div>
     </li>
     <li>

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -96,7 +96,7 @@ The CockroachDB Admin UI lets you monitor cluster-wide, node-level, and database
 
 ~~~ shell
 $ ./cockroach start --insecure --host=node1.example.com
-build:     beta-20160328-2-g902c616 @ 2016/03/29 21:39:05 (go1.6)
+build:     {{site.data.strings.build}}
 admin:     http://node1.example.com:8080 <-------------------------- USE THIS URL
 sql:       postgresql://root@node1.example.com:26257?sslmode=disable
 logs:      cockroach-data/logs
@@ -201,7 +201,7 @@ The CockroachDB Admin UI lets you monitor cluster-wide, node-level, and database
 
 ~~~ shell
 $ ./cockroach start --insecure --host=node1.example.com
-build:     beta-20160328-2-g902c616 @ 2016/03/29 21:39:05 (go1.6)
+build:     {{site.data.strings.build}}
 admin:     https://node1.example.com:8080 <-------------------------------- USE THIS URL
 sql:       postgresql://root@node1.example.com:26257?sslcert=%2FUsers%2F...
 logs:      cockroach-data/logs

--- a/secure-a-cluster.md
+++ b/secure-a-cluster.md
@@ -46,7 +46,7 @@ Now that you have a [local cluster](start-a-local-cluster.html) up and running, 
     ~~~ shell
     $ ./cockroach start --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key &
 
-    build:     beta-20160328-2-g902c616 @ 2016/03/29 21:39:05 (go1.6)
+    build:     {{site.data.strings.build}}
     admin:     https://ROACHs-MBP:8080
     sql:       postgresql://root@ROACHs-MBP:26257?sslcert=%2FUsers%2F...
     logs:      cockroach-data/logs

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -11,7 +11,7 @@ Once you've [installed CockroachDB](install-cockroachdb.html), you can quickly s
     ~~~ shell
     $ ./cockroach start --insecure &
 
-    build:     beta-20160328-2-g902c616 @ 2016/03/29 21:39:05 (go1.6)
+    build:     {{site.data.strings.build}}
     admin:     http://ROACHs-MBP:8080
     sql:       postgresql://root@ROACHs-MBP:26257?sslmode=disable
     logs:      cockroach-data/logs

--- a/start-a-node.md
+++ b/start-a-node.md
@@ -53,7 +53,7 @@ Field | Description
 When you run `cockroach start`, some helpful details are printed to the standard output:
 
 ~~~ shell
-build:     beta-20160328-2-g902c616 @ 2016/03/29 21:39:05 (go1.6)
+build:     {{site.data.strings.build}}
 admin:     http://ROACHs-MBP:8080
 sql:       postgresql://root@ROACHs-MBP:26257?sslmode=disable
 logs:      cockroach-data/logs


### PR DESCRIPTION
Instead of updating the version and build strings in multiple places, I added the `version` and `build` variables to `_data/strings.yml` and used them wherever necessary as follows:

`{{site.data.strings.version}}`
`{{site.data.strings.build}}`

Going forward, when the current version and build change, we need only update these variables. 

Fixes #173

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/174)
<!-- Reviewable:end -->
