### PR TITLE
Updating critter buttons on docs homepage

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1117,11 +1117,31 @@ body h1 {
   color: #46a417; }
 
 .post-content img {
-  margin: 12px 0px 3px 0px; }
+  margin: 12px 0px 3px 0px; 
+}
+
 .post-content .row .roach {
-  text-align: center; }
-  .post-content .row .roach a img {
-    height: 150px; }
+  -webkit-transition: all .2s ease;
+  transition: all .2s ease;
+  text-align: center; 
+  top: 0px;
+  opacity: .85;
+}
+
+.post-content .row .roach:hover {
+  -webkit-transition: all .2s ease;
+  transition: all .2s ease;
+  top: -10px;
+  opacity: 1;
+}
+
+.post-content .row .roach a img {
+    height: 150px; 
+  }
+
+.post-content .row .roach h3 {
+  color: #46a417;
+}
 
 .post-content ol li, .post-content ul li {
   margin: 10px 0px; }

--- a/index.md
+++ b/index.md
@@ -10,6 +10,7 @@ CockroachDB is a distributed SQL database built on a transactional and strongly-
 
 The project is currently in **Beta**. For details about upcoming features, see the [Roadmap](https://github.com/cockroachdb/cockroach/wiki).
 
+<br>
 <div class="row">
 <div class="col-md-4 roach">
     <a href="install-cockroachdb.html">
@@ -32,13 +33,15 @@ The project is currently in **Beta**. For details about upcoming features, see t
     </a>
 </div>
 </div>
+<br>
 
 ---
 
+<br>
 <div class="recent-articles" markdown="1">
 
 ## Recent Articles By CockroachDB Engineers
-
+<br>
 **[Time-Travel Queries: SELECT witty_subtitle FROM THE FUTURE](https://www.cockroachlabs.com/blog/time-travel-queries-select-witty_subtitle-the_future/)**
 
 **[Outsmarting Go Dependencies in Testing Code](https://www.cockroachlabs.com/blog/outsmarting-go-dependencies-testing-code/)**


### PR DESCRIPTION
In advance of a larger overhaul of the docs homepage by Division Of, this PR improves the styling of the critter buttons:
- Button text is now green, to indicate they are links/clickable.
- Pre-hover, the buttons are at 80% opacity.
- On hover, the buttons are at 100% opacity and lift up a bit.

HTML version here: http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/1baeec53e3c6ac25014dd18cbf37220c67c07e13/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/433)
<!-- Reviewable:end -->
