### PR TITLE
Release notes for beta-20160623

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -117,6 +117,9 @@ entries:
 
     - title: Release Notes
       items:
+        - title: beta-20160623
+          url: /beta-20160623.html
+
         - title: beta-20160616
           url: /beta-20160616.html
 
@@ -125,9 +128,6 @@ entries:
 
         - title: beta-20160602
           url: /beta-20160602.html
-
-        - title: beta-20160526
-          url: /beta-20160526.html
 
         - title: Older Versions
           url: /older-versions.html

--- a/beta-20160623.md
+++ b/beta-20160623.md
@@ -1,0 +1,41 @@
+---
+title: What's New in beta-20160623
+toc: false
+summary: Additions and changes in CockroachDB version beta-20160623.
+---
+
+## Jun 23, 2016
+
+### New Features
+
+- `EXPLAIN` can now be used with `CREATE`, `DROP`, and `ALTER` statements. [#7269](https://github.com/cockroachdb/cockroach/pull/7269)
+- The command-line SQL client now prints tab-separated values instead of ASCII-art tables when `stdout` is not a TTY (unless `--pretty` is used). [#7268](https://github.com/cockroachdb/cockroach/pull/7268)
+- In interactive mode, the command-line SQL client now prints the number of rows at the end of a result set. [#7266](https://github.com/cockroachdb/cockroach/pull/7266)
+- The web UI has been rewritten in a new framework. [#7242](https://github.com/cockroachdb/cockroach/pull/7242)
+- Prepared statements can now be deallocated with the `DEALLOCATE` command. [#7367](https://github.com/cockroachdb/cockroach/pull/7367)
+
+### Performance Improvements
+
+- The load balancing system now operates at a steadier pace, reducing spikes in memory usage and reaching equilibrium more quickly. [#7147](https://github.com/cockroachdb/cockroach/pull/7147)
+
+### Bug Fixes
+
+- Fixed a crash when session arguments could not be parsed. [#7231](https://github.com/cockroachdb/cockroach/pull/7231)
+- Improved error messages for parts of the PostgreSQL protocol we do not support. [#7233](https://github.com/cockroachdb/cockroach/pull/7233)
+- `AS OF SYSTEM TIME` can now be used in prepared statements. [#7251](https://github.com/cockroachdb/cockroach/pull/7251)
+- Raft messages are no longer canceled due to unrelated errors. [#7252](https://github.com/cockroachdb/cockroach/pull/7252)
+- Constraint names that are specified at the column level are now preserved. [#7271](https://github.com/cockroachdb/cockroach/pull/7271)
+- When `COMMIT` returns an error, the transaction is considered closed and a separate `ROLLBACK` is no longer necessary. [#7282](https://github.com/cockroachdb/cockroach/pull/7282)
+- The command-line SQL client now escapes strings in a format that the SQL parser will accept. [#7294](https://github.com/cockroachdb/cockroach/pull/7294)
+- Fixed issues when two snapshots were being sent simultaneously. [#7299](https://github.com/cockroachdb/cockroach/pull/7299)
+- When a column is renamed, any `CHECK` constraints referring to that column are now updated. [#7311](https://github.com/cockroachdb/cockroach/pull/7311)
+- When piping commands into the command-line SQL client, the last line was previously ignored. Now it will be executed if it ends with a semicolon, or report an error if it is non-empty but not a complete statement. [#7328](https://github.com/cockroachdb/cockroach/pull/7328)
+
+### Contributors
+
+This release includes 75 merged PRs by 20 authors. We would like to
+thank the following contributors from the CockroachDB community, especially first-time contributor [phynalle](https://github.com/cockroachdb/cockroach/pull/7361):
+
+- Jingguo Yao
+- Kenji Kaneda
+- phynalle

--- a/older-versions.md
+++ b/older-versions.md
@@ -6,6 +6,7 @@ toc: false
 
 Release Date | Version
 -------------|--------
+May 26, 2016 | [beta-20160526](beta-20160526.html)
 May 19, 2016 | [beta-20160519](beta-20160519.html)
 May 12, 2016 | [beta-20160512](beta-20160512.html)
 May 5, 2016 | [beta-20160505](beta-20160505.html)


### PR DESCRIPTION
Getting an early start because of my vacation. @mberhault and @jseldess, you'll need to finish this up tomorrow, and next week you're on your own. These notes are accurate as of cockroachdb/cockroach@6d60fb62881a, but feel free to incorporate anything else that gets merged between now and our usual wednesday morning cutoff. The mention of the new UI is a placeholder; I don't know how we want to message this to users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/409)
<!-- Reviewable:end -->
