### PR TITLE
Docs feedback widget

### DIFF
--- a/_includes/feedback-widget.html
+++ b/_includes/feedback-widget.html
@@ -1,0 +1,47 @@
+<!-- Helpful? question with Yes and No buttons. Yes button submits directly to hubspot via the forms api. No button triggers a popup with an embedded hubspot form. -->
+
+<div id="feedback-prompt">
+  <p class="feedback-question">Was this page helpful?</p>
+  <form action='https://forms.hubspot.com/uploads/form/v2/1753393/6739d0dd-8ecb-40a6-a814-d6f84b05a6ee' method="post">
+    <input name="helpful" value="yes" type="hidden">
+    <input name="hs_context" value='{"pageTitle":"{{page.title}}"}' type="hidden">
+    <button class="yes-button">Yes</button>
+  </form>
+  <a href="#feedback-popup" class="no-button">No</a>
+</div>
+
+<div id="feedback-popup" class="white-popup mfp-hide">
+  <!--[if lte IE 8]>
+  <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+  <![endif]-->
+  <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+  <script>
+    hbspt.forms.create({ 
+      css: '',
+      portalId: '1753393',
+      formId: '6739d0dd-8ecb-40a6-a814-d6f84b05a6ee'
+    });
+  </script>
+</div>
+
+<script>
+  $(document).ready(function() {
+    $('.no-button').magnificPopup({
+      type:'inline',
+      midClick: true // Allow opening popup on middle mouse click. Always set it to true if you don't provide alternative source in href.
+    });
+  });
+</script>
+
+
+<!-- Alternate design: stars for rating the page. Clicking a star opens a feedback modal.
+<div class="rating" data-toggle="modal" data-target="#feedback">
+  <p><i>Was this page helpful?</i></p>
+  <ul>
+    <li><p class="vote 1" id="vote" data-toggle="tooltip" data-container="body" title="Unusable">&starf;</p></li>
+    <li><p class="vote 2" id="vote" data-toggle="tooltip" data-container="body" title="Poor">&starf;</p></li>
+    <li><p class="vote 3" id="vote" data-toggle="tooltip" data-container="body" title="OK">&starf;</p></li>
+    <li><p class="vote 4" id="vote" data-toggle="tooltip" data-container="body" title="Good">&starf;</p></li>
+    <li><p class="vote 5" id="vote" data-toggle="tooltip" data-container="body" title="Exellent">&starf;</p></li>
+  </ul> 
+</div> -->

--- a/_includes/feedback-widget.html
+++ b/_includes/feedback-widget.html
@@ -2,7 +2,7 @@
 
 <div id="feedback-prompt">
   <p class="feedback-question">Was this page helpful?</p>
-  <form action='https://forms.hubspot.com/uploads/form/v2/1753393/6739d0dd-8ecb-40a6-a814-d6f84b05a6ee' method="post">
+  <form action='https://forms.hubspot.com/uploads/form/v2/1753393/6739d0dd-8ecb-40a6-a814-d6f84b05a6ee' method="post" target="hiddenFrame">
     <input name="helpful" value="yes" type="hidden">
     <input name="hs_context" value='{"pageTitle":"{{page.title}}"}' type="hidden">
     <button class="yes-button">Yes</button>
@@ -32,3 +32,5 @@
     });
   });
 </script>
+
+<iframe name="hiddenFrame" width="0" height="0" border="0" style="display: none;"></iframe>

--- a/_includes/feedback-widget.html
+++ b/_includes/feedback-widget.html
@@ -32,16 +32,3 @@
     });
   });
 </script>
-
-
-<!-- Alternate design: stars for rating the page. Clicking a star opens a feedback modal.
-<div class="rating" data-toggle="modal" data-target="#feedback">
-  <p><i>Was this page helpful?</i></p>
-  <ul>
-    <li><p class="vote 1" id="vote" data-toggle="tooltip" data-container="body" title="Unusable">&starf;</p></li>
-    <li><p class="vote 2" id="vote" data-toggle="tooltip" data-container="body" title="Poor">&starf;</p></li>
-    <li><p class="vote 3" id="vote" data-toggle="tooltip" data-container="body" title="OK">&starf;</p></li>
-    <li><p class="vote 4" id="vote" data-toggle="tooltip" data-container="body" title="Good">&starf;</p></li>
-    <li><p class="vote 5" id="vote" data-toggle="tooltip" data-container="body" title="Exellent">&starf;</p></li>
-  </ul> 
-</div> -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,6 +14,7 @@
 <link rel="stylesheet" type="text/css" href="css/lavish-bootstrap.css">
 <link rel="stylesheet" type="text/css" href="css/customstyles.css">
 <link rel="stylesheet" type="text/css" href="css/{{site.theme_file}}">
+<link rel="stylesheet" type="text/css" href="css/feedback-widget.css">
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
@@ -22,3 +23,4 @@
 <script src="js/toc.js"></script>
 <script src="js/customscripts.js"></script>
 <script src="js/anchor.js"></script>
+<script src="js/feedback-widget.js"></script>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -18,6 +18,11 @@ layout: default
 
    {% include linkrefs.html %}
 
+   {% if page.feedback != false %}
+      <br><br>
+      {% include feedback-widget.html %}
+   {% endif %}
+
 </div>
 
 {% if page.homepage != true %}

--- a/back-up-and-restore-data.md
+++ b/back-up-and-restore-data.md
@@ -2,6 +2,7 @@
 title: Back Up and Restore Data
 summary: Learn how to back up and restore a CockroachDB cluster.
 toc: false
+feedback: false
 ---
 
 CockroachDB is working on a command that lets you back up a live cluster. More details coming soon.

--- a/cockroachdb-architecture.md
+++ b/cockroachdb-architecture.md
@@ -2,6 +2,7 @@
 title: CockroachDB Architecture
 summary: Explore the architecture of CockroachDB.
 toc: false
+feedback: false
 ---
 
 Coming soon. For now, see the [CockroachDB Design](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md) doc.

--- a/cockroachdb-in-comparison.md
+++ b/cockroachdb-in-comparison.md
@@ -5,7 +5,7 @@ toc: false
 ---
 
 <script>
-$(document).ready(function(){
+$(function() {
     $('[data-toggle="tooltip"]').tooltip();   
 });
 </script>

--- a/css/feedback-widget.css
+++ b/css/feedback-widget.css
@@ -1,0 +1,530 @@
+/* Feedback question and buttons */
+
+.feedback-question {
+  float: left;
+  display: inline-block;
+  line-height: 0px;
+  padding-right: 10px;
+}
+
+.no-button {
+  width: 5%;
+  margin: 0 0.5%;
+  font-family: 'AvenirLTStd-Light', serif;
+  font-size: 14px;
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 16px;
+  display: inline-block;
+  border: 1px solid #46A418;
+  border-radius: 2px;
+  background-color: #ffffff;
+  text-align: center;
+  color: #46A418;
+  text-decoration: none !important;
+  text-transform: uppercase;
+  transition: .2s background ease-in-out;
+  padding: 10px 0;
+  outline: none;
+}
+
+.yes-button {
+  float: left;
+  width: 5%;
+  margin: 0 0.5%;
+  font-family: 'AvenirLTStd-Light', serif;
+  font-size: 14px;
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 16px;
+  display: inline-block;
+  border: 1px solid #46A418;
+  border-radius: 2px;
+  background-color: #ffffff;
+  text-align: center;
+  color: #46A418;
+  text-decoration: none !important;
+  text-transform: uppercase;
+  transition: .2s background ease-in-out;
+  padding: 10px 0;
+  outline: none;
+}
+
+.no-button:hover, .yes-button:hover, .no-button:focus, .yes-button:focus {
+  outline: none;
+  transition: .2s background ease-in-out;
+  background-color: #46A418;
+  color: #fff !important;
+}
+
+/* Feedback popup and hubspot form */
+
+.white-popup {
+  position: relative;
+  background: #FFF;
+  padding: 30px;
+  width:auto;
+  max-width: 500px;
+  margin: 20px auto;
+}
+
+.white-popup .hbspt-form label {
+  color: #142848;
+  font-family: 'AvenirLTStd-Light', serif;
+  font-size: 17px;
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 28px;
+}
+
+.white-popup .hbspt-form ul {
+  margin-top: 10px;
+}
+
+.white-popup .hbspt-form li {
+  list-style: none;
+  margin-left: -30px;
+}
+
+.white-popup .hbspt-form li label {
+  list-style: none;
+  font-weight: normal;
+}
+
+.white-popup .hbspt-form li label input {
+  margin-right: 10px;
+}
+
+.white-popup .hbspt-form textarea {
+  width: 80%;
+  margin-bottom: 20px;
+  padding: 10px;
+}
+
+.white-popup .hbspt-form .hs_email input {
+  width: 80%;
+  margin-bottom: 20px;
+  padding-left: 10px;
+}
+
+.white-popup .hbspt-form .hs-button {
+  color: #fff;
+  background: #46a417;
+  border: 2px solid #46a417;
+  border-radius: 35px;
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  padding: 5px 20px;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.white-popup .hbspt-form .hs-button:hover {
+  background: #fff;
+  color: #46a417;
+}
+
+.mfp-bg {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1042;
+  overflow: hidden;
+  position: fixed;
+  background: #0b0b0b;
+  opacity: 0.8; }
+
+.mfp-wrap {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1043;
+  position: fixed;
+  outline: none !important;
+  -webkit-backface-visibility: hidden; }
+
+.mfp-container {
+  text-align: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  padding: 0 8px;
+  box-sizing: border-box; }
+
+.mfp-container:before {
+  content: '';
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle; }
+
+.mfp-align-top .mfp-container:before {
+  display: none; }
+
+.mfp-content {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 auto;
+  text-align: left;
+  z-index: 1045; }
+
+.mfp-inline-holder .mfp-content,
+.mfp-ajax-holder .mfp-content {
+  width: 100%;
+  cursor: auto; }
+
+.mfp-ajax-cur {
+  cursor: progress; }
+
+.mfp-zoom-out-cur, .mfp-zoom-out-cur .mfp-image-holder .mfp-close {
+  cursor: -moz-zoom-out;
+  cursor: -webkit-zoom-out;
+  cursor: zoom-out; }
+
+.mfp-zoom {
+  cursor: pointer;
+  cursor: -webkit-zoom-in;
+  cursor: -moz-zoom-in;
+  cursor: zoom-in; }
+
+.mfp-auto-cursor .mfp-content {
+  cursor: auto; }
+
+.mfp-close,
+.mfp-arrow,
+.mfp-preloader,
+.mfp-counter {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none; }
+
+.mfp-loading.mfp-figure {
+  display: none; }
+
+.mfp-hide {
+  display: none !important; }
+
+.mfp-preloader {
+  color: #CCC;
+  position: absolute;
+  top: 50%;
+  width: auto;
+  text-align: center;
+  margin-top: -0.8em;
+  left: 8px;
+  right: 8px;
+  z-index: 1044; }
+  .mfp-preloader a {
+    color: #CCC; }
+    .mfp-preloader a:hover {
+      color: #FFF; }
+
+.mfp-s-ready .mfp-preloader {
+  display: none; }
+
+.mfp-s-error .mfp-content {
+  display: none; }
+
+button.mfp-close,
+button.mfp-arrow {
+  overflow: visible;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  -webkit-appearance: none;
+  display: block;
+  outline: none;
+  padding: 0;
+  z-index: 1046;
+  box-shadow: none;
+  touch-action: manipulation; }
+
+button::-moz-focus-inner {
+  padding: 0;
+  border: 0; }
+
+.mfp-close {
+  width: 44px;
+  height: 44px;
+  line-height: 44px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  text-decoration: none;
+  text-align: center;
+  opacity: 0.65;
+  padding: 0 0 18px 10px;
+  color: #FFF;
+  font-style: normal;
+  font-size: 28px;
+  font-family: Arial, Baskerville, monospace; }
+  .mfp-close:hover,
+  .mfp-close:focus {
+    opacity: 1; }
+  .mfp-close:active {
+    top: 1px; }
+
+.mfp-close-btn-in .mfp-close {
+  color: #46A418; }
+
+.mfp-image-holder .mfp-close,
+.mfp-iframe-holder .mfp-close {
+  color: #FFF;
+  right: -6px;
+  text-align: right;
+  padding-right: 6px;
+  width: 100%; }
+
+.mfp-counter {
+  position: absolute;
+  top: 0;
+  right: 0;
+  color: #CCC;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: nowrap; }
+
+.mfp-arrow {
+  position: absolute;
+  opacity: 0.65;
+  margin: 0;
+  top: 50%;
+  margin-top: -55px;
+  padding: 0;
+  width: 90px;
+  height: 110px;
+  -webkit-tap-highlight-color: transparent; }
+  .mfp-arrow:active {
+    margin-top: -54px; }
+  .mfp-arrow:hover,
+  .mfp-arrow:focus {
+    opacity: 1; }
+  .mfp-arrow:before,
+  .mfp-arrow:after {
+    content: '';
+    display: block;
+    width: 0;
+    height: 0;
+    position: absolute;
+    left: 0;
+    top: 0;
+    margin-top: 35px;
+    margin-left: 35px;
+    border: medium inset transparent; }
+  .mfp-arrow:after {
+    border-top-width: 13px;
+    border-bottom-width: 13px;
+    top: 8px; }
+  .mfp-arrow:before {
+    border-top-width: 21px;
+    border-bottom-width: 21px;
+    opacity: 0.7; }
+
+.mfp-arrow-left {
+  left: 0; }
+  .mfp-arrow-left:after {
+    border-right: 17px solid #FFF;
+    margin-left: 31px; }
+  .mfp-arrow-left:before {
+    margin-left: 25px;
+    border-right: 27px solid #3F3F3F; }
+
+.mfp-arrow-right {
+  right: 0; }
+  .mfp-arrow-right:after {
+    border-left: 17px solid #FFF;
+    margin-left: 39px; }
+  .mfp-arrow-right:before {
+    border-left: 27px solid #3F3F3F; }
+
+.mfp-iframe-holder {
+  padding-top: 40px;
+  padding-bottom: 40px; }
+  .mfp-iframe-holder .mfp-content {
+    line-height: 0;
+    width: 100%;
+    max-width: 900px; }
+  .mfp-iframe-holder .mfp-close {
+    top: -40px; }
+
+.mfp-iframe-scaler {
+  width: 100%;
+  height: 0;
+  overflow: hidden;
+  padding-top: 56.25%; }
+  .mfp-iframe-scaler iframe {
+    position: absolute;
+    display: block;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+    background: #000; }
+
+/* Main image in popup */
+img.mfp-img {
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  display: block;
+  line-height: 0;
+  box-sizing: border-box;
+  padding: 40px 0 40px;
+  margin: 0 auto; }
+
+/* The shadow behind the image */
+.mfp-figure {
+  line-height: 0; }
+  .mfp-figure:after {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 40px;
+    bottom: 40px;
+    display: block;
+    right: 0;
+    width: auto;
+    height: auto;
+    z-index: -1;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+    background: #444; }
+  .mfp-figure small {
+    color: #BDBDBD;
+    display: block;
+    font-size: 12px;
+    line-height: 14px; }
+  .mfp-figure figure {
+    margin: 0; }
+
+.mfp-bottom-bar {
+  margin-top: -36px;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  cursor: auto; }
+
+.mfp-title {
+  text-align: left;
+  line-height: 18px;
+  color: #F3F3F3;
+  word-wrap: break-word;
+  padding-right: 36px; }
+
+.mfp-image-holder .mfp-content {
+  max-width: 100%; }
+
+.mfp-gallery .mfp-image-holder .mfp-figure {
+  cursor: pointer; }
+
+@media screen and (max-width: 800px) and (orientation: landscape), screen and (max-height: 300px) {
+  /**
+       * Remove all paddings around the image on small screen
+       */
+  .mfp-img-mobile .mfp-image-holder {
+    padding-left: 0;
+    padding-right: 0; }
+  .mfp-img-mobile img.mfp-img {
+    padding: 0; }
+  .mfp-img-mobile .mfp-figure:after {
+    top: 0;
+    bottom: 0; }
+  .mfp-img-mobile .mfp-figure small {
+    display: inline;
+    margin-left: 5px; }
+  .mfp-img-mobile .mfp-bottom-bar {
+    background: rgba(0, 0, 0, 0.6);
+    bottom: 0;
+    margin: 0;
+    top: auto;
+    padding: 3px 5px;
+    position: fixed;
+    box-sizing: border-box; }
+    .mfp-img-mobile .mfp-bottom-bar:empty {
+      padding: 0; }
+  .mfp-img-mobile .mfp-counter {
+    right: 5px;
+    top: 3px; }
+  .mfp-img-mobile .mfp-close {
+    top: 0;
+    right: 0;
+    width: 35px;
+    height: 35px;
+    line-height: 35px;
+    background: rgba(0, 0, 0, 0.6);
+    position: fixed;
+    text-align: center;
+    padding: 0; } }
+
+@media all and (max-width: 900px) {
+  .mfp-arrow {
+    -webkit-transform: scale(0.75);
+    transform: scale(0.75); }
+  .mfp-arrow-left {
+    -webkit-transform-origin: 0;
+    transform-origin: 0; }
+  .mfp-arrow-right {
+    -webkit-transform-origin: 100%;
+    transform-origin: 100%; }
+  .mfp-container {
+    padding-left: 6px;
+    padding-right: 6px; } }
+
+
+/*
+.rating {
+  padding-top: 20px;
+}
+
+.rating.top {
+  float: right;
+  padding-top: 5px;
+  margin: 0px 10px;
+}
+
+.rating ul { 
+  margin: 0;
+  padding: 0;
+  list-style-type: none; 
+}
+
+.rating ul li { 
+  display: inline-block; 
+  margin: -15px 0px;
+}
+
+p.vote {
+  color: #46a417;
+  opacity: 0.2;
+  font-size: 25px;
+  cursor: pointer;
+}
+
+img.vote {
+  width: 27px;
+  margin: 12px 5px 0px 0px;
+  opacity: 0.2;
+}
+
+@media screen and (min-width: 768px) {
+  .modal, .modal-dialog, .modal-content {
+    left: 0;
+    position: static;
+  }
+}
+
+.modal-backdrop {
+  z-index: 0;
+}
+*/

--- a/css/feedback-widget.css
+++ b/css/feedback-widget.css
@@ -3,7 +3,7 @@
 .feedback-question {
   float: left;
   display: inline-block;
-  line-height: 0px;
+  line-height: 0;
   padding-right: 10px;
 }
 
@@ -59,7 +59,10 @@
   color: #fff !important;
 }
 
-/* Feedback popup and hubspot form */
+/* Feedback popup and hubspot form 
+* Most of this is from Magnific Popup - v1.1.0 - 2016-02-20
+* http://dimsemenov.com/plugins/magnific-popup/
+* Copyright (c) 2016 Dmitry Semenov; */
 
 .white-popup {
   position: relative;
@@ -488,51 +491,3 @@ img.mfp-img {
   .mfp-container {
     padding-left: 6px;
     padding-right: 6px; } }
-
-
-/*
-.rating {
-  padding-top: 20px;
-}
-
-.rating.top {
-  float: right;
-  padding-top: 5px;
-  margin: 0px 10px;
-}
-
-.rating ul { 
-  margin: 0;
-  padding: 0;
-  list-style-type: none; 
-}
-
-.rating ul li { 
-  display: inline-block; 
-  margin: -15px 0px;
-}
-
-p.vote {
-  color: #46a417;
-  opacity: 0.2;
-  font-size: 25px;
-  cursor: pointer;
-}
-
-img.vote {
-  width: 27px;
-  margin: 12px 5px 0px 0px;
-  opacity: 0.2;
-}
-
-@media screen and (min-width: 768px) {
-  .modal, .modal-dialog, .modal-content {
-    left: 0;
-    position: static;
-  }
-}
-
-.modal-backdrop {
-  z-index: 0;
-}
-*/

--- a/css/feedback-widget.css
+++ b/css/feedback-widget.css
@@ -123,11 +123,19 @@
   padding: 5px 20px;
   font-weight: bold;
   text-transform: uppercase;
+  outline: none;
+  margin-top: 5px;
 }
 
 .white-popup .hbspt-form .hs-button:hover {
   background: #fff;
   color: #46a417;
+  outline: none;
+}
+
+.white-popup .hbspt-form .submitted-message {
+  font-size: 30px;
+  font-weight: bold;
 }
 
 .mfp-bg {

--- a/css/feedback-widget.css
+++ b/css/feedback-widget.css
@@ -8,7 +8,7 @@
 }
 
 .no-button {
-  width: 5%;
+  width: 40px;
   margin: 0 0.5%;
   font-family: 'AvenirLTStd-Light', serif;
   font-size: 14px;
@@ -31,7 +31,7 @@
 
 .yes-button {
   float: left;
-  width: 5%;
+  width: 40px;
   margin: 0 0.5%;
   font-family: 'AvenirLTStd-Light', serif;
   font-size: 14px;

--- a/css/theme-blue.css
+++ b/css/theme-blue.css
@@ -104,7 +104,7 @@ a[data-toggle="tooltip"], a:hover[data-toggle="tooltip"] {
 }
 
 .cockroach-gitter-open-chat-button {
-    z-index: 9999;
+    z-index: 1000;
     color: #fff;
     position: fixed;
     bottom: 0;

--- a/explore-the-admin-ui.md
+++ b/explore-the-admin-ui.md
@@ -1,4 +1,5 @@
 ---
 title: Explore the Admin UI
 toc: false
+feedback: false
 ---

--- a/js/feedback-widget.js
+++ b/js/feedback-widget.js
@@ -1,0 +1,1227 @@
+/*! Magnific Popup - v1.1.0 - 2016-02-20
+* http://dimsemenov.com/plugins/magnific-popup/
+* Copyright (c) 2016 Dmitry Semenov; */
+;(function (factory) { 
+if (typeof define === 'function' && define.amd) { 
+ // AMD. Register as an anonymous module. 
+ define(['jquery'], factory); 
+ } else if (typeof exports === 'object') { 
+ // Node/CommonJS 
+ factory(require('jquery')); 
+ } else { 
+ // Browser globals 
+ factory(window.jQuery || window.Zepto); 
+ } 
+ }(function($) { 
+
+/*>>core*/
+/**
+ * 
+ * Magnific Popup Core JS file
+ * 
+ */
+
+
+/**
+ * Private static constants
+ */
+var CLOSE_EVENT = 'Close',
+  BEFORE_CLOSE_EVENT = 'BeforeClose',
+  AFTER_CLOSE_EVENT = 'AfterClose',
+  BEFORE_APPEND_EVENT = 'BeforeAppend',
+  MARKUP_PARSE_EVENT = 'MarkupParse',
+  OPEN_EVENT = 'Open',
+  CHANGE_EVENT = 'Change',
+  NS = 'mfp',
+  EVENT_NS = '.' + NS,
+  READY_CLASS = 'mfp-ready',
+  REMOVING_CLASS = 'mfp-removing',
+  PREVENT_CLOSE_CLASS = 'mfp-prevent-close';
+
+
+/**
+ * Private vars 
+ */
+/*jshint -W079 */
+var mfp, // As we have only one instance of MagnificPopup object, we define it locally to not to use 'this'
+  MagnificPopup = function(){},
+  _isJQ = !!(window.jQuery),
+  _prevStatus,
+  _window = $(window),
+  _document,
+  _prevContentType,
+  _wrapClasses,
+  _currPopupType;
+
+
+/**
+ * Private functions
+ */
+var _mfpOn = function(name, f) {
+    mfp.ev.on(NS + name + EVENT_NS, f);
+  },
+  _getEl = function(className, appendTo, html, raw) {
+    var el = document.createElement('div');
+    el.className = 'mfp-'+className;
+    if(html) {
+      el.innerHTML = html;
+    }
+    if(!raw) {
+      el = $(el);
+      if(appendTo) {
+        el.appendTo(appendTo);
+      }
+    } else if(appendTo) {
+      appendTo.appendChild(el);
+    }
+    return el;
+  },
+  _mfpTrigger = function(e, data) {
+    mfp.ev.triggerHandler(NS + e, data);
+
+    if(mfp.st.callbacks) {
+      // converts "mfpEventName" to "eventName" callback and triggers it if it's present
+      e = e.charAt(0).toLowerCase() + e.slice(1);
+      if(mfp.st.callbacks[e]) {
+        mfp.st.callbacks[e].apply(mfp, $.isArray(data) ? data : [data]);
+      }
+    }
+  },
+  _getCloseBtn = function(type) {
+    if(type !== _currPopupType || !mfp.currTemplate.closeBtn) {
+      mfp.currTemplate.closeBtn = $( mfp.st.closeMarkup.replace('%title%', mfp.st.tClose ) );
+      _currPopupType = type;
+    }
+    return mfp.currTemplate.closeBtn;
+  },
+  // Initialize Magnific Popup only when called at least once
+  _checkInstance = function() {
+    if(!$.magnificPopup.instance) {
+      /*jshint -W020 */
+      mfp = new MagnificPopup();
+      mfp.init();
+      $.magnificPopup.instance = mfp;
+    }
+  },
+  // CSS transition detection, http://stackoverflow.com/questions/7264899/detect-css-transitions-using-javascript-and-without-modernizr
+  supportsTransitions = function() {
+    var s = document.createElement('p').style, // 's' for style. better to create an element if body yet to exist
+      v = ['ms','O','Moz','Webkit']; // 'v' for vendor
+
+    if( s['transition'] !== undefined ) {
+      return true; 
+    }
+      
+    while( v.length ) {
+      if( v.pop() + 'Transition' in s ) {
+        return true;
+      }
+    }
+        
+    return false;
+  };
+
+
+
+/**
+ * Public functions
+ */
+MagnificPopup.prototype = {
+
+  constructor: MagnificPopup,
+
+  /**
+   * Initializes Magnific Popup plugin. 
+   * This function is triggered only once when $.fn.magnificPopup or $.magnificPopup is executed
+   */
+  init: function() {
+    var appVersion = navigator.appVersion;
+    mfp.isLowIE = mfp.isIE8 = document.all && !document.addEventListener;
+    mfp.isAndroid = (/android/gi).test(appVersion);
+    mfp.isIOS = (/iphone|ipad|ipod/gi).test(appVersion);
+    mfp.supportsTransition = supportsTransitions();
+
+    // We disable fixed positioned lightbox on devices that don't handle it nicely.
+    // If you know a better way of detecting this - let me know.
+    mfp.probablyMobile = (mfp.isAndroid || mfp.isIOS || /(Opera Mini)|Kindle|webOS|BlackBerry|(Opera Mobi)|(Windows Phone)|IEMobile/i.test(navigator.userAgent) );
+    _document = $(document);
+
+    mfp.popupsCache = {};
+  },
+
+  /**
+   * Opens popup
+   * @param  data [description]
+   */
+  open: function(data) {
+
+    var i;
+
+    if(data.isObj === false) { 
+      // convert jQuery collection to array to avoid conflicts later
+      mfp.items = data.items.toArray();
+
+      mfp.index = 0;
+      var items = data.items,
+        item;
+      for(i = 0; i < items.length; i++) {
+        item = items[i];
+        if(item.parsed) {
+          item = item.el[0];
+        }
+        if(item === data.el[0]) {
+          mfp.index = i;
+          break;
+        }
+      }
+    } else {
+      mfp.items = $.isArray(data.items) ? data.items : [data.items];
+      mfp.index = data.index || 0;
+    }
+
+    // if popup is already opened - we just update the content
+    if(mfp.isOpen) {
+      mfp.updateItemHTML();
+      return;
+    }
+    
+    mfp.types = []; 
+    _wrapClasses = '';
+    if(data.mainEl && data.mainEl.length) {
+      mfp.ev = data.mainEl.eq(0);
+    } else {
+      mfp.ev = _document;
+    }
+
+    if(data.key) {
+      if(!mfp.popupsCache[data.key]) {
+        mfp.popupsCache[data.key] = {};
+      }
+      mfp.currTemplate = mfp.popupsCache[data.key];
+    } else {
+      mfp.currTemplate = {};
+    }
+
+
+
+    mfp.st = $.extend(true, {}, $.magnificPopup.defaults, data ); 
+    mfp.fixedContentPos = mfp.st.fixedContentPos === 'auto' ? !mfp.probablyMobile : mfp.st.fixedContentPos;
+
+    if(mfp.st.modal) {
+      mfp.st.closeOnContentClick = false;
+      mfp.st.closeOnBgClick = false;
+      mfp.st.showCloseBtn = false;
+      mfp.st.enableEscapeKey = false;
+    }
+    
+
+    // Building markup
+    // main containers are created only once
+    if(!mfp.bgOverlay) {
+
+      // Dark overlay
+      mfp.bgOverlay = _getEl('bg').on('click'+EVENT_NS, function() {
+        mfp.close();
+      });
+
+      mfp.wrap = _getEl('wrap').attr('tabindex', -1).on('click'+EVENT_NS, function(e) {
+        if(mfp._checkIfClose(e.target)) {
+          mfp.close();
+        }
+      });
+
+      mfp.container = _getEl('container', mfp.wrap);
+    }
+
+    mfp.contentContainer = _getEl('content');
+    if(mfp.st.preloader) {
+      mfp.preloader = _getEl('preloader', mfp.container, mfp.st.tLoading);
+    }
+
+
+    // Initializing modules
+    var modules = $.magnificPopup.modules;
+    for(i = 0; i < modules.length; i++) {
+      var n = modules[i];
+      n = n.charAt(0).toUpperCase() + n.slice(1);
+      mfp['init'+n].call(mfp);
+    }
+    _mfpTrigger('BeforeOpen');
+
+
+    if(mfp.st.showCloseBtn) {
+      // Close button
+      if(!mfp.st.closeBtnInside) {
+        mfp.wrap.append( _getCloseBtn() );
+      } else {
+        _mfpOn(MARKUP_PARSE_EVENT, function(e, template, values, item) {
+          values.close_replaceWith = _getCloseBtn(item.type);
+        });
+        _wrapClasses += ' mfp-close-btn-in';
+      }
+    }
+
+    if(mfp.st.alignTop) {
+      _wrapClasses += ' mfp-align-top';
+    }
+
+  
+
+    if(mfp.fixedContentPos) {
+      mfp.wrap.css({
+        overflow: mfp.st.overflowY,
+        overflowX: 'hidden',
+        overflowY: mfp.st.overflowY
+      });
+    } else {
+      mfp.wrap.css({ 
+        top: _window.scrollTop(),
+        position: 'absolute'
+      });
+    }
+    if( mfp.st.fixedBgPos === false || (mfp.st.fixedBgPos === 'auto' && !mfp.fixedContentPos) ) {
+      mfp.bgOverlay.css({
+        height: _document.height(),
+        position: 'absolute'
+      });
+    }
+
+    
+
+    if(mfp.st.enableEscapeKey) {
+      // Close on ESC key
+      _document.on('keyup' + EVENT_NS, function(e) {
+        if(e.keyCode === 27) {
+          mfp.close();
+        }
+      });
+    }
+
+    _window.on('resize' + EVENT_NS, function() {
+      mfp.updateSize();
+    });
+
+
+    if(!mfp.st.closeOnContentClick) {
+      _wrapClasses += ' mfp-auto-cursor';
+    }
+    
+    if(_wrapClasses)
+      mfp.wrap.addClass(_wrapClasses);
+
+
+    // this triggers recalculation of layout, so we get it once to not to trigger twice
+    var windowHeight = mfp.wH = _window.height();
+
+    
+    var windowStyles = {};
+
+    if( mfp.fixedContentPos ) {
+            if(mfp._hasScrollBar(windowHeight)){
+                var s = mfp._getScrollbarSize();
+                if(s) {
+                    windowStyles.marginRight = s;
+                }
+            }
+        }
+
+    if(mfp.fixedContentPos) {
+      if(!mfp.isIE7) {
+        windowStyles.overflow = 'hidden';
+      } else {
+        // ie7 double-scroll bug
+        $('body, html').css('overflow', 'hidden');
+      }
+    }
+
+    
+    
+    var classesToadd = mfp.st.mainClass;
+    if(mfp.isIE7) {
+      classesToadd += ' mfp-ie7';
+    }
+    if(classesToadd) {
+      mfp._addClassToMFP( classesToadd );
+    }
+
+    // add content
+    mfp.updateItemHTML();
+
+    _mfpTrigger('BuildControls');
+
+    // remove scrollbar, add margin e.t.c
+    $('html').css(windowStyles);
+    
+    // add everything to DOM
+    mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || $(document.body) );
+
+    // Save last focused element
+    mfp._lastFocusedEl = document.activeElement;
+    
+    // Wait for next cycle to allow CSS transition
+    setTimeout(function() {
+      
+      if(mfp.content) {
+        mfp._addClassToMFP(READY_CLASS);
+        mfp._setFocus();
+      } else {
+        // if content is not defined (not loaded e.t.c) we add class only for BG
+        mfp.bgOverlay.addClass(READY_CLASS);
+      }
+      
+      // Trap the focus in popup
+      _document.on('focusin' + EVENT_NS, mfp._onFocusIn);
+
+    }, 16);
+
+    mfp.isOpen = true;
+    mfp.updateSize(windowHeight);
+    _mfpTrigger(OPEN_EVENT);
+
+    return data;
+  },
+
+  /**
+   * Closes the popup
+   */
+  close: function() {
+    if(!mfp.isOpen) return;
+    _mfpTrigger(BEFORE_CLOSE_EVENT);
+
+    mfp.isOpen = false;
+    // for CSS3 animation
+    if(mfp.st.removalDelay && !mfp.isLowIE && mfp.supportsTransition )  {
+      mfp._addClassToMFP(REMOVING_CLASS);
+      setTimeout(function() {
+        mfp._close();
+      }, mfp.st.removalDelay);
+    } else {
+      mfp._close();
+    }
+  },
+
+  /**
+   * Helper for close() function
+   */
+  _close: function() {
+    _mfpTrigger(CLOSE_EVENT);
+
+    var classesToRemove = REMOVING_CLASS + ' ' + READY_CLASS + ' ';
+
+    mfp.bgOverlay.detach();
+    mfp.wrap.detach();
+    mfp.container.empty();
+
+    if(mfp.st.mainClass) {
+      classesToRemove += mfp.st.mainClass + ' ';
+    }
+
+    mfp._removeClassFromMFP(classesToRemove);
+
+    if(mfp.fixedContentPos) {
+      var windowStyles = {marginRight: ''};
+      if(mfp.isIE7) {
+        $('body, html').css('overflow', '');
+      } else {
+        windowStyles.overflow = '';
+      }
+      $('html').css(windowStyles);
+    }
+    
+    _document.off('keyup' + EVENT_NS + ' focusin' + EVENT_NS);
+    mfp.ev.off(EVENT_NS);
+
+    // clean up DOM elements that aren't removed
+    mfp.wrap.attr('class', 'mfp-wrap').removeAttr('style');
+    mfp.bgOverlay.attr('class', 'mfp-bg');
+    mfp.container.attr('class', 'mfp-container');
+
+    // remove close button from target element
+    if(mfp.st.showCloseBtn &&
+    (!mfp.st.closeBtnInside || mfp.currTemplate[mfp.currItem.type] === true)) {
+      if(mfp.currTemplate.closeBtn)
+        mfp.currTemplate.closeBtn.detach();
+    }
+
+
+    if(mfp.st.autoFocusLast && mfp._lastFocusedEl) {
+      $(mfp._lastFocusedEl).focus(); // put tab focus back
+    }
+    mfp.currItem = null;  
+    mfp.content = null;
+    mfp.currTemplate = null;
+    mfp.prevHeight = 0;
+
+    _mfpTrigger(AFTER_CLOSE_EVENT);
+  },
+  
+  updateSize: function(winHeight) {
+
+    if(mfp.isIOS) {
+      // fixes iOS nav bars https://github.com/dimsemenov/Magnific-Popup/issues/2
+      var zoomLevel = document.documentElement.clientWidth / window.innerWidth;
+      var height = window.innerHeight * zoomLevel;
+      mfp.wrap.css('height', height);
+      mfp.wH = height;
+    } else {
+      mfp.wH = winHeight || _window.height();
+    }
+    // Fixes #84: popup incorrectly positioned with position:relative on body
+    if(!mfp.fixedContentPos) {
+      mfp.wrap.css('height', mfp.wH);
+    }
+
+    _mfpTrigger('Resize');
+
+  },
+
+  /**
+   * Set content of popup based on current index
+   */
+  updateItemHTML: function() {
+    var item = mfp.items[mfp.index];
+
+    // Detach and perform modifications
+    mfp.contentContainer.detach();
+
+    if(mfp.content)
+      mfp.content.detach();
+
+    if(!item.parsed) {
+      item = mfp.parseEl( mfp.index );
+    }
+
+    var type = item.type;
+
+    _mfpTrigger('BeforeChange', [mfp.currItem ? mfp.currItem.type : '', type]);
+    // BeforeChange event works like so:
+    // _mfpOn('BeforeChange', function(e, prevType, newType) { });
+
+    mfp.currItem = item;
+
+    if(!mfp.currTemplate[type]) {
+      var markup = mfp.st[type] ? mfp.st[type].markup : false;
+
+      // allows to modify markup
+      _mfpTrigger('FirstMarkupParse', markup);
+
+      if(markup) {
+        mfp.currTemplate[type] = $(markup);
+      } else {
+        // if there is no markup found we just define that template is parsed
+        mfp.currTemplate[type] = true;
+      }
+    }
+
+    if(_prevContentType && _prevContentType !== item.type) {
+      mfp.container.removeClass('mfp-'+_prevContentType+'-holder');
+    }
+
+    var newContent = mfp['get' + type.charAt(0).toUpperCase() + type.slice(1)](item, mfp.currTemplate[type]);
+    mfp.appendContent(newContent, type);
+
+    item.preloaded = true;
+
+    _mfpTrigger(CHANGE_EVENT, item);
+    _prevContentType = item.type;
+
+    // Append container back after its content changed
+    mfp.container.prepend(mfp.contentContainer);
+
+    _mfpTrigger('AfterChange');
+  },
+
+
+  /**
+   * Set HTML content of popup
+   */
+  appendContent: function(newContent, type) {
+    mfp.content = newContent;
+
+    if(newContent) {
+      if(mfp.st.showCloseBtn && mfp.st.closeBtnInside &&
+        mfp.currTemplate[type] === true) {
+        // if there is no markup, we just append close button element inside
+        if(!mfp.content.find('.mfp-close').length) {
+          mfp.content.append(_getCloseBtn());
+        }
+      } else {
+        mfp.content = newContent;
+      }
+    } else {
+      mfp.content = '';
+    }
+
+    _mfpTrigger(BEFORE_APPEND_EVENT);
+    mfp.container.addClass('mfp-'+type+'-holder');
+
+    mfp.contentContainer.append(mfp.content);
+  },
+
+
+  /**
+   * Creates Magnific Popup data object based on given data
+   * @param  {int} index Index of item to parse
+   */
+  parseEl: function(index) {
+    var item = mfp.items[index],
+      type;
+
+    if(item.tagName) {
+      item = { el: $(item) };
+    } else {
+      type = item.type;
+      item = { data: item, src: item.src };
+    }
+
+    if(item.el) {
+      var types = mfp.types;
+
+      // check for 'mfp-TYPE' class
+      for(var i = 0; i < types.length; i++) {
+        if( item.el.hasClass('mfp-'+types[i]) ) {
+          type = types[i];
+          break;
+        }
+      }
+
+      item.src = item.el.attr('data-mfp-src');
+      if(!item.src) {
+        item.src = item.el.attr('href');
+      }
+    }
+
+    item.type = type || mfp.st.type || 'inline';
+    item.index = index;
+    item.parsed = true;
+    mfp.items[index] = item;
+    _mfpTrigger('ElementParse', item);
+
+    return mfp.items[index];
+  },
+
+
+  /**
+   * Initializes single popup or a group of popups
+   */
+  addGroup: function(el, options) {
+    var eHandler = function(e) {
+      e.mfpEl = this;
+      mfp._openClick(e, el, options);
+    };
+
+    if(!options) {
+      options = {};
+    }
+
+    var eName = 'click.magnificPopup';
+    options.mainEl = el;
+
+    if(options.items) {
+      options.isObj = true;
+      el.off(eName).on(eName, eHandler);
+    } else {
+      options.isObj = false;
+      if(options.delegate) {
+        el.off(eName).on(eName, options.delegate , eHandler);
+      } else {
+        options.items = el;
+        el.off(eName).on(eName, eHandler);
+      }
+    }
+  },
+  _openClick: function(e, el, options) {
+    var midClick = options.midClick !== undefined ? options.midClick : $.magnificPopup.defaults.midClick;
+
+
+    if(!midClick && ( e.which === 2 || e.ctrlKey || e.metaKey || e.altKey || e.shiftKey ) ) {
+      return;
+    }
+
+    var disableOn = options.disableOn !== undefined ? options.disableOn : $.magnificPopup.defaults.disableOn;
+
+    if(disableOn) {
+      if($.isFunction(disableOn)) {
+        if( !disableOn.call(mfp) ) {
+          return true;
+        }
+      } else { // else it's number
+        if( _window.width() < disableOn ) {
+          return true;
+        }
+      }
+    }
+
+    if(e.type) {
+      e.preventDefault();
+
+      // This will prevent popup from closing if element is inside and popup is already opened
+      if(mfp.isOpen) {
+        e.stopPropagation();
+      }
+    }
+
+    options.el = $(e.mfpEl);
+    if(options.delegate) {
+      options.items = el.find(options.delegate);
+    }
+    mfp.open(options);
+  },
+
+
+  /**
+   * Updates text on preloader
+   */
+  updateStatus: function(status, text) {
+
+    if(mfp.preloader) {
+      if(_prevStatus !== status) {
+        mfp.container.removeClass('mfp-s-'+_prevStatus);
+      }
+
+      if(!text && status === 'loading') {
+        text = mfp.st.tLoading;
+      }
+
+      var data = {
+        status: status,
+        text: text
+      };
+      // allows to modify status
+      _mfpTrigger('UpdateStatus', data);
+
+      status = data.status;
+      text = data.text;
+
+      mfp.preloader.html(text);
+
+      mfp.preloader.find('a').on('click', function(e) {
+        e.stopImmediatePropagation();
+      });
+
+      mfp.container.addClass('mfp-s-'+status);
+      _prevStatus = status;
+    }
+  },
+
+
+  /*
+    "Private" helpers that aren't private at all
+   */
+  // Check to close popup or not
+  // "target" is an element that was clicked
+  _checkIfClose: function(target) {
+
+    if($(target).hasClass(PREVENT_CLOSE_CLASS)) {
+      return;
+    }
+
+    var closeOnContent = mfp.st.closeOnContentClick;
+    var closeOnBg = mfp.st.closeOnBgClick;
+
+    if(closeOnContent && closeOnBg) {
+      return true;
+    } else {
+
+      // We close the popup if click is on close button or on preloader. Or if there is no content.
+      if(!mfp.content || $(target).hasClass('mfp-close') || (mfp.preloader && target === mfp.preloader[0]) ) {
+        return true;
+      }
+
+      // if click is outside the content
+      if(  (target !== mfp.content[0] && !$.contains(mfp.content[0], target))  ) {
+        if(closeOnBg) {
+          // last check, if the clicked element is in DOM, (in case it's removed onclick)
+          if( $.contains(document, target) ) {
+            return true;
+          }
+        }
+      } else if(closeOnContent) {
+        return true;
+      }
+
+    }
+    return false;
+  },
+  _addClassToMFP: function(cName) {
+    mfp.bgOverlay.addClass(cName);
+    mfp.wrap.addClass(cName);
+  },
+  _removeClassFromMFP: function(cName) {
+    this.bgOverlay.removeClass(cName);
+    mfp.wrap.removeClass(cName);
+  },
+  _hasScrollBar: function(winHeight) {
+    return (  (mfp.isIE7 ? _document.height() : document.body.scrollHeight) > (winHeight || _window.height()) );
+  },
+  _setFocus: function() {
+    (mfp.st.focus ? mfp.content.find(mfp.st.focus).eq(0) : mfp.wrap).focus();
+  },
+  _onFocusIn: function(e) {
+    if( e.target !== mfp.wrap[0] && !$.contains(mfp.wrap[0], e.target) ) {
+      mfp._setFocus();
+      return false;
+    }
+  },
+  _parseMarkup: function(template, values, item) {
+    var arr;
+    if(item.data) {
+      values = $.extend(item.data, values);
+    }
+    _mfpTrigger(MARKUP_PARSE_EVENT, [template, values, item] );
+
+    $.each(values, function(key, value) {
+      if(value === undefined || value === false) {
+        return true;
+      }
+      arr = key.split('_');
+      if(arr.length > 1) {
+        var el = template.find(EVENT_NS + '-'+arr[0]);
+
+        if(el.length > 0) {
+          var attr = arr[1];
+          if(attr === 'replaceWith') {
+            if(el[0] !== value[0]) {
+              el.replaceWith(value);
+            }
+          } else if(attr === 'img') {
+            if(el.is('img')) {
+              el.attr('src', value);
+            } else {
+              el.replaceWith( $('<img>').attr('src', value).attr('class', el.attr('class')) );
+            }
+          } else {
+            el.attr(arr[1], value);
+          }
+        }
+
+      } else {
+        template.find(EVENT_NS + '-'+key).html(value);
+      }
+    });
+  },
+
+  _getScrollbarSize: function() {
+    // thx David
+    if(mfp.scrollbarSize === undefined) {
+      var scrollDiv = document.createElement("div");
+      scrollDiv.style.cssText = 'width: 99px; height: 99px; overflow: scroll; position: absolute; top: -9999px;';
+      document.body.appendChild(scrollDiv);
+      mfp.scrollbarSize = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+      document.body.removeChild(scrollDiv);
+    }
+    return mfp.scrollbarSize;
+  }
+
+}; /* MagnificPopup core prototype end */
+
+
+
+
+/**
+ * Public static functions
+ */
+$.magnificPopup = {
+  instance: null,
+  proto: MagnificPopup.prototype,
+  modules: [],
+
+  open: function(options, index) {
+    _checkInstance();
+
+    if(!options) {
+      options = {};
+    } else {
+      options = $.extend(true, {}, options);
+    }
+
+    options.isObj = true;
+    options.index = index || 0;
+    return this.instance.open(options);
+  },
+
+  close: function() {
+    return $.magnificPopup.instance && $.magnificPopup.instance.close();
+  },
+
+  registerModule: function(name, module) {
+    if(module.options) {
+      $.magnificPopup.defaults[name] = module.options;
+    }
+    $.extend(this.proto, module.proto);
+    this.modules.push(name);
+  },
+
+  defaults: {
+
+    // Info about options is in docs:
+    // http://dimsemenov.com/plugins/magnific-popup/documentation.html#options
+
+    disableOn: 0,
+
+    key: null,
+
+    midClick: false,
+
+    mainClass: '',
+
+    preloader: true,
+
+    focus: '', // CSS selector of input to focus after popup is opened
+
+    closeOnContentClick: false,
+
+    closeOnBgClick: true,
+
+    closeBtnInside: true,
+
+    showCloseBtn: true,
+
+    enableEscapeKey: true,
+
+    modal: false,
+
+    alignTop: false,
+
+    removalDelay: 0,
+
+    prependTo: null,
+
+    fixedContentPos: 'auto',
+
+    fixedBgPos: 'auto',
+
+    overflowY: 'auto',
+
+    closeMarkup: '<button title="%title%" type="button" class="mfp-close">&#215;</button>',
+
+    tClose: 'Close (Esc)',
+
+    tLoading: 'Loading...',
+
+    autoFocusLast: true
+
+  }
+};
+
+
+
+$.fn.magnificPopup = function(options) {
+  _checkInstance();
+
+  var jqEl = $(this);
+
+  // We call some API method of first param is a string
+  if (typeof options === "string" ) {
+
+    if(options === 'open') {
+      var items,
+        itemOpts = _isJQ ? jqEl.data('magnificPopup') : jqEl[0].magnificPopup,
+        index = parseInt(arguments[1], 10) || 0;
+
+      if(itemOpts.items) {
+        items = itemOpts.items[index];
+      } else {
+        items = jqEl;
+        if(itemOpts.delegate) {
+          items = items.find(itemOpts.delegate);
+        }
+        items = items.eq( index );
+      }
+      mfp._openClick({mfpEl:items}, jqEl, itemOpts);
+    } else {
+      if(mfp.isOpen)
+        mfp[options].apply(mfp, Array.prototype.slice.call(arguments, 1));
+    }
+
+  } else {
+    // clone options obj
+    options = $.extend(true, {}, options);
+
+    /*
+     * As Zepto doesn't support .data() method for objects
+     * and it works only in normal browsers
+     * we assign "options" object directly to the DOM element. FTW!
+     */
+    if(_isJQ) {
+      jqEl.data('magnificPopup', options);
+    } else {
+      jqEl[0].magnificPopup = options;
+    }
+
+    mfp.addGroup(jqEl, options);
+
+  }
+  return jqEl;
+};
+
+/*>>core*/
+
+/*>>inline*/
+
+var INLINE_NS = 'inline',
+  _hiddenClass,
+  _inlinePlaceholder,
+  _lastInlineElement,
+  _putInlineElementsBack = function() {
+    if(_lastInlineElement) {
+      _inlinePlaceholder.after( _lastInlineElement.addClass(_hiddenClass) ).detach();
+      _lastInlineElement = null;
+    }
+  };
+
+$.magnificPopup.registerModule(INLINE_NS, {
+  options: {
+    hiddenClass: 'hide', // will be appended with `mfp-` prefix
+    markup: '',
+    tNotFound: 'Content not found'
+  },
+  proto: {
+
+    initInline: function() {
+      mfp.types.push(INLINE_NS);
+
+      _mfpOn(CLOSE_EVENT+'.'+INLINE_NS, function() {
+        _putInlineElementsBack();
+      });
+    },
+
+    getInline: function(item, template) {
+
+      _putInlineElementsBack();
+
+      if(item.src) {
+        var inlineSt = mfp.st.inline,
+          el = $(item.src);
+
+        if(el.length) {
+
+          // If target element has parent - we replace it with placeholder and put it back after popup is closed
+          var parent = el[0].parentNode;
+          if(parent && parent.tagName) {
+            if(!_inlinePlaceholder) {
+              _hiddenClass = inlineSt.hiddenClass;
+              _inlinePlaceholder = _getEl(_hiddenClass);
+              _hiddenClass = 'mfp-'+_hiddenClass;
+            }
+            // replace target inline element with placeholder
+            _lastInlineElement = el.after(_inlinePlaceholder).detach().removeClass(_hiddenClass);
+          }
+
+          mfp.updateStatus('ready');
+        } else {
+          mfp.updateStatus('error', inlineSt.tNotFound);
+          el = $('<div>');
+        }
+
+        item.inlineElement = el;
+        return el;
+      }
+
+      mfp.updateStatus('ready');
+      mfp._parseMarkup(template, {}, item);
+      return template;
+    }
+  }
+});
+
+/*>>inline*/
+
+
+
+
+
+/*>>zoom*/
+var hasMozTransform,
+  getHasMozTransform = function() {
+    if(hasMozTransform === undefined) {
+      hasMozTransform = document.createElement('p').style.MozTransform !== undefined;
+    }
+    return hasMozTransform;
+  };
+
+$.magnificPopup.registerModule('zoom', {
+
+  options: {
+    enabled: false,
+    easing: 'ease-in-out',
+    duration: 300,
+    opener: function(element) {
+      return element.is('img') ? element : element.find('img');
+    }
+  },
+
+  proto: {
+
+    initZoom: function() {
+      var zoomSt = mfp.st.zoom,
+        ns = '.zoom',
+        image;
+
+      if(!zoomSt.enabled || !mfp.supportsTransition) {
+        return;
+      }
+
+      var duration = zoomSt.duration,
+        getElToAnimate = function(image) {
+          var newImg = image.clone().removeAttr('style').removeAttr('class').addClass('mfp-animated-image'),
+            transition = 'all '+(zoomSt.duration/1000)+'s ' + zoomSt.easing,
+            cssObj = {
+              position: 'fixed',
+              zIndex: 9999,
+              left: 0,
+              top: 0,
+              '-webkit-backface-visibility': 'hidden'
+            },
+            t = 'transition';
+
+          cssObj['-webkit-'+t] = cssObj['-moz-'+t] = cssObj['-o-'+t] = cssObj[t] = transition;
+
+          newImg.css(cssObj);
+          return newImg;
+        },
+        showMainContent = function() {
+          mfp.content.css('visibility', 'visible');
+        },
+        openTimeout,
+        animatedImg;
+
+      _mfpOn('BuildControls'+ns, function() {
+        if(mfp._allowZoom()) {
+
+          clearTimeout(openTimeout);
+          mfp.content.css('visibility', 'hidden');
+
+          // Basically, all code below does is clones existing image, puts in on top of the current one and animated it
+
+          image = mfp._getItemToZoom();
+
+          if(!image) {
+            showMainContent();
+            return;
+          }
+
+          animatedImg = getElToAnimate(image);
+
+          animatedImg.css( mfp._getOffset() );
+
+          mfp.wrap.append(animatedImg);
+
+          openTimeout = setTimeout(function() {
+            animatedImg.css( mfp._getOffset( true ) );
+            openTimeout = setTimeout(function() {
+
+              showMainContent();
+
+              setTimeout(function() {
+                animatedImg.remove();
+                image = animatedImg = null;
+                _mfpTrigger('ZoomAnimationEnded');
+              }, 16); // avoid blink when switching images
+
+            }, duration); // this timeout equals animation duration
+
+          }, 16); // by adding this timeout we avoid short glitch at the beginning of animation
+
+
+          // Lots of timeouts...
+        }
+      });
+      _mfpOn(BEFORE_CLOSE_EVENT+ns, function() {
+        if(mfp._allowZoom()) {
+
+          clearTimeout(openTimeout);
+
+          mfp.st.removalDelay = duration;
+
+          if(!image) {
+            image = mfp._getItemToZoom();
+            if(!image) {
+              return;
+            }
+            animatedImg = getElToAnimate(image);
+          }
+
+          animatedImg.css( mfp._getOffset(true) );
+          mfp.wrap.append(animatedImg);
+          mfp.content.css('visibility', 'hidden');
+
+          setTimeout(function() {
+            animatedImg.css( mfp._getOffset() );
+          }, 16);
+        }
+
+      });
+
+      _mfpOn(CLOSE_EVENT+ns, function() {
+        if(mfp._allowZoom()) {
+          showMainContent();
+          if(animatedImg) {
+            animatedImg.remove();
+          }
+          image = null;
+        }
+      });
+    },
+
+    _allowZoom: function() {
+      return mfp.currItem.type === 'image';
+    },
+
+    _getItemToZoom: function() {
+      if(mfp.currItem.hasSize) {
+        return mfp.currItem.img;
+      } else {
+        return false;
+      }
+    },
+
+    // Get element postion relative to viewport
+    _getOffset: function(isLarge) {
+      var el;
+      if(isLarge) {
+        el = mfp.currItem.img;
+      } else {
+        el = mfp.st.zoom.opener(mfp.currItem.el || mfp.currItem);
+      }
+
+      var offset = el.offset();
+      var paddingTop = parseInt(el.css('padding-top'),10);
+      var paddingBottom = parseInt(el.css('padding-bottom'),10);
+      offset.top -= ( $(window).scrollTop() - paddingTop );
+
+
+      /*
+
+      Animating left + top + width/height looks glitchy in Firefox, but perfect in Chrome. And vice-versa.
+
+       */
+      var obj = {
+        width: el.width(),
+        // fix Zepto height+padding issue
+        height: (_isJQ ? el.innerHeight() : el[0].offsetHeight) - paddingBottom - paddingTop
+      };
+
+      // I hate to do this, but there is no another option
+      if( getHasMozTransform() ) {
+        obj['-moz-transform'] = obj['transform'] = 'translate(' + offset.left + 'px,' + offset.top + 'px)';
+      } else {
+        obj.left = offset.left;
+        obj.top = offset.top;
+      }
+      return obj;
+    }
+
+  }
+});
+
+
+
+/*>>zoom*/
+
+
+
+
+
+
+ _checkInstance(); }));


### PR DESCRIPTION
This PR adds a feedback mechanism to the bottom of every page of our docs. We're using a hubspot form to collect submitted feedback.

- When a user clicks **Yes**, we send a "yes" response, along with the current page title, to hubspot via their forms api. 
- When a user clicks **No**, we open a popup (using the [magnificent popup script](http://dimsemenov.com/plugins/magnific-popup/#mfp-build-tool)) containing the embedded hubspot form. When the user then clicks **Submit**, all completed fields, along with the current page title, are sent to hubspot.

In cases where we don't want the feedback widget to show up on a page (i.e., the page is just a placeholder), `feedback: false` can be added to the page's frontmatter.

One benefit of using hubspot is that we can track known users' actions across our site. For example, we'll be able to see if a user submitting docs feedback is also signed up for a newsletter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/467)
<!-- Reviewable:end -->
