### PR TITLE
Docs for SHOW INDEX

### DIFF
--- a/bool.md
+++ b/bool.md
@@ -7,9 +7,7 @@ toc: true
 
 The `BOOL` [data type](data-types.html) stores a Boolean value of `false` or `true`. 
 
-## Synonyms
-
-In CockroachDB, `BOOLEAN` is a synonym of `BOOL`. 
+In CockroachDB, `BOOLEAN` is an alias for `BOOL`. 
 
 ## Format
 

--- a/bytes.md
+++ b/bytes.md
@@ -7,9 +7,7 @@ toc: true
 
 The `BYTES` [data type](data-types.html) stores binary strings of variable length.
 
-## Synonyms
-
-In CockroachDB, the following are synonyms of `BYTES`: 
+In CockroachDB, the following are aliases for `BYTES`: 
 
 - `BYTEA` 
 - `BLOB` 

--- a/create-database.md
+++ b/create-database.md
@@ -5,18 +5,36 @@ toc: true
 
 ## Description
 
-The `CREATE DATABASE` statement creates a new CockroachDB database.  
-
-## Synopsis
-
-{% include sql/diagrams/create_database.html %}
+The `CREATE DATABASE` [statement](sql-statements.html) creates a new CockroachDB database.  
 
 ## Privileges
 
 Only the `root` user can create a database.
 
+## Synopsis
+
+{% include sql/diagrams/create_database.html %}
+
 ## Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| `name` | The name of the database to create. Names must follow [these rules](data-definition.html#identifiers). |
+Parameter | Description
+----------|------------
+`name` | The name of the database to create. Names must follow [these rules](data-definition.html#identifiers).
+
+## Examples
+
+~~~
+CREATE DATABASE bank;
+
+SHOW DATABASES;
++----------+
+| Database |
++----------+
+| bank     |
+| system   |
++----------+
+~~~
+
+## See Also
+
+[SQL Statements](sql-statements.html)

--- a/decimal.md
+++ b/decimal.md
@@ -7,9 +7,7 @@ toc: true
 
 The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers with no limit on digits to the left and right of the decimal point. This type is used when it is important to preserve exact precision, for example, with monetary data. 
 
-## Synonyms
-
-In CockroachDB, the following are synonyms of `DECIMAL`:
+In CockroachDB, the following are aliases for `DECIMAL`:
 
 - `DEC` 
 - `NUMERIC` 

--- a/float.md
+++ b/float.md
@@ -7,9 +7,7 @@ toc: true
 
 The `FLOAT` [data type](data-types.html) stores inexact, floating-point numbers with up to 17 digits in total and at least one digit to the right of the decimal point. 
 
-## Synonyms
-
-In CockroachDB, the following are synonyms of `FLOAT`:
+In CockroachDB, the following are aliases for `FLOAT`:
 
 - `REAL` 
 - `DOUBLE PRECISION` 

--- a/int.md
+++ b/int.md
@@ -7,9 +7,7 @@ toc: true
 
 The `INT` [data type](data-types.html) stores 64-bit signed integers, that is, whole numbers from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807. 
 
-## Synonyms 
-
-In CockroachDB, the following are synonyms of `INT`: 
+In CockroachDB, the following are aliases for `INT`: 
 
 - `SMALLINT` 
 - `INTEGER` 

--- a/release-savepoint.md
+++ b/release-savepoint.md
@@ -7,8 +7,6 @@ toc: true
  
 ## Synopsis
 
-## Synonyms
-
 ## Privileges
 
 ## Parameters

--- a/release-savepoint.md
+++ b/release-savepoint.md
@@ -1,0 +1,19 @@
+---
+title: RELEASE SAVEPOINT
+toc: true
+---
+
+## Description
+ 
+## Synopsis
+
+## Synonyms
+
+## Privileges
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+|  |  |
+

--- a/savepoint.md
+++ b/savepoint.md
@@ -1,0 +1,19 @@
+---
+title: SAVEPOINT
+toc: true
+---
+
+## Description
+ 
+## Synopsis
+
+## Synonyms
+
+## Privileges
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+|  |  |
+

--- a/savepoint.md
+++ b/savepoint.md
@@ -7,8 +7,6 @@ toc: true
  
 ## Synopsis
 
-## Synonyms
-
 ## Privileges
 
 ## Parameters

--- a/show-index.md
+++ b/show-index.md
@@ -5,15 +5,62 @@ toc: true
 
 ## Description
 
+The `SHOW INDEX` [statement](sql-statements.html) returns index information for a table. 
+
+In CockroachDB, the following are aliases for `SHOW INDEX`: 
+
+- `SHOW INDEXES` 
+- `SHOW KEYS`
+
+## Privileges
+
+No privileges are required to show indexes for a table.
+
 ## Synopsis
 
 {% include sql/diagrams/show_index.html %}
 
-## Privileges
-
 ## Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-|  |  |
+Parameter | Description
+----------|------------
+`var_name` | The name of the table to show indexes for. 
 
+## Response
+
+The following fields are returned for each index.
+
+Field | Description
+----------|------------
+`Table` | The name of the table.
+`Name` | The name of the index.
+`Unique` | Whether or not values in the indexed column are unique. Possible values: `true` or `false`. 
+`Seq` | The position of the column in the index, starting with 1.
+`Column` | The indexed column.  
+`Direction` | How the column is sorted in the index. Possible values: `ASC` or `DESC`.
+`Storing` | 
+
+## Examples 
+
+~~~
+CREATE TABLE test (
+    a INT PRIMARY KEY,
+    b DECIMAL,
+    c TIMESTAMP
+);
+
+CREATE INDEX b_c_idx ON test (b, c);
+
+SHOW INDEX FROM test;
++-------+---------+--------+-----+--------+-----------+---------+
+| Table |  Name   | Unique | Seq | Column | Direction | Storing |
++-------+---------+--------+-----+--------+-----------+---------+
+| test  | primary | true   |   1 | a      | ASC       | false   |
+| test  | b_c_idx | false  |   1 | b      | ASC       | false   |
+| test  | b_c_idx | false  |   2 | c      | ASC       | false   |
++-------+---------+--------+-----+--------+-----------+---------+
+~~~
+
+## See Also
+
+[SQL Statements](sql-statements.html)

--- a/show-index.md
+++ b/show-index.md
@@ -37,28 +37,30 @@ Field | Description
 `Unique` | Whether or not values in the indexed column are unique. Possible values: `true` or `false`. 
 `Seq` | The position of the column in the index, starting with 1.
 `Column` | The indexed column.  
-`Direction` | How the column is sorted in the index. Possible values: `ASC` or `DESC`.
-`Storing` | 
+`Direction` | How the column is sorted in the index. Possible values: `ASC` or `DESC` for indexed columns; `N/A` for stored columns. 
+`Storing` | Whether or not the column is stored with the indexed column(s). Possible values: `true` or `false`. 
 
 ## Examples 
 
 ~~~
-CREATE TABLE test (
+CREATE TABLE table1 (
     a INT PRIMARY KEY,
     b DECIMAL,
-    c TIMESTAMP
+    c TIMESTAMP,
+    d STRING
 );
 
-CREATE INDEX b_c_idx ON test (b, c);
+CREATE INDEX b_c_idx ON table1 (b, c) STORING (d);
 
-SHOW INDEX FROM test;
-+-------+---------+--------+-----+--------+-----------+---------+
-| Table |  Name   | Unique | Seq | Column | Direction | Storing |
-+-------+---------+--------+-----+--------+-----------+---------+
-| test  | primary | true   |   1 | a      | ASC       | false   |
-| test  | b_c_idx | false  |   1 | b      | ASC       | false   |
-| test  | b_c_idx | false  |   2 | c      | ASC       | false   |
-+-------+---------+--------+-----+--------+-----------+---------+
+SHOW INDEX FROM table1;
++--------+---------+--------+-----+--------+-----------+---------+
+| Table  |  Name   | Unique | Seq | Column | Direction | Storing |
++--------+---------+--------+-----+--------+-----------+---------+
+| table1 | primary | true   |   1 | a      | ASC       | false   |
+| table1 | b_c_idx | false  |   1 | b      | ASC       | false   |
+| table1 | b_c_idx | false  |   2 | c      | ASC       | false   |
+| table1 | b_c_idx | false  |   3 | d      | N/A       | true    |
++--------+---------+--------+-----+--------+-----------+---------+
 ~~~
 
 ## See Also

--- a/sql-statements.md
+++ b/sql-statements.md
@@ -4,7 +4,7 @@ toc: false
 ---
 <style>
 table td:first-child {
-  min-width: 200px;
+  min-width: 350px;
 
 }
 </style>
@@ -39,10 +39,10 @@ Statement | Description
 [`SHOW COLUMNS`](show-columns.html) | 
 [`SHOW DATABASES`](show-databases.html) | 
 [`SHOW GRANTS`](show-grants.html) | 
-[`SHOW INDEX`](show-index.html) | 
+[`SHOW INDEX`](show-index.html) | Returns index information for a table.
 [`SHOW TABLES`](show-tables.html) | 
 [`SHOW TIMEZONE`](show-timezone.html) | 
-[`SHOW TRANSACTION ISOLOATION LEVEL`](show-transaction-isolation-level.html) | 
+[`SHOW TRANSACTION ISOLATION LEVEL`](show-transaction-isolation-level.html) | 
 [`SHOW TRANSACTION PRIORITY`](show-transaction-priority.html) | 
 [`TABLE`](table.html) | 
 [`TRUNCATE`](truncate.html) | 

--- a/string.md
+++ b/string.md
@@ -7,9 +7,7 @@ toc: true
 
 The `STRING` [data type](data-types.html) stores strings of variable length. 
 
-## Synonyms 
-
-In CockroachDB, the following are synonyms of `STRING`: 
+In CockroachDB, the following are aliases for `STRING`: 
 
 - `CHAR` 
 - `CHAR(n)` 


### PR DESCRIPTION
Updated docs for `SHOW INDEX`, added some placeholder files for `savepoint` and `release savepoint`, and made other minor tweaks.

@petermattis, does the scope of the show index doc look sufficient? Trying to establish the right conventions for moving forward with sql statement docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/199)
<!-- Reviewable:end -->
