### PR TITLE
hexidecimal string and numeric literals

### DIFF
--- a/int.md
+++ b/int.md
@@ -20,7 +20,15 @@ In CockroachDB, the following are aliases for `INT`:
 
 ## Format
 
-When inserting into an `INT` column, format the value as `12345`.
+An `INT` column accepts Unicode numeric literals and hexadecimal numeric literals.
+
+### Unicode Numeric Literal
+
+When inserting a Unicode numeric literal into an `INT` column, format the value as `12345`.
+
+### Hexadecimal Numeric Literal
+
+When inserting a hexadecimal numeric literal into a `INT` column, use hexadecimal digits preceded by `0x`. For example, `0xcafe1111` corresponds to the Unicode numeric literal `3405648145`.
 
 ## Size
 

--- a/int.md
+++ b/int.md
@@ -20,15 +20,15 @@ In CockroachDB, the following are aliases for `INT`:
 
 ## Format
 
-An `INT` column accepts Unicode numeric literals and hexadecimal numeric literals.
+An `INT` column accepts numeric literals and hexadecimal-encoded numeric literals.
 
-### Unicode Numeric Literal
+### Numeric Literal
 
-When inserting a Unicode numeric literal into an `INT` column, format the value as `12345`.
+When inserting a numeric literal into an `INT` column, format the value as `12345`.
 
-### Hexadecimal Numeric Literal
+### Hexadecimal-Encoded Numeric Literal
 
-When inserting a hexadecimal numeric literal into a `INT` column, use hexadecimal digits preceded by `0x`. For example, `0xcafe1111` corresponds to the Unicode numeric literal `3405648145`.
+When inserting a hexadecimal-encoded numeric literal into a `INT` column, format the value as hexadecimal digits preceded by `0x`. For example, `0xcafe1111` corresponds to the numeric literal `3405648145`.
 
 ## Size
 

--- a/string.md
+++ b/string.md
@@ -38,17 +38,17 @@ When inserting a string:
 
 A `STRING` column accepts Unicode string literals, hexadecimal string literals, and escape strings. 
 
-### Unicode String Literal
+### String Literal
 
-When inserting a Unicode string literal into a `STRING` column, format the value as Unicode characters within single quotes, e.g., `'a1b2c3'`.
+When inserting a string literal into a `STRING` column, format the value as Unicode characters within single quotes, e.g., `'a1b2c3'`.
 
-### Hexadecimal String Literal
+### Hexadecimal-Encoded String Literal
 
-When inserting a hexadecimal string literal into a `STRING` column, use `x` or `X` followed by hexadecimal digits in single quotes. For example, `x'636174'` or `X'636174'` correspond to the Unicode string literal `'cat'`.
+When inserting a hexadecimal-encoded string literal into a `STRING` column, format the value as `x` or `X` followed by hexadecimal digits in single quotes. For example, `x'636174'` or `X'636174'` correspond to the Unicode string literal `'cat'`.
 
 ### Escape String
 
-When inserting an escape string into a `STRING` column, use either `e` or `E` followed by one or more of the following backslash escape sequences within single quotes:   
+When inserting an escape string into a `STRING` column, format the value as `e` or `E` followed by one or more of the following backslash escape sequences within single quotes:   
 
 Backslash Escape Sequence | Interpretation
 --------------------------|---------------

--- a/string.md
+++ b/string.md
@@ -36,15 +36,19 @@ When inserting a string:
 
 ## Format
 
-A `STRING` column accepts both string literals and escape strings. 
+A `STRING` column accepts Unicode string literals, hexadecimal string literals, and escape strings. 
 
-### String Literal
+### Unicode String Literal
 
-When inserting a string literal into a `STRING` column, format the value as Unicode characters within single quotes, e.g., `'a1b2c3'`.
+When inserting a Unicode string literal into a `STRING` column, format the value as Unicode characters within single quotes, e.g., `'a1b2c3'`.
+
+### Hexadecimal String Literal
+
+When inserting a hexadecimal string literal into a `STRING` column, use `x` or `X` followed by hexadecimal digits in single quotes. For example, `x'636174'` or `X'636174'` correspond to the Unicode string literal `'cat'`.
 
 ### Escape String
 
-When inserting an escape string into a `STRING` column, use either `e` or `E` and followed by one or more of the following backslash escape sequences within single quotes:   
+When inserting an escape string into a `STRING` column, use either `e` or `E` followed by one or more of the following backslash escape sequences within single quotes:   
 
 Backslash Escape Sequence | Interpretation
 --------------------------|---------------


### PR DESCRIPTION
Adding hexadecimal string literal format to `STRING` type docs and hexadecimal numeric literal format to `INT` type docs.

Fixes #377

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/392)
<!-- Reviewable:end -->
