### PR TITLE
features-on-develop-branch

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -316,5 +316,8 @@ entries:
         - title: beta-20160629
           url: /beta-20160629.html
 
-        - title: Older Versions
+        - title: Older Beta Versions
           url: /older-versions.html
+
+        - title: Features on Develop Branch
+          url: /develop-branch.html

--- a/_includes/develop-callout.html
+++ b/_includes/develop-callout.html
@@ -1,0 +1,1 @@
+{{site.data.alerts.callout_info}}This feature is available only when you <a href="install-cockroachdb.html">build a CockroachDB binary</a> from the code on our <code>develop</code> branch. For a list of other features available only when building from source, see <a href="develop-branch.html">Features on the Develop Branch</a>.{{site.data.alerts.end}}

--- a/_includes/develop-paragraph.md
+++ b/_includes/develop-paragraph.md
@@ -1,0 +1,1 @@
+**Note:** This feature is available only when you [build a CockroachDB binary](install-cockroachdb.html) from the code on our `develop` branch. For a list of other features available only when building from source, see [Features on the Develop Branch](develop-branch.html).

--- a/bytes.md
+++ b/bytes.md
@@ -15,7 +15,7 @@ In CockroachDB, the following are aliases for `BYTES`:
 - `BYTEA` 
 - `BLOB` 
 
-## Format
+## Formats
 
 When inserting into a `BYTES` column, use either of the following byte escape formats:
 

--- a/develop-branch.md
+++ b/develop-branch.md
@@ -1,0 +1,10 @@
+---
+title: Features on Develop Branch
+toc: false
+---
+
+These features are available only when you <a href="install-cockroachdb.html">build a CockroachDB binary</a> from the code on our <code>develop</code> branch. They are not yet included in an official beta release.
+
+Feature | Merge Date
+--------|-----------
+[`INTERVAL`](interval.html) columns accept the SQL Standard format. | [8/18/16](https://github.com/cockroachdb/cockroach/pull/8657)

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -77,7 +77,7 @@ $(document).ready(function(){
 </div>
 
 <div id="macinstall">
-<p>There are four ways to install CockroachDB on Mac OS X. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest version.</p>
+<p>There are four ways to install CockroachDB on Mac OS X. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest version. </p>
 
 <div id="mac-installs" class="clearfix">
 <a href="#download-the-binary" class="install-button mac-button current" data-eventcategory="buttonClick-doc-install" data-eventaction="mac-binary">Download the <div class="c2a">Binary</div></a>
@@ -200,9 +200,11 @@ $(document).ready(function(){
   <li>
     <p>Compile the CockroachDB binary:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-source-step3"><span class="gp" data-eventcategory="mac-source-step3">$ </span><span class="nb">cd</span> <span class="nv">$GOPATH</span>/src/github.com/cockroachdb/cockroach<br><span class="gp" data-eventcategory="mac-source-step3">$ </span>git checkout {{site.data.strings.version}}<br><span class="gp">$ </span>make install</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-source-step3"><span class="gp" data-eventcategory="mac-source-step3">$ </span><span class="nb">cd</span> <span class="nv">$GOPATH</span>/src/github.com/cockroachdb/cockroach<br>$ git checkout {{site.data.strings.version}}<br><span class="gp">$ </span>make install</code></pre></div>
 
     <p>The first time you run <code class="highlighter-rouge">make install</code>, it can take awhile to download and install various dependencies.</p>
+
+    <div class="bs-callout bs-callout-success">This step builds a binary for the latest beta release. To get access to <a href="develop-branch.html">features not yet included in a beta release</a>, you can build a binary from the <code>develop</code> branch instead. Simply leave out the <code>git checkout {{site.data.strings.version}}</code> step above.</div>
   </li>
   <li>
     <p>The <code class="highlighter-rouge">make install</code> command puts the binary in <code class="highlighter-rouge"><span class="nv">$GOPATH</span>/bin</code>. Add this directory to your <code class="highlighter-rouge">PATH</code>, if it isn't already there. This makes it easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell.</p>
@@ -333,7 +335,6 @@ $(document).ready(function(){
 
 <div id="build-from-source-linux" class="install-option" style="display: none;">
 <h2>Build from Source</h2>
-
 <ol>
   <li>
     <p>Install the following prerequisites, as necessary:</p>
@@ -362,9 +363,11 @@ $(document).ready(function(){
   <li>
     <p>Compile the CockroachDB binary:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-source-step3"><span class="gp" data-eventcategory="linux-source-step3">$ </span><span class="nb" data-eventcategory="linux-source-step3">cd</span> <span class="nv" data-eventcategory="linux-source-step3">$GOPATH</span>/src/github.com/cockroachdb/cockroach<br><span class="gp" data-eventcategory="linux-source-step3">$ </span>git checkout {{site.data.strings.version}}<br><span class="gp">$ </span>make install</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-source-step3"><span class="gp" data-eventcategory="linux-source-step3">$ </span><span class="nb" data-eventcategory="linux-source-step3">cd</span> <span class="nv" data-eventcategory="linux-source-step3">$GOPATH</span>/src/github.com/cockroachdb/cockroach<br>$ git checkout {{site.data.strings.version}}<br><span class="gp">$ </span>make install</code></pre></div>
 
     <p>The first time you run <code class="highlighter-rouge">make install</code>, it can take awhile to download and install various dependencies.</p>
+
+    <div class="bs-callout bs-callout-success">This step builds a binary for the latest beta release. To get access to <a href="develop-branch.html">features not yet included in a beta release</a>, you can build a binary from the <code>develop</code> branch instead. Simply leave out the <code>git checkout {{site.data.strings.version}}</code> step above.</div>
   </li>
   <li>
     <p>The <code class="highlighter-rouge">make install</code> command puts the binary in <code class="highlighter-rouge"><span class="nv">$GOPATH</span>/bin</code>. Add this directory to your <code class="highlighter-rouge">PATH</code>, if it isn't already there. This makes it easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell.</p>

--- a/int.md
+++ b/int.md
@@ -19,7 +19,7 @@ In CockroachDB, the following are aliases for `INT`:
 - `INT64` 
 - `BIGINT`
 
-## Format
+## Formats
 
 An `INT` column accepts numeric literals and hexadecimal-encoded numeric literals.
 

--- a/interval.md
+++ b/interval.md
@@ -8,7 +8,7 @@ The `INTERVAL` [data type](data-types.html) stores a value that represents a spa
 
 <div id="toc"></div>
 
-## Format
+## Formats
 
 When inserting into an `INTERVAL` column, use one of the following formats:
 
@@ -17,7 +17,7 @@ Format | Description
 Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'` 
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
-SQL Standard | `INTERVAL 'H:M:S'`<br><br>Note that using a single field defines seconds only, and using two fields defines hours and minutes. Also, all fields support both integers and floats.
+SQL Standard | {% include develop-paragraph.md %}<br><br>`INTERVAL 'H:M:S'`<br><br>Using a single field defines seconds only, and using two fields defines hours and minutes. Also, all fields support both integers and floats.
 
 Alternatively, you can use a string literal, e.g., `'1h2m3s4ms5us6ns'` or`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`, which CockroachDB will resolve into the `INTERVAL` type.
 
@@ -27,7 +27,7 @@ Intervals are stored internally as months, days, and nanoseconds.
 
 An `INTERVAL` column supports values up to 24 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata. 
 
-## Examples
+## Example
 
 ~~~
 > CREATE TABLE intervals (a INT PRIMARY KEY, b INTERVAL);

--- a/string.md
+++ b/string.md
@@ -35,7 +35,7 @@ When inserting a string:
 - If the value is cast as a string with a length limit (e.g., `CAST('hello world' AS STRING(5))`), CockroachDB truncates to the limit.
 - If the value is under the column's length limit, CockroachDB does **not** add padding. This applies to `STRING(n)` and all its aliases.
 
-## Format
+## Formats
 
 A `STRING` column accepts Unicode string literals, hexadecimal string literals, and escape strings. 
 

--- a/timestamp.md
+++ b/timestamp.md
@@ -12,7 +12,7 @@ The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC,
 
 In CockroachDB, `TIMESTAMP WITHOUT TIME ZONE` is an alias for `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` is an alias for `TIMESTAMPTZ`.
 
-## Format
+## Formats
 
 When inserting into a `TIMESTAMP` column, use one of the following formats:
 


### PR DESCRIPTION
This PR covers how to get access to features on `develop` but not yet included in any official beta binary. 

- `install-cockroachdb.md`: Updated the build from source install instructions to mention building from code on the `develop` branch.
- `_includes/develop-paragraph.md` and `_includes/develop-callout.html`: Added reusable disclaimers to be used in docs for any feature only on `develop`. 
- `develop-branch.md`: Added a page where we can list features available only on the `develop` branch. Ideally, we'll link to the docs for the feature and list the date on which the feature was merged.

@spencerkimball, @petermattis, @bdarnell, PTAL. Ben mentioned in chat that his preference would be to leave the install docs focused on the latest beta version and use `contributing.md` to focus on `develop`. At that point, these changes were pretty much done, so I've decided to discuss here. Thoughts?

Fixes #548 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/552)
<!-- Reviewable:end -->
