### PR TITLE
Remove --http-port flag from all quit references

### DIFF
--- a/stop-a-node.md
+++ b/stop-a-node.md
@@ -30,7 +30,7 @@ Flag | Description
 `--host` | A valid address for reaching the node. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** localhost
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
 `--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
-`--port` | The port to listen on for internal and client communication. <br><br>**Default:** `26257`
+`--port`<br>`-p` | The port to listen on for internal and client communication. <br><br>**Default:** 26257
 
 ## Example
 

--- a/stop-a-node.md
+++ b/stop-a-node.md
@@ -30,7 +30,7 @@ Flag | Description
 `--host` | A valid address for reaching the node. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** localhost
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
 `--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
-`--port`<br>`-p` | The port that the node listens on for for internal and client communication. <br><br>**Default:** 26257
+`--port`<br>`-p` | The port that the node listens on for internal and client communication. <br><br>**Default:** 26257
 
 ## Example
 

--- a/stop-a-node.md
+++ b/stop-a-node.md
@@ -28,9 +28,9 @@ Flag | Description
 `--ca-cert` | The path to the [CA certificate](create-security-certificates.html). This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_CA_CERT`
 `--cert` | The path to the [client certificate](create-security-certificates.html). This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_CERT`
 `--host` | A valid address for reaching the node. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** localhost
-`--http-port` | The port that the node listens on for HTTP requests. <br><br>**Env Variable:** `COCKROACH_HTTP_PORT`<br>**Default:** `8080`
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
-`--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY` 
+`--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
+`--port` | The port to listen on for internal and client communication. <br><br>**Default:** `26257`
 
 ## Example
 
@@ -38,10 +38,10 @@ Flag | Description
 
 ~~~ shell
 # Insecure:
-$ ./cockroach quit --host=nodehostname.com --http-port=8081
+$ ./cockroach quit --host=nodehostname.com --port=26258
 
 # Secure:
-$ ./cockroach quit --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --host=nodehostname.com --http-port=8081
+$ ./cockroach quit --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --host=nodehostname.com --port=26258
 ~~~
 
 ## See Also

--- a/stop-a-node.md
+++ b/stop-a-node.md
@@ -30,7 +30,7 @@ Flag | Description
 `--host` | A valid address for reaching the node. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** localhost
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
 `--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
-`--port`<br>`-p` | The port to listen on for internal and client communication. <br><br>**Default:** 26257
+`--port`<br>`-p` | The port that the node listens on for for internal and client communication. <br><br>**Default:** 26257
 
 ## Example
 


### PR DESCRIPTION
Figured I already had everything open and running, so I'd just check everything for references of `quit` using the `--http-port` flag (i.e. regex search for `quit(.+)?--http-port`). Only one other page referred to the flag.

On `stop-a-node.md`:
1. Removed `--http-port` flag reference
2. Inserted `--port` flag reference using the definition from `start-a-node.md` as a reference
3. Updated examples using same same format of incrementing the default port by 1

_Possibly still needed?_
Couldn't find any reference to `--port` having an environment variable that's the equivalent of `--http-port`'s **COCKROACH_HTTP_PORT**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/335)
<!-- Reviewable:end -->
