### PR TITLE
beta-20160602 release notes

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -117,6 +117,9 @@ entries:
 
     - title: Release Notes
       items:
+        - title: beta-20160602
+          url: /beta-20160602.html
+
         - title: beta-20160526
           url: /beta-20160526.html
 

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -1,0 +1,28 @@
+---
+title: What's New in beta-20160602
+toc: false
+---
+
+## Jun 2, 2016
+
+### New Features
+
+* String literals can now be parsed as `DATE`, `TIMESTAMP`, `TIMESTAMPTZ`, or `INTERVAL` without an explicit cast. [#6925](https://github.com/cockroachdb/cockroach/pull/6925)
+* Floor division is now supported with a new operator `//`. [#6642](https://github.com/cockroachdb/cockroach/pull/6642)
+* Sub-queries are now allowed in `LIMIT`, `OFFSET`, and `RETURNING` expressions. [#6735](https://github.com/cockroachdb/cockroach/pull/6735)
+
+### Bug Fixes
+
+* Fixed a missing error check that could result in inconsistencies when transactions conflict. [#6899](https://github.com/cockroachdb/cockroach/pull/6899)
+
+### Performance Improvements
+
+* Improved performance of one-phase transactions. [#6857](https://github.com/cockroachdb/cockroach/pull/6857), [#6861](https://github.com/cockroachdb/cockroach/pull/6861)
+* Improved the ability of `MIN()` and `MAX()` to detect the ordering of the data and read only a single row. [#6891](https://github.com/cockroachdb/cockroach/pull/6891)
+
+### Contributors
+
+This release includes 55 merged PRs by 18 authors. We would like to
+thank the following new contributor from the CockroachDB community:
+
+* Thanakom Sangnetra


### PR DESCRIPTION
Kind of a slow week for visible changes - a lot of work has gone into preparation for future features (ui/next, distsql, column families, dump/restore) or internal improvements with no direct user impact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/345)
<!-- Reviewable:end -->
