### PR TITLE
update to INTERVAL type documentation

### DIFF
--- a/interval.md
+++ b/interval.md
@@ -14,9 +14,10 @@ When inserting into an `INTERVAL` column, use one of the following formats:
 
 Format | Description
 -------|--------
-Golang | `INTERVAL '1h2m3s4ms5us6ns'`, where `ms` is millisecond, `us` is microsecond, and `ns` is nanosecond
+Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'` 
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
+SQL Standard | `INTERVAL 'H:M:S'`<br><br>Note that using a single field defines seconds only, and using two fields defines hours and minutes. Also, all fields support both integers and floats.
 
 Alternatively, you can use a string literal, e.g., `'1h2m3s4ms5us6ns'` or`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`, which CockroachDB will resolve into the `INTERVAL` type.
 
@@ -29,9 +30,10 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 ## Examples
 
 ~~~
-CREATE TABLE intervals (a INT PRIMARY KEY, b INTERVAL);
+> CREATE TABLE intervals (a INT PRIMARY KEY, b INTERVAL);
+CREATE TABLE
 
-SHOW COLUMNS FROM intervals;
+> SHOW COLUMNS FROM intervals;
 +-------+----------+-------+---------+
 | Field |   Type   | Null  | Default |
 +-------+----------+-------+---------+
@@ -39,16 +41,21 @@ SHOW COLUMNS FROM intervals;
 | b     | INTERVAL | true  | NULL    |
 +-------+----------+-------+---------+
 
-INSERT INTO intervals VALUES (1, INTERVAL '1h2m3s4ms5us6ns'), (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds');
+> INSERT INTO intervals VALUES 
+    (1, INTERVAL '1h2m3s4ms5us6ns'), 
+    (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'), 
+    (3, INTERVAL '4:5:6')
+;
+INSERT 3
 
-SELECT * FROM intervals;
 +---+------------------+
 | a |        b         |
 +---+------------------+
 | 1 | 1h2m3.004005006s |
 | 2 | 14m3d4h5m6s      |
+| 3 | 4h5m6s           |
 +---+------------------+
-(2 rows)
+(3 rows)
 ~~~
 
 ## See Also


### PR DESCRIPTION
This PR updates the `INTERVAL` type documentation to cover the SQL standard format. 

Fixes #559

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/560)
<!-- Reviewable:end -->
