### PR TITLE
Change quit flag to --port

### DIFF
--- a/secure-a-cluster.md
+++ b/secure-a-cluster.md
@@ -17,7 +17,7 @@ Now that you have a [local cluster](start-a-local-cluster.html) up and running, 
     <button type="button" class="btn details collapsed" data-toggle="collapse" data-target="#details-secure1">Details</button>
     <div id="details-secure1" class="collapse" markdown="1">
 
-    - If you used the `cockroach start` commands on [Start a Cluster](start-a-local-cluster.html) verbatim, the commands above will work as well. Otherwise, just set the `--http-port` flag to the ports you used.
+    - If you used the `cockroach start` commands on [Start a Cluster](start-a-local-cluster.html) verbatim, the commands above will work as well. Otherwise, just set the `--port` flag to the ports you used.
     - For more details about the `cockroach quit` command, see [Stop a Node](stop-a-node.html).
     - If you leave the Admin UI open, when you restart the cluster with security (steps 3 and 4), you'll see "TLS handshake" errors until you adjust the URL to https (step 7).
 


### PR DESCRIPTION
~~~ shell
./cockroach quit --http-port= 8081 
~~~

returns the following error:

~~~ shell
Error: unknown flag: --http-port
~~~

`cockroach quit --help` doesn't currently list `--http-port` as a flag, but does list `--port`

Suggesting to convert syntax for quit to use `--port` flag instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/332)
<!-- Reviewable:end -->
