### PR TITLE
Docker updates

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -219,10 +219,14 @@ $(document).ready(function(){
 
 <ol>
   <li>
-    <p>Install <a href="https://docs.docker.com/docker-for-mac/">Docker for Mac</a>.</p><p><strong>Docker for Mac</strong> is Docker's native OS X application, currently in public beta. It's a lot simpler to use than Docker Toolbox; whereas Toolbox requires manual setup and management of virtual machines and makes it hard to use volumes to persist data, Docker for Mac provisions a VM at install time and works correctly with volumes. That said, you can use Docker Toolbox with CockroachDB if you prefer; you'll just need to <a href="https://docs.docker.com/machine/get-started/">create a local VM and point your environment to it</a>.</p>
+    <p>Install <a href="https://docs.docker.com/docker-for-mac/">Docker for Mac</a>.</p>
   </li>
   <li>
-    <p>If it's not already running, start the <strong>Docker</strong> application.</p>
+    <p>Confirm that the Docker daemon is running in the background:</p>
+
+    <div class="highlighter-rouge"><pre class="highlight"><code>$ docker version</code></pre>
+    </div>
+    <p>If you don't see the server listed, start the <strong>Docker</strong> application.</p>
   </li>
   <li>
     <p>Pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/" data-eventcategory="mac-docker-step3">Docker Hub</a>:</p>
@@ -364,7 +368,11 @@ $(document).ready(function(){
     <p>Install <a href="https://docs.docker.com/engine/installation/linux/ubuntulinux/">Docker for Linux</a>.</p>
   </li>
   <li>
-    <p>If the Docker daemon is not already running in the background, run:</p>
+    <p>Confirm that the Docker daemon is running in the background:</p>
+
+    <div class="highlighter-rouge"><pre class="highlight"><code>$ sudo docker version</code></pre>
+    </div>
+    <p>If you don't see the server listed, run:</p>
 
     <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-docker-step2"><span class="gp" data-eventcategory="linux-docker-step2">$ </span>sudo docker -d &amp;</code></pre>
     </div>
@@ -404,10 +412,14 @@ $(document).ready(function(){
 
 <ol>
   <li>
-    <p>Install <a href="https://docs.docker.com/docker-for-windows/">Docker for Windows</a>.</p><p><strong>Docker for Windows</strong> is Docker's native Windows application, currently in public beta. It's a lot simpler to use than Docker Toolbox; whereas Toolbox requires manual setup and management of virtual machines and makes it hard to use volumes to persist data, Docker for Windows provisions a VM at install time and works correctly with volumes. That said, you can use Docker Toolbox with CockroachDB if you prefer; you'll just need to <a href="https://docs.docker.com/machine/get-started/">create a local VM and point your environment to it</a>.</p>
+    <p>Install <a href="https://docs.docker.com/docker-for-windows/">Docker for Windows</a>.
   </li>
   <li>
-    <p>If it's not already running, start the <strong>Docker</strong> application.</p>
+    <p>Confirm that the Docker daemon is running in the background:</p>
+
+    <div class="highlighter-rouge"><pre class="highlight"><code>$ docker version</code></pre>
+    </div>
+    <p>If you don't see the server listed, start the <strong>Docker</strong> application.</p>
   </li>
   <li>
     <p>Pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/" data-eventcategory="win-docker-step3">Docker Hub</a>:</p>

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -219,17 +219,10 @@ $(document).ready(function(){
 
 <ol>
   <li>
-    <p><a href="https://docs.docker.com/mac/">Install Docker</a>.</p>
+    <p>Install <a href="https://docs.docker.com/docker-for-mac/">Docker for Mac</a>.</p><p><strong>Docker for Mac</strong> is Docker's native OS X application, currently in public beta. It's a lot simpler to use than Docker Toolbox; whereas Toolbox requires manual setup and management of virtual machines and makes it hard to use volumes to persist data, Docker for Mac provisions a VM at install time and works correctly with volumes. That said, you can use Docker Toolbox with CockroachDB if you prefer; you'll just need to <a href="https://docs.docker.com/machine/get-started/">create a local VM and point your environment to it</a>.</p>
   </li>
   <li>
-    <p>Open <strong>Launchpad</strong> and start the <strong>Docker Quickstart Terminal</strong>. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM.</p>
-
-    <p>If you’d rather do this manually, run:</p>
-
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>docker-machine create --driver virtualbox default
-<span class="gp">$ </span><span class="nb">eval</span> <span class="s2">"</span><span class="k">$(</span>docker-machine env default<span class="k">)</span><span class="s2">"</span>
-</code></pre>
-    </div>
+    <p>If it's not already running, start the <strong>Docker</strong> application.</p>
   </li>
   <li>
     <p>Pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/" data-eventcategory="mac-docker-step3">Docker Hub</a>:</p>
@@ -368,10 +361,10 @@ $(document).ready(function(){
 
 <ol>
   <li>
-    <p><a href="https://docs.docker.com/engine/installation/linux/ubuntulinux/">Install Docker</a>.</p>
+    <p>Install <a href="https://docs.docker.com/engine/installation/linux/ubuntulinux/">Docker for Linux</a>.</p>
   </li>
   <li>
-    <p>If you don’t already have the Docker daemon running in the background, run:</p>
+    <p>If the Docker daemon is not already running in the background, run:</p>
 
     <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-docker-step2"><span class="gp" data-eventcategory="linux-docker-step2">$ </span>sudo docker -d &amp;</code></pre>
     </div>
@@ -407,21 +400,14 @@ $(document).ready(function(){
 </div>
 
 <div id="windowsinstall" style="display: none;">
-<p>You can run CockroachDB on Windows from within a Docker virtual machine, which is a stripped-to-basics version of a Linux operating system. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest version.</p>
+<p>At this time, it's possible to run CockroachDB on Windows only from within a Docker virtual environment. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest version of CockroachDB.</p>
 
 <ol>
   <li>
-    <p><a href="https://docs.docker.com/engine/installation/windows/">Install Docker</a>.</p>
+    <p>Install <a href="https://docs.docker.com/docker-for-windows/">Docker for Windows</a>.</p><p><strong>Docker for Windows</strong> is Docker's native Windows application, currently in public beta. It's a lot simpler to use than Docker Toolbox; whereas Toolbox requires manual setup and management of virtual machines and makes it hard to use volumes to persist data, Docker for Windows provisions a VM at install time and works correctly with volumes. That said, you can use Docker Toolbox with CockroachDB if you prefer; you'll just need to <a href="https://docs.docker.com/machine/get-started/">create a local VM and point your environment to it</a>.</p>
   </li>
   <li>
-    <p>Start the <strong>Docker Quickstart Terminal</strong>. This opens a new shell, creates and starts a default Docker virtual machine (VM), and points the terminal environment to this VM.</p>
-
-    <p>If you’d rather do this manually, run:</p>
-
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp">$ </span>docker-machine create --driver virtualbox default
-<span class="gp">$ </span><span class="nb">eval</span> <span class="s2">"</span><span class="k">$(</span>docker-machine env default<span class="k">)</span><span class="s2">"</span>
-</code></pre>
-    </div>    
+    <p>If it's not already running, start the <strong>Docker</strong> application.</p>
   </li>
   <li>
     <p>Pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/" data-eventcategory="win-docker-step3">Docker Hub</a>:</p>

--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -55,7 +55,7 @@ This command creates a container and starts the first CockroachDB node inside it
 - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
 - `--net`: The bridge network for the container to join. See step 1 for more details.
 - `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port of HTTP requests from the Admin UI (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the Admin UI from a browser.
-- `-v $(PWD)/cockroach-data/roach1:/cockroach/cockroach-data`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `$(PWD)/cockroach-data/roach1` on your host and will persist after the container is stopped or deleted. For more details about volumes, see Docker's <a href="https://docs.docker.com/engine/userguide/containers/dockervolumes/">Manage data in containers</a> topic.
+- `-v $(PWD)/cockroach-data/roach1:/cockroach/cockroach-data`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `$(PWD)/cockroach-data/roach1` on the host and will persist after the container is stopped or deleted. For more details about volumes, see Docker's <a href="https://docs.docker.com/engine/userguide/containers/dockervolumes/">Manage data in containers</a> topic.
 - `cockroachdb/cockroach:{{site.data.strings.version}} start --insecure`: The CockroachDB command to [start a node](start-a-node.html) in the container in insecure mode. 
 
 ## Step 3. Start additional containers/nodes
@@ -67,8 +67,8 @@ $ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P -v $(PWD)/cock
 
 These commands add two more containers and start CockroachDB nodes inside them, joining them to the first node. There are only a few differences to note from step 2:
 
-- `-P`: This flag maps each container's exposed ports to random ports on the host. This random mapping is fine since we've already mapped the relevant ports for the first container.
-- `-v`: For each container, this flag mounts a unique host directory as a data volume. Data and logs for these nodes will be stored in `$(PWD)/cockroach-data/roach2` and `$(PWD)/cockroach-data/roach3` on your host and will persist after the containers are stopped or deleted.
+- `-P`: This flag maps exposed ports to random ports on the host. This random mapping is fine since we've already mapped the relevant ports for the first container.
+- `-v`: This flag mounts a host directory as a data volume. Data and logs for these nodes will be stored in `$(PWD)/cockroach-data/roach2` and `$(PWD)/cockroach-data/roach3` on the host and will persist after the containers are stopped or deleted.
 - `--join`: This flag joins the new nodes to the cluster, using the first container's `hostname`. Otherwise, all [`cockroach start`](start-a-node.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
 
 ## Step 4. Use the built-in SQL client
@@ -132,7 +132,7 @@ root@:26257> SHOW DATABASES;
 
 ## Step 5. Open the Admin UI
 
-When you started your first container/node, you mapped the node's default HTTP port `8080` to port `8080` on your host. To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, point your browser to that port on `localhost`, i.e., `http://localhost:8080`.
+When you started the first container/node, you mapped the node's default HTTP port `8080` to port `8080` on the host. To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, point your browser to that port on `localhost`, i.e., `http://localhost:8080`.
 
 <img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 

--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -20,19 +20,16 @@ toc: false
   <button class="filter-button scope-button current">In <strong>Docker</strong></button>
 </div><p></p>
 
-Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run a multi-node cluster across multiple Docker containers on a single host. This page shows you how. 
+Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run a multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data. This page shows you how. 
 
 ## Before You Begin
 
 Make sure you have already:
 
-- Installed Docker
-- Started a `docker-machine` in which to run CockroachDB (Mac and Windows only)
+- Installed and started Docker
 - Pulled the official CockroachDB image from Docker Hub
 
 For full details, go to [Install CockroachDB](install-cockroachdb.html) and choose **Use Docker** for your OS. 
-
-{{site.data.alerts.callout_info}}On Mac and Windows, it's not currently possible to use <strong>Docker volumes</strong> to persist CockroachDB node data. Therefore, Docker is recommended only for testing on those operating systems.  On Linux, however, it is possible to use volumes to persist container data. See Docker's <a href="https://docs.docker.com/engine/userguide/containers/dockervolumes/">Manage data in containers</a> topic for details.{{site.data.alerts.end}}
 
 ## Step 1. Create a bridge network
 
@@ -47,7 +44,7 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
 ## Step 2. Start your first container/node
 
 ~~~ shell
-$ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080 cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
+$ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080 -v $(PWD)/cockroach-data/roach1:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
 ~~~
 
 This command creates a container and starts the first CockroachDB node inside it. Let's look at each part:
@@ -57,20 +54,22 @@ This command creates a container and starts the first CockroachDB node inside it
 - `--name`: The name for the container. This is optional, but a custom name makes it significantly easier to reference the container in other commands, for example, when opening a Bash session in the container or stopping the container. 
 - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
 - `--net`: The bridge network for the container to join. See step 1 for more details.
-- `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port of HTTP requests from the Admin UI (`8080`) from the container to the `docker-machine`. This enables inter-container communication and makes it possible to call up the Admin UI from a browser outside of the `docker-machine`.
+- `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port of HTTP requests from the Admin UI (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the Admin UI from a browser.
+- `-v $(PWD)/cockroach-data/roach1:/cockroach/cockroach-data`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `$(PWD)/cockroach-data/roach1` on your host and will persist after the container is stopped or deleted. For more details about volumes, see Docker's <a href="https://docs.docker.com/engine/userguide/containers/dockervolumes/">Manage data in containers</a> topic.
 - `cockroachdb/cockroach:{{site.data.strings.version}} start --insecure`: The CockroachDB command to [start a node](start-a-node.html) in the container in insecure mode. 
 
 ## Step 3. Start additional containers/nodes
 
 ~~~ shell
-$ docker run -d --name=roach2 --hostname=roach2 --net=roachnet -P cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
-$ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+$ docker run -d --name=roach2 --hostname=roach2 --net=roachnet -P -v $(PWD)/cockroach-data/roach2:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+$ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P -v $(PWD)/cockroach-data/roach3:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
 ~~~
 
 These commands add two more containers and start CockroachDB nodes inside them, joining them to the first node. There are only a few differences to note from step 2:
 
-- `-P`: This flag maps all of the container's exposed ports to random ports on the `docker-machine`. This random mapping is fine since we've already mapped the relevant ports for the first container.
-- `--join`: This flag joins the new node to the cluster, using the first container's `hostname`. Otherwise, all [`cockroach start`](start-a-node.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
+- `-P`: This flag maps each container's exposed ports to random ports on the host. This random mapping is fine since we've already mapped the relevant ports for the first container.
+- `-v`: For each container, this flag mounts a unique host directory as a data volume. Data and logs for these nodes will be stored in `$(PWD)/cockroach-data/roach2` and `$(PWD)/cockroach-data/roach3` on your host and will persist after the containers are stopped or deleted.
+- `--join`: This flag joins the new nodes to the cluster, using the first container's `hostname`. Otherwise, all [`cockroach start`](start-a-node.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
 
 ## Step 4. Use the built-in SQL client
 
@@ -133,14 +132,7 @@ root@:26257> SHOW DATABASES;
 
 ## Step 5. Open the Admin UI
 
-To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, first look up the IP address for your `docker-machine`:
-
-~~~ shell
-$ docker-machine ip default
-192.168.99.100
-~~~
-
-Then point your browser to that IP and port `8080`, e.g., `http://192.168.99.100:8080`: 
+When you started your first container/node, you mapped the node's default HTTP port `8080` to port `8080` on your host. To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, point your browser to that port on `localhost`, i.e., `http://localhost:8080`.
 
 <img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
@@ -148,6 +140,6 @@ Then point your browser to that IP and port `8080`, e.g., `http://192.168.99.100
 
 [Secure your cluster](secure-a-cluster.html) with authentication and encryption. You might also be interested in:
 
+- **Run CockroachDB across Multiple Docker Hosts** (coming soon)
 - [Manual Deployment](manual-deployment.html): How to run CockroachDB across multiple machines
 - [Cloud Deployment](cloud-deployment.html): How to run CockroachDB in the cloud
-- **Run CockroachDB across Multiple Docker Hosts** (coming soon)


### PR DESCRIPTION
This PR updates our installation and cluster startup docs based on native Docker for Mac and Docker for Windows.

- `install-cockroachdb.md` recommends Docker for Mac and Docker for Windows instead of Docker Toolbox.
- `start-a-cluster-in-docker.md` now includes using volumes to persist node data (that wasn't easy using Docker Toolbox on Mac/Windows) and simplifies accessing the Admin UI from the host (no longer need to get the VM's IP.

HTML versions here: 
- http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/d38dd1c9de98e16e8e833bff7340ce43ebc201f9/install-cockroachdb.html
- http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/d38dd1c9de98e16e8e833bff7340ce43ebc201f9/start-a-local-cluster-in-docker.html

Fixes #415

I've decided not to cover a Docker-specific rewrite of `secure-a-cluster.md`. I need to learn more there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/431)
<!-- Reviewable:end -->
