### PR TITLE
updates to release notes

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -1,5 +1,5 @@
 search_placeholder_text: Search
 search_no_results_text: No results found.
 copyright_line: "&copy;2016 Cockroach Labs. All rights reserved."
-version: beta-20160526
-build_time: 2016/05/26 16:48:43 (go1.6.1)
+version: beta-20160602
+build_time: 2016/06/02 16:53:54 (go1.6.1)

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -7,22 +7,31 @@ toc: false
 
 ### New Features
 
-* String literals can now be parsed as `DATE`, `TIMESTAMP`, `TIMESTAMPTZ`, or `INTERVAL` without an explicit cast. [#6925](https://github.com/cockroachdb/cockroach/pull/6925)
-* Floor division is now supported with a new operator `//`. [#6642](https://github.com/cockroachdb/cockroach/pull/6642)
+- String literals can now be parsed as [`DATE`](date.html), [`TIMESTAMP`](timestamp.html), [`TIMESTAMPTZ`](timestamp.html), or [`INTERVAL`](interval.html) without an explicit cast. [#6925](https://github.com/cockroachdb/cockroach/pull/6925)
+- Floor division is now supported with a new [operator](functions-and-operators.html#operators), `//`. [#6642](https://github.com/cockroachdb/cockroach/pull/6642)
 * Sub-queries are now allowed in `LIMIT`, `OFFSET`, and `RETURNING` expressions. [#6735](https://github.com/cockroachdb/cockroach/pull/6735)
 
 ### Bug Fixes
 
-* Fixed a missing error check that could result in inconsistencies when transactions conflict. [#6899](https://github.com/cockroachdb/cockroach/pull/6899)
+- Fixed a missing error check that could result in inconsistencies when transactions conflict. [#6899](https://github.com/cockroachdb/cockroach/pull/6899)
 
 ### Performance Improvements
 
-* Improved performance of one-phase transactions. [#6857](https://github.com/cockroachdb/cockroach/pull/6857), [#6861](https://github.com/cockroachdb/cockroach/pull/6861)
-* Improved the ability of `MIN()` and `MAX()` to detect the ordering of the data and read only a single row. [#6891](https://github.com/cockroachdb/cockroach/pull/6891)
+- Improved performance of one-phase transactions. [#6857](https://github.com/cockroachdb/cockroach/pull/6857), [#6861](https://github.com/cockroachdb/cockroach/pull/6861)
+- Improved the ability of `MIN()` and `MAX()` [functions](functions-and-operators.html#functions) to detect the ordering of the data and read only a single row. [#6891](https://github.com/cockroachdb/cockroach/pull/6891)
+
+### Docs Updates
+
+- Added a tutorial on [building an Application with CockroachDB and SQLAlchemy](https://www.cockroachlabs.com/blog/building-application-cockroachdb-sqlalchemy-2/) 
+- Added docs on [how CockroachDB handles `NULL` values](null-handling.html) in various contexts. [#333](https://github.com/cockroachdb/docs/pull/333)
+- Improved guidance on [Contributing to CockroachDB docs](https://github.com/cockroachdb/docs/blob/gh-pages/CONTRIBUTING.md). [#344](https://github.com/cockroachdb/docs/pull/344)
+- Improved [zone configuration examples](configure-replication-zones.html#examples). [#327](https://github.com/cockroachdb/docs/pull/327) 
 
 ### Contributors
 
 This release includes 55 merged PRs by 18 authors. We would like to
-thank the following new contributor from the CockroachDB community:
+thank the following contributors from the CockroachDB community, especially first-time contributors, Sean Loiselle and Thonakom Sangnetra:
 
-* Thanakom Sangnetra
+- Sean Loiselle
+- Thanakom Sangnetra
+- Paul Steffensen

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -9,7 +9,7 @@ toc: false
 
 - String literals can now be parsed as [`DATE`](date.html), [`TIMESTAMP`](timestamp.html), [`TIMESTAMPTZ`](timestamp.html), or [`INTERVAL`](interval.html) without an explicit cast. [#6925](https://github.com/cockroachdb/cockroach/pull/6925)
 - Floor division is now supported with a new [operator](functions-and-operators.html#operators), `//`. [#6642](https://github.com/cockroachdb/cockroach/pull/6642)
-* Sub-queries are now allowed in `LIMIT`, `OFFSET`, and `RETURNING` expressions. [#6735](https://github.com/cockroachdb/cockroach/pull/6735)
+- Sub-queries are now allowed in `LIMIT`, `OFFSET`, and `RETURNING` expressions. [#6735](https://github.com/cockroachdb/cockroach/pull/6735)
 
 ### Bug Fixes
 

--- a/date.md
+++ b/date.md
@@ -9,9 +9,11 @@ The `DATE` [data type](data-types.html) stores a year, month, and day.
 
 ## Format
 
-When inserting into a `DATE` column, format the value as `DATE '2016-01-25'`. 
+When inserting into a `DATE` column, format the value as `DATE '2016-01-25'`.  
 
-In some contexts, dates may be displayed with hours, minutes, seconds, and timezone set to 0.
+Alternatively, you can use a string literal, e.g., `'2016-01-25'`, which CockroachDB will resolve into the `DATE` type.
+
+Note that in some contexts, dates may be displayed with hours, minutes, seconds, and timezone set to 0.
 
 ## Size
 

--- a/date.md
+++ b/date.md
@@ -9,7 +9,7 @@ The `DATE` [data type](data-types.html) stores a year, month, and day.
 
 ## Format
 
-When inserting into a `DATE` column, format the value as `DATE '2016-01-25'`.  
+When inserting into a `DATE` column, format the value as `DATE '2016-01-25'`.
 
 Alternatively, you can use a string literal, e.g., `'2016-01-25'`, which CockroachDB will resolve into the `DATE` type.
 
@@ -17,7 +17,7 @@ Note that in some contexts, dates may be displayed with hours, minutes, seconds,
 
 ## Size
 
-A `DATE` column supports values up to 8 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata. 
+A `DATE` column supports values up to 8 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
 
 ## Examples
 

--- a/interval.md
+++ b/interval.md
@@ -18,7 +18,9 @@ When inserting into an `INTERVAL` column, format the value as `INTERVAL '2h30m30
 - `us` (microsecond)
 - `ns` (nanosecond)
 
-Regardless of the units used, the interval is stored as hour, minute, and second, for example, `12h2m1.023s`.
+Alternatively, you can use a string literal, e.g., `'2h30m30s'`, which CockroachDB will resolve into the `INTERVAL` type.
+
+Note that regardless of the units used, the interval is stored as hour, minute, and second, for example, `12h2m1.023s`.
 
 ## Size
 

--- a/timestamp.md
+++ b/timestamp.md
@@ -21,7 +21,7 @@ When inserting into a `TIMESTAMP` column, use one of the following formats:
 
 When inserting into a `TIMESTAMPTZ` column (with time zone offset from UTC), use the following format: `TIMESTAMPTZ '2016-01-25 10:10:10.555555-5:00'`
 
-Alternatively, you can cast a string as a timestamp: `CAST('2016-01-25T10:10:10' AS TIMESTAMP)`.
+Alternatively, you can use a string literal, e.g., `'2016-01-25T10:10:10'` or `'2016-01-25 10:10:10.555555-5:00'`, which CockroachDB will resolve into the `TIMESTAMP` or `TIMESTAMPTZ` type.
 
 Note that the fractional portion is optional and is rounded to
 microseconds (6 digits after decimal) for compatibility with the


### PR DESCRIPTION
Added links and doc updates to release notes.

Also update `date`, `timestamp`, and `interval` docs to reflect that you can use string literals. @nvanbenschoten

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/351)
<!-- Reviewable:end -->
