### PR TITLE
Decimal precision/scale and string length

### DIFF
--- a/decimal.md
+++ b/decimal.md
@@ -5,7 +5,7 @@ toc: true
 
 ## Description
 
-The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers with no limit on digits to the left and right of the decimal point. This type is used when it is important to preserve exact precision, for example, with monetary data. 
+The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers. This type is used when it is important to preserve exact precision, for example, with monetary data. 
 
 In CockroachDB, the following are aliases for `DECIMAL`:
 
@@ -14,12 +14,9 @@ In CockroachDB, the following are aliases for `DECIMAL`:
 
 ## Precision and Scale
 
-To limit the precision and scale of a `DECIMAL` column, use this syntax: `DECIMAL(precision, scale)`. 
+To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the maximum count of digits in a whole number, both to the left and right of the decimal point, and `scale` is the maximum count of digits to the right of the decimal point.
 
-- **Precision** is the maximum count of digits in a whole number, both to the left and right of the decimal.
-- **Scale** is the maximum count of digits to the right of the decimal point.
-
-If the digits to the right of a decimal value exceed the specified scale, CockroachDB rounds the decimal to the scale. After rounding to the specified scale, if the total count of digits exceeds the specified precision, CockroachDB gives an error.  
+When inserting a decimal value, if the digits to the right of the decimal point exceed the column's `scale`, CockroachDB rounds to the scale. After rounding, if the total count of digits exceeds the column's `precision`, CockroachDB gives an error.  
 
 ## Format
 

--- a/decimal.md
+++ b/decimal.md
@@ -14,7 +14,12 @@ In CockroachDB, the following are aliases for `DECIMAL`:
 
 ## Precision and Scale
 
-Precision (the maximum count of digits in a whole number, both to the left and right of the decimal point) and scale (the maximum count of digits to the right of the decimal point) are always unlimited for a `DECIMAL` value. If you specify these limits by declaring `DECIMAL(precision, scale)` on a column, they will not be enforced. 
+To limit the precision and scale of a `DECIMAL` column, use this syntax: `DECIMAL(precision, scale)`. 
+
+- **Precision** is the maximum count of digits in a whole number, both to the left and right of the decimal.
+- **Scale** is the maximum count of digits to the right of the decimal point.
+
+If the digits to the right of a decimal value exceed the specified scale, CockroachDB rounds the decimal to the scale. After rounding to the specified scale, if the total count of digits exceeds the specified precision, CockroachDB gives an error.  
 
 ## Format
 

--- a/decimal.md
+++ b/decimal.md
@@ -14,13 +14,17 @@ In CockroachDB, the following are aliases for `DECIMAL`:
 
 ## Precision and Scale
 
-To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the maximum count of digits both to the left and right of the decimal point, and `scale` is the maximum count of digits to the right of the decimal point.
+To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the **maximum** count of digits both to the left and right of the decimal point and `scale` is the **exact** count of digits to the right of the decimal point. Note that using `DECIMAL(precision)` is equivalent to `DECIMAL(precision, 0)`.
 
-When inserting a decimal value, if the digits to the right of the decimal point exceed the column's `scale`, CockroachDB rounds to the scale. After rounding, if the total count of digits exceeds the column's `precision`, CockroachDB gives an error.  
+When inserting into a decimal column with specied precision and scale:
+
+- If digits to the right of the decimal point exceed the column's `scale`, CockroachDB rounds to the scale. 
+- If digits to the right of the decimal point are less than the column's `scale`, CockroachDB pads to the scale with `0`s.
+- If digits to the left and right of the decimal point exceed the column's `precision`, CockroachDB gives an error.  
 
 ## Format
 
-When declaring a decimal, format it as `DECIMAL '1.2345'`. This casts the value as a string, which preserves the number's exact precision.
+When inserting a decimal value, format it as `DECIMAL '1.2345'`. This casts the value as a string, which preserves the number's exact precision.
 
 Alternately, you can cast a float as a decimal: `CAST(1.2345 AS DECIMAL)`. However, note that precision will be limited to 17 digits in total (both to the left and right of the decimal point). 
 
@@ -29,25 +33,28 @@ Alternately, you can cast a float as a decimal: `CAST(1.2345 AS DECIMAL)`. Howev
 ## Examples
 
 ~~~
-CREATE TABLE decimals (a DECIMAL PRIMARY KEY, b NUMERIC);
+create table decimals (a DECIMAL PRIMARY KEY, b DECIMAL(10,5), c NUMERIC);
 
 SHOW COLUMNS FROM decimals;
-+-------+---------+-------+---------+
-| Field |  Type   | Null  | Default |
-+-------+---------+-------+---------+
-| a     | DECIMAL | false | NULL    |
-| b     | DECIMAL | true  | NULL    |
-+-------+---------+-------+---------+
++-------+---------------+-------+---------+
+| Field |     Type      | Null  | Default |
++-------+---------------+-------+---------+
+| a     | DECIMAL       | false | NULL    |
+| b     | DECIMAL(10,5) | true  | NULL    |
+| c     | DECIMAL       | true  | NULL    |
++-------+---------------+-------+---------+
 
-INSERT INTO decimals VALUES (DECIMAL '1.01234567890123456789', CAST('2.01234567890123456789' AS DECIMAL));
+INSERT INTO decimals VALUES (DECIMAL '1.01234567890123456789', DECIMAL '1.01234567890123456789', CAST(1.01234567890123456789 AS DECIMAL));
 
 SELECT * FROM decimals;
-+------------------------+--------------------+
-|           a            |         b          |
-+------------------------+--------------------+
-| 1.01234567890123456789 | 2.0123456789012346 |
-+------------------------+--------------------+
-# The value in "a" is precise, while the value in "b" has been limited to 17 digits.
++------------------------+---------+--------------------+
+|           a            |    b    |         c          |
++------------------------+---------+--------------------+
+| 1.01234567890123456789 | 1.01235 | 1.0123456789012346 |
++------------------------+---------+--------------------+
+# The value in "a" matches what was inserted exactly.
+# The value in "b" has been rounded to the column's scale.
+# The value in "c" has been limited to 17 digits.
 ~~~
 
 ## See Also

--- a/decimal.md
+++ b/decimal.md
@@ -14,7 +14,7 @@ In CockroachDB, the following are aliases for `DECIMAL`:
 
 ## Precision and Scale
 
-To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the maximum count of digits in a whole number, both to the left and right of the decimal point, and `scale` is the maximum count of digits to the right of the decimal point.
+To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the maximum count of digits both to the left and right of the decimal point, and `scale` is the maximum count of digits to the right of the decimal point.
 
 When inserting a decimal value, if the digits to the right of the decimal point exceed the column's `scale`, CockroachDB rounds to the scale. After rounding, if the total count of digits exceeds the column's `precision`, CockroachDB gives an error.  
 

--- a/string.md
+++ b/string.md
@@ -5,7 +5,7 @@ toc: true
 
 ## Description
 
-The `STRING` [data type](data-types.html) stores strings of variable length. 
+The `STRING` [data type](data-types.html) stores a string of characters.
 
 In CockroachDB, the following are aliases for `STRING`: 
 
@@ -17,9 +17,9 @@ In CockroachDB, the following are aliases for `STRING`:
 
 ## Length
 
-At this time, length is always variable for a `STRING` value. If you specify a fixed length by declaring `CHAR(n)` or `VARCHAR(n)` on a column, it will not be enforced.
+To limit the length of a string column, use `CHAR(n)` or `VARCHAR(n)`, where `n` is the maximum number of characters allowed.
 
-{{site.data.alerts.callout_info}}A future version of CockroachDB will support enforcing length limits on strings.{{site.data.alerts.end}}
+When inserting a string value, if the value exceeds the column's length limit, Cockroach gives an error.
 
 ## Format
 
@@ -28,16 +28,16 @@ When declaring a `STRING`, format it as `'a1b2c3'`.
 ## Examples
 
 ~~~
-CREATE TABLE strings (a STRING PRIMARY KEY, b CHAR, c TEXT);
+CREATE TABLE strings (a STRING PRIMARY KEY, b CHAR(6), c TEXT);
 
 SHOW COLUMNS FROM strings;
-+-------+--------+-------+---------+
-| Field |  Type  | Null  | Default |
-+-------+--------+-------+---------+
-| a     | STRING | false | NULL    |
-| b     | STRING | true  | NULL    |
-| c     | STRING | true  | NULL    |
-+-------+--------+-------+---------+
++-------+-----------+-------+---------+
+| Field |  Type     | Null  | Default |
++-------+-----------+-------+---------+
+| a     | STRING    | false | NULL    |
+| b     | STRING(6) | true  | NULL    |
+| c     | STRING    | true  | NULL    |
++-------+-----------+-------+---------+
 
 INSERT INTO strings VALUES ('a1b2c3', 'd4e5f6', 'g7h8i9');
 

--- a/string.md
+++ b/string.md
@@ -7,8 +7,10 @@ toc: true
 
 The `STRING` [data type](data-types.html) stores a string of characters.
 
-In CockroachDB, the following are aliases for `STRING`: 
+In CockroachDB, the following are aliases for `STRING` and `STRING(n)`: 
 
+- `CHARACTER`
+- `CHARACTER(n)`
 - `CHAR` 
 - `CHAR(n)` 
 - `VARCHAR`
@@ -17,36 +19,36 @@ In CockroachDB, the following are aliases for `STRING`:
 
 ## Length
 
-To limit the length of a string column, use `CHAR(n)` or `VARCHAR(n)`, where `n` is the maximum number of characters allowed.
+To limit the length of a string column, use `CHARCTER(n)`, `CHAR(n)` or `VARCHAR(n)`, where `n` is the maximum number of characters allowed.
 
-When inserting a string value, if the value exceeds the column's length limit, Cockroach gives an error.
+When inserting a string, if the value exceeds the column's length limit, Cockroach gives an error. However, when a value is cast as a string with a length limit (e.g., `CAST('hello world' AS CHAR(5))`), CockroachDB truncates to the limit.
 
 ## Format
 
-When declaring a `STRING`, format it as `'a1b2c3'`.
+When inserting a string value, format it as `'a1b2c3'`.
 
 ## Examples
 
 ~~~
-CREATE TABLE strings (a STRING PRIMARY KEY, b CHAR(6), c TEXT);
+CREATE TABLE strings (a STRING PRIMARY KEY, b CHAR(4), c TEXT);
 
 SHOW COLUMNS FROM strings;
 +-------+-----------+-------+---------+
 | Field |  Type     | Null  | Default |
 +-------+-----------+-------+---------+
 | a     | STRING    | false | NULL    |
-| b     | STRING(6) | true  | NULL    |
+| b     | STRING(4) | true  | NULL    |
 | c     | STRING    | true  | NULL    |
 +-------+-----------+-------+---------+
 
-INSERT INTO strings VALUES ('a1b2c3', 'd4e5f6', 'g7h8i9');
+INSERT INTO strings VALUES ('a1b2c3d4', 'e5f6', 'g7h8i9');
 
 SELECT * FROM strings;
-+--------+--------+--------+
-|   a    |   b    |   c    |
-+--------+--------+--------+
-| a1b2c3 | d4e5f6 | g7h8i9 |
-+--------+--------+--------+
++----------+------+--------+
+|    a     |  b   |   c    |
++----------+------+--------+
+| a1b2c3d4 | e5f6 | g7h8i9 |
++----------+------+--------+
 ~~~
 
 ## See Also


### PR DESCRIPTION
Update decimal docs to cover precision and scale.

Update string docs to cover length limit. 

In response to https://github.com/cockroachdb/cockroach/pull/5750

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/200)
<!-- Reviewable:end -->
