### PR TITLE
Small typo in float doc example

### DIFF
--- a/float.md
+++ b/float.md
@@ -50,7 +50,7 @@ SELECT * FROM floats;
 +----------------+--------------------+------+
 | 1.012345678901 | 2.0123456789012346 | +Inf |
 +----------------+--------------------+------+
-# Note that the value in "a" has been limited to 17 digits.
+# Note that the value in "b" has been limited to 17 digits.
 ~~~
 
 ## See Also


### PR DESCRIPTION
typo in SELECT * FROM floats example, said value in column `a` was rounded when it was actually column `b`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/370)
<!-- Reviewable:end -->
