### PR TITLE
Fixing typo in docker quickstart

### DIFF
--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -131,7 +131,7 @@ root@:26257> SHOW DATABASES;
 +----------+
 ~~~
 
-## Step 4. Open the Admin UI
+## Step 5. Open the Admin UI
 
 To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, first look up the IP address for your `docker-machine`:
 


### PR DESCRIPTION
There were two step 4s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/398)
<!-- Reviewable:end -->
