### PR TITLE
php: use PDO, add transactional example

### DIFF
--- a/_includes/app/basic-sample.php
+++ b/_includes/app/basic-sample.php
@@ -1,22 +1,19 @@
 <?php
-function kill($msg) {
-	echo($msg);
-	exit(1);
+try {
+  $dbh = new PDO('pgsql:host=localhost;port=26257;dbname=bank;sslmode=disable',
+    'maxroach', null, array(
+      PDO::ATTR_ERRMODE          => PDO::ERRMODE_EXCEPTION,
+      PDO::ATTR_EMULATE_PREPARES => true,
+  ));
+
+  $dbh->exec('INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)');
+
+  print "Account balances:\r\n";
+  foreach ($dbh->query('SELECT id, balance FROM accounts') as $row) {
+      print $row['id'] . ': ' . $row['balance'] . "\r\n";
+  }
+} catch (Exception $e) {
+    print $e->getMessage() . "\r\n";
+    exit(1);
 }
-
-$dbconn = pg_connect('postgresql://maxroach@localhost:26257/bank?sslmode=disable') or kill('Could not connect: ' . pg_last_error());
-
-pg_query('INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)')
-    or kill('Insert failed: ' . pg_last_error());
-
-$result = pg_query('SELECT id, balance FROM accounts')
-    or kill('Select failed: ' . pg_last_error());
-
-echo "Account balances:\n";
-while ($line = pg_fetch_array($result, null, PGSQL_NUM)) {
-    echo join(' ', $line) . "\n";
-}
-
-pg_free_result($result);
-pg_close($dbconn);
 ?>

--- a/_includes/app/txn-sample.php
+++ b/_includes/app/txn-sample.php
@@ -1,0 +1,71 @@
+<?php
+
+function transferMoney($dbh, $from, $to, $amount) {
+  try {
+    $dbh->beginTransaction();
+    // This savepoint allows us to retry our transaction.
+    $dbh->exec("SAVEPOINT cockroach_restart");
+  } catch (Exception $e) {
+    throw $e;
+  }
+
+  while (true) {
+    try {
+      $stmt = $dbh->prepare(
+        'UPDATE accounts SET balance = balance + :deposit ' .
+        'WHERE id = :account AND (:deposit > 0 OR balance + :deposit >= 0)');
+
+      // First, withdraw the money from the old account (if possible).
+      $stmt->bindValue(':account', $from, PDO::PARAM_INT);
+      $stmt->bindValue(':deposit', -$amount, PDO::PARAM_INT);
+      $stmt->execute();
+      if ($stmt->rowCount() == 0) {
+        print "source account does not exist or is underfunded\r\n";
+        return;
+      }
+
+      // Next, deposit into the new account (if it exists).
+      $stmt->bindValue(':account', $to, PDO::PARAM_INT);
+      $stmt->bindValue(':deposit', $amount, PDO::PARAM_INT);
+      $stmt->execute();
+      if ($stmt->rowCount() == 0) {
+        print "destination account does not exist\r\n";
+        return;
+      }
+
+      // Attempt to release the savepoint (which is really the commit).
+      $dbh->exec('RELEASE SAVEPOINT cockroach_restart');
+      $dbh->commit();
+      return;
+    } catch (PDOException $e) {
+      if ($e->getCode() != 'CR000') {
+        // Non-recoverable error. Rollback and bubble error up the chain.
+        $dbh->rollBack();
+        throw $e;
+      } else {
+        // Cockroach transaction retry code. Rollback to the savepoint and
+        // restart.
+        $dbh->exec('ROLLBACK TO SAVEPOINT cockroach_restart');
+      }
+    }
+  }
+}
+
+try {
+  $dbh = new PDO('pgsql:host=localhost;port=26257;dbname=bank;sslmode=disable',
+    'maxroach', null, array(
+      PDO::ATTR_ERRMODE          => PDO::ERRMODE_EXCEPTION,
+      PDO::ATTR_EMULATE_PREPARES => true,
+    ));
+
+  transferMoney($dbh, 1, 2, 10);
+
+  print "Account balances after transfer:\r\n";
+  foreach ($dbh->query('SELECT id, balance FROM accounts') as $row) {
+      print $row['id'] . ': ' . $row['balance'] . "\r\n";
+  }
+} catch (Exception $e) {
+    print $e->getMessage() . "\r\n";
+    exit(1);
+}
+?>


### PR DESCRIPTION
Some refactoring and adds the transactional example (it's not presentable until https://github.com/cockroachdb/cockroach/issues/5758 gets fixed, but that shouldn't be long).
I tested this locally by adding a `sleep(3)` between the two transactional writes and running `for i in $(seq 0 1); do php ../docs/_includes/app/txn-sample.php& done` (which is guaranteed to see a restart).

Ping #182 - all of those transactional examples need tests even more since those wrappers might actually get picked up by production code one day.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/183)
<!-- Reviewable:end -->
