### PR TITLE
Simplify format of single-replica zone config

### DIFF
--- a/configure-replication-zones.md
+++ b/configure-replication-zones.md
@@ -29,7 +29,7 @@ When replicating a piece of data, CockroachDB uses the most granular zone availa
 A replication zone is specified in [YAML](https://en.wikipedia.org/wiki/YAML) format and looks like this:
 
 ~~~ yaml
-replicas:
+replicas: 
 - attrs: [comma-separated attribute list]
 - attrs: [comma-separated attribute list]
 - attrs: [comma-separated attribute list]
@@ -39,9 +39,19 @@ gc:
   ttlseconds: <time-in-seconds>
 ~~~
 
+Alternately, the `replicas` field can be simplified into a single line:
+
+~~~ yaml
+replicas: [attrs: [attribute list], attrs: [attribute list], attrs: [attribute list]]
+range_min_bytes: <size-in-bytes>
+range_max_bytes: <size-in-bytes>
+gc:
+  ttlseconds: <time-in-seconds>
+~~~
+
 Field | Description
 ------|------------
-`replicas` | The number and location of replicas for the zone. Each `attrs` line equals one replica. See [Node/Replica Recommendations](#nodereplica-recommendations) below. <br><br>It's normal and sufficient to define the number of replicas by listing `attrs` lines without any specific attributes (i.e., `- attrs: []`). But if you do set specific attributes for a replica (i.e., `- attrs: [us-east-1a, ssd]`), the replica will be placed on the nodes/stores with the matching attributes.<br><br>Node-level and store-level attributes are arbitrary strings specified when starting a node. You must match these strings exactly here in order for replication to work as you intend, so be sure to check carefully. See [Start a Node](start-a-node.html) for more details about node and store attributes.<br><br>**Default:** 3 replicas with no specific attributes 
+`replicas` | The number and location of replicas for the zone. Each `attrs` item equals one replica. See [Node/Replica Recommendations](#nodereplica-recommendations) below. <br><br>It's normal and sufficient to define the number of replicas by listing `attrs` without any specific attributes (i.e., `- attrs: []`). But if you do set specific attributes for a replica (i.e., `- attrs: [us-east-1a, ssd]`), the replica will be placed on the nodes/stores with the matching attributes.<br><br>Node-level and store-level attributes are arbitrary strings specified when starting a node. You must match these strings exactly here in order for replication to work as you intend, so be sure to check carefully. See [Start a Node](start-a-node.html) for more details about node and store attributes.<br><br>**Default:** 3 replicas with no specific attributes 
 `range_max_bytes` | The maximum size, in bytes, for a range of data in the zone. When a range reaches this size, CockroachDB will spit it into two ranges.<br><br>**Default:** `67108864` (64MB)
 `range_min_bytes` | Not yet implemented.
 `ttlseconds` | The number of seconds overwritten values will be retained before garbage collection. Smaller values can save disk space if values are frequently overwritten; larger values increase the range allowed for `AS OF SYSTEM TIME` queries. It is not recommended to set this below `600` (10 minutes).<br><br>**Default:** `86400` (24 hours)

--- a/troubleshoot.md
+++ b/troubleshoot.md
@@ -17,8 +17,7 @@ E160407 09:53:50.337328 storage/queue.go:511  [replicate] 7 replicas failing wit
 This error occurs because CockroachDB expects three nodes by default. If you do not intend to add additional nodes, you can stop this error by updating your default zone configuration to expect only one node as follows:
 
 ~~~ shell
-$ cockroach zone set .default 'replicas:
-- attrs: []'
+$ cockroach zone set .default 'replicas: [attrs: []]'
 ~~~
 
 See [Configure Replication Zones](configure-replication-zones.html) for more details.


### PR DESCRIPTION
Fixes remaining issue in https://github.com/cockroachdb/cockroach/issues/4192

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/434)
<!-- Reviewable:end -->
