### PR TITLE
SERIAL type

### DIFF
--- a/data-types.md
+++ b/data-types.md
@@ -8,11 +8,11 @@ CockroachDB supports the following data types. Click a type for more details.
 Type | Description | Example
 -----|-------------|--------
 [`INT`](int.html) | A 64-bit signed integer. | `12345`
-[`SERIAL`](serial.html) | A 64-bit signed integer that defaults to a unique value per row. | `148591304110702593 `
+[`SERIAL`](serial.html) | A unique 64-bit signed integer. | `148591304110702593 `
 [`DECIMAL`](decimal.html) | An exact, fixed-point number. | `1.2345`
 [`FLOAT`](float.html) | A 64-bit, inexact, floating-point number. | `1.2345`
 [`BOOL`](bool.html) | A Boolean value. | `true` 
-[`DATE`](date.html) | Year, month, day. | `DATE '2016-01-25'`
+[`DATE`](date.html) | A date. | `DATE '2016-01-25'`
 [`TIMESTAMP`](timestamp.html) | A date and time pairing. | `TIMESTAMP '2016-01-25 10:10:10'`
 [`INTERVAL`](interval.html) | A span of time. | `INTERVAL '2h30m30s'`
 [`STRING`](string.html) | A string of characters. | `'a1b2c3'`

--- a/data-types.md
+++ b/data-types.md
@@ -7,7 +7,8 @@ CockroachDB supports the following data types. Click a type for more details.
 
 Type | Description | Example
 -----|-------------|--------
-[`INT`](int.html) | 64-bit signed integer. | `12345`
+[`INT`](int.html) | A 64-bit signed integer. | `12345`
+[`SERIAL`](serial.html) | A 64-bit signed integer that defaults to a unique value per row. | `148591304110702593 `
 [`DECIMAL`](decimal.html) | An exact, fixed-point number. | `1.2345`
 [`FLOAT`](float.html) | A 64-bit, inexact, floating-point number. | `1.2345`
 [`BOOL`](bool.html) | A Boolean value. | `true` 

--- a/int.md
+++ b/int.md
@@ -5,6 +5,8 @@ toc: false
 
 The `INT` [data type](data-types.html) stores 64-bit signed integers, that is, whole numbers from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807. 
 
+{{site.data.alerts.callout_info}}To auto-generate globally unique integers, use the <a href="serial.html"><code>SERIAL</code></a> data type.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Aliases

--- a/serial.md
+++ b/serial.md
@@ -3,17 +3,19 @@ title: SERIAL
 toc: false
 ---
 
-The `SERIAL` [data type](data-types.html) stores 64-bit signed integers and  defaults to a unique value per row. A `SERIAL` column is therefore the same as an [`INT`](int.html) column with the `unique_rowid()` function as the default. 
-
-The default value for a `SERIAL` column is the combination of the insert timestamp and the ID of the node executing the insert. This combination is guaranteed to be globally unique, and because value generation does not require talking to other nodes, it is much faster than sequentially auto-incrementing a value, which requires distributed coordination.
+The `SERIAL` [data type](data-types.html) defaults to a unique 64-bit signed integer. The default value is the combination of the insert timestamp and the ID of the node executing the insert. This combination is guaranteed to be globally unique. Also, because value generation does not require talking to other nodes, it is much faster than sequentially auto-incrementing a value, which requires distributed coordination.
 
 {{site.data.alerts.callout_info}}This data type is <strong>experimental</strong>. We believe it is a better solution than PostgeSQL's <code>SERIAL</code> and MySQL's <code>AUTO_INCREMENT</code> types, both of which auto-increment integers but not necessarily in a strictly sequential fashion (see the <a href="#auto-incrementing-is-not-always-sequential">Auto-Incrementing Is Not Always Sequential</a> example below). However, if you find that this feature is incompatible with your application, please <a href="https://github.com/cockroachdb/cockroach/issues">open an issue</a> or <a href="https://gitter.im/cockroachdb/cockroach">chat with us on Gitter</a>.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
+## Aliases
+
+The `SERIAL` type is an alias for [`INT DEFAULT unique_rowid()`](int.html).
+
 ## Format
 
-When inserting into an `SERIAL` column, format the value as a numeric literal, e.g.,  `12345`. 
+The `SERIAL` type is generally used to default to a unique ID. When inserting into a `SERIAL` column, you therefore do not manually specify a value. 
 
 ## Size
 
@@ -43,7 +45,7 @@ The [`SHOW COLUMNS`](show-columns.html) statement shows that the `SERIAL` type i
 +-------+------------+-------+----------------+
 ~~~
 
-When we insert 3 rows without column `a` values and return the new rows, we see that each row has defaulted to a unique value in column `a`. 
+When we insert 3 rows without values in column `a` and return the new rows, we see that each row has defaulted to a unique value in column `a`. 
 
 ~~~
 > INSERT INTO serial (b,c) VALUES ('red', true), ('yellow', false), ('pink', true) RETURNING *;
@@ -56,58 +58,40 @@ When we insert 3 rows without column `a` values and return the new rows, we see 
 +--------------------+--------+-------+
 ~~~
 
-Of course, we can explicitly insert an integer value into the `SERIAL` column as long as it meets the unique and non-null constraints.
-
-~~~
-> INSERT INTO serial VALUES (12345, 'orange', false) RETURNING *;
-+--------------------+--------+-------+
-|         a          |   b    |   c   |
-+--------------------+--------+-------+
-|              12345 | orange | false |
-| 148656994422095873 | red    | true  |
-| 148656994422161409 | yellow | false |
-| 148656994422194177 | pink   | true  |
-+--------------------+--------+-------+
-~~~
-
 ### Auto-Incrementing Is Not Always Sequential
 
-Some people assume that the auto-incrementing types in PostgreSQL and MySQL generate strictly sequential values that provide an accurate count of rows in a table. In fact, each insert increases the sequence by one, even when the insert is not commited. This means that these auto-incrementing types may leave gaps in a sequence. 
+It's a common misconception that the auto-incrementing types in PostgreSQL and MySQL generate strictly sequential values. In fact, each insert increases the sequence by one, even when the insert is not commited. This means that auto-incrementing types may leave gaps in a sequence. 
 
-To demonstrate this possibility, we create a table and treat the `INT` column like an auto-incrementing column in PostgreSQL or MySQL. 
+To experience this for yourself, run through the following example in PostgreSQL: 
 
-~~~
-> CREATE TABLE increment (a INT PRIMARY KEY, b TIMESTAMP DEFAULT now());
-CREATE TABLE
-~~~ 
+1. Create a table with a `SERIAL` column.
 
-We then run four transactions for inserting rows. 
+   ~~~
+   CREATE TABLE increment (a SERIAL PRIMARY KEY);
+   ~~~ 
 
-~~~
-> BEGIN; INSERT INTO increment (a) VALUES (1); ROLLBACK;
-ROLLBACK
+2. Run four transactions for inserting rows. 
 
-> BEGIN; INSERT INTO increment (a) VALUES (2); COMMIT;
-COMMIT
+   ~~~
+   BEGIN; INSERT INTO increment DEFAULT VALUES; ROLLBACK;
+   BEGIN; INSERT INTO increment DEFAULT VALUES; COMMIT;
+   BEGIN; INSERT INTO increment DEFAULT VALUES; ROLLBACK;
+   BEGIN; INSERT INTO increment DEFAULT VALUES; COMMIT;
+   ~~~ 
 
-> BEGIN; INSERT INTO increment (a) VALUES (3); ROLLBACK;
-ROLLBACK
+3. View the rows created.
 
-> BEGIN; INSERT INTO increment (a) VALUES (4); COMMIT;
-COMMIT
-~~~ 
+   ~~~
+   SELECT * from increment;
+   +---+
+   | a |
+   +---+
+   | 2 |
+   | 4 |
+   +---+
+   ~~~
 
-Since each insert increases the sequence in column `a` by one, the first commited insert gets the value 2, and the second commited insert gets the value 4. Therefore, as we see in the `SELECT` results below, column `a` values aren't strictly sequential and the last value doesn't give an accurate count of rows in the table.
-
-~~~
-> SELECT * from increment;
-+---+----------------------------------------+
-| a |                   b                    |
-+---+----------------------------------------+
-| 2 | 2016-06-09 03:07:24.051212 +0000 +0000 |
-| 4 | 2016-06-09 03:07:28.563259 +0000 +0000 |
-+---+----------------------------------------+
-~~~
+Since each insert increased the sequence in column `a` by one, the first commited insert got the value `2`, and the second commited insert got the value `4`. As you can see, the values aren't strictly sequential, and the last value doesn't give an accurate count of rows in the table.
 
 ## See Also
 

--- a/serial.md
+++ b/serial.md
@@ -91,7 +91,10 @@ To experience this for yourself, run through the following example in PostgreSQL
    +---+
    ~~~
 
-Since each insert increased the sequence in column `a` by one, the first commited insert got the value `2`, and the second commited insert got the value `4`. As you can see, the values aren't strictly sequential, and the last value doesn't give an accurate count of rows in the table.
+   Since each insert increased the sequence in column `a` by one, the first commited insert got the value `2`, and the second commited insert got the value `4`. As you can see, the values aren't strictly sequential, and the last value doesn't give an accurate count of rows in the table. 
+
+In summary, the `SERIAL` type in PostgreSQL and CockroachDB, and the `AUTO_INCREMENT` type in MySQL, all behave the same in that they do not create strict sequences. CockroachDB will likely create more gaps than these other databases, but will generate these values much faster. 
+
 
 ## See Also
 

--- a/serial.md
+++ b/serial.md
@@ -5,9 +5,9 @@ toc: false
 
 The `SERIAL` [data type](data-types.html) stores 64-bit signed integers and  defaults to a unique value per row. A `SERIAL` column is therefore the same as an [`INT`](int.html) column with the `unique_rowid()` function as the default. 
 
-When inserting into a `SERIAL` column, the default value is the combination of the timestamp and the ID of the node handling the operation. This combination is guaranteed to be globally unique, and because value generation does not require talking to other nodes, it is much faster than sequentially auto-incrementing values, which requires distributed coordination.
+The default value for a `SERIAL` column is the combination of the insert timestamp and the ID of the node executing the insert. This combination is guaranteed to be globally unique, and because value generation does not require talking to other nodes, it is much faster than sequentially auto-incrementing a value, which requires distributed coordination.
 
-{{site.data.alerts.callout_info}}This data type is <strong>experimental</strong>. We believe it is a better solution than PostgeSQL's <code>SERIAL</code> and MySQL's <code>AUTO_INCREMENT</code> types, both of which auto-increment integers but not necessarily in a strictly sequential fashion (see the xxx example below for more details). However, if you find that this feature is incompatible with your application, please file an issue or chat with us on Gitter.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}This data type is <strong>experimental</strong>. We believe it is a better solution than PostgeSQL's <code>SERIAL</code> and MySQL's <code>AUTO_INCREMENT</code> types, both of which auto-increment integers but not necessarily in a strictly sequential fashion (see the <a href="#auto-incrementing-is-not-always-sequential">Auto-Incrementing Is Not Always Sequential</a> example below). However, if you find that this feature is incompatible with your application, please <a href="https://github.com/cockroachdb/cockroach/issues">open an issue</a> or <a href="https://gitter.im/cockroachdb/cockroach">chat with us on Gitter</a>.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -21,26 +21,92 @@ A `SERIAL` column supports values up to 8 bytes in width, but the total storage 
 
 ## Examples
 
+### Use `SERIAL` to Auto-Generate Primary Keys
+
+In this example, we create a table with the `SERIAL` column as the `PRIMARY KEY` so we can auto-generate unique IDs on insert.
+
 ~~~
-CREATE TABLE ints (a INT PRIMARY KEY, b SMALLINT, c INTEGER);
+> CREATE TABLE serial (a SERIAL PRIMARY KEY, b STRING(30), c BOOL);
+CREATE TABLE
+~~~
 
-SHOW COLUMNS FROM ints;
-+-------+------+-------+---------+
-| Field | Type | Null  | Default |
-+-------+------+-------+---------+
-| a     | INT  | false | NULL    |
-| b     | INT  | true  | NULL    |
-| c     | INT  | true  | NULL    |
-+-------+------+-------+---------+
+The [`SHOW COLUMNS`](show-columns.html) statement shows that the `SERIAL` type is just an alias for `INT` with `unique_rowid()` as the default. 
 
-INSERT INTO ints VALUES (11111, 22222, 33333);
+~~~
+> SHOW COLUMNS FROM serial;
++-------+------------+-------+----------------+
+| Field |    Type    | Null  |    Default     |
++-------+------------+-------+----------------+
+| a     | INT        | false | unique_rowid() |
+| b     | STRING(30) | true  | NULL           |
+| c     | BOOL       | true  | NULL           |
++-------+------------+-------+----------------+
+~~~
 
-SELECT * FROM ints;
-+-------+-------+-------+
-|   a   |   b   |   c   |
-+-------+-------+-------+
-| 11111 | 22222 | 33333 |
-+-------+-------+-------+
+When we insert 3 rows without column `a` values and return the new rows, we see that each row has defaulted to a unique value in column `a`. 
+
+~~~
+> INSERT INTO serial (b,c) VALUES ('red', true), ('yellow', false), ('pink', true) RETURNING *;
++--------------------+--------+-------+
+|         a          |   b    |   c   |
++--------------------+--------+-------+
+| 148656994422095873 | red    | true  |
+| 148656994422161409 | yellow | false |
+| 148656994422194177 | pink   | true  |
++--------------------+--------+-------+
+~~~
+
+Of course, we can explicitly insert an integer value into the `SERIAL` column as long as it meets the unique and non-null constraints.
+
+~~~
+> INSERT INTO serial VALUES (12345, 'orange', false) RETURNING *;
++--------------------+--------+-------+
+|         a          |   b    |   c   |
++--------------------+--------+-------+
+|              12345 | orange | false |
+| 148656994422095873 | red    | true  |
+| 148656994422161409 | yellow | false |
+| 148656994422194177 | pink   | true  |
++--------------------+--------+-------+
+~~~
+
+### Auto-Incrementing Is Not Always Sequential
+
+Some people assume that the auto-incrementing types in PostgreSQL and MySQL generate strictly sequential values that provide an accurate count of rows in a table. In fact, each insert increases the sequence by one, even when the insert is not commited. This means that these auto-incrementing types may leave gaps in a sequence. 
+
+To demonstrate this possibility, we create a table and treat the `INT` column like an auto-incrementing column in PostgreSQL or MySQL. 
+
+~~~
+> CREATE TABLE increment (a INT PRIMARY KEY, b TIMESTAMP DEFAULT now());
+CREATE TABLE
+~~~ 
+
+We then run four transactions for inserting rows. 
+
+~~~
+> BEGIN; INSERT INTO increment (a) VALUES (1); ROLLBACK;
+ROLLBACK
+
+> BEGIN; INSERT INTO increment (a) VALUES (2); COMMIT;
+COMMIT
+
+> BEGIN; INSERT INTO increment (a) VALUES (3); ROLLBACK;
+ROLLBACK
+
+> BEGIN; INSERT INTO increment (a) VALUES (4); COMMIT;
+COMMIT
+~~~ 
+
+Since each insert increases the sequence in column `a` by one, the first commited insert gets the value 2, and the second commited insert gets the value 4. Therefore, as we see in the `SELECT` results below, column `a` values aren't strictly sequential and the last value doesn't give an accurate count of rows in the table.
+
+~~~
+> SELECT * from increment;
++---+----------------------------------------+
+| a |                   b                    |
++---+----------------------------------------+
+| 2 | 2016-06-09 03:07:24.051212 +0000 +0000 |
+| 4 | 2016-06-09 03:07:28.563259 +0000 +0000 |
++---+----------------------------------------+
 ~~~
 
 ## See Also

--- a/serial.md
+++ b/serial.md
@@ -1,0 +1,48 @@
+---
+title: SERIAL
+toc: false
+---
+
+The `SERIAL` [data type](data-types.html) stores 64-bit signed integers and  defaults to a unique value per row. A `SERIAL` column is therefore the same as an [`INT`](int.html) column with the `unique_rowid()` function as the default. 
+
+When inserting into a `SERIAL` column, the default value is the combination of the timestamp and the ID of the node handling the operation. This combination is guaranteed to be globally unique, and because value generation does not require talking to other nodes, it is much faster than sequentially auto-incrementing values, which requires distributed coordination.
+
+{{site.data.alerts.callout_info}}This data type is <strong>experimental</strong>. We believe it is a better solution than PostgeSQL's <code>SERIAL</code> and MySQL's <code>AUTO_INCREMENT</code> types, both of which auto-increment integers but not necessarily in a strictly sequential fashion (see the xxx example below for more details). However, if you find that this feature is incompatible with your application, please file an issue or chat with us on Gitter.{{site.data.alerts.end}}
+
+<div id="toc"></div>
+
+## Format
+
+When inserting into an `SERIAL` column, format the value as a numeric literal, e.g.,  `12345`. 
+
+## Size
+
+A `SERIAL` column supports values up to 8 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata. 
+
+## Examples
+
+~~~
+CREATE TABLE ints (a INT PRIMARY KEY, b SMALLINT, c INTEGER);
+
+SHOW COLUMNS FROM ints;
++-------+------+-------+---------+
+| Field | Type | Null  | Default |
++-------+------+-------+---------+
+| a     | INT  | false | NULL    |
+| b     | INT  | true  | NULL    |
+| c     | INT  | true  | NULL    |
++-------+------+-------+---------+
+
+INSERT INTO ints VALUES (11111, 22222, 33333);
+
+SELECT * FROM ints;
++-------+-------+-------+
+|   a   |   b   |   c   |
++-------+-------+-------+
+| 11111 | 22222 | 33333 |
++-------+-------+-------+
+~~~
+
+## See Also
+
+[Data Types](data-types.html)


### PR DESCRIPTION
Adding docs for the new `SERIAL` type. Fixes #356.

HTML version: http://cockroach-draft-docs.s3-website-us-east-1.amazonaws.com/serial.html

@paperstreet, @petermattis, not sure if the last example is clear enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/362)
<!-- Reviewable:end -->
