### PR TITLE
Bolding code formatted text in tables

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1686,7 +1686,9 @@ span.muted {
   color: #C0C0C0; }
 
 table code {
-  background-color: transparent; }
+  background-color: transparent; 
+  font-weight: bold;
+}
 
 .highlight .err {
   color: #a61717;


### PR DESCRIPTION
This change makes it easier to differentiate code-formatted text from normal text in tables. Outside of tables, this isn't a problem since code-formatted text has a grey background.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/439)
<!-- Reviewable:end -->
