### PR TITLE
more function categorization

### DIFF
--- a/_includes/sql/aggregates.md
+++ b/_includes/sql/aggregates.md
@@ -1,92 +1,45 @@
-### BOOL Functions
-
-Function | Return
---- | ---
-bool_and([bool](bool.html)) | [bool](bool.html)
-bool_or([bool](bool.html)) | [bool](bool.html)
-count([bool](bool.html)) | [int](int.html)
-max([bool](bool.html)) | [bool](bool.html)
-min([bool](bool.html)) | [bool](bool.html)
-
-### BYTES Functions
-
-Function | Return
---- | ---
-count([bytes](bytes.html)) | [int](int.html)
-max([bytes](bytes.html)) | [bytes](bytes.html)
-min([bytes](bytes.html)) | [bytes](bytes.html)
-
-### DATE Functions
-
-Function | Return
---- | ---
-count([date](date.html)) | [int](int.html)
-max([date](date.html)) | [date](date.html)
-min([date](date.html)) | [date](date.html)
-
-### DECIMAL Functions
-
 Function | Return
 --- | ---
 avg([decimal](decimal.html)) | [decimal](decimal.html)
-count([decimal](decimal.html)) | [int](int.html)
-max([decimal](decimal.html)) | [decimal](decimal.html)
-min([decimal](decimal.html)) | [decimal](decimal.html)
-stddev([decimal](decimal.html)) | [decimal](decimal.html)
-sum([decimal](decimal.html)) | [decimal](decimal.html)
-variance([decimal](decimal.html)) | [decimal](decimal.html)
-
-### FLOAT Functions
-
-Function | Return
---- | ---
 avg([float](float.html)) | [float](float.html)
-count([float](float.html)) | [int](int.html)
-max([float](float.html)) | [float](float.html)
-min([float](float.html)) | [float](float.html)
-stddev([float](float.html)) | [float](float.html)
-sum([float](float.html)) | [float](float.html)
-variance([float](float.html)) | [float](float.html)
-
-### INT Functions
-
-Function | Return
---- | ---
 avg([int](int.html)) | [decimal](decimal.html)
+bool_and([bool](bool.html)) | [bool](bool.html)
+bool_or([bool](bool.html)) | [bool](bool.html)
+count([bool](bool.html)) | [int](int.html)
+count([bytes](bytes.html)) | [int](int.html)
+count([date](date.html)) | [int](int.html)
+count([decimal](decimal.html)) | [int](int.html)
+count([float](float.html)) | [int](int.html)
 count([int](int.html)) | [int](int.html)
-max([int](int.html)) | [int](int.html)
-min([int](int.html)) | [int](int.html)
-stddev([int](int.html)) | [decimal](decimal.html)
-sum([int](int.html)) | [decimal](decimal.html)
-variance([int](int.html)) | [decimal](decimal.html)
-
-### INTERVAL Functions
-
-Function | Return
---- | ---
 count([interval](interval.html)) | [int](int.html)
-max([interval](interval.html)) | [interval](interval.html)
-min([interval](interval.html)) | [interval](interval.html)
-
-### STRING Functions
-
-Function | Return
---- | ---
 count([string](string.html)) | [int](int.html)
-max([string](string.html)) | [string](string.html)
-min([string](string.html)) | [string](string.html)
-
-### TIMESTAMP Functions
-
-Function | Return
---- | ---
 count([timestamp](timestamp.html)) | [int](int.html)
-max([timestamp](timestamp.html)) | [timestamp](timestamp.html)
-min([timestamp](timestamp.html)) | [timestamp](timestamp.html)
-
-### TUPLE Functions
-
-Function | Return
---- | ---
 count(tuple) | [int](int.html)
+max([bool](bool.html)) | [bool](bool.html)
+max([bytes](bytes.html)) | [bytes](bytes.html)
+max([date](date.html)) | [date](date.html)
+max([decimal](decimal.html)) | [decimal](decimal.html)
+max([float](float.html)) | [float](float.html)
+max([int](int.html)) | [int](int.html)
+max([interval](interval.html)) | [interval](interval.html)
+max([string](string.html)) | [string](string.html)
+max([timestamp](timestamp.html)) | [timestamp](timestamp.html)
+min([bool](bool.html)) | [bool](bool.html)
+min([bytes](bytes.html)) | [bytes](bytes.html)
+min([date](date.html)) | [date](date.html)
+min([decimal](decimal.html)) | [decimal](decimal.html)
+min([float](float.html)) | [float](float.html)
+min([int](int.html)) | [int](int.html)
+min([interval](interval.html)) | [interval](interval.html)
+min([string](string.html)) | [string](string.html)
+min([timestamp](timestamp.html)) | [timestamp](timestamp.html)
+stddev([decimal](decimal.html)) | [decimal](decimal.html)
+stddev([float](float.html)) | [float](float.html)
+stddev([int](int.html)) | [decimal](decimal.html)
+sum([decimal](decimal.html)) | [decimal](decimal.html)
+sum([float](float.html)) | [float](float.html)
+sum([int](int.html)) | [decimal](decimal.html)
+variance([decimal](decimal.html)) | [decimal](decimal.html)
+variance([float](float.html)) | [float](float.html)
+variance([int](int.html)) | [decimal](decimal.html)
 

--- a/_includes/sql/functions.md
+++ b/_includes/sql/functions.md
@@ -1,74 +1,26 @@
-### BYTES Functions
+### Comparison Functions
 
 Function | Return
 --- | ---
-left([bytes](bytes.html), [int](int.html)) | [bytes](bytes.html)
-length([bytes](bytes.html)) | [int](int.html)
-octet_length([bytes](bytes.html)) | [int](int.html)
-right([bytes](bytes.html), [int](int.html)) | [bytes](bytes.html)
+greatest(T, ...) | T
+least(T, ...) | T
 
-### DATE Functions
+### Date and Time Functions
 
 Function | Return
 --- | ---
+age([timestamp](timestamp.html)) | [interval](interval.html)
+age([timestamp](timestamp.html), [timestamp](timestamp.html)) | [interval](interval.html)
+clock_timestamp() | [timestamp](timestamp.html)
 current_date() | [date](date.html)
-
-### DECIMAL Functions
-
-Function | Return
---- | ---
-abs([decimal](decimal.html)) | [decimal](decimal.html)
-cbrt([decimal](decimal.html)) | [decimal](decimal.html)
-ceil([decimal](decimal.html)) | [decimal](decimal.html)
-ceiling([decimal](decimal.html)) | [decimal](decimal.html)
-cluster_logical_timestamp() | [decimal](decimal.html)
-div([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
-exp([decimal](decimal.html)) | [decimal](decimal.html)
-floor([decimal](decimal.html)) | [decimal](decimal.html)
-ln([decimal](decimal.html)) | [decimal](decimal.html)
-log([decimal](decimal.html)) | [decimal](decimal.html)
-mod([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
-pow([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
-power([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
-round([decimal](decimal.html)) | [decimal](decimal.html)
-round([decimal](decimal.html), [int](int.html)) | [decimal](decimal.html)
-sign([decimal](decimal.html)) | [decimal](decimal.html)
-sqrt([decimal](decimal.html)) | [decimal](decimal.html)
-trunc([decimal](decimal.html)) | [decimal](decimal.html)
-
-### FLOAT Functions
-
-Function | Return
---- | ---
-abs([float](float.html)) | [float](float.html)
-acos([float](float.html)) | [float](float.html)
-asin([float](float.html)) | [float](float.html)
-atan([float](float.html)) | [float](float.html)
-atan2([float](float.html), [float](float.html)) | [float](float.html)
-cbrt([float](float.html)) | [float](float.html)
-ceil([float](float.html)) | [float](float.html)
-ceiling([float](float.html)) | [float](float.html)
-cos([float](float.html)) | [float](float.html)
-cot([float](float.html)) | [float](float.html)
-degrees([float](float.html)) | [float](float.html)
-div([float](float.html), [float](float.html)) | [float](float.html)
-exp([float](float.html)) | [float](float.html)
-floor([float](float.html)) | [float](float.html)
-ln([float](float.html)) | [float](float.html)
-log([float](float.html)) | [float](float.html)
-mod([float](float.html), [float](float.html)) | [float](float.html)
-pi() | [float](float.html)
-pow([float](float.html), [float](float.html)) | [float](float.html)
-power([float](float.html), [float](float.html)) | [float](float.html)
-radians([float](float.html)) | [float](float.html)
-random() | [float](float.html)
-round([float](float.html)) | [float](float.html)
-round([float](float.html), [int](int.html)) | [float](float.html)
-sign([float](float.html)) | [float](float.html)
-sin([float](float.html)) | [float](float.html)
-sqrt([float](float.html)) | [float](float.html)
-tan([float](float.html)) | [float](float.html)
-trunc([float](float.html)) | [float](float.html)
+current_timestamp() | [timestamp](timestamp.html)
+current_timestamp_ns() | [timestamp](timestamp.html)
+extract([string](string.html), [timestamp](timestamp.html)) | [int](int.html)
+format_timestamp_ns([timestamp](timestamp.html)) | [string](string.html)
+now() | [timestamp](timestamp.html)
+parse_timestamp_ns([string](string.html)) | [timestamp](timestamp.html)
+statement_timestamp() | [timestamp](timestamp.html)
+transaction_timestamp() | [timestamp](timestamp.html)
 
 ### ID Generation Functions
 
@@ -79,24 +31,62 @@ experimental_uuid_v4() | [bytes](bytes.html)
 unique_rowid() | [int](int.html)
 uuid_v4() | [bytes](bytes.html)
 
-### INT Functions
+### Math and Numeric Functions
 
 Function | Return
 --- | ---
+abs([decimal](decimal.html)) | [decimal](decimal.html)
+abs([float](float.html)) | [float](float.html)
 abs([int](int.html)) | [int](int.html)
-extract([string](string.html), [timestamp](timestamp.html)) | [int](int.html)
+acos([float](float.html)) | [float](float.html)
+asin([float](float.html)) | [float](float.html)
+atan([float](float.html)) | [float](float.html)
+atan2([float](float.html), [float](float.html)) | [float](float.html)
+cbrt([decimal](decimal.html)) | [decimal](decimal.html)
+cbrt([float](float.html)) | [float](float.html)
+ceil([decimal](decimal.html)) | [decimal](decimal.html)
+ceil([float](float.html)) | [float](float.html)
+ceiling([decimal](decimal.html)) | [decimal](decimal.html)
+ceiling([float](float.html)) | [float](float.html)
+cos([float](float.html)) | [float](float.html)
+cot([float](float.html)) | [float](float.html)
+degrees([float](float.html)) | [float](float.html)
+div([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
+div([float](float.html), [float](float.html)) | [float](float.html)
+exp([decimal](decimal.html)) | [decimal](decimal.html)
+exp([float](float.html)) | [float](float.html)
+floor([decimal](decimal.html)) | [decimal](decimal.html)
+floor([float](float.html)) | [float](float.html)
+ln([decimal](decimal.html)) | [decimal](decimal.html)
+ln([float](float.html)) | [float](float.html)
+log([decimal](decimal.html)) | [decimal](decimal.html)
+log([float](float.html)) | [float](float.html)
+mod([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
+mod([float](float.html), [float](float.html)) | [float](float.html)
 mod([int](int.html), [int](int.html)) | [int](int.html)
+pi() | [float](float.html)
+pow([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
+pow([float](float.html), [float](float.html)) | [float](float.html)
+power([decimal](decimal.html), [decimal](decimal.html)) | [decimal](decimal.html)
+power([float](float.html), [float](float.html)) | [float](float.html)
+radians([float](float.html)) | [float](float.html)
+random() | [float](float.html)
+round([decimal](decimal.html)) | [decimal](decimal.html)
+round([decimal](decimal.html), [int](int.html)) | [decimal](decimal.html)
+round([float](float.html)) | [float](float.html)
+round([float](float.html), [int](int.html)) | [float](float.html)
+sign([decimal](decimal.html)) | [decimal](decimal.html)
+sign([float](float.html)) | [float](float.html)
 sign([int](int.html)) | [int](int.html)
-strpos([string](string.html), [string](string.html)) | [int](int.html)
+sin([float](float.html)) | [float](float.html)
+sqrt([decimal](decimal.html)) | [decimal](decimal.html)
+sqrt([float](float.html)) | [float](float.html)
+tan([float](float.html)) | [float](float.html)
 to_hex([int](int.html)) | [string](string.html)
+trunc([decimal](decimal.html)) | [decimal](decimal.html)
+trunc([float](float.html)) | [float](float.html)
 
-### INTERVAL Functions
-
-Function | Return
---- | ---
-age([timestamp](timestamp.html), [timestamp](timestamp.html)) | [interval](interval.html)
-
-### STRING Functions
+### String and Byte Functions
 
 Function | Return
 --- | ---
@@ -106,28 +96,32 @@ btrim([string](string.html), [string](string.html)) | [string](string.html)
 concat(string, ...) | [string](string.html)
 concat_ws(string, ...) | [string](string.html)
 initcap([string](string.html)) | [string](string.html)
+left([bytes](bytes.html), [int](int.html)) | [bytes](bytes.html)
 left([string](string.html), [int](int.html)) | [string](string.html)
+length([bytes](bytes.html)) | [int](int.html)
 length([string](string.html)) | [int](int.html)
 lower([string](string.html)) | [string](string.html)
 ltrim([string](string.html)) | [string](string.html)
 ltrim([string](string.html), [string](string.html)) | [string](string.html)
 md5([string](string.html)) | [string](string.html)
+octet_length([bytes](bytes.html)) | [int](int.html)
 octet_length([string](string.html)) | [int](int.html)
 overlay([string](string.html), [string](string.html), [int](int.html)) | [string](string.html)
 overlay([string](string.html), [string](string.html), [int](int.html), [int](int.html)) | [string](string.html)
-parse_timestamp_ns([string](string.html)) | [timestamp](timestamp.html)
 regexp_extract([string](string.html), [string](string.html)) | [string](string.html)
 regexp_replace([string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
 regexp_replace([string](string.html), [string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
 repeat([string](string.html), [int](int.html)) | [string](string.html)
 replace([string](string.html), [string](string.html), [string](string.html)) | [string](string.html)
 reverse([string](string.html)) | [string](string.html)
+right([bytes](bytes.html), [int](int.html)) | [bytes](bytes.html)
 right([string](string.html), [int](int.html)) | [string](string.html)
 rtrim([string](string.html)) | [string](string.html)
 rtrim([string](string.html), [string](string.html)) | [string](string.html)
 sha1([string](string.html)) | [string](string.html)
 sha256([string](string.html)) | [string](string.html)
 split_part([string](string.html), [string](string.html), [int](int.html)) | [string](string.html)
+strpos([string](string.html), [string](string.html)) | [int](int.html)
 substr([string](string.html), [int](int.html)) | [string](string.html)
 substr([string](string.html), [int](int.html), [int](int.html)) | [string](string.html)
 substr([string](string.html), [string](string.html)) | [string](string.html)
@@ -143,25 +137,6 @@ upper([string](string.html)) | [string](string.html)
 
 Function | Return
 --- | ---
+cluster_logical_timestamp() | [decimal](decimal.html)
 version() | [string](string.html)
-
-### T Functions
-
-Function | Return
---- | ---
-greatest(T, ...) | T
-least(T, ...) | T
-
-### TIMESTAMP Functions
-
-Function | Return
---- | ---
-age([timestamp](timestamp.html)) | [interval](interval.html)
-clock_timestamp() | [timestamp](timestamp.html)
-current_timestamp() | [timestamp](timestamp.html)
-current_timestamp_ns() | [timestamp](timestamp.html)
-format_timestamp_ns([timestamp](timestamp.html)) | [string](string.html)
-now() | [timestamp](timestamp.html)
-statement_timestamp() | [timestamp](timestamp.html)
-transaction_timestamp() | [timestamp](timestamp.html)
 


### PR DESCRIPTION
* eliminate subcategorization of aggregates since the majority are numeric and the
remainder aren't meaningfully categorized by types (eg count).

* pick up the changes in builtins self-categorization that wraps up the
math functions into a single category.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/397)
<!-- Reviewable:end -->
