### PR TITLE
Release notes for beta-20160721

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -121,6 +121,9 @@ entries:
 
     - title: Release Notes
       items:
+        - title: beta-20160721
+          url: /beta-20160721.html
+
         - title: beta-20160714
           url: /beta-20160714.html
 
@@ -129,9 +132,6 @@ entries:
 
         - title: beta-20160616
           url: /beta-20160616.html
-
-        - title: beta-20160609
-          url: /beta-20160609.html
 
         - title: Older Versions
           url: /older-versions.html

--- a/beta-20160721.md
+++ b/beta-20160721.md
@@ -1,0 +1,42 @@
+---
+title: What's New in beta-20160721
+toc: false
+summary: Additions and changes in CockroachDB version beta-20160721.
+---
+
+## Jul 21, 2016
+
+### New Features
+
+* Metrics are now exported on `/_status/vars` in a format suitable for aggregation by Prometheus. [#7895](https://github.com/cockroachdb/cockroach/pull/7895)
+
+### Build Changes
+
+* Go 1.6.3 and 1.7rc2 are now supported. [#7811](https://github.com/cockroachdb/cockroach/pull/7811)
+* The native versions of Docker for Mac and Windows are now supported. Users of a `docker-machine` VM may need to set environment variables by hand as this case is no longer detected automatically. [#7820](https://github.com/cockroachdb/cockroach/pull/7820)
+
+### UI Changes
+
+* The UI now displays a warning when there are fewer than three nodes. [#7783](https://github.com/cockroachdb/cockroach/pull/7783)
+
+### Performance Improvements
+
+* Writes to different ranges are now performed in parallel. [#7860](https://github.com/cockroachdb/cockroach/pull/7860)
+* The first range descriptor is kept more up-to-date. [#7766](https://github.com/cockroachdb/cockroach/pull/7766)
+* Ranges are now considered for splits after any replication or rebalancing change. [#7800](https://github.com/cockroachdb/cockroach/pull/7800)
+* An existing table lease can now be reused without writing to the lease table as long as it has enough time left before expiration. [#7781](https://github.com/cockroachdb/cockroach/pull/7781)
+* The rebalancing system now avoids moving the current leader of a range. [#7918](https://github.com/cockroachdb/cockroach/pull/7918)
+* Transaction records related to splits are now garbage-collected promptly. [#7903](https://github.com/cockroachdb/cockroach/pull/7903)
+
+### Bug Fixes
+
+* Command history works again in the command-line SQL interface. [#7818](https://github.com/cockroachdb/cockroach/pull/7818)
+* The `cockroach dump` command now works with tables that have `DECIMAL` columns that specify a precision and scale. [#7842](https://github.com/cockroachdb/cockroach/pull/7842)
+* Fixed several panics when handling invalid SQL commands. [#7867](https://github.com/cockroachdb/cockroach/pull/7867) [#7868](https://github.com/cockroachdb/cockroach/pull/7868)
+* `ALTER TABLE ADD COLUMN` now supports the `IF NOT EXISTS` modifier. [#7898](https://github.com/cockroachdb/cockroach/pull/7898)
+* Fixed a race in gossip status logging. [#7836](https://github.com/cockroachdb/cockroach/pull/7836)
+
+### Contributors
+
+This release includes 76 merged PRs by 21 authors. We would like to
+thank first-time contributor [Christian Meunier](https://github.com/cockroachdb/cockroach/pull/7937) from the CockroachDB community.

--- a/older-versions.md
+++ b/older-versions.md
@@ -6,6 +6,7 @@ toc: false
 
 Release Date | Version
 -------------|--------
+Jun 9, 2016 | [beta-20160609](beta-20160609.html)
 Jun 2, 2016 | [beta-20160602](beta-20160602.html)
 May 26, 2016 | [beta-20160526](beta-20160526.html)
 May 19, 2016 | [beta-20160519](beta-20160519.html)


### PR DESCRIPTION
See cockroachdb/cockroach#7950

I'll be offline tomorrow; @jseldess please merge and fix as needed assuming the beta is going out on schedule. 

@paperstreet We're not mentioning interleaved tables yet, right?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/468)
<!-- Reviewable:end -->
