### PR TITLE
additional interval formats

### DIFF
--- a/interval.md
+++ b/interval.md
@@ -10,18 +10,15 @@ The `INTERVAL` [data type](data-types.html) stores a value that represents a spa
 
 ## Format
 
-When inserting into an `INTERVAL` column, format the value as `INTERVAL '2h30m30s'`, where the following units can be specified either as positive or negative decimal numbers:
+When inserting into an `INTERVAL` column, use one of the following formats:
 
-- `h` (hour)
-- `m` (minute)
-- `s` (second)
-- `ms` (millisecond)
-- `us` (microsecond)
-- `ns` (nanosecond)
+Format | Description
+-------|--------
+Golang | `INTERVAL '1h2m3s4ms5us6ns'`, where `ms` is millisecond, `us` is microsecond, and `ns` is nanosecond<br><br>Regardless of the units used, the interval is stored as hour, minute, and second, for example, `1h2m3.004005006s`.
+Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`<br><br>Regardless of the units used, the interval is stored as month, day, hour, minute, and second, for example, `14m3d4h5m6s`. 
+ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`<br><br>Regardless of the units used, the interval is stored as month, day, hour, minute, and second, for example, `14m3d4h5m6s`.
 
-Alternatively, you can use a string literal, e.g., `'2h30m30s'`, which CockroachDB will resolve into the `INTERVAL` type.
-
-Note that regardless of the units used, the interval is stored as hour, minute, and second, for example, `12h2m1.023s`.
+Alternatively, you can use a string literal, e.g., `'1h2m3s4ms5us6ns'` or`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`, which CockroachDB will resolve into the `INTERVAL` type.
 
 ## Size
 
@@ -40,15 +37,16 @@ SHOW COLUMNS FROM intervals;
 | b     | INTERVAL | true  | NULL    |
 +-------+----------+-------+---------+
 
-INSERT INTO intervals VALUES (1111, INTERVAL '2h30m50ns'), (2222, INTERVAL '-2h30m50ns');
+INSERT INTO intervals VALUES (1, INTERVAL '1h2m3s4ms5us6ns'), (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds');
 
 SELECT * FROM intervals;
-+------+-------------------+
-|  a   |         b         |
-+------+-------------------+
-| 1111 | 2h30m0.00000005s  |
-| 2222 | -2h30m0.00000005s |
-+------+-------------------+
++---+------------------+
+| a |        b         |
++---+------------------+
+| 1 | 1h2m3.004005006s |
+| 2 | 14m3d4h5m6s      |
++---+------------------+
+(2 rows)
 ~~~
 
 ## See Also

--- a/interval.md
+++ b/interval.md
@@ -14,11 +14,13 @@ When inserting into an `INTERVAL` column, use one of the following formats:
 
 Format | Description
 -------|--------
-Golang | `INTERVAL '1h2m3s4ms5us6ns'`, where `ms` is millisecond, `us` is microsecond, and `ns` is nanosecond<br><br>Regardless of the units used, the interval is stored as hour, minute, and second, for example, `1h2m3.004005006s`.
-Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`<br><br>Regardless of the units used, the interval is stored as month, day, hour, minute, and second, for example, `14m3d4h5m6s`. 
-ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`<br><br>Regardless of the units used, the interval is stored as month, day, hour, minute, and second, for example, `14m3d4h5m6s`.
+Golang | `INTERVAL '1h2m3s4ms5us6ns'`, where `ms` is millisecond, `us` is microsecond, and `ns` is nanosecond
+Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'` 
+ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
 
 Alternatively, you can use a string literal, e.g., `'1h2m3s4ms5us6ns'` or`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`, which CockroachDB will resolve into the `INTERVAL` type.
+
+Intervals are stored internally as months, days, and nanoseconds.
 
 ## Size
 


### PR DESCRIPTION
This PR adds the Postgres and ISO formats to our docs on the `INTERVAL` data type. 

Once https://github.com/cockroachdb/cockroach/issues/7916 is resolved, I'll add in mention of negative intervals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/462)
<!-- Reviewable:end -->
