### PR TITLE
Move stop command in getting started section

### DIFF
--- a/secure-a-cluster.md
+++ b/secure-a-cluster.md
@@ -4,21 +4,11 @@ summary: Learn how to secure a CockroachDB cluster with authentication and encry
 toc: false
 ---
 
-Now that you have a [local cluster](start-a-local-cluster.html) up and running, let's secure it with authentication and encryption. This involves stopping the cluster, creating certificates, and restarting nodes with a few additional flags.
+Now that you have a [local cluster](start-a-local-cluster.html) up and running, let's secure it with authentication and encryption. This involves creating certificates and restarting your nodes with a few additional flags.
 
-## Step 1.  Stop the cluster and close the Admin UI
+{{site.data.alerts.callout_danger}}If you didn't <a href="start-a-local-cluster.html#step-6--stop-the-cluster">stop the insecure cluster</a>, when you restart the cluster with security (steps 2 and 3), you'll see "TLS handshake" errors when accessing the Admin UI until you adjust the URL to include <code>https</code> (step 6).{{site.data.alerts.end}}
 
-~~~ shell
-$ cockroach quit
-$ cockroach quit --port=26258
-$ cockroach quit --port=26259
-~~~
-
-- If you used the `cockroach start` commands on [Start a Cluster](start-a-local-cluster.html) verbatim, the commands above will work as well. Otherwise, just set the `--port` flag to the ports you used.
-- For more details about the `cockroach quit` command, see [Stop a Node](stop-a-node.html).
-- If you leave the Admin UI open, when you restart the cluster with security (steps 3 and 4), you'll see "TLS handshake" errors until you adjust the URL to https (step 7).
-
-## Step 2.  Create security certificates
+## Step 1.  Create security certificates
 
 ~~~ shell
 $ mkdir certs
@@ -32,7 +22,7 @@ $ cockroach cert create-client root --ca-cert=certs/ca.cert --ca-key=certs/ca.ke
 - The third command creates the node certificate and key: `node.cert` and `node.key`. These files will be used to secure communication between nodes. Typically, you would generate these separately for each node since each node has unique addresses; in this case, however, since all nodes will be running locally, you need to generate only one node certificate and key.
 - The fourth command creates the client certificate and key, in this case for the `root` user: `root.cert` and `root.key`. These files will be used to secure communication between the built-in SQL shell and the cluster (see step 5).
 
-## Step 3.  Restart the first node
+## Step 2.  Restart the first node
 
 ~~~ shell
 $ cockroach start --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --http-addr=localhost --background
@@ -49,7 +39,7 @@ This command restarts your first node with its existing data, but securely. The 
 - The `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the node certificate and key created in step 2. 
 - When certs are used, the Admin UI defaults to listening on all interfaces. The `--http-addr` flag is therefore used to restrict Admin UI access to the specified interface, in this case, `localhost`.
 
-## Step 4.  Restart additional nodes
+## Step 3.  Restart additional nodes
 
 ~~~ shell
 $ cockroach start --store=node2 --port=26258 --http-port=8081 --http-addr=localhost --join=localhost:26257 --ca-cert=certs/ca.cert --cert=certs/node.cert --key=certs/node.key --background
@@ -61,7 +51,7 @@ These commands restart additional nodes with their existing data, but securely. 
 - The `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the node certificate and key created in step 2. 
 - When certs are used, the Admin UI defaults to listening on all interfaces. The `--http-addr` flags are therefore used to restrict Admin UI access to the specified interface, in this case, `localhost`.
 
-## Step 5.  Restart the [built-in SQL client](use-the-built-in-sql-client.html) as an interactive shell
+## Step 4.  Restart the [built-in SQL client](use-the-built-in-sql-client.html) as an interactive shell
 
 ~~~ shell
 $ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
@@ -72,7 +62,7 @@ $ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.
 
 This command is the same as before, but now uses the additional `--ca-cert`, `--cert`, and `--key` flags to point to the CA certificate and the certificate and key for the `root` user created in step 2.
 
-## Step 6.  Run more [CockroachDB SQL statements](learn-cockroachdb-sql.html)
+## Step 5.  Run more [CockroachDB SQL statements](learn-cockroachdb-sql.html)
 
 ~~~ shell
 root@:26257> SET DATABASE = bank;
@@ -99,7 +89,7 @@ root@26257> SELECT * FROM accounts;
 
 When you're done using the SQL shell, press **CTRL + D** to exit.
  
-## Step 7.  Access the Admin UI
+## Step 6.  Access the Admin UI
 
 Reopen the [Admin UI](explore-the-admin-ui.html) by pointing your browser to `https://localhost:8080`. You can also find the address in the `admin` field in the standard output of any node on startup. 
 

--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -136,6 +136,19 @@ When you started the first container/node, you mapped the node's default HTTP po
 
 <img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
+
+## Step 6.  Stop the cluster
+
+Once you're done looking through the Admin UI, you can stop the nodes (and therefore the cluster):
+
+~~~ shell
+$ cockroach quit
+$ cockroach quit --port=26258
+$ cockroach quit --port=26259
+~~~
+
+For more details about the `cockroach quit` command, see [Stop a Node](stop-a-node.html).
+
 ## What's Next?
 
 [Secure your cluster](secure-a-cluster.html) with authentication and encryption. You might also be interested in:

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -115,6 +115,18 @@ To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, point y
 
 <img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
+## Step 6.  Stop the cluster
+
+Once you're done looking through the Admin UI, you can stop the nodes (and therefore the cluster):
+
+~~~ shell
+$ cockroach quit
+$ cockroach quit --port=26258
+$ cockroach quit --port=26259
+~~~
+
+For more details about the `cockroach quit` command, see [Stop a Node](stop-a-node.html).
+
 ## What's Next?
 
 [Secure your cluster](secure-a-cluster.html) with authentication and encryption. You might also be interested in:


### PR DESCRIPTION
Moved `cockroach stop` command from the beginning of `secure-a-cluster` to end of `start-a-local-cluster`.

Closes #553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/581)
<!-- Reviewable:end -->
