### PR TITLE
Draft release notes for beta-20160825

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -304,6 +304,9 @@ entries:
 
     - title: Release Notes
       items:
+        - title: beta-20160829
+          url: /beta-20160829.html
+
         - title: beta-20160728
           url: /beta-20160728.html
 
@@ -312,9 +315,6 @@ entries:
 
         - title: beta-20160714
           url: /beta-20160714.html
-
-        - title: beta-20160629
-          url: /beta-20160629.html
 
         - title: Older Beta Versions
           url: /older-versions.html

--- a/beta-20160829.md
+++ b/beta-20160829.md
@@ -1,0 +1,67 @@
+---
+title: What's New in beta-20160829
+toc: false
+summary: Additions and changes in CockroachDB version beta-20160829.
+---
+
+## Aug 29, 2016
+
+### General Changes
+
+- CockroachDB now uses Go 1.7. [#8579](https://github.com/cockroachdb/cockroach/pull/8579)
+- CockroachDB now uses RocksDB 4.9. [#8815](https://github.com/cockroachdb/cockroach/pull/8815)
+
+### Command-Line Interface Changes
+
+- The `cockroach zone set` no longer takes its input directly on the command line. Instead, it accepts a `--file` flag to read from a file, or `--file=-` to read from standard input. [#7953](https://github.com/cockroachdb/cockroach/pull/7953)
+
+### New Features
+
+- `AS OF SYSTEM TIME` can now be used with `JOIN` queries. [#8198](https://github.com/cockroachdb/cockroach/pull/8198)
+- The type `BIT` now works correctly (as a shorthand for `BIT(1)`). The length limit is now enforced. [#8326](https://github.com/cockroachdb/cockroach/pull/8326)
+- The `SHOW` commands now only show tables that the current user has permission to access. [#8070](https://github.com/cockroachdb/cockroach/pull/8070)
+- Foreign keys can now use a prefix of an index. [#8059](https://github.com/cockroachdb/cockroach/pull/8059)
+- The standard `information_schema` database is now partially supported. New tables will be added to this database in future beta releases. [#7965](https://github.com/cockroachdb/cockroach/pull/7965), [#8119](https://github.com/cockroachdb/cockroach/pull/8119)
+
+### Bug Fixes
+
+- Clusters with a large number of ranges no longer experience persistently broken connections on node restarts. [#8828](https://github.com/cockroachdb/cockroach/pull/8828)
+- The `RENAME` command now requires the `DROP` privilege on the table or database. It is no longer possible to rename the `system` database. [#7998](https://github.com/cockroachdb/cockroach/pull/7998)
+- The `repeat()` and `substr()` functions with very large numeric arguments will no longer crash the server as easily. [#8073](https://github.com/cockroachdb/cockroach/pull/8073), [#8078](https://github.com/cockroachdb/cockroach/pull/8078)
+- Certain errors now cause a replica to be marked as corrupt so the corruption will not be replicated to other nodes. [#7684](https://github.com/cockroachdb/cockroach/pull/7684)
+- A `CloseComplete` packet is now sent in response to a `Close` command, improving compatibility with come PostgreSQL client drivers (including the Elixir driver). [#8309](https://github.com/cockroachdb/cockroach/pull/8309)
+- SQL name parsing has been improved to fix several panics and allow foreign key constraints that span databases. [#8152](https://github.com/cockroachdb/cockroach/pull/8152)
+- Fixed some panics. [#8283](https://github.com/cockroachdb/cockroach/pull/8283), [#8282](https://github.com/cockroachdb/cockroach/pull/8282)
+- Fixed a deadlock if a range grew too large. [#8387](https://github.com/cockroachdb/cockroach/pull/8387)
+- Fixed a race in which multiple conflicting snapshots could be accepted at the same time. [#8365](https://github.com/cockroachdb/cockroach/pull/8365)
+- Decimal values are now represented correctly in the binary protocol. [#8319](https://github.com/cockroachdb/cockroach/pull/8319)
+
+### Performance Improvements
+
+- Snapshots are now sent synchronously during replica changes. This controls the rate of the replication process and prevents spikes in memory usage that often caused servers to crash. [#8613](https://github.com/cockroachdb/cockroach/pull/8613)
+- Raft logs are now truncated less aggressively, reducing the chance that replication will need to send a snapshot instead of the log. [#8343](https://github.com/cockroachdb/cockroach/pull/8343), [#8629](https://github.com/cockroachdb/cockroach/pull/8629), [#8656](https://github.com/cockroachdb/cockroach/pull/8656)
+- Snapshots and the raft log are now written more efficiently. [#8644](https://github.com/cockroachdb/cockroach/pull/8644)
+- Raft log entries are now cached. [#8494](https://github.com/cockroachdb/cockroach/pull/8494)
+- Raft groups are now created lazily at startup. [#8592](https://github.com/cockroachdb/cockroach/pull/8592)
+- Raft heartbeats are now sent less often by default. [#8695](https://github.com/cockroachdb/cockroach/pull/8695)
+- Improved performance and reliability of clusters with large numbers of ranges. [#8125](https://github.com/cockroachdb/cockroach/pull/8125), [#8162](https://github.com/cockroachdb/cockroach/pull/8162), [#8495](https://github.com/cockroachdb/cockroach/pull/8495)
+- The heuristics used by the rebalancing system have been improved. [#8124](https://github.com/cockroachdb/cockroach/pull/8124)
+- Some noisy log messages have been removed or reduced. [#8071](https://github.com/cockroachdb/cockroach/pull/8071), [#8021](https://github.com/cockroachdb/cockroach/pull/8021), [#8240](https://github.com/cockroachdb/cockroach/pull/8240), [#8292](https://github.com/cockroachdb/cockroach/pull/8292), [#8529](https://github.com/cockroachdb/cockroach/pull/8529), [#8687](https://github.com/cockroachdb/cockroach/pull/8687), [#8689](https://github.com/cockroachdb/cockroach/pull/8689)
+- The gossip network reconnects more reliably after a failure. [#8128](https://github.com/cockroachdb/cockroach/pull/8128)
+- RPC connections to failed nodes are now detected sooner. [#8163](https://github.com/cockroachdb/cockroach/pull/8163)
+- The cache of the first range descriptor is now properly invalidated. [#8163](https://github.com/cockroachdb/cockroach/pull/8163)
+- Removed replicas are now garbage-collected sooner in many cases. [#8172](https://github.com/cockroachdb/cockroach/pull/8172)
+- The resolution of the block profiler has been reduced, saving CPU. [#8384](https://github.com/cockroachdb/cockroach/pull/8384)
+- Range lease extensions no longer block concurrent reads. [#8352](https://github.com/cockroachdb/cockroach/pull/8352)
+
+### UI Changes
+
+- The "capacity used" is now computed correctly. [#8048](https://github.com/cockroachdb/cockroach/pull/8048)
+- The CPU and garbage-collection graphs now display averages. [#8048](https://github.com/cockroachdb/cockroach/pull/8048)
+- The Databases section now includes more details. [#8364](https://github.com/cockroachdb/cockroach/pull/8364)
+
+### Contributors
+
+This release includes 280 merged PRs by 26 authors. We would like to thank the following contributors from the CockroachDB community:
+
+- songhao

--- a/older-versions.md
+++ b/older-versions.md
@@ -6,6 +6,7 @@ toc: false
 
 Release Date | Version
 -------------|--------
+Jun 29, 2016 | [beta-20160629](beta-20160629.html)
 Jun 16, 2016 | [beta-20160616](beta-20160616.html)
 Jun 9, 2016 | [beta-20160609](beta-20160609.html)
 Jun 2, 2016 | [beta-20160602](beta-20160602.html)


### PR DESCRIPTION
I'm being optimistic here and assuming that the GRPC change will make us stable enough to do a release this week. 

Counts in the "Contributors" section are based on the master branch as
of d0a4a64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/579)
<!-- Reviewable:end -->
