### PR TITLE
updating docs readme.md and contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,15 @@ The CockroachDB docs are open source just like the database itself. We welcome y
 Once you're ready to contribute:
 
 1. Fork the CockroachDB [docs repository](https://github.com/cockroachdb/docs).
+
 2. [Create a local clone](https://help.github.com/articles/cloning-a-repository/) of your fork.
+
 3. Make your changes.
+
 4. [Build the docs locally](#build-the-docs-locally) and test them.
+
 5. [Push to your remote fork](https://help.github.com/articles/pushing-to-a-remote/).
+
 6. Back in the CockroachDB docs repo, [open a pull request](https://github.com/cockroachdb/docs/pulls).
 
 ## Docs Structure
@@ -34,7 +39,7 @@ toc: false
 ---
 ```
  
-The **title** field in the front matter is used as the h1 header. The **toc** field is for adding an auto-generated table of contents to the page. See [Page TOC](#page-toc) for full details.
+The `title` field in the front matter is used as the h1 header. The `toc` field is for adding an auto-generated table of contents to the page. See [Page TOC](#page-toc) for full details.
 
 ### Page TOC 
 
@@ -48,7 +53,7 @@ The CockroachDB Jekyll theme can auto-generate a page-level table of contents li
     <div id="toc"></div>
     ```
 
--   By default, the toc panel is 300px wide. To change this, add the following bit of styling to the page as well, adjusting the `max-width` as appropriate:
+-   By default, the toc panel is 300px wide. To change this, add the following bit of styling to the page, adjusting the `max-width` as appropriate:
     
     ``` html
     <style>
@@ -64,7 +69,9 @@ The [`_data/sidebar_doc.yml`](_data/sidebar_doc.yml) file controls which pages a
 
 ### Auto-Included Content
 
-Some pages auto-include content from the [`_includes`](_includes) directory. For example, each SQL statement page inludes a syntax diagram from `_includes/sql/diagrams`, and the [Build a Test App](build-a-test-app.md) page includes code samples from `_includes/app`.
+Some pages auto-include content from the [`_includes`](_includes) directory. For example, each SQL statement page inludes a syntax diagram from `_includes/sql/diagrams`, and [build-a-test-app.md](build-a-test-app.md) includes code samples from `_includes/app`.
+
+The syntax for including content is `{% include <filepath> %}`, for example, `{% include app/basic-sample.rb %}`.
 
 ## Style Guide
 
@@ -76,7 +83,7 @@ CockroachDB docs should be:
 
 ## Build the Docs Locally
 
-Once you've installed Jekyll and cloned the docs repository to your local machine, you can can build the docs as follows:
+Once you've installed Jekyll and have a local clone of the docs repository, you can build the docs as follows:
 
 1.  From the root directory of your clone, run:
     
@@ -88,4 +95,4 @@ Once you've installed Jekyll and cloned the docs repository to your local machin
 
     - If the page you want to test isn't listed in the sidebar, just point to it directly, for example, `http://127.0.0.1:4000/docs/new-page.html`.
 
-    - When you make changes to content, Jekyll automatically regenerates the html content. No need to stop and re-start Jekyll; just refresh your browser.
+    - When you make changes, Jekyll automatically regenerates the html content. No need to stop and re-start Jekyll; just refresh your browser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,91 @@
-# Contributing 
+# Contributing to CockroachDB Docs
 
-Coming soon.
+The CockroachDB docs are open source just like the database itself. We welcome your contributions!
 
+## Setup
+
+1. Install [Jekyll](https://jekyllrb.com/docs/installation/). CockroachDB uses Jekyll to transform markdown and layout files into a complete, static site. You need to install Jekyll so you can test doc changes locally.
+ 
+2. Learn the essentials of our [Docs Structure](#docs-structure). 
+
+3. Review our simple [Style Guide](#style-guide).
+
+## Get Started
+
+Once you're ready to contribute:
+
+1. Fork the CockroachDB [docs repository](https://github.com/cockroachdb/docs).
+2. [Create a local clone](https://help.github.com/articles/cloning-a-repository/) of your fork.
+3. Make your changes.
+4. [Build the docs locally](#build-the-docs-locally) and test them.
+5. [Push to your remote fork](https://help.github.com/articles/pushing-to-a-remote/).
+6. Back in the CockroachDB docs repo, [open a pull request](https://github.com/cockroachdb/docs/pulls).
+
+## Docs Structure
+
+### Pages
+
+Each docs page must be an `.md` file in the root directory of the repository, must be written in the [kramdown](http://kramdown.gettalong.org/quickref.html) dialect of Markdown, and must start with the following front-matter:
+
+```
+---
+title: Title of Page
+toc: false
+---
+```
+ 
+The **title** field in the front matter is used as the h1 header. The **toc** field is for adding an auto-generated table of contents to the page. See [Page TOC](#page-toc) for full details.
+
+### Page TOC 
+
+The CockroachDB Jekyll theme can auto-generate a page-level table of contents listing all h2 headers on the page. 
+
+-   To add a page TOC to the very top of the page, set `toc: true` in the page's front-matter.
+
+-   To add a page TOC anywhere else on the page (for example, after an intro paragraph), set `toc: false` in the page's front-matter and add the following html where you want the toc to appear on the page:
+    
+    ``` html
+    <div id="toc"></div>
+    ```
+
+-   By default, the toc panel is 300px wide. To change this, add the following bit of styling to the page as well, adjusting the `max-width` as appropriate:
+    
+    ``` html
+    <style>
+        div#toc ul {
+            max-width: 50%;
+        }
+    </style>
+    ```
+
+### Sidebar
+
+The [`_data/sidebar_doc.yml`](_data/sidebar_doc.yml) file controls which pages appear in the docs sidebar. If you're adding a page that you think should appear in the sidebar, please mention this in your pull request.
+
+### Auto-Included Content
+
+Some pages auto-include content from the [`_includes`](_includes) directory. For example, each SQL statement page inludes a syntax diagram from `_includes/sql/diagrams`, and the [Build a Test App](build-a-test-app.md) page includes code samples from `_includes/app`.
+
+## Style Guide
+
+CockroachDB docs should be:
+
+- Clear 
+- Correct 
+- Concise 
+
+## Build the Docs Locally
+
+Once you've installed Jekyll and cloned the docs repository to your local machine, you can can build the docs as follows:
+
+1.  From the root directory of your clone, run:
+    
+    ``` shell
+    $ jekyll serve
+    ```
+
+2.  Point your browser to `http://127.0.0.1:4000/docs/`.
+
+    - If the page you want to test isn't listed in the sidebar, just point to it directly, for example, `http://127.0.0.1:4000/docs/new-page.html`.
+
+    - When you make changes to content, Jekyll automatically regenerates the html content. No need to stop and re-start Jekyll; just refresh your browser.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # CockroachDB Docs 
 
-This repository contains the source files for the CockroachDB technical docs. The docs are in progress.
+This repository contains the source files for the CockroachDB documentation available at [cockroachlabs.com/docs](https://cockroachlabs.com/docs).
 
+## Suggest Improvements
 
+Want a topic added to the docs? Need additional details or clarification? See an error or other problem? Please [open an issue](https://github.com/cockroachdb/docs/issues).
+
+## Write Docs
+
+Want to contribute to the docs? See [CONTRIBUTING](CONTRIBUTING.md) for details about setting yourself up and getting started.

--- a/improve-the-docs.md
+++ b/improve-the-docs.md
@@ -3,7 +3,7 @@ title: Improve the Docs
 toc: false
 ---
 
-The CockroachDB docs are a work in progress, and we very much welcome your help. 
+The CockroachDB docs are open source just like the database itself. We welcome your contributions!
 
 ## Suggest Improvements
 
@@ -11,10 +11,4 @@ Want a topic added to the docs? Need additional details or clarification? See an
 
 ## Write Docs
 
-We're still working out our overall docs plan, so these instructions are a bit premature. Once we've established a comfortable baseline, here's how you'll be able to help:
-
-1. Review [CONTRIBUTING.md](https://github.com/cockroachdb/docs/blob/gh-pages/CONTRIBUTING.md) to understand how the docs are put together and to get yourself set up.
-2. Fork the [docs repository](https://github.com/cockroachdb/docs).
-3. [Create a local clone](https://help.github.com/articles/cloning-a-repository/) of your fork.
-4. Make your changes and [push to your remote fork](https://help.github.com/articles/pushing-to-a-remote/).
-5. Back in the CockroachDB docs repo, [open a pull request](https://github.com/cockroachdb/docs/pulls).
+Want to contribute to the docs? See [CONTRIBUTING.md](https://github.com/cockroachdb/docs/blob/gh-pages/CONTRIBUTING.md) to set yourself up and get started.


### PR DESCRIPTION
The `README.md` now points to our live docs and to `CONTRIBUTING.md` for details on chipping in. 

Any feedback, @spencerkimball, @petermattis, @bdarnell? Might be good for someone to install Jekyll and test out building the docs locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/194)
<!-- Reviewable:end -->
