### PR TITLE
Link to VirtualBox VM setup guide and other minor deployment doc updates

### DIFF
--- a/cloud-deployment.md
+++ b/cloud-deployment.md
@@ -3,4 +3,11 @@ title: Cloud Deployment
 toc: false
 ---
 
-Coming soon.
+To deploy an insecure development or test cluster on Google Cloud Engine using [Terraform](https://www.terraform.io/), see the configuration files and instructions in the [gce directory](https://github.com/cockroachdb/cockroach/blob/master/cloud/gce) of our main cockroach GitHub repository. 
+
+More cloud deployment docs coming soon.
+
+## See Also
+
+- [Manual Deployment](manual-deployment.html)
+- [Start a Local Cluster](start-a-local-cluster.html)

--- a/cloud-deployment.md
+++ b/cloud-deployment.md
@@ -3,7 +3,7 @@ title: Cloud Deployment
 toc: false
 ---
 
-To deploy an insecure development or test cluster on Google Cloud Engine using [Terraform](https://www.terraform.io/), see the configuration files and instructions in the [gce directory](https://github.com/cockroachdb/cockroach/blob/master/cloud/gce) of our main cockroach GitHub repository. 
+To deploy an insecure development or test cluster on Google Cloud Engine or AWS using [Terraform](https://www.terraform.io/), see the configuration files and instructions in the [`gce`](https://github.com/cockroachdb/cockroach/blob/master/cloud/gce) and [`aws`](https://github.com/cockroachdb/cockroach/blob/master/cloud/aws) directories of our main cockroach GitHub repository. 
 
 More cloud deployment docs coming soon.
 

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -5,7 +5,7 @@ toc: false
 
 This page shows you how to manually deploy a multi-node CockroachDB cluster on multiple machines. 
 
-{{site.data.alerts.callout_info}} For testing and development, you can <a href="start-a-local-cluster.html">Start a Local Cluster</a> or <a href="cloud-deployment.html">Deploy on Google Cloud Engine using Terraform</a>. You can also <a href="http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html">Run CockroachDB inside a VirtualBox VM</a> (community-supported).{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}} For testing and development, you can <a href="start-a-local-cluster.html">Start a Local Cluster</a> or <a href="cloud-deployment.html">Deploy on GCE or AWS using Terraform</a>. You can also <a href="http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html">Run CockroachDB inside a VirtualBox VM</a> (community-supported).{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -5,7 +5,7 @@ toc: false
 
 This page shows you how to manually deploy a multi-node CockroachDB cluster on multiple machines. 
 
-{{site.data.alerts.callout_info}} For deployment on AWS and other cloud providers, see <a href="cloud-deployment.html">Cloud Deployment</a>. For local testing and development, see <a href="start-a-local-cluster.html">Start a Local Cluster</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}} For testing and development, you can <a href="start-a-local-cluster.html">Start a Local Cluster</a> or <a href="cloud-deployment.html">Deploy on Google Cloud Engine using Terraform</a>. You can also <a href="http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html">Run CockroachDB inside a VirtualBox VM</a> (community-supported).{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -221,3 +221,9 @@ store[0]:  path=cockroach-data
 ~~~
 
 <img src="images/admin_ui.png" style="border:1px solid #eee;max-width:100%" />
+
+## See Also
+
+- [Cloud Deployment](cloud-deployment.html)
+- [Start a Local Cluster](start-a-local-cluster.html)
+- [Run CockroachDB in a VirtualBox VM](http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html) (community-supported)

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -6,7 +6,7 @@ expand: true
 
 Once you've [installed CockroachDB](install-cockroachdb.html), you can quickly start a single- or multi-node cluster locally with each node listening on a different port. 
 
-{{site.data.alerts.callout_info}}To run CockroachDB on multiple machines, see <a href="manual-deployment.html">Manual Deployment</a>. For guidance on running CockroachDB inside a single VirtualBox virtual machine, see these <a href="http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html">community-supported docs</a>.{{site.data.alerts.end}}    
+{{site.data.alerts.callout_info}}To run CockroachDB on multiple machines or in the cloud, see <a href="manual-deployment.html">Manual Deployment</a> or <a href="cloud-deployment.html">Cloud Deployment</a>. To run CockroachDB inside a single VirtualBox virtual machine, see these <a href="http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html">community-supported docs</a>.{{site.data.alerts.end}}
 
 1.  From the directory with the `cockroach` binary, start your first node:
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -4,7 +4,9 @@ toc: false
 expand: true
 ---
 
-Once you've [installed CockroachDB](install-cockroachdb.html), you can quickly start a single- or multi-node cluster locally with each node listening on a different port. For details about running CockroachDB on multiple machines or in the cloud, see <a href="manual-deployment.html">Manual Deployment</a> or <a href="cloud-deployment.html">Cloud Deployment</a>. 
+Once you've [installed CockroachDB](install-cockroachdb.html), you can quickly start a single- or multi-node cluster locally with each node listening on a different port. 
+
+{{site.data.alerts.callout_info}}To run CockroachDB on multiple machines, see <a href="manual-deployment.html">Manual Deployment</a>. For guidance on running CockroachDB inside a single VirtualBox virtual machine, see these <a href="http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html">community-supported docs</a>.{{site.data.alerts.end}}    
 
 1.  From the directory with the `cockroach` binary, start your first node:
 


### PR DESCRIPTION
@uptimeDBA wrote up a guide for running CockroachDB in a VirtualBox VM. This PR links to his guide, updates our cloud deployment docs to link to our GCE instructions, and a few other minor updates.

Fixes #262

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/263)
<!-- Reviewable:end -->
