### PR TITLE
adding third level to sidenav

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -4,13 +4,22 @@
 entries:
 - title: Sidebar
   subcategories:
+
     - title: Get Started
       items:
+
         - title: Install CockroachDB
           url: /install-cockroachdb.html
 
-        - title: Start a Cluster
-          url: /start-a-local-cluster.html
+          thirdlevel:
+            - title: Start a Cluster
+              thirdlevelitems:
+
+                - title: From Binary
+                  url: /start-a-local-cluster.html
+
+                - title: In Docker
+                  url: /start-a-local-cluster-in-docker.html
 
         - title: Secure a Cluster
           url: /secure-a-cluster.html
@@ -26,20 +35,182 @@ entries:
 
     - title: Develop
       items:
+
         - title: Install Client Drivers
           url: /install-client-drivers.html
 
-        - title: SQL Statements
-          url: /sql-statements.html
+          thirdlevel:
+            - title: SQL Statements
+              thirdlevelitems:
+
+                - title: Overview
+                  url: /sql-statements.html
+
+                - title: <code>ALTER TABLE</code>
+                  url: /alter-table.html
+
+                - title: <code>BEGIN</code>
+                  url: /begin-transaction.html
+
+                - title: <code>COMMIT</code>
+                  url: /commit-transaction.html
+
+                - title: <code>CREATE DATABASE</code>
+                  url: /create-database.html
+
+                - title: <code>CREATE INDEX</code>
+                  url: /create-index.html
+
+                - title: <code>CREATE TABLE</code>
+                  url: /create-table.html
+
+                - title: <code>DELETE</code>
+                  url: /delete.html
+
+                - title: <code>DROP DATABASE</code>
+                  url: /drop-database.html
+
+                - title: <code>DROP INDEX</code>
+                  url: /drop-index.html
+
+                - title: <code>DROP TABLE</code>
+                  url: /drop-table.html
+
+                - title: <code>EXPLAIN</code>
+                  url: /explain.html
+
+                - title: <code>GRANT</code>
+                  url: /grant.html
+
+                - title: <code>INSERT</code>
+                  url: /insert.html
+
+                - title: <code>RENAME COLUMN</code>
+                  url: /rename-column.html
+
+                - title: <code>RENAME DATABASE</code>
+                  url: /rename-database.html
+
+                - title: <code>RENAME INDEX</code>
+                  url: /rename-index.html
+
+                - title: <code>RENAME TABLE</code>
+                  url: /rename-table.html
+
+                - title: <code>ALTER TABLE</code>
+                  url: /alter-table.html
+
+                - title: <code>RELEASE SAVEPOINT</code>
+                  url: /release-savepoint.html
+
+                - title: <code>REVOKE</code>
+                  url: /revoke.html
+
+                - title: <code>ROLLBACK</code>
+                  url: /rollback-transaction.html
+
+                - title: <code>SELECT</code>
+                  url: /select.html
+
+                - title: <code>SET DATABASE</code>
+                  url: /set-database.html
+
+                - title: <code>SET TIMESZONE</code>
+                  url: /set-time-zone.html
+
+                - title: <code>SET TRANSACTION</code>
+                  url: /set-transaction.html
+
+                - title: <code>SHOW COLUMNS</code>
+                  url: /show-columns.html
+
+                - title: <code>SHOW DATABASES</code>
+                  url: /show-databases.html
+
+                - title: <code>SHOW GRANTS</code>
+                  url: /show-grants.html
+
+                - title: <code>SHOW INDEX</code>
+                  url: /show-index.html
+
+                - title: <code>SHOW TABLES</code>
+                  url: /show-tables.html
+
+                - title: <code>SHOW TIME ZONE</code>
+                  url: /show-time-zone.html
+
+                - title: <code>SHOW TRANSACTION</code>
+                  url: /show-transaction.html
+
+                - title: <code>TRUNCATE</code>
+                  url: /show-grants.html
+
+                - title: <code>UPDATE</code>
+                  url: /update.html
+
+                - title: <code>UPSERT</code>
+                  url: /upsert.html
+
+                - title: <code>VALUES</code>
+                  url: /values.html
 
         - title: SQL Grammar
           url: /sql-grammar.html
 
-        - title: Data Definition
-          url: /data-definition.html
+          thirdlevel:
+            - title: Data Definition
+              thirdlevelitems:
 
-        - title: Data Types
-          url: /data-types.html
+                - title: Keywords & Identifiers
+                  url: /keywords-and-identifiers.html
+
+                - title: Constraints
+                  url: /constraints.html
+
+                - title: Column Families
+                  url: /column-families.html
+
+                - title: Indexes
+                  url: /indexes.html
+
+                - title: <code>NULL</code> Handling
+                  url: /null-handling.html
+
+            - title: Data Types
+              thirdlevelitems:
+
+                - title: Overview
+                  url: /data-types.html
+
+                - title: <code>INT</code>
+                  url: /int.html
+
+                - title: <code>SERIAL</code>
+                  url: /serial.html
+
+                - title: <code>DECIMAL</code>
+                  url: /decimal.html
+
+                - title: <code>FLOAT</code>
+                  url: /float.html
+
+                - title: <code>BOOL</code>
+                  url: /bool.html
+
+                - title: <code>DATE</code>
+                  url: /date.html
+
+                - title: <code>TIMESTAMP</code>
+                  url: /timestamp.html
+
+                - title: <code>INTERVAL</code>
+                  url: /interval.html
+
+                - title: <code>STRING</code>
+                  url: /string.html
+
+                - title: <code>BYTES</code>
+                  url: /bytes.html
 
         - title: Privileges
           url: /privileges.html
@@ -79,6 +250,7 @@ entries:
 
     - title: Manage
       items:
+
         - title: Explore the Admin UI
           url: /explore-the-admin-ui.html
 
@@ -96,6 +268,7 @@ entries:
 
     - title: Learn How It Works
       items:
+
         - title: Frequently Asked Questions
           url: /frequently-asked-questions.html
 
@@ -113,6 +286,7 @@ entries:
 
     - title: Contribute
       items:
+
         - title: Contribute to CockroachDB
           url: /contribute-to-cockroachdb.html
 
@@ -121,6 +295,7 @@ entries:
 
     - title: Release Notes
       items:
+
         - title: beta-20160721
           url: /beta-20160721.html
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -19,7 +19,7 @@
                         path: '/'
                     },
                     slide: {
-                        duration: 400,
+                        duration: 200,
                         easing: 'swing'
                     },
                     onToggleAfter: function(){
@@ -57,41 +57,39 @@
                 </div>
             </li>
             {% for entry in sidebar %}
-            {% for subcategory in entry.subcategories %}
-            <li><a href="#">{{ subcategory.title }}</a>
-                <ul>
-                    {% for item in subcategory.items %}
-                    {% if item.external_url %}
-                    <li><a href="{{item.external_url}}" target="_blank">{{subcategory.title}}</a></li>
-                    {% elsif page.url == item.url %}
-                    <li class="active"><a href="{{item.url | replace: "/",""}}">{{item.title}}</a></li>
-                    {% else %}
-                    <li><a href="{{item.url | replace: "/",""}}">{{item.title}}</a></li>
-
-                    {% for thirdlevel in item.thirdlevel %}
-                    <li class="thirdlevel"><a href="#">{{ thirdlevel.title }}</a>
-                        <ul>
-                            {% for deeplevel in thirdlevel.thirdlevelitems %}
-                            {% if deeplevel.external_url %}
-                            <li><a href="{{deeplevel.external_url}}" target="_blank">{{deeplevel.title}}</a></li>
-                            {% elsif page.url == deeplevel.url %}
-                            <li class="active"><a href="{{deeplevel.url | replace: "/",""}}">{{deeplevel.title}}</a></li>
+                {% for subcategory in entry.subcategories %}
+                <li><a href="#">{{ subcategory.title }}</a>
+                    <ul>
+                        {% for item in subcategory.items %}
+                            {% if item.external_url %}
+                            <li><a href="{{item.external_url}}" target="_blank">{{subcategory.title}}</a></li>
+                            {% elsif page.url == item.url %}
+                            <li class="active"><a href="{{item.url | replace: "/",""}}">{{item.title}}</a></li>
                             {% else %}
-                            <li><a href="{{deeplevel.url | replace: "/",""}}">{{deeplevel.title}}</a></li>
+                            <li><a href="{{item.url | replace: "/",""}}">{{item.title}}</a></li>
                             {% endif %}
 
-                            {% endfor %}
-                        </ul>
-                    </li>
-                    {% endfor %}
-            </li>
-            {% endif %}
+                        {% for thirdlevel in item.thirdlevel %}
+                            <li><a href="#">{{ thirdlevel.title }}</a>
+                                <ul>
+                                    {% for deeplevel in thirdlevel.thirdlevelitems %}
+                                        {% if deeplevel.external_url %}
+                                        <li><a href="{{deeplevel.external_url}}" target="_blank">{{deeplevel.title}}</a></li>
+                                        {% elsif page.url == deeplevel.url %}
+                                        <li class="active"><a href="{{deeplevel.url | replace: "/",""}}">{{deeplevel.title}}</a></li>
+                                        {% else %}
+                                        <li><a href="{{deeplevel.url | replace: "/",""}}">{{deeplevel.title}}</a></li>
+                                        {% endif %}
+                                    {% endfor %}
+                                </ul>
+                            </li>
+                        {% endfor %}
+                        {% endfor %}
+                    </ul>
+                </li>
+                {% endfor %}
             {% endfor %}
-            {% if subcategory.class == "series" %}</ul>{% else %}</ul>{% endif %}
-        </li>
-        {% endfor %}
-        {% endfor %}
-        </ul>
+        {% if subcategory.class == "series" %}</ul>{% else %}</ul>{% endif %}
 
     </div>
        <!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above.-->

--- a/column-families.md
+++ b/column-families.md
@@ -89,4 +89,4 @@ Using the [`beta-20160714`](beta-20160714.html) release makes your data incompat
 ## See Also
 
 - [`CREATE TABLE`](create-table.html)
-- [Data Definition](data-definition.html)
+- [Other SQL Statements](sql-statements.html)

--- a/constraints.md
+++ b/constraints.md
@@ -204,4 +204,4 @@ If no `DEFAULT` constraint is specified and an explicit value is not given, a va
 
 ## See Also
 
-[Data Definition](data-definition.html)
+[`CREATE TABLE`](create-table.html)

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1324,6 +1324,12 @@ dl.dl-horizontal dd {
   /*margin:0px;*/
   padding: 7px 7px; }
 
+.nav ul li ul {
+  border-left: none;
+  margin: 0 0 0 15px;
+  padding: 0 0 0 0;
+}
+
 .nav {
   /* padding: 4px;*/
   padding: 0px;
@@ -1346,6 +1352,14 @@ dl.dl-horizontal dd {
   border-radius: 4px;*/
   text-decoration: none; }
 
+.nav a code {
+  color: #142848;
+}
+
+.nav a code:hover, .nav li.active > a > code {
+  color: #46a417;
+}
+
 .nav li > a > span {
   float: right;
   font-size: 19px;
@@ -1365,7 +1379,7 @@ dl.dl-horizontal dd {
 
 .nav li.active > a {
   /*background-color: #8D8D8D;*/
-  /*color: #f5f5f5;*/
+  color: #46a417;
   background-color: transparent;
   /*color: #f80;*/
   /*font-weight: bold;*/ }
@@ -1394,9 +1408,6 @@ ul#mysidebar {
   margin-top: 40px;
   background-color: transparent;
   border-radius: 0px; }
-
-.nav ul li ul li a {
-  padding-left: 20px; }
 
 .nav li.thirdlevel > a {
   background-color: transparent;
@@ -1678,7 +1689,7 @@ ol.series li {
 @media (min-width: 1000px) {
   ul#mysidebar {
     width: 225px;
-    position: fixed; } }
+    position: relative; } }
 @media (max-width: 900px) {
   ul#mysidebar {
     max-width: 100%; } }

--- a/indexes.md
+++ b/indexes.md
@@ -16,4 +16,4 @@ To understand how CockroachDB chooses the best index for running a query, see [I
 
 ## See Also
 
-[Data Definition](data-definition.html)
+[SQL Statements](sql-statements.html)

--- a/keywords-and-identifiers.md
+++ b/keywords-and-identifiers.md
@@ -42,4 +42,5 @@ To bypass either of these rules, simply surround the identifier with double-quot
 
 ## See Also
 
-[Data Definition](data-definition.html)
+- [SQL Statements](sql-statements.html)
+- [Full SQL Grammar](sql-grammar.html)

--- a/learn-cockroachdb-sql.md
+++ b/learn-cockroachdb-sql.md
@@ -4,7 +4,7 @@ summary: Learn some of the most essential CockroachDB SQL statements.
 toc: false
 ---
 
-This page walks you through some of the most essential CockroachDB SQL statements. For a complete list and related details, see [SQL Statements](sql-statements.html) and [Data Definition](data-definition.html).
+This page walks you through some of the most essential CockroachDB SQL statements. For a complete list and related details, see [SQL Statements](sql-statements.html).
 
 {{site.data.alerts.callout_info}}CockroachDB aims to provide standard SQL with extensions, but some standard SQL functionality is not yet available. Joins, for example, will be built into version 1.0. See our <a href="https://github.com/cockroachdb/cockroach/wiki">Product Roadmap</a> for more details.{{site.data.alerts.end}}
 


### PR DESCRIPTION
This PR adds a third level to the docs sidenav. This is particularly useful for sql statements and other reference areas. For example, when you're on the page for a particular statement or datatype, the sidenav now both shows you where you are in the overall structure and lets you browse other statements.

HTML version: http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/86084b8591acd9bc9fea8ecd7630724132090b3c/serial.html

Fixes #186

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/476)
<!-- Reviewable:end -->
