### PR TITLE
note about precision = scale

### DIFF
--- a/decimal.md
+++ b/decimal.md
@@ -14,15 +14,14 @@ In CockroachDB, the following are aliases for `DECIMAL`:
 
 ## Precision and Scale
 
-To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the **maximum** count of digits both to the left and right of the decimal point and `scale` is the **exact** count of digits to the right of the decimal point. The `precision` must be larger than the `scale`. 
-
-Note that using `DECIMAL(precision)` is equivalent to `DECIMAL(precision, 0)`.
+To limit a decimal column, use `DECIMAL(precision, scale)`, where `precision` is the **maximum** count of digits both to the left and right of the decimal point and `scale` is the **exact** count of digits to the right of the decimal point. The `precision` must not be smaller than the `scale`. Also note that using `DECIMAL(precision)` is equivalent to `DECIMAL(precision, 0)`.
 
 When inserting a decimal value:
 
 - If digits to the right of the decimal point exceed the column's `scale`, CockroachDB rounds to the scale. 
-- If digits to the right of the decimal point are less than the column's `scale`, CockroachDB pads to the scale with `0`s.
+- If digits to the right of the decimal point are fewer than the column's `scale`, CockroachDB pads to the scale with `0`s.
 - If digits to the left and right of the decimal point exceed the column's `precision`, CockroachDB gives an error.  
+- If the column's `precision` and `scale` are identical, the inserted value must round to less than 1.
 
 ## Format
 


### PR DESCRIPTION
Updated the decimal.md page to mention that when a decimal column's precision and scale are identical, the inserted value must round to less than 1. 

In response to https://github.com/cockroachdb/cockroach/pull/5994.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/219)
<!-- Reviewable:end -->
