### PR TITLE
adding quote around volume option in docker command

### DIFF
--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -44,7 +44,7 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
 ## Step 2. Start your first container/node
 
 ~~~ shell
-$ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080 -v $(PWD)/cockroach-data/roach1:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
+$ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080 -v "$(PWD)/cockroach-data/roach1:/cockroach/cockroach-data" cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
 ~~~
 
 This command creates a container and starts the first CockroachDB node inside it. Let's look at each part:
@@ -61,8 +61,8 @@ This command creates a container and starts the first CockroachDB node inside it
 ## Step 3. Start additional containers/nodes
 
 ~~~ shell
-$ docker run -d --name=roach2 --hostname=roach2 --net=roachnet -P -v $(PWD)/cockroach-data/roach2:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
-$ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P -v $(PWD)/cockroach-data/roach3:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+$ docker run -d --name=roach2 --hostname=roach2 --net=roachnet -P -v "$(PWD)/cockroach-data/roach2:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}}" start --insecure --join=roach1
+$ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P -v "$(PWD)/cockroach-data/roach3:/cockroach/cockroach-data cockroachdb/cockroach:{{site.data.strings.version}}" start --insecure --join=roach1
 ~~~
 
 These commands add two more containers and start CockroachDB nodes inside them, joining them to the first node. There are only a few differences to note from step 2:


### PR DESCRIPTION
Docker on windows doesn't like volume tags without quotes. Following is the error. Works after adding quotes.

C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error parsing reference: "/cockroach-data/roach1:/cockroach/coc
kroach-data" is not a valid repository/tag.
See 'C:\Program Files\Docker\Docker\Resources\bin\docker.exe run --help'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/457)
<!-- Reviewable:end -->
