### PR TITLE
use self-categorized functions

### DIFF
--- a/_includes/sql/aggregates.md
+++ b/_includes/sql/aggregates.md
@@ -1,87 +1,92 @@
-### bool Functions
+### BOOL Functions
 
 Function | Return
 --- | ---
 bool_and([bool](bool.html)) | [bool](bool.html)
 bool_or([bool](bool.html)) | [bool](bool.html)
+count([bool](bool.html)) | [int](int.html)
 max([bool](bool.html)) | [bool](bool.html)
 min([bool](bool.html)) | [bool](bool.html)
 
-### bytes Functions
+### BYTES Functions
 
 Function | Return
 --- | ---
+count([bytes](bytes.html)) | [int](int.html)
 max([bytes](bytes.html)) | [bytes](bytes.html)
 min([bytes](bytes.html)) | [bytes](bytes.html)
 
-### date Functions
+### DATE Functions
 
 Function | Return
 --- | ---
+count([date](date.html)) | [int](int.html)
 max([date](date.html)) | [date](date.html)
 min([date](date.html)) | [date](date.html)
 
-### decimal Functions
+### DECIMAL Functions
 
 Function | Return
 --- | ---
 avg([decimal](decimal.html)) | [decimal](decimal.html)
-avg([int](int.html)) | [decimal](decimal.html)
+count([decimal](decimal.html)) | [int](int.html)
 max([decimal](decimal.html)) | [decimal](decimal.html)
 min([decimal](decimal.html)) | [decimal](decimal.html)
 stddev([decimal](decimal.html)) | [decimal](decimal.html)
-stddev([int](int.html)) | [decimal](decimal.html)
 sum([decimal](decimal.html)) | [decimal](decimal.html)
-sum([int](int.html)) | [decimal](decimal.html)
 variance([decimal](decimal.html)) | [decimal](decimal.html)
-variance([int](int.html)) | [decimal](decimal.html)
 
-### float Functions
+### FLOAT Functions
 
 Function | Return
 --- | ---
 avg([float](float.html)) | [float](float.html)
+count([float](float.html)) | [int](int.html)
 max([float](float.html)) | [float](float.html)
 min([float](float.html)) | [float](float.html)
 stddev([float](float.html)) | [float](float.html)
 sum([float](float.html)) | [float](float.html)
 variance([float](float.html)) | [float](float.html)
 
-### int Functions
+### INT Functions
 
 Function | Return
 --- | ---
-count([bool](bool.html)) | [int](int.html)
-count([bytes](bytes.html)) | [int](int.html)
-count([date](date.html)) | [int](int.html)
-count([decimal](decimal.html)) | [int](int.html)
-count([float](float.html)) | [int](int.html)
+avg([int](int.html)) | [decimal](decimal.html)
 count([int](int.html)) | [int](int.html)
-count([interval](interval.html)) | [int](int.html)
-count([string](string.html)) | [int](int.html)
-count([timestamp](timestamp.html)) | [int](int.html)
-count(tuple) | [int](int.html)
 max([int](int.html)) | [int](int.html)
 min([int](int.html)) | [int](int.html)
+stddev([int](int.html)) | [decimal](decimal.html)
+sum([int](int.html)) | [decimal](decimal.html)
+variance([int](int.html)) | [decimal](decimal.html)
 
-### interval Functions
+### INTERVAL Functions
 
 Function | Return
 --- | ---
+count([interval](interval.html)) | [int](int.html)
 max([interval](interval.html)) | [interval](interval.html)
 min([interval](interval.html)) | [interval](interval.html)
 
-### string Functions
+### STRING Functions
 
 Function | Return
 --- | ---
+count([string](string.html)) | [int](int.html)
 max([string](string.html)) | [string](string.html)
 min([string](string.html)) | [string](string.html)
 
-### timestamp Functions
+### TIMESTAMP Functions
 
 Function | Return
 --- | ---
+count([timestamp](timestamp.html)) | [int](int.html)
 max([timestamp](timestamp.html)) | [timestamp](timestamp.html)
 min([timestamp](timestamp.html)) | [timestamp](timestamp.html)
+
+### TUPLE Functions
+
+Function | Return
+--- | ---
+count(tuple) | [int](int.html)
 

--- a/_includes/sql/functions.md
+++ b/_includes/sql/functions.md
@@ -1,27 +1,19 @@
-### T Functions
+### BYTES Functions
 
 Function | Return
 --- | ---
-greatest(T, ...) | T
-least(T, ...) | T
-
-### bytes Functions
-
-Function | Return
---- | ---
-experimental_unique_bytes() | [bytes](bytes.html)
-experimental_uuid_v4() | [bytes](bytes.html)
 left([bytes](bytes.html), [int](int.html)) | [bytes](bytes.html)
+length([bytes](bytes.html)) | [int](int.html)
+octet_length([bytes](bytes.html)) | [int](int.html)
 right([bytes](bytes.html), [int](int.html)) | [bytes](bytes.html)
-uuid_v4() | [bytes](bytes.html)
 
-### date Functions
+### DATE Functions
 
 Function | Return
 --- | ---
 current_date() | [date](date.html)
 
-### decimal Functions
+### DECIMAL Functions
 
 Function | Return
 --- | ---
@@ -44,7 +36,7 @@ sign([decimal](decimal.html)) | [decimal](decimal.html)
 sqrt([decimal](decimal.html)) | [decimal](decimal.html)
 trunc([decimal](decimal.html)) | [decimal](decimal.html)
 
-### float Functions
+### FLOAT Functions
 
 Function | Return
 --- | ---
@@ -78,46 +70,52 @@ sqrt([float](float.html)) | [float](float.html)
 tan([float](float.html)) | [float](float.html)
 trunc([float](float.html)) | [float](float.html)
 
-### int Functions
+### ID Generation Functions
+
+Function | Return
+--- | ---
+experimental_unique_bytes() | [bytes](bytes.html)
+experimental_uuid_v4() | [bytes](bytes.html)
+unique_rowid() | [int](int.html)
+uuid_v4() | [bytes](bytes.html)
+
+### INT Functions
 
 Function | Return
 --- | ---
 abs([int](int.html)) | [int](int.html)
-ascii([string](string.html)) | [int](int.html)
 extract([string](string.html), [timestamp](timestamp.html)) | [int](int.html)
-length([bytes](bytes.html)) | [int](int.html)
-length([string](string.html)) | [int](int.html)
 mod([int](int.html), [int](int.html)) | [int](int.html)
-octet_length([bytes](bytes.html)) | [int](int.html)
-octet_length([string](string.html)) | [int](int.html)
 sign([int](int.html)) | [int](int.html)
 strpos([string](string.html), [string](string.html)) | [int](int.html)
-unique_rowid() | [int](int.html)
+to_hex([int](int.html)) | [string](string.html)
 
-### interval Functions
+### INTERVAL Functions
 
 Function | Return
 --- | ---
-age([timestamp](timestamp.html)) | [interval](interval.html)
 age([timestamp](timestamp.html), [timestamp](timestamp.html)) | [interval](interval.html)
 
-### string Functions
+### STRING Functions
 
 Function | Return
 --- | ---
+ascii([string](string.html)) | [int](int.html)
 btrim([string](string.html)) | [string](string.html)
 btrim([string](string.html), [string](string.html)) | [string](string.html)
 concat(string, ...) | [string](string.html)
 concat_ws(string, ...) | [string](string.html)
-format_timestamp_ns([timestamp](timestamp.html)) | [string](string.html)
 initcap([string](string.html)) | [string](string.html)
 left([string](string.html), [int](int.html)) | [string](string.html)
+length([string](string.html)) | [int](int.html)
 lower([string](string.html)) | [string](string.html)
 ltrim([string](string.html)) | [string](string.html)
 ltrim([string](string.html), [string](string.html)) | [string](string.html)
 md5([string](string.html)) | [string](string.html)
+octet_length([string](string.html)) | [int](int.html)
 overlay([string](string.html), [string](string.html), [int](int.html)) | [string](string.html)
 overlay([string](string.html), [string](string.html), [int](int.html), [int](int.html)) | [string](string.html)
+parse_timestamp_ns([string](string.html)) | [timestamp](timestamp.html)
 regexp_extract([string](string.html), [string](string.html)) | [string](string.html)
 regexp_replace([string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
 regexp_replace([string](string.html), [string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
@@ -138,20 +136,32 @@ substring([string](string.html), [int](int.html)) | [string](string.html)
 substring([string](string.html), [int](int.html), [int](int.html)) | [string](string.html)
 substring([string](string.html), [string](string.html)) | [string](string.html)
 substring([string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
-to_hex([int](int.html)) | [string](string.html)
 translate([string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
 upper([string](string.html)) | [string](string.html)
-version() | [string](string.html)
 
-### timestamp Functions
+### System Info Functions
 
 Function | Return
 --- | ---
+version() | [string](string.html)
+
+### T Functions
+
+Function | Return
+--- | ---
+greatest(T, ...) | T
+least(T, ...) | T
+
+### TIMESTAMP Functions
+
+Function | Return
+--- | ---
+age([timestamp](timestamp.html)) | [interval](interval.html)
 clock_timestamp() | [timestamp](timestamp.html)
 current_timestamp() | [timestamp](timestamp.html)
 current_timestamp_ns() | [timestamp](timestamp.html)
+format_timestamp_ns([timestamp](timestamp.html)) | [string](string.html)
 now() | [timestamp](timestamp.html)
-parse_timestamp_ns([string](string.html)) | [timestamp](timestamp.html)
 statement_timestamp() | [timestamp](timestamp.html)
 transaction_timestamp() | [timestamp](timestamp.html)
 

--- a/generate/funcs.go
+++ b/generate/funcs.go
@@ -163,8 +163,12 @@ func GenerateFunctions(from map[string][]parser.Builtin) []byte {
 				fp = reflect.ValueOf(fn.ReturnType).Pointer()
 				ret = typePtrs[fp]
 			}
+			cat := ret
+			if c := fn.Category(); c != "" {
+				cat = c
+			}
 			s := fmt.Sprintf("%s(%s) | %s", name, args, linkType(ret))
-			functions[ret] = append(functions[ret], s)
+			functions[cat] = append(functions[cat], s)
 		}
 	}
 	var rets []string


### PR DESCRIPTION
use the new Category method on parser.Builtin to categorize functions rather than the return type

In practice this means that most functions are categorized by their argument type or return type
but a couple examples of manual categorization (ID Generation and System Info) show what else
is possible

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/387)
<!-- Reviewable:end -->
