### PR TITLE
TRUNCATE doc

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -143,7 +143,7 @@ entries:
                   url: /show-transaction.html
 
                 - title: <code>TRUNCATE</code>
-                  url: /show-grants.html
+                  url: /truncate.html
 
                 - title: <code>UPDATE</code>
                   url: /update.html

--- a/_includes/sql/diagrams/truncate.html
+++ b/_includes/sql/diagrams/truncate.html
@@ -1,50 +1,22 @@
-<svg width="690" height="330">
+<svg width="464" height="102">
          
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <rect x="31" y="47" width="90" height="32" rx="10"></rect>
-         <rect x="29" y="45" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="65">TRUNCATE</text>
-         <rect x="161" y="79" width="62" height="32" rx="10"></rect>
-         <rect x="159" y="77" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="169" y="97">TABLE</text>
-         <a xlink:href="sql-grammar.html#qualified_name" xlink:title="qualified_name">
-            <rect x="303" y="47" width="116" height="32"></rect>
-            <rect x="301" y="45" width="116" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="311" y="65">qualified_name</text>
-         </a>
-         <rect x="459" y="79" width="28" height="32" rx="10"></rect>
-         <rect x="457" y="77" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="467" y="97">*</text>
-         <rect x="303" y="123" width="58" height="32" rx="10"></rect>
-         <rect x="301" y="121" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="311" y="141">ONLY</text>
-         <a xlink:href="sql-grammar.html#qualified_name" xlink:title="qualified_name">
-            <rect x="401" y="123" width="116" height="32"></rect>
-            <rect x="399" y="121" width="116" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="409" y="141">qualified_name</text>
-         </a>
-         <rect x="401" y="167" width="26" height="32" rx="10"></rect>
-         <rect x="399" y="165" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="409" y="185">(</text>
-         <a xlink:href="sql-grammar.html#qualified_name" xlink:title="qualified_name">
-            <rect x="447" y="167" width="116" height="32"></rect>
-            <rect x="445" y="165" width="116" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="455" y="185">qualified_name</text>
-         </a>
-         <rect x="583" y="167" width="26" height="32" rx="10"></rect>
-         <rect x="581" y="165" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="591" y="185">)</text>
+         <polygon points="9 51 1 47 1 55"></polygon>
+         <polygon points="17 51 9 47 9 55"></polygon>
+         <rect x="31" y="37" width="90" height="32" rx="10"></rect>
+         <rect x="29" y="35" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="55">TRUNCATE</text>
+         <rect x="161" y="69" width="62" height="32" rx="10"></rect>
+         <rect x="159" y="67" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="169" y="87">TABLE</text>
+         
+            <rect x="303" y="69" width="94" height="32"></rect>
+            <rect x="301" y="67" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="311" y="87">table_name</text>
+         
          <rect x="283" y="3" width="24" height="32" rx="10"></rect>
          <rect x="281" y="1" width="24" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="291" y="21">,</text>
-         <rect x="557" y="253" width="82" height="32" rx="10"></rect>
-         <rect x="555" y="251" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="565" y="271">CASCADE</text>
-         <rect x="557" y="297" width="86" height="32" rx="10"></rect>
-         <rect x="555" y="295" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="565" y="315">RESTRICT</text>
-         <path class="line" d="m17 61 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -32 h10 m116 0 h10 m20 0 h10 m0 0 h38 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v12 m68 0 v-12 m-68 12 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m20 -32 h122 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v56 m366 0 v-56 m-366 56 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m58 0 h10 m20 0 h10 m116 0 h10 m0 0 h92 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m26 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m26 0 h10 m-366 -120 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m386 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-386 0 h10 m24 0 h10 m0 0 h342 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-         <polygon points="681 235 689 231 689 239"></polygon>
-         <polygon points="681 235 673 231 673 239"></polygon>
+         <path class="line" d="m17 51 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m60 -32 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m-154 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m154 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-154 0 h10 m24 0 h10 m0 0 h110 m23 34 h-3"></path>
+         <polygon points="455 51 463 47 463 55"></polygon>
+         <polygon points="455 51 447 47 447 55"></polygon>
       </svg>

--- a/generate/main.go
+++ b/generate/main.go
@@ -218,7 +218,7 @@ func main() {
 				{name: "show_timezone", stmt: "show_stmt", match: regexp.MustCompile("'SHOW' 'TIME' 'ZONE'")},
 				{name: "show_transaction", stmt: "show_stmt", match: regexp.MustCompile("'SHOW' 'TRANSACTION'")},
 				{name: "table_constraint", inline: []string{"constraint_elem", "opt_storing", "storing"}},
-				{name: "truncate_stmt", inline: []string{"opt_table", "relation_expr_list", "relation_expr", "opt_drop_behavior"}},
+				{name: "truncate_stmt", inline: []string{"opt_table", "relation_expr_list", "relation_expr", "opt_drop_behavior"}, replace: map[string]string{"'ONLY' '(' qualified_name ')'" : "", "'ONLY' qualified_name" : "", "qualified_name": "table_name", "'*'": "", "'CASCADE'": "", "'RESTRICT'": ""}, unlink: []string{"table_name"}},
 				{name: "update_stmt", inline: []string{"relation_expr_opt_alias", "set_clause_list", "set_clause", "single_set_clause", "multiple_set_clause", "ctext_row", "ctext_expr_list", "ctext_expr", "from_clause", "from_list", "where_clause", "returning_clause"}},
 				{name: "upsert_stmt", stmt: "insert_stmt", inline: []string{"insert_target", "insert_rest", "returning_clause"}, match: regexp.MustCompile("'UPSERT'")},
 				{name: "values", stmt: "values_clause", inline: []string{"ctext_row", "ctext_expr_list", "ctext_expr"}},

--- a/sql-statements.md
+++ b/sql-statements.md
@@ -39,7 +39,7 @@ Statement | Usage
 [`SHOW TABLES`](show-tables.html) | List tables in a database.
 [`SHOW TIME ZONE`](show-time-zone.html) | View the default time zone for the session.
 [`SHOW TRANSACTION`](show-transaction.html) | View the isolation level or priority for the session or for an individual [transaction](transactions.html).
-[`TRUNCATE`](truncate.html) | Delete all rows from a table.
+[`TRUNCATE`](truncate.html) | Deletes all rows from specified tables.
 [`UPDATE`](update.html) | Update rows in a table.
 [`UPSERT`](upsert.html) | Insert rows that do not violate uniquenesss constraints; update rows that do.
 [`VALUES`](values.html) | Compute a row value or set of row values.

--- a/truncate.md
+++ b/truncate.md
@@ -1,10 +1,10 @@
 ---
 title: TRUNCATE
-summany: The TRUNCATE statement deletes all rows from a table.
+summary: The TRUNCATE statement deletes all rows from specified tables.
 toc: false
 ---
 
-The `TRUNCATE` [statement](sql-statements.html) deletes all rows from a table.
+The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
 
 <div id="toc"></div>
 
@@ -20,4 +20,26 @@ The user must have the `DROP` [privilege](privileges.html) on the table.
 
 | Parameter | Description |
 |-----------|-------------|
-|  |  |
+| `table_name` | The [`qualified_name`](sql-grammar.html#qualified_name) of the table you want to truncate. |
+
+## Example
+
+~~~sql
+> SELECT * FROM tbl;
++----+
+| id |
++----+
+|  1 |
+|  2 |
+|  3 |
++----+
+
+> TRUNCATE tbl;
+TRUNCATE
+
+> SELECT * FROM tbl;
++----+
+| id |
++----+
++----+
+~~~


### PR DESCRIPTION
Heavily redacted the diagram that displays vs. the syntax that's accepted.
- Descendent tables don't exist, so `ONLY` and `*` are vestigial
- `CASCADE` doesn't delete rows, so everything behaves like `RESTRICT`, so no need to list either as options.

Closes #498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/542)
<!-- Reviewable:end -->
