### PR TITLE
SERIAL aliases

### DIFF
--- a/serial.md
+++ b/serial.md
@@ -11,7 +11,12 @@ The `SERIAL` [data type](data-types.html) defaults to a unique 64-bit signed int
 
 ## Aliases
 
-The `SERIAL` type is an alias for [`INT DEFAULT unique_rowid()`](int.html).
+In CockroachDB, the following are aliases for `SERIAL`:
+
+- `SMALLSERIAL`
+- `BIGSERIAL`
+
+Also, note that `SERIAL` is equivalent to [`INT DEFAULT unique_rowid()`](int.html).
 
 ## Format
 

--- a/serial.md
+++ b/serial.md
@@ -11,12 +11,12 @@ The `SERIAL` [data type](data-types.html) defaults to a unique 64-bit signed int
 
 ## Aliases
 
+The `SERIAL` type is equivalent to [`INT DEFAULT unique_rowid()`](int.html).
+
 In CockroachDB, the following are aliases for `SERIAL`:
 
 - `SMALLSERIAL`
 - `BIGSERIAL`
-
-Also, note that `SERIAL` is equivalent to [`INT DEFAULT unique_rowid()`](int.html).
 
 ## Format
 


### PR DESCRIPTION
Added `BIGSERIAL` and `SMALLSERIAL` as aliases for `SERIAL`.

Based on https://github.com/cockroachdb/cockroach/pull/7187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/378)
<!-- Reviewable:end -->
