### PR TITLE
Various doc updates related to character support

### DIFF
--- a/data-types.md
+++ b/data-types.md
@@ -15,5 +15,5 @@ Type | Description | Example
 [`DATE`](date.html) | A date. | `DATE '2016-01-25'`
 [`TIMESTAMP`](timestamp.html) | A date and time pairing. | `TIMESTAMP '2016-01-25 10:10:10'`
 [`INTERVAL`](interval.html) | A span of time. | `INTERVAL '2h30m30s'`
-[`STRING`](string.html) | A string of characters. | `'a1b2c3'`
+[`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'`
 [`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'`

--- a/identifiers.md
+++ b/identifiers.md
@@ -5,11 +5,11 @@ toc: false
 
 When naming a database, table, column, or other object, the identifier you use must follow these rules:
 
-- Must begin with a letter (a-z, but also letters with diacritical marks and non-Latin letters) or an underscore (_). Subsequent characters can be letters, underscores, digits (0-9), or dollar signs ($).
-- Must not be a [reserved keyword](sql-grammar.html#reserved_keyword). This rule does not apply to column names.
-- Must be unique within its context. For example, you cannot have two identically-named databases in a cluster or two identically-named columns in a single table. 
+1. Must begin with a UNICODE letter or an underscore (_). Subsequent characters can be letters, underscores, digits (0-9), or dollar signs ($).
+2. Must not be a [reserved keyword](sql-grammar.html#reserved_keyword). This rule does not apply to column names.
+3. Must be unique within its context. For example, you cannot have two identically-named databases in a cluster or two identically-named columns in a single table. 
 
-To bypass either of the first two rules, simply surround the identifier with double-quotes.
+To include characters not permitted by the first two rules, simply surround the identifier with double quotes.
 
 ## See Also
 

--- a/identifiers.md
+++ b/identifiers.md
@@ -5,7 +5,7 @@ toc: false
 
 When naming a database, table, column, or other object, the identifier you use must follow these rules:
 
-1. Must begin with a UNICODE letter or an underscore (_). Subsequent characters can be letters, underscores, digits (0-9), or dollar signs ($).
+1. Must begin with a Unicode letter or an underscore (_). Subsequent characters can be letters, underscores, digits (0-9), or dollar signs ($).
 2. Must not be a [reserved keyword](sql-grammar.html#reserved_keyword). This rule does not apply to column names.
 3. Must be unique within its context. For example, you cannot have two identically-named databases in a cluster or two identically-named columns in a single table. 
 

--- a/string.md
+++ b/string.md
@@ -3,7 +3,7 @@ title: STRING
 toc: false
 ---
 
-The `STRING` [data type](data-types.html) stores a string of characters.
+The `STRING` [data type](data-types.html) stores a string of Unicode characters.
 
 <div id="toc"></div>
 
@@ -36,7 +36,30 @@ When inserting a string:
 
 ## Format
 
-When inserting into a `STRING` column, format the value as `'a1b2c3'`.
+A `STRING` column accepts both string literals and escape strings. 
+
+### String Literal
+
+When inserting a string literal into a `STRING` column, format the value as Unicode characters within single quotes, e.g., `'a1b2c3'`.
+
+### Escape String
+
+When inserting an escape string into a `STRING` column, use either `e` or `E` and followed by one or more of the following backslash escape sequences within single quotes:   
+
+Backslash Escape Sequence | Interpretation
+--------------------------|---------------
+`\b` | backspace
+`\f` | form feed
+`\n` | newline
+`\r` | carriage return
+`\t` | tab
+`\xHH` | hexadecimal byte value
+`\ooo` | octal byte value
+`\uXXXX` | 16-bit hexadecimal Unicode character value
+
+For example, the `e'x61\141\u0061'` escape string represents the hexadecimal byte, octal byte, and 16-bit hexadecimal Unicode character values equivalent to the `'aaa'` string literal. 
+
+Note that any character not in the table above is taken literally in an escape string. Also, when continuing an escape string across lines, write `e` or `E` only before the first opening quote.
 
 ## Size
 

--- a/string.md
+++ b/string.md
@@ -56,6 +56,7 @@ Backslash Escape Sequence | Interpretation
 `\xHH` | hexadecimal byte value
 `\ooo` | octal byte value
 `\uXXXX` | 16-bit hexadecimal Unicode character value
+`\UXXXXXXXX` | 32-bit hexadecimal Unicode character value
 
 For example, the `e'x61\141\u0061'` escape string represents the hexadecimal byte, octal byte, and 16-bit hexadecimal Unicode character values equivalent to the `'aaa'` string literal. 
 

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -41,7 +41,7 @@ Flag | Description
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
 `--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
 `--port`<br>`-p` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
-`--pretty` | When this flag is used in conjunction with `--execute`, table rows printed to the standard output are formatted using ASCII art and look the same as within the interactive SQL shell. Also, special characters are printed unescaped.<br><br>When `--execute` is used without the `--pretty` flag, table rows are printed as tab-separated values, and special characters are escaped.
+`--pretty` | When this flag is used in conjunction with `--execute`, table rows printed to the standard output are formatted using ASCII art and look the same as within the interactive SQL shell. Also, special characters are printed unescaped.<br><br>When `--execute` is used without the `--pretty` flag, table rows are printed as tab-separated values, and special characters are escaped. This makes the output easy to parse by other programs.
 `--url` | The connection URL. If you use this flag, do not set any other connection flags.<br><br>For insecure connections, the URL format is: <br>`--url=postgresql://<user>@<host>:<port>/<database>?sslmode=disable`<br><br>For secure connections, the URL format is:<br>`--url=postgresql://<user>@<host>:<port>/<database>`<br>with the following parameters in the query string:<br>`sslcert=<path-to-client-crt>`<br>`sslkey=<path-to-client-key>`<br>`sslmode=verify-full`<br>`sslrootcert=<path-to-ca-crt>` <br><br>**Env Variable:** `COCKROACH_URL`
 `--user`<br>`-u` | The user connecting to the database. The user must have [privileges](privileges.html) for any statement executed.<br><br>**Env Variable:** `COCKROACH_USER`<br>**Default:** `root`
 
@@ -135,7 +135,7 @@ $ echo "SHOW TABLES; SELECT * FROM roaches;" | ./cockroach sql --user=maxroach -
 +-----------------------+---------------+
 ~~~
 
-In these examples, we show tables and special characters printed with and without the `--pretty` flag.
+In these examples, we show tables and special characters printed with and without the `--pretty` flag. Note that when not using `--pretty`, table rows are printed as tab-separated values, and special characters are escaped; thus, the output is easy to parse by other programs.
 
 ~~~ shell
 # Using the --pretty flag in conjunction with --execute:

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -82,7 +82,7 @@ $ ./cockroach sql --url=postgresql://maxroach@roachnode1.com:26257/critterdb?ssl
 
 ### Execute SQL statement within the SQL shell
 
-This examples assume that we have already started the SQL shell (see examples above).
+This example assume that we have already started the SQL shell (see examples above).
 
 ~~~ shell
 > CREATE TABLE animals (id SERIAL PRIMARY KEY, name STRING);

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -58,24 +58,47 @@ Command | Usage
 
 ## Examples
 
-### Start a SQL shell using standard connection flags
+### Start a SQL shell
+
+In these examples, we connect a SQL shell to a **secure cluster**.
 
 ~~~ shell
-# Secure:
+# Using standard connection flags:
 $ ./cockroach sql --ca-cert=certs/ca.cert --cert=certs/maxroach.cert --key=certs/maxroach.key --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb 
 
-# Insecure:
-$ ./cockroach sql --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb 
+# Using the --url flag:
+$ ./cockroach sql --url=postgresql://maxroach@roachcluster.com:26257/critterdb?sslcert=certs/maxroach.crt&sslkey=certs/maxroach.key&sslmode=verify-full&sslrootcert=certs/ca.crt 
 ~~~
 
-### Start a SQL shell using the `--url` flag
+In these examples, we connect a SQL shell to an **insecure cluster**.
 
 ~~~ shell
-# Secure:
-$ ./cockroach sql --url=postgresql://maxroach@roachcluster.com:26257/critterdb?sslcert=certs/maxroach.crt&sslkey=certs/maxroach.key&sslmode=verify-full&sslrootcert=certs/ca.crt 
+# Using standard connection flags:
+$ ./cockroach sql --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb 
 
-# Insecure:
+# Using the --url flag:
 $ ./cockroach sql --url=postgresql://maxroach@roachnode1.com:26257/critterdb?sslmode=disable 
+~~~
+
+### Execute SQL statement within the SQL shell
+
+This examples assume that we have already started the SQL shell (see examples above).
+
+~~~ shell
+> CREATE TABLE animals (id SERIAL PRIMARY KEY, name STRING);
+CREATE TABLE
+
+> INSERT INTO animals (name) VALUES ('bobcat'), ('🐢 '), ('barn owl');
+INSERT 3
+
+> SELECT * FROM animals;
++--------------------+----------+
+|         id         |   name   |
++--------------------+----------+
+| 148899952591994881 | bobcat   |
+| 148899952592060417 | 🐢        |
+| 148899952592093185 | barn owl |
++--------------------+----------+
 ~~~
 
 ### Execute SQL statements from the command line

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -36,11 +36,12 @@ Flag | Description
 `--ca-cert` | The path to the [CA certificate](create-security-certificates.html). This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_CA_CERT` 
 `--cert` | The path to the [client certificate](create-security-certificates.html). This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_CERT`
 `--database`<br>`-d` | The database to connect to.<br><br>**Env Variable:** `COCKROACH_DATABASE`  
-`--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each SQL statement are printed to the standard output.<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [examples](#execute-sql-statements-from-the-command-line) below. 
+`--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--pretty` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [examples](#execute-sql-statements-from-the-command-line) below. 
 `--host` | The server host to connect to. This can be the address of any node in the cluster. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** localhost
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
 `--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
 `--port`<br>`-p` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
+`--pretty` | When this flag is used in conjunction with `--execute`, table rows printed to the standard output are formatted using ASCII art and look the same as within the interactive SQL shell. Also, special characters are printed unescaped.<br><br>When `--execute` is used without the `--pretty` flag, table rows are printed as tab-separated values, and special characters are escaped.
 `--url` | The connection URL. If you use this flag, do not set any other connection flags.<br><br>For insecure connections, the URL format is: <br>`--url=postgresql://<user>@<host>:<port>/<database>?sslmode=disable`<br><br>For secure connections, the URL format is:<br>`--url=postgresql://<user>@<host>:<port>/<database>`<br>with the following parameters in the query string:<br>`sslcert=<path-to-client-crt>`<br>`sslkey=<path-to-client-key>`<br>`sslmode=verify-full`<br>`sslrootcert=<path-to-ca-crt>` <br><br>**Env Variable:** `COCKROACH_URL`
 `--user`<br>`-u` | The user connecting to the database. The user must have [privileges](privileges.html) for any statement executed.<br><br>**Env Variable:** `COCKROACH_USER`<br>**Default:** `root`
 
@@ -79,6 +80,8 @@ $ ./cockroach sql --url=postgresql://maxroach@roachnode1.com:26257/critterdb?ssl
 
 ### Execute SQL statements from the command line
 
+In these examples, we use the `--execute` flag to execute statements from the command line.
+
 ~~~ shell
 # Statements with a single --execute flag:
 $ ./cockroach sql --execute="CREATE TABLE roaches (name STRING, country STRING); INSERT INTO roaches VALUES ('American Cockroach', 'United States'), ('Brownbanded Cockroach', 'United States')" --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb
@@ -89,16 +92,11 @@ INSERT 2
 $ ./cockroach sql --execute="CREATE TABLE roaches (name STRING, country STRING)" --execute="INSERT INTO roaches VALUES ('American Cockroach', 'United States'), ('Brownbanded Cockroach', 'United States')" --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb   
 CREATE TABLE
 INSERT 2
+~~~
 
-# Statements from a file:
-$ cat statements.sql
-CREATE TABLE roaches (name STRING, country STRING);
-INSERT INTO roaches VALUES ('American Cockroach', 'United States'), ('Brownbanded Cockroach', 'United States');
+In this example, we use the `echo` command to execute statements from the command line.
 
-$ ./cockroach sql --user=maxroach --host=roachcluster.com ---port=26257 --database=critterdb < statements.sql
-CREATE TABLE
-INSERT 2
-
+~~~ shell
 # Statements with the echo command:
 $ echo "SHOW TABLES; SELECT * FROM roaches;" | ./cockroach sql --user=maxroach --host=roachcluster.com --port=26257 --database=critterdb
 +----------+
@@ -112,6 +110,40 @@ $ echo "SHOW TABLES; SELECT * FROM roaches;" | ./cockroach sql --user=maxroach -
 | American Cockroach    | United States |
 | Brownbanded Cockroach | United States |
 +-----------------------+---------------+
+~~~
+
+In these examples, we show tables and special characters printed with and without the `--pretty` flag.
+
+~~~ shell
+# Using the --pretty flag in conjunction with --execute:
+$ cockroach sql --pretty --execute="INSERT INTO emojis VALUES ('🐥 '), ('🐢 ') RETURNING *;"
++----+
+| a  |
++----+
+| 🐥  |
+| 🐢  |
++----+
+
+# Using --execute without the --pretty flag:
+$ ./cockroach sql --execute="INSERT INTO emojis VALUES ('🐥 '), ('🐢 ') RETURNING *;"
+2 rows
+a
+"\U0001f425 "
+"\U0001f422 "
+~~~
+
+### Execute SQL statements from a file
+
+In this example, we show and then execute the contents of a file containing SQL statements.
+
+~~~ shell
+$ cat statements.sql
+CREATE TABLE roaches (name STRING, country STRING);
+INSERT INTO roaches VALUES ('American Cockroach', 'United States'), ('Brownbanded Cockroach', 'United States');
+
+$ ./cockroach sql --user=maxroach --host=roachcluster.com ---port=26257 --database=critterdb < statements.sql
+CREATE TABLE
+INSERT 2
 ~~~
 
 ### Run external commands from the SQL shell


### PR DESCRIPTION
- In `identifiers.md`, updated limitations.
- In `strings.md`, documented escape strings.
- In `use-the-built-in-sql-cliend.md`, documented `--pretty` flag for executing SQL from the command line. Also restructured the examples a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/373)
<!-- Reviewable:end -->
