### PR TITLE
Expand Truncate diagram

### DIFF
--- a/_includes/sql/diagrams/truncate.html
+++ b/_includes/sql/diagrams/truncate.html
@@ -1,4 +1,4 @@
-<svg width="690" height="266">
+<svg width="690" height="330">
          
          <polygon points="9 61 1 57 1 65"></polygon>
          <polygon points="17 61 9 57 9 65"></polygon>
@@ -38,12 +38,13 @@
          <rect x="283" y="3" width="24" height="32" rx="10"></rect>
          <rect x="281" y="1" width="24" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="291" y="21">,</text>
-         <a xlink:href="sql-grammar.html#opt_drop_behavior" xlink:title="opt_drop_behavior">
-            <rect x="523" y="233" width="140" height="32"></rect>
-            <rect x="521" y="231" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="531" y="251">opt_drop_behavior</text>
-         </a>
-         <path class="line" d="m17 61 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -32 h10 m116 0 h10 m20 0 h10 m0 0 h38 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v12 m68 0 v-12 m-68 12 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m20 -32 h122 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v56 m366 0 v-56 m-366 56 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m58 0 h10 m20 0 h10 m116 0 h10 m0 0 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m-366 -120 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m386 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-386 0 h10 m24 0 h10 m0 0 h342 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-190 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m140 0 h10 m3 0 h-3"></path>
-         <polygon points="681 247 689 243 689 251"></polygon>
-         <polygon points="681 247 673 243 673 251"></polygon>
+         <rect x="557" y="253" width="82" height="32" rx="10"></rect>
+         <rect x="555" y="251" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="565" y="271">CASCADE</text>
+         <rect x="557" y="297" width="86" height="32" rx="10"></rect>
+         <rect x="555" y="295" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="565" y="315">RESTRICT</text>
+         <path class="line" d="m17 61 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -32 h10 m116 0 h10 m20 0 h10 m0 0 h38 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v12 m68 0 v-12 m-68 12 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m20 -32 h122 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v56 m366 0 v-56 m-366 56 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m58 0 h10 m20 0 h10 m116 0 h10 m0 0 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m-366 -120 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m386 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-386 0 h10 m24 0 h10 m0 0 h342 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
+         <polygon points="681 235 689 231 689 239"></polygon>
+         <polygon points="681 235 673 231 673 239"></polygon>
       </svg>

--- a/generate/main.go
+++ b/generate/main.go
@@ -205,7 +205,7 @@ func main() {
 				{name: "show_timezone", stmt: "show_stmt", match: regexp.MustCompile("'SHOW' 'TIME' 'ZONE'")},
 				{name: "show_transaction", stmt: "show_stmt", match: regexp.MustCompile("'SHOW' 'TRANSACTION'")},
 				{name: "table_constraint", inline: []string{"constraint_elem", "opt_storing", "storing"}},
-				{name: "truncate_stmt", inline: []string{"opt_table", "relation_expr_list", "relation_expr"}},
+				{name: "truncate_stmt", inline: []string{"opt_table", "relation_expr_list", "relation_expr", "opt_drop_behavior"}},
 				{name: "update_stmt", inline: []string{"relation_expr_opt_alias", "set_clause_list", "set_clause", "single_set_clause", "multiple_set_clause", "ctext_row", "ctext_expr_list", "ctext_expr", "from_clause", "from_list", "where_clause", "returning_clause"}},
 				{name: "upsert_stmt", stmt: "insert_stmt", inline: []string{"insert_target", "insert_rest", "returning_clause"}, match: regexp.MustCompile("'UPSERT'")},
 				{name: "values", stmt: "values_clause", inline: []string{"ctext_row", "ctext_expr_list", "ctext_expr"}},


### PR DESCRIPTION
No biggie, just expanded the `opt_drop_behavior` clause to expose the `CASCADE` and `RESTRICT` keywords, ready to be documented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/408)
<!-- Reviewable:end -->
