### PR TITLE
Running external commands from sql shell

### DIFF
--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -85,7 +85,7 @@ Once you've [installed CockroachDB](install-cockroachdb.html), you can quickly s
     +------+----------+
     ~~~
 
-    When you're done using the SQL shell, press **CTRL + D** to exit.
+    When you're done using the SQL shell, use **CTRL + D**, **CTRL + C**, or `\q` to exit.
  
 5.  [Check out the Admin UI](explore-the-admin-ui.html) by pointing your browser to `http://localhost:8080`. You can also find the address in the `admin` field in the standard output of any node on startup.
 

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -12,7 +12,7 @@ To exit the interactive shell, use **CTRL + D**, **CTRL + C**, or `\q`.
 ## Synopsis
 
 ~~~ shell
-# Open the interactive SQL shell:
+# Start the interactive SQL shell:
 $ ./cockroach sql <flags>
 
 # Run external commands from the SQL shell:
@@ -31,7 +31,7 @@ $ ./cockroach help sql
 
 The `cockroach sql` command supports the following flags as well as [logging flags](cockroach-commands.html#logging-flags).
 
-- To open an interactive SQL shell, run `cockroach sql` with all appropriate connection flags or use just the `--url` flag, which includes connection details. 
+- To start an interactive SQL shell, run `cockroach sql` with all appropriate connection flags or use just the `--url` flag, which includes connection details. 
 - To execute SQL statements from the command line, use the `--execute` flag.
 
 Flag | Description 
@@ -49,7 +49,7 @@ Flag | Description
 
 ## Examples
 
-### Open a SQL shell using standard connection flags
+### Start a SQL shell using standard connection flags
 
 ~~~ shell
 # Secure:
@@ -59,7 +59,7 @@ $ ./cockroach sql --ca-cert=certs/ca.cert --cert=certs/maxroach.cert --key=certs
 $ ./cockroach sql --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb 
 ~~~
 
-### Open a SQL shell using the `--url` flag
+### Start a SQL shell using the `--url` flag
 
 ~~~ shell
 # Secure:

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -15,10 +15,6 @@ To exit the interactive shell, use **CTRL + D**, **CTRL + C**, or `\q`.
 # Start the interactive SQL shell:
 $ ./cockroach sql <flags>
 
-# Run external commands from the SQL shell:
-> \! <external command>    <-- Run command and print its results to stdout
-> \| <external command>    <-- Run output of command as SQL statements
-
 # Execute SQL from the command line:
 $ ./cockroach sql --execute="<sql statement>;<sql statement>" --execute="<sql-statement>" <flags>
 $ echo "<sql statement>;<sql statement>" | ./cockroach sql <flags>
@@ -46,6 +42,17 @@ Flag | Description
 `--port`<br>`-p` | The port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
 `--url` | The connection URL. If you use this flag, do not set any other connection flags.<br><br>For insecure connections, the URL format is: <br>`--url=postgresql://<user>@<host>:<port>/<database>?sslmode=disable`<br><br>For secure connections, the URL format is:<br>`--url=postgresql://<user>@<host>:<port>/<database>`<br>with the following parameters in the query string:<br>`sslcert=<path-to-client-crt>`<br>`sslkey=<path-to-client-key>`<br>`sslmode=verify-full`<br>`sslrootcert=<path-to-ca-crt>` <br><br>**Env Variable:** `COCKROACH_URL`
 `--user`<br>`-u` | The user connecting to the database. The user must have [privileges](privileges.html) for any statement executed.<br><br>**Env Variable:** `COCKROACH_USER`<br>**Default:** `root`
+
+## SQL Shell Commands
+
+In addition to executing [SQL statements](sql-statements.html) within the shell, you can use the following commands:
+
+Command | Usage
+--------|------------
+`\!` | Run an external command and print its results to `stdout`. See the [example](#run-external-commands-from-the-sql-shell) below.
+`\|` | Run the output of an external command as SQL statements. See the [example](#run-external-commands-from-the-sql-shell) below.
+`\q`<br>**CTRL + D**<br>**CTRL + C** | Exit the shell.
+`\?`<br>`help` | View this help within the shell.
 
 ## Examples
 
@@ -99,9 +106,7 @@ $ echo "SHOW TABLES; SELECT * FROM roaches;" | ./cockroach sql --user=maxroach -
 
 ### Run external commands from the SQL shell
 
-From within the SQL shell, you use `\!` to run an external command and print its results to `stdout`, and you use `\|` to run the output of an external command as SQL statements. 
-
-For example, here we use `\!` to look at the rows in a csv file before creating a table and then using `\|` to insert those rows into the table: 
+In this example, we use `\!` to look at the rows in a csv file before creating a table and then using `\|` to insert those rows into the table.
 
 ~~~ shell
 > \! cat test.csv
@@ -123,7 +128,7 @@ INSERT 1
 +----+----+----+
 ~~~
 
-In this example, we create a table and then use `\|` to programmatically insert values:
+In this example, we create a table and then use `\|` to programmatically insert values.
 
 ~~~ shell
 > CREATE TABLE for_loop (x INT);
@@ -151,4 +156,6 @@ INSERT 1
 
 ## See Also
 
-[Other Cockroach Commands](cockroach-commands.html)
+- [Other Cockroach Commands](cockroach-commands.html)
+- [SQL Statements](sql-statements.html)
+- [Learn CockroachDB SQL](learn-cockroachdb-sql.html)

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -20,7 +20,8 @@ $ ./cockroach sql <flags>
 > \| <external command>    <-- Run output of command as SQL statements
 
 # Execute SQL from the command line:
-$ ./cockroach sql --execute='<sql-statement>;<sql-statement>' --execute='<sql-statement>' <flags>
+$ ./cockroach sql --execute="<sql statement>;<sql statement>" --execute="<sql-statement>" <flags>
+$ echo "<sql statement>;<sql statement>" | ./cockroach sql <flags>
  
 # View help:
 $ ./cockroach help sql
@@ -48,7 +49,7 @@ Flag | Description
 
 ## Examples
 
-#### Open a SQL shell using standard connection flags
+### Open a SQL shell using standard connection flags
 
 ~~~ shell
 # Secure:
@@ -58,7 +59,7 @@ $ ./cockroach sql --ca-cert=certs/ca.cert --cert=certs/maxroach.cert --key=certs
 $ ./cockroach sql --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb 
 ~~~
 
-#### Open a SQL shell using the `--url` flag
+### Open a SQL shell using the `--url` flag
 
 ~~~ shell
 # Secure:
@@ -68,21 +69,39 @@ $ ./cockroach sql --url=postgresql://maxroach@roachcluster.com:26257/critterdb?s
 $ ./cockroach sql --url=postgresql://maxroach@roachnode1.com:26257/critterdb?sslmode=disable 
 ~~~
 
-#### Execute SQL statements from the command line
+### Execute SQL statements from the command line
 
 ~~~ shell
-# Multiple statements in one `--execute` flag:
-$ ./cockroach sql --execute='CREATE DATABASE roaches;CREATE TABLE roaches.countries (name STRING, code STRING, roach_population INT)' --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb 
+# Statements with a single --execute flag:
+$ ./cockroach sql --execute="CREATE TABLE roaches2 (name STRING, country STRING); INSERT INTO roaches VALUES ('American Cockroach', 'United States'), ('Brownbanded Cockroach', 'United States')" --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb
+CREATE TABLE
+INSERT 2 
 
-# Multiple statements in separate `--execute` flags:
-$ ./cockroach sql --execute='CREATE DATABASE roaches' --execute='CREATE TABLE roaches.countries (name STRING, code STRING, roach_population INT);INSERT INTO roaches.countries VALUES ('United States', 'US', 20000000000000)' --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb  
+# Statements with multiple --execute flags:
+$ ./cockroach sql --execute="CREATE TABLE roaches2 (name STRING, country STRING)" --execute="INSERT INTO roaches VALUES ('American Cockroach', 'United States'), ('Brownbanded Cockroach', 'United States')" --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb   
+CREATE TABLE
+INSERT 2
+
+# Statements with echo command:
+$ echo "SHOW TABLES; SELECT * FROM roaches;" | ./cockroach sql --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb
++----------+
+|  Table   |
++----------+
+| roaches  |
++----------+
++-----------------------+---------------+
+|         name          |    country    |
++-----------------------+---------------+
+| American Cockroach    | United States |
+| Brownbanded Cockroach | United States |
++-----------------------+---------------+
 ~~~
 
-#### Run external commands from the SQL shell:
+### Run external commands from the SQL shell
 
-From within the SQL shell, you use `\!` to run an external command and print its results to stdout, and you use `\|` to run the output of an external command as SQL statements. 
+From within the SQL shell, you use `\!` to run an external command and print its results to `stdout`, and you use `\|` to run the output of an external command as SQL statements. 
 
-For example, here we use `\!` to look at the rows in a csv file before creating a table and then using `\|` to insert those rows into the table. 
+For example, here we use `\!` to look at the rows in a csv file before creating a table and then using `\|` to insert those rows into the table: 
 
 ~~~ shell
 > \! cat test.csv
@@ -104,7 +123,7 @@ INSERT 1
 +----+----+----+
 ~~~
 
-In this example, we create a table and then use `\|` to programmatically insert values.
+In this example, we create a table and then use `\|` to programmatically insert values:
 
 ~~~ shell
 > CREATE TABLE for_loop (x INT);

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -5,17 +5,25 @@ toc: false
 
 CockroachDB comes with a built-in client for executing SQL statements from an interactive shell or directly from the command line. To use this client, run the `cockroach sql` [command](cockroach-commands.html) as described below.  
 
+To exit the interactive shell, use **CTRL + D**, **CTRL + C**, or `\q`.
+
 <div id="toc"></div>
 
 ## Synopsis
 
 ~~~ shell
-# Open the interactive SQL shell:
-$ ./cockroach sql <flags>
-
 # Execute SQL from the command line:
 $ ./cockroach sql --execute='<sql-statement>;<sql-statement>' --execute='<sql-statement>' <flags>
 
+# Open the interactive SQL shell:
+$ ./cockroach sql <flags>
+
+# In the SQL shell, run an external command and prints its results to stdout:
+> \! <external command>
+ 
+# In the SQL shell, run the output of an external command as SQL statements
+> \| <external command>
+ 
 # View help:
 $ ./cockroach help sql
 ~~~


### PR DESCRIPTION
Updated `cockroach sql` docs to explain how to run external commands from the shell. Added to synopsis and added examples. Also covered executing sql from command line using `echo` instead of the `-e` flag.

Thanks for supplying great, examples, @knz. Assigned to Raphael, but perhaps @mberhault can review while he's out?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/270)
<!-- Reviewable:end -->
