### PR TITLE
Limiting length of STRING column

### DIFF
--- a/decimal.md
+++ b/decimal.md
@@ -14,9 +14,11 @@ In CockroachDB, the following are aliases for `DECIMAL`:
 
 ## Precision and Scale
 
-To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the **maximum** count of digits both to the left and right of the decimal point and `scale` is the **exact** count of digits to the right of the decimal point. Note that using `DECIMAL(precision)` is equivalent to `DECIMAL(precision, 0)`.
+To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the **maximum** count of digits both to the left and right of the decimal point and `scale` is the **exact** count of digits to the right of the decimal point. The `precision` must be larger than the `scale`. 
 
-When inserting a decimal:
+Note that using `DECIMAL(precision)` is equivalent to `DECIMAL(precision, 0)`.
+
+When inserting a decimal value:
 
 - If digits to the right of the decimal point exceed the column's `scale`, CockroachDB rounds to the scale. 
 - If digits to the right of the decimal point are less than the column's `scale`, CockroachDB pads to the scale with `0`s.

--- a/string.md
+++ b/string.md
@@ -7,19 +7,22 @@ toc: true
 
 The `STRING` [data type](data-types.html) stores a string of characters.
 
-In CockroachDB, the following are aliases for `STRING` and `STRING(n)`: 
+In CockroachDB, the following are aliases for `STRING`: 
 
 - `CHARACTER`
-- `CHARACTER(n)`
 - `CHAR` 
-- `CHAR(n)` 
 - `VARCHAR`
-- `VARCHAR(n)` 
 - `TEXT`
+
+And the following are aliases for `STRING(n)`:
+
+- `CHARACTER(n)`
+- `CHAR(n)` 
+- `VARCHAR(n)` 
 
 ## Length
 
-To limit the length of a string column, use `CHARCTER(n)`, `CHAR(n)` or `VARCHAR(n)`, where `n` is the maximum number of characters allowed.
+To limit the length of a string column, use `STRING(n)`, where `n` is the maximum number of characters allowed.
 
 When inserting a string, if the value exceeds the column's length limit, Cockroach gives an error. However, when a value is cast as a string with a length limit (e.g., `CAST('hello world' AS CHAR(5))`), CockroachDB truncates to the limit.
 
@@ -30,7 +33,7 @@ When inserting a string value, format it as `'a1b2c3'`.
 ## Examples
 
 ~~~
-CREATE TABLE strings (a STRING PRIMARY KEY, b CHAR(4), c TEXT);
+CREATE TABLE strings (a STRING PRIMARY KEY, b STRING(4), c TEXT);
 
 SHOW COLUMNS FROM strings;
 +-------+-----------+-------+---------+

--- a/string.md
+++ b/string.md
@@ -17,14 +17,20 @@ In CockroachDB, the following are aliases for `STRING`:
 And the following are aliases for `STRING(n)`:
 
 - `CHARACTER(n)`
-- `CHAR(n)` 
+- `CHARACTER VARYING(n)`
+- `CHAR(n)`
+- `CHAR VARYING(n)` 
 - `VARCHAR(n)` 
 
 ## Length
 
-To limit the length of a string column, use `STRING(n)`, where `n` is the maximum number of characters allowed.
+To limit the length of a string column, use `STRING(n)`, where `n` is the maximum number of characters allowed. 
 
-When inserting a string, if the value exceeds the column's length limit, Cockroach gives an error. However, when a value is cast as a string with a length limit (e.g., `CAST('hello world' AS CHAR(5))`), CockroachDB truncates to the limit.
+When inserting a string: 
+
+- If the value exceeds the column's length limit, CockroachDB gives an error.
+- If the value is cast as a string with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit.
+- If the value is under the column's length limit, CockroachDB does **not** add padding. This applies to `STRING(n)` and all its aliases.
 
 ## Format
 


### PR DESCRIPTION
Updated `strings.md` to list `STRING(n)` as the primary form for limiting length on a string column.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/211)
<!-- Reviewable:end -->
