### PR TITLE
Revisions related to http-addr

### DIFF
--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -224,7 +224,7 @@ store[0]:  path=cockroach-data
 
 <img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-{{site.data.alerts.callout_info}}In cases where you set <code>--http-addr</code> to <code>localhost</code> and need to access the Admin UI from a machine separate from the cluster, you can use SSH to tunnel from the machine to a node.{{site.data.alerts.end}}  
+{{site.data.alerts.callout_info}}In cases where you set <code>--http-addr</code> to <code>localhost</code> and need to access the Admin UI from a separate machine, you can use SSH to tunnel from the machine to a node.{{site.data.alerts.end}}  
 
 ## See Also
 

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -41,7 +41,7 @@ This command sets the node to insecure and identifies the address at which other
 Copy the `cockroach` binary to the second machine and then start the node:
     
 ~~~ shell
-$ cockroach start --insecure --join=<node1-hostname>:26257
+$ cockroach start --insecure --host=<node2-hostname> --join=<node1-hostname>:26257
 ~~~
 
 The only difference when starting the second node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
@@ -142,17 +142,17 @@ Store the CA key somewhere safe and keep a backup; if you lose it, you will not 
 Copy the `cockroach` binary, CA certificate, and node 1 certificate and key to the first machine and then start the node:
 
 ~~~ shell
-$ cockroach start --http-addr=127.0.0.1 --ca-cert=ca.cert --cert=node1.cert --key=node1.key --host=<node1-hostname>
+$ cockroach start --host=<node1-hostname> --http-addr=<private-address> --ca-cert=ca.cert --cert=node1.cert --key=node1.key
 ~~~
 
-This command specifies the location of certificates and the address at which other nodes can reach it. It also restricts the http Admin UI to 127.0.0.1 traffic only. Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, listens for internal and client communication on port 26257, and listens for HTTP requests from the Admin UI port 8080. To set these options manually, see [Start a Node](start-a-node.html). 
+This command specifies the location of certificates and the address at which other nodes can reach it. It also restricts Admin UI traffic to the address specified by `--http-addr`. Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, binds internal and client communication to port `26257`, and binds Admin UI HTTP requests to port `8080`. To set these options manually, see [Start a Node](start-a-node.html). 
 
 ### 3. Set up the second node
 
 Copy the `cockroach` binary, CA certificate, and node 2 certificate and key to the second machine and then start the node:
 
 ~~~ shell
-$ cockroach start --http-addr=127.0.0.1 --ca-cert=ca.cert --cert=node2.cert --key=node2.key --host=<node2-hostname> --join=<node1-hostname>:26257
+$ cockroach start --host=<node2-hostname> --http-addr=<private-address> --join=<node1-hostname>:26257 --ca-cert=ca.cert --cert=node2.cert --key=node2.key
 ~~~
 
 The only difference when starting the second node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
@@ -211,28 +211,20 @@ For a list of recommended drivers that we've tested, see [Install Client Drivers
 
 ### 8. Monitor your cluster
 
-The CockroachDB Admin UI lets you monitor cluster-wide, node-level, and database-level metrics and events. To view the secured Admin UI on remote node1.example.com, first establish an ssh tunnel, then point your browser to the URL in the `admin` field listed in the standard output of any node on startup. For example, your start command may have gaven output like this:
+The CockroachDB Admin UI lets you monitor cluster-wide, node-level, and database-level metrics and events. To access the Admin UI, from the address specified by the `--http-addr` flag in steps 2 and 3, point a browser to the URL in the `admin` field listed in the standard output on startup, for example:
 
 ~~~ shell
 $ cockroach start --http-addr=127.0.0.1 --ca-cert=ca.cert --cert=node1.cert --key=node1.key --host=node1.example.com
 build:     {{site.data.strings.version}} @ {{site.data.strings.build_time}}
-admin:     https://127.0.0.1:8080 <-------------- ESTABLISH SSH TUNNEL TO HERE
+admin:     https://<private-address>:8080 <-------------- USE THIS URL
 sql:       postgresql://root@node1.example.com:26257?sslcert=%2FUsers%2F...
 logs:      cockroach-data/logs
 store[0]:  path=cockroach-data
 ~~~
 
-Here is how to use ssh to tunnel port 8081 from your desktop to the node1.example.com cluster node:
-
-~~~ shell
-$ ssh -L 8081:127.0.0.1:8080 node1.example.com
-~~~
-
-(See the ssh man pages for details the -L port forwarding command)[http://linuxcommand.org/man_pages/ssh1.html]. Once the ssh login is complete, you may just leave the remote shell open in the terminal window. This allows you to easily monitor the tunnel, should network problems cause a disconnect.
-
-Continuing the example above, you would point your browser to `https://127.0.0.1:8081` to view the Admin UI. The ssh tunnel takes care of securely routing this traffic to port 8080 on the node1.example.com, without exposing the Admin UI to the public world.
-
 <img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
+
+{{site.data.alerts.callout_info}}In cases where you set <code>--http-addr</code> to <code>localhost</code> and need to access the Admin UI from a machine separate from the cluster, you can use SSH to tunnel from the machine to a node.{{site.data.alerts.end}}  
 
 ## See Also
 

--- a/secure-a-cluster.md
+++ b/secure-a-cluster.md
@@ -2,126 +2,108 @@
 title: Secure a Cluster
 summary: Learn how to secure a CockroachDB cluster with authentication and encryption.
 toc: false
-expand: true
 ---
 
 Now that you have a [local cluster](start-a-local-cluster.html) up and running, let's secure it with authentication and encryption. This involves stopping the cluster, creating certificates, and restarting nodes with a few additional flags.
 
-1.  Stop the cluster and close the Admin UI:
+## Step 1.  Stop the cluster and close the Admin UI
 
-    ~~~ shell
-    $ cockroach quit
-    $ cockroach quit --port=26258
-    $ cockroach quit --port=26259
-    ~~~
+~~~ shell
+$ cockroach quit
+$ cockroach quit --port=26258
+$ cockroach quit --port=26259
+~~~
 
-    <button type="button" class="btn details collapsed" data-toggle="collapse" data-target="#details-secure1">Details</button>
-    <div id="details-secure1" class="collapse" markdown="1">
+- If you used the `cockroach start` commands on [Start a Cluster](start-a-local-cluster.html) verbatim, the commands above will work as well. Otherwise, just set the `--port` flag to the ports you used.
+- For more details about the `cockroach quit` command, see [Stop a Node](stop-a-node.html).
+- If you leave the Admin UI open, when you restart the cluster with security (steps 3 and 4), you'll see "TLS handshake" errors until you adjust the URL to https (step 7).
 
-    - If you used the `cockroach start` commands on [Start a Cluster](start-a-local-cluster.html) verbatim, the commands above will work as well. Otherwise, just set the `--port` flag to the ports you used.
-    - For more details about the `cockroach quit` command, see [Stop a Node](stop-a-node.html).
-    - If you leave the Admin UI open, when you restart the cluster with security (steps 3 and 4), you'll see "TLS handshake" errors until you adjust the URL to https (step 7).
+## Step 2.  Create security certificates
 
-    </div>
+~~~ shell
+$ mkdir certs
+$ cockroach cert create-ca --ca-cert=certs/ca.cert --ca-key=certs/ca.key
+$ cockroach cert create-node localhost $(hostname) --ca-cert=certs/ca.cert --ca-key=certs/ca.key --cert=certs/node.cert --key=certs/node.key
+$ cockroach cert create-client root --ca-cert=certs/ca.cert --ca-key=certs/ca.key --cert=certs/root.cert --key=certs/root.key
+~~~
 
-2.  Create security certificates:
+- The first command makes a new directory for the certificates.
+- The second command creates the Certificate Authority (CA) certificate and key: `ca.cert` and `ca.key`.
+- The third command creates the node certificate and key: `node.cert` and `node.key`. These files will be used to secure communication between nodes. Typically, you would generate these separately for each node since each node has unique addresses; in this case, however, since all nodes will be running locally, you need to generate only one node certificate and key.
+- The fourth command creates the client certificate and key, in this case for the `root` user: `root.cert` and `root.key`. These files will be used to secure communication between the built-in SQL shell and the cluster (see step 5).
 
-    ~~~ shell
-    $ mkdir certs
-    $ cockroach cert create-ca --ca-cert=certs/ca.cert --ca-key=certs/ca.key
-    $ cockroach cert create-node localhost $(hostname) --ca-cert=certs/ca.cert --ca-key=certs/ca.key --cert=certs/node.cert --key=certs/node.key
-    $ cockroach cert create-client root --ca-cert=certs/ca.cert --ca-key=certs/ca.key --cert=certs/root.cert --key=certs/root.key
-    ~~~
+## Step 3.  Restart the first node
 
-    <button type="button" class="btn details collapsed" data-toggle="collapse" data-target="#details-secure2">Details</button>
-    <div id="details-secure2" class="collapse" markdown="1">
+~~~ shell
+$ cockroach start --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --http-addr=localhost --background
 
-    - The first command makes a new directory for the certificates.
-    - The second command creates the Certificate Authority (CA) certificate and key: `ca.cert` and `ca.key`.
-    - The third command creates the node certificate and key: `node.cert` and `node.key`. These files will be used to secure communication between nodes. Typically, you would generate these separately for each node since each node has unique addresses; in this case, however, since all nodes will be running locally, you need to generate only one node certificate and key.
-    - The fourth command creates the client certificate and key, in this case for the `root` user: `root.cert` and `root.key`. These files will be used to secure communication between the built-in SQL shell and the cluster (see step 5).
-        
-    </div>
+build:     {{site.data.strings.version}} @ {{site.data.strings.build_time}}
+admin:     https://ROACHs-MBP:8080
+sql:       postgresql://root@ROACHs-MBP:26257?sslcert=%2FUsers%2F...
+logs:      cockroach-data/logs
+store[0]:  path=cockroach-data
+~~~
 
-3.  Restart the first node:
+This command restarts your first node with its existing data, but securely. The command is the same as before with the following additions: 
+
+- The `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the node certificate and key created in step 2. 
+- When certs are used, the Admin UI defaults to listening on all interfaces. The `--http-addr` flag is therefore used to restrict Admin UI access to the specified interface, in this case, `localhost`.
+
+## Step 4.  Restart additional nodes
+
+~~~ shell
+$ cockroach start --store=node2 --port=26258 --http-port=8081 --http-addr=localhost --join=localhost:26257 --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --background
+$ cockroach start --store=node3 --port=26259 --http-port=8082 --http-addr=localhost --join=localhost:26257 --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --background
+~~~
+
+These commands restart additional nodes with their existing data, but securely. The commands are the same as before with the following additions:
+
+- The `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the node certificate and key created in step 2. 
+- When certs are used, the Admin UI defaults to listening on all interfaces. The `--http-addr` flags are therefore used to restrict Admin UI access to the specified interface, in this case, `localhost`.
+
+## Step 5.  Restart the [built-in SQL client](use-the-built-in-sql-client.html) as an interactive shell
+
+~~~ shell
+$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
+# Welcome to the cockroach SQL interface.
+# All statements must be terminated by a semicolon.
+# To exit: CTRL + D.
+~~~
+
+This command is the same as before, but now uses the additional `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the certificate and key for the `root` user created in step 2.
+
+## Step 6.  Run more [CockroachDB SQL statements](learn-cockroachdb-sql.html)
+
+~~~ shell
+root@:26257> SET DATABASE = bank;
+SET DATABASE
+
+root@26257> SELECT * FROM accounts;
++------+----------+
+|  id  | balance  |
++------+----------+
+| 1234 | 10000.50 |
++------+----------+
+
+root@26257> INSERT INTO accounts VALUES (5678, 250.75);
+INSERT 1
+
+root@26257> SELECT * FROM accounts;
++------+----------+
+|  id  | balance  |
++------+----------+
+| 1234 | 10000.50 |
+| 5678 | 250.75   |
++------+----------+
+~~~
+
+When you're done using the SQL shell, press **CTRL + D** to exit.
  
-    ~~~ shell
-    $ cockroach start --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --http-addr=127.0.0.1 --background
+## Step 7.  Access the Admin UI
 
-    build:     {{site.data.strings.version}} @ {{site.data.strings.build_time}}
-    admin:     https://ROACHs-MBP:8080
-    sql:       postgresql://root@ROACHs-MBP:26257?sslcert=%2FUsers%2F...
-    logs:      cockroach-data/logs
-    store[0]:  path=cockroach-data
-    ~~~
+Reopen the [Admin UI](explore-the-admin-ui.html) by pointing your browser to `https://localhost:8080`. You can also find the address in the `admin` field in the standard output of any node on startup. 
 
-    <button type="button" class="btn details collapsed" data-toggle="collapse" data-target="#details-secure3">Details</button>
-    <div id="details-secure3" class="collapse" markdown="1">
-
-    This command restarts your first node with its existing data, but securely. The command is the same as before but now uses the additional `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the node certificate and key created in step 2. It also uses the --http-addr command to bind the http Admin UI to a non-public IP. This restricts access to the Admin UI to those who are authorized to establish an ssh tunnel to the host, as demonstrated below.
-
-    </div>
-
-4.  Restart additional nodes:
-
-    ~~~ shell
-    $ cockroach start --store=node2 --port=26258 --http-port=8081 --http-addr=127.0.0.1 --join=localhost:26257 --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --background
-    $ cockroach start --store=node3 --port=26259 --http-port=8082 --http-addr=127.0.0.1 --join=localhost:26257 --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --background
-    ~~~
-
-    <button type="button" class="btn details collapsed" data-toggle="collapse" data-target="#details-secure4">Details</button>
-    <div id="details-secure4" class="collapse" markdown="1">
-
-    These commands restart additional nodes with their existing data, but securely. The commands are the same as before but now uses the additional `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the node certificate and key created in step 2. The additional `--http-addr` restricts access to the http Admin UI interface, so that only local 127.0.0.1 or ssh-tunnelled administrators may access it.
-
-    </div>
-
-5.  Restart the [built-in SQL client](use-the-built-in-sql-client.html) as an interactive shell:
-
-    ~~~ shell
-    $ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
-    # Welcome to the cockroach SQL interface.
-    # All statements must be terminated by a semicolon.
-    # To exit: CTRL + D.
-    ~~~
-
-    <button type="button" class="btn details collapsed" data-toggle="collapse" data-target="#details-secure5">Details</button>
-    <div id="details-secure5" class="collapse" markdown="1">
-
-    This command is the same as before, but now uses the additional `--ca-cert`, `--cert`, and `--key` flags point to the CA certificate and the certificate and key for the `root` user created in step 2.
-
-    </div>
-
-6.  Run more [CockroachDB SQL statements](learn-cockroachdb-sql.html):
-
-    ~~~ shell
-    root@:26257> SET DATABASE = bank;
-    SET DATABASE
-
-    root@26257> SELECT * FROM accounts;
-    +------+----------+
-    |  id  | balance  |
-    +------+----------+
-    | 1234 | 10000.50 |
-    +------+----------+
-
-    root@26257> INSERT INTO accounts VALUES (5678, 250.75);
-    INSERT 1
-
-    root@26257> SELECT * FROM accounts;
-    +------+----------+
-    |  id  | balance  |
-    +------+----------+
-    | 1234 | 10000.50 |
-    | 5678 | 250.75   |
-    +------+----------+
-    ~~~
-
-    When you're done using the SQL shell, press **CTRL + D** to exit.
- 
-7.  Access the [Admin UI](explore-the-admin-ui.html) by first establishing an SSH tunnel for the http traffic from you laptop to the cockroach server by doing `ssh -L 8081:127.0.0.1:8080 ROACHs-MBP` at the shell prompt (substitute your first node's address for ROACHs-MBP). Note that you can and should skip the ssh tunnel if you are running cockroach locally on your laptop. Then point your browser at `https://127.0.0.1:8081`. You can find the address to tunnel to in the `admin` field in the standard output of any node on startup. 
-
-    Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.
+Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.
 
 ## What's Next?
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -45,7 +45,7 @@ This command starts a node, accepting all [`cockroach start`](start-a-node.html)
 
 - Communication is insecure, with the server listening only on `localhost` on port `26257` for internal and client communication and on port `8080` for HTTP requests from the Admin UI. 
    - To bind to different ports, set `--port=<port>` and `--http-port=<port>`. 
-   - To bind the Admin web UI to a private IP address or host, set `--http-addr=<private-addr>`.
+   - To bind the Admin UI to a private IP address or host, set `--http-addr=<private-addr>`.
    - To listen on an external hostname or IP address, set `--insecure` and `--host=<external address>`. For a demonstration, see [Manual Deployment](manual-deployment.html). 
 
 - Node data is stored in the `cockroach-data` directory. To store data in a different location, set `--store=<filepath>`. To use multiple stores, set this flag separately for each.


### PR DESCRIPTION
This PR contains revisions/clarifications around the new `--http-addr` flag. It also removes instructions about ssh tunneling, as requested by @tamird [here](https://github.com/cockroachdb/docs/pull/443/files/ff8589c12d1b01fa78d1aa9eb55acb148aa1ff87#r70448227). 

Also, this PR tries to clarify what `--host` defaults to, depending on scenario. Fixes #446 

HTTP version available here: http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/b379df2ae3f552cff5fea8bbb13a0d3178206c35

@tamird, @glycerine, PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/447)
<!-- Reviewable:end -->
