### PR TITLE
fixing canonical link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="canonical" href="{{ page.url | replace:'index.html','' }}">
+<link rel="canonical" href="{{ site.baseurl }}{{ page.url | replace:'index.html',''}}">
 <link rel="shortcut icon" href="images/favicon.png" type="image/png">
 
 <link rel="stylesheet" type="text/css" href="css/syntax.css">


### PR DESCRIPTION
Fixing the canonical link element to point to the `/docs` directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/229)
<!-- Reviewable:end -->
