### PR TITLE
Showing echo for zone set

### DIFF
--- a/configure-replication-zones.md
+++ b/configure-replication-zones.md
@@ -162,7 +162,7 @@ $ ./cockroach start --insecure --host=node2-hostname --attrs=us-east-1b --join=n
 $ ./cockroach start --insecure --host=node3-hostname --attrs=us-west-1a --join=node1-hostname:27257
 ~~~
 
-You would then edit the default zone configuration as follows:
+You would then edit the default zone configuration with one datacenter attribute set for each replica.
 
 ~~~ shell
 $ ./cockroach zone set .default --insecure 'replicas:
@@ -171,11 +171,10 @@ $ ./cockroach zone set .default --insecure 'replicas:
 - attrs: [us-west-1a]'
 ~~~
 
-To confirm that the default zone was updated correctly, you would then run:
+The `zone set` command automatically echoes the full zone configuration, so you can easily validate your changes without needing to run `zone get`.
 
 ~~~ shell
-$ ./cockroach zone get .default --insecure
-.default
+UPDATE 1
 replicas:
 - attrs: [us-east-1a]
 - attrs: [us-east-1b]
@@ -208,6 +207,20 @@ $ ./cockroach zone set bank --insecure 'replicas:
 range_max_bytes: 67108864'
 ~~~
 
+The `zone set` command automatically echoes the full zone configuration, so you can easily validate your changes without needing to run `zone get`.
+
+~~~ shell
+INSERT 1
+replicas:
+- attrs: [ssd]
+- attrs: [ssd]
+- attrs: [ssd]
+range_min_bytes: 1048576
+range_max_bytes: 67108864
+gc:
+  ttlseconds: 86400
+~~~
+
 ### Create a Replication Zone for a Table
 
 To create a replication zone for a specific table, use the `./cockroach zone set`, specifying the table name in `database.table` format, any appropriate flags, and the zone settings as a YAML string. 
@@ -228,4 +241,18 @@ $ ./cockroach zone set bank.accounts --insecure 'replicas:
 - attrs: [ssd]
 - attrs: [ssd]
 range_max_bytes: 67108864'
+~~~
+
+The `zone set` command automatically echoes the full zone configuration, so you can easily validate your changes without needing to run `zone get`.
+
+~~~ shell
+INSERT 1
+replicas:
+- attrs: [ssd]
+- attrs: [ssd]
+- attrs: [ssd]
+range_min_bytes: 1048576
+range_max_bytes: 67108864
+gc:
+  ttlseconds: 86400
 ~~~

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -48,7 +48,13 @@ The only difference when starting the second node is that you connect it to the 
 
 Repeat step 2 for each additional node.
 
-### 4. Use the Built-in SQL Client
+### 4. Configure replication
+
+In CockroachDB, you use **replication zones** to control the number and location of replicas for specific sets of data. Initially, there is a single, default replication zone for the entire cluster. You can adjust this default zone as well as add zones for individual databases and tables as needed. 
+
+For more information, see [Configure Replication Zones](configure-replication-zones.html).
+
+### 5. Use the Built-in SQL Client
 
 Start the built-in SQL client from any machine with the `cockroach` binary. This could be one of the node machines or a different machine. 
 
@@ -84,13 +90,13 @@ root@26257> SELECT * FROM accounts;
 +------+---------+
 ~~~
 
-### 5. Connect an app to the cluster
+### 6. Connect an app to the cluster
 
 CockroachDB supports the PostgreSQL wire protocol, so you can use any available PostgreSQL client driver to connect an app to the cluster. 
 
 For a list of recommended drivers that we've tested, see [Install Client Drivers](install-client-drivers.html). For some basic code samples, see [Build a Test App](built-a-test-app.html).  
 
-### 6. Monitor your cluster
+### 7. Monitor your cluster
 
 The CockroachDB Admin UI lets you monitor cluster-wide, node-level, and database-level metrics and events. To start up the Admin UI, point your browser to the URL in the `admin` field listed in the standard output of any node on startup, for example:
 
@@ -153,7 +159,13 @@ The only difference when starting the second node is that you connect it to the 
 
 Repeat step 3 for each additional node. 
 
-### 5. Use the built-in SQL client
+### 5. Configure replication
+
+In CockroachDB, you use **replication zones** to control the number and location of replicas for specific sets of data. Initially, there is a single, default replication zone for the entire cluster. You can adjust this default zone as well as add zones for individual databases and tables as needed. 
+
+For more information, see [Configure Replication Zones](configure-replication-zones.html).
+
+### 6. Use the built-in SQL client
 
 You can run the built-in SQL client from any machine with the `cockroach` binary, CA cert, client certificate, and client key. Make sure the machine you want to use has these files and then start the client:  
 
@@ -189,13 +201,13 @@ root@26257> SELECT * FROM accounts;
 +------+---------+
 ~~~
 
-### 6. Connect an app to the cluster
+### 7. Connect an app to the cluster
 
 CockroachDB supports the PostgreSQL wire protocol, so you can use any available PostgreSQL client driver to connect an app to the cluster. 
 
 For a list of recommended drivers that we've tested, see [Install Client Drivers](install-client-drivers.html). For some basic code samples, see [Build a Test App](built-a-test-app.html).  
 
-### 7. Monitor your cluster
+### 8. Monitor your cluster
 
 The CockroachDB Admin UI lets you monitor cluster-wide, node-level, and database-level metrics and events. To start up the Admin UI, point your browser to the URL in the `admin` field listed in the standard output of any node on startup, for example:
 


### PR DESCRIPTION
Updated configure-replication-zone.md examples to show that `zone set` echos the full zone configuration. 

Also added step to `manual-deployment.md` for configuring replication. 

@petermattis, please take a look.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/193)
<!-- Reviewable:end -->
