### PR TITLE
pass page url to hubspot

### DIFF
--- a/_includes/feedback-widget.html
+++ b/_includes/feedback-widget.html
@@ -4,7 +4,7 @@
   <p class="feedback-question">Was this page helpful?</p>
   <form action='https://forms.hubspot.com/uploads/form/v2/1753393/6739d0dd-8ecb-40a6-a814-d6f84b05a6ee' method="post" target="hiddenFrame">
     <input name="helpful" value="yes" type="hidden">
-    <input name="hs_context" value='{"pageTitle":"{{page.title}}"}' type="hidden">
+    <input name="hs_context" value='{"pageUrl":"{{page.url}}", "pageTitle":"{{page.title}}"}' type="hidden">
     <button class="yes-button">Yes</button>
   </form>
   <a href="#feedback-popup" class="no-button">No</a>


### PR DESCRIPTION
Previously, when a user clicked the "Yes" feedback button on a page of the docs, we would send the page title to hubspot. This PR adds the page url as well. This ensures that, when we export submission data from hubspot, we get sufficient contextual information about each submission. 

Fixes #562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/563)
<!-- Reviewable:end -->
