### PR TITLE
Linking to related pages on indexes

### DIFF
--- a/data-definition.md
+++ b/data-definition.md
@@ -23,4 +23,6 @@ Coming soon.
 
 ## Indexes
 
-Coming soon.
+For index-related SQL statements, see [`CREATE INDEX`](create-index.html), [`DROP INDEX`](drop-index.html), [`RENAME INDEX`](rename-index.html), and [`SHOW INDEX`](show-index.html). To understand how CockroachDB chooses the best index for running a query, see [Index Selection in CockroachDB](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/).
+
+More docs on indexes coming soon.


### PR DESCRIPTION
Previously, the "Indexes" section on `data-definition.md` said "coming soon," which mislead a user into thinking that indexes aren't already available. That "coming soon" really meant "docs coming soon."

For now, replacing that with links to related SQL statements and Radu's blog post on index selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/293)
<!-- Reviewable:end -->
