### PR TITLE
Use beta-20130330

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -1,5 +1,5 @@
 search_placeholder_text: Search
 search_no_results_text: No results found.
 copyright_line: "&copy;2016 Cockroach Labs. All rights reserved."
-version: beta-20160329
-build: beta-20160329 @ 2016/03/30 02:43:57 (go1.6)
+version: beta-20160330
+build: beta-20160330 @ 2016/03/30 14:43:57 (go1.6)


### PR DESCRIPTION
```
$ ./cockroach-beta-20160330.linux-amd64/cockroach version|head -n 5
Build Vers:  go1.6
Build Tag:   beta-20160330
Build Time:  2016/03/30 14:53:35
Build Deps:
  github.com/VividCortex/ewma                c34099b489e4ac33ca8d8c5f9d29d6eeaf69f2ed
```

Can someone check the OSX binary?
https://binaries.cockroachdb.com/cockroach-beta-20160330.darwin-10.9-amd64.tgz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/175)
<!-- Reviewable:end -->
