### PR TITLE
Document SerializationFailureError for retryable errors

### DIFF
--- a/_includes/app/txn-sample.js
+++ b/_includes/app/txn-sample.js
@@ -24,7 +24,7 @@ function txnWrapper(client, op, next) {
     async.doWhilst(function (done) {
       var handleError = function (err) {
         // If we got an error, see if it's a retryable one and, if so, restart.
-        if (err.code === 'CR000') {
+        if (err.code === '40001') {
           // Signal the database that we'll retry.
           return client.query('ROLLBACK TO SAVEPOINT cockroach_restart', done);
         }

--- a/_includes/app/txn-sample.php
+++ b/_includes/app/txn-sample.php
@@ -38,7 +38,7 @@ function transferMoney($dbh, $from, $to, $amount) {
       $dbh->commit();
       return;
     } catch (PDOException $e) {
-      if ($e->getCode() != 'CR000') {
+      if ($e->getCode() != '40001') {
         // Non-recoverable error. Rollback and bubble error up the chain.
         $dbh->rollBack();
         throw $e;

--- a/_includes/app/txn-sample.py
+++ b/_includes/app/txn-sample.py
@@ -27,7 +27,7 @@ def txnWrapper(conn, op):
                 break
 
             except psycopg2.DatabaseError as e:
-                if e.pgcode != 'CR000':
+                if e.pgcode != '40001':
                     # A non-retryable error; report this up the call stack.
                     raise e
                 # Signal the database that we'll retry.

--- a/_includes/sql/diagrams/grammar.html
+++ b/_includes/sql/diagrams/grammar.html
@@ -1214,6 +1214,7 @@
             <li><a href="#insert_target" title="insert_target">insert_target</a></li>
             <li><a href="#name_list" title="name_list">name_list</a></li>
             <li><a href="#opt_name" title="opt_name">opt_name</a></li>
+            <li><a href="#opt_name_parens" title="opt_name_parens">opt_name_parens</a></li>
             <li><a href="#qualified_name" title="qualified_name">qualified_name</a></li>
             <li><a href="#relation_expr_opt_alias" title="relation_expr_opt_alias">relation_expr_opt_alias</a></li>
             <li><a href="#rename_stmt" title="rename_stmt">rename_stmt</a></li>
@@ -1543,6 +1544,7 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#c_expr" title="c_expr">c_expr</a></li>
+            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
             <li><a href="#create_index_stmt" title="create_index_stmt">create_index_stmt</a></li>
             <li><a href="#insert_target" title="insert_target">insert_target</a></li>
             <li><a href="#qualified_name_list" title="qualified_name_list">qualified_name_list</a></li>
@@ -6253,7 +6255,7 @@
             <li><a href="#joined_table" title="joined_table">joined_table</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_qualification_elem" href="#col_qualification_elem">col_qualification_elem:</a></p>
-      <svg width="338" height="244">
+      <svg width="496" height="288">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -6294,9 +6296,22 @@
             <rect x="149" y="209" width="64" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="159" y="229">b_expr</text>
          </a>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m56 0 h10 m0 0 h76 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v56 m280 0 v-56 m-280 56 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m74 0 h10 m0 0 h166 m-270 -10 v20 m280 0 v-20 m-280 20 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h92 m-270 -10 v20 m280 0 v-20 m-280 20 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m-270 -10 v20 m280 0 v-20 m-280 20 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m80 0 h10 m0 0 h10 m64 0 h10 m0 0 h76 m23 -208 h-3"></path>
-         <polygon points="329 17 337 13 337 21"></polygon>
-         <polygon points="329 17 321 13 321 21"></polygon>
+         <rect x="51" y="255" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="253" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="273">REFERENCES</text>
+         <a xlink:href="#qualified_name" xlink:title="qualified_name">
+            <rect x="177" y="255" width="116" height="32"></rect>
+            <rect x="175" y="253" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="185" y="273">qualified_name</text>
+         </a>
+         <a xlink:href="#opt_name_parens" xlink:title="opt_name_parens">
+            <rect x="313" y="255" width="136" height="32"></rect>
+            <rect x="311" y="253" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="321" y="273">opt_name_parens</text>
+         </a>
+         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m56 0 h10 m0 0 h234 m-438 0 h20 m418 0 h20 m-458 0 q10 0 10 10 m438 0 q0 -10 10 -10 m-448 10 v56 m438 0 v-56 m-438 56 q0 10 10 10 m418 0 q10 0 10 -10 m-428 10 h10 m74 0 h10 m0 0 h324 m-428 -10 v20 m438 0 v-20 m-438 20 v24 m438 0 v-24 m-438 24 q0 10 10 10 m418 0 q10 0 10 -10 m-428 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h250 m-428 -10 v20 m438 0 v-20 m-438 20 v24 m438 0 v-24 m-438 24 q0 10 10 10 m418 0 q10 0 10 -10 m-428 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h158 m-428 -10 v20 m438 0 v-20 m-438 20 v24 m438 0 v-24 m-438 24 q0 10 10 10 m418 0 q10 0 10 -10 m-428 10 h10 m80 0 h10 m0 0 h10 m64 0 h10 m0 0 h234 m-428 -10 v20 m438 0 v-20 m-438 20 v24 m438 0 v-24 m-438 24 q0 10 10 10 m418 0 q10 0 10 -10 m-428 10 h10 m106 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m23 -252 h-3"></path>
+         <polygon points="487 17 495 13 495 21"></polygon>
+         <polygon points="487 17 479 13 479 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -6778,6 +6793,30 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#join_type" title="join_type">join_type</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_name_parens" href="#opt_name_parens">opt_name_parens:</a></p>
+      <svg width="244" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">(</text>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="97" y="23" width="54" height="32"></rect>
+            <rect x="95" y="21" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="41">name</text>
+         </a>
+         <rect x="171" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="169" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="179" y="41">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h156 m-186 0 h20 m166 0 h20 m-206 0 q10 0 10 10 m186 0 q0 -10 10 -10 m-196 10 v12 m186 0 v-12 m-186 12 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m26 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
+         <polygon points="235 5 243 1 243 9"></polygon>
+         <polygon points="235 5 227 1 227 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_varying" href="#opt_varying">opt_varying:</a></p>
       <svg width="180" height="56">

--- a/rollback-transaction.md
+++ b/rollback-transaction.md
@@ -5,7 +5,7 @@ toc: false
 
 The `ROLLBACK` [statement](sql-statements.html) aborts the current [transaction](transactions.html), discarding all updates made by statements included in the transaction.
 
-When using the CockroachDB-provided function for client-side transaction retries, the `ROLLBACK TO SAVEPOINT cockroach_restart` statement restarts the transaction if any included statement returns a retryable error (identified via the CR000 error code or retry transaction string in the error message). For more details, see [Transaction Retries](transactions.html#transaction-retries). 
+When using the CockroachDB-provided function for client-side transaction retries, the `ROLLBACK TO SAVEPOINT cockroach_restart` statement restarts the transaction if any included statement returns a retryable error (identified via the 40001 error code or retry transaction string in the error message). For more details, see [Transaction Retries](transactions.html#transaction-retries). 
 
 <div id="toc"></div>
 

--- a/transactions.md
+++ b/transactions.md
@@ -37,7 +37,7 @@ To assist with client-side retries, CockroachDB provides a generic **retry funct
 
 3. The statements in the transaction are executed. 
 
-4. If a statement returns a retryable error (identified via the `CR000` error code or `retry transaction` string in the error message), the [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html) statement restarts the transaction. 
+4. If a statement returns a retryable error (identified via the `40001` error code or `retry transaction` string in the error message), the [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html) statement restarts the transaction. 
 
    In cases where you do not want the application to retry the transaction, you can adapt the wrapper function to simply `ROLLBACK` at this point. Any other statements will be rejected by the server, as is generally the case after an error has been encountered and the transaction has not been closed.
 


### PR DESCRIPTION
See cockroachdb/cockroach#6797.

We changed the error code that clients should expect for retryable
serialization errors. This change reflects how clients should react to
this new error.

Any seemingly unrelated changes here are because I ran `make`.

For now I've simply replaced the expected error code in samples, but if sample authors 
know about more idiomatic ways to catch standard PG errors from their respective drivers
(i.e. specific exceptions to catch), please let me know. 
@bdarnell @andreimatei @tschottdorf @tamird @dt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/315)
<!-- Reviewable:end -->
