### PR TITLE
CSS change to improve link style on hover

### DIFF
--- a/css/lavish-bootstrap.css
+++ b/css/lavish-bootstrap.css
@@ -312,7 +312,7 @@ a:focus {
 
 .post-content a:hover {
   color: #46a417;
-  text-decoration: underline;
+  border-bottom: 1px dotted #46a417;
 }
 
 img {

--- a/css/lavish-bootstrap.css
+++ b/css/lavish-bootstrap.css
@@ -312,7 +312,7 @@ a:focus {
 
 .post-content a:hover {
   color: #46a417;
-  border-bottom: 1px dotted #46a417;
+  border-bottom: 1px solid #46a417;
 }
 
 img {


### PR DESCRIPTION
Using `border-bottom: 1px solid #46a417` instead of `text-decoration: underline`. This adds a bit more vertical space between word and underline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/330)
<!-- Reviewable:end -->
