### PR TITLE
Misc CSS improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,22 @@ CockroachDB docs should be:
 
 - Clear 
 - Correct 
-- Concise 
+- Concise
+
+We also have additional guidance to ensure consistency with our existing documents.
+
+### Code Samples
+
+Code samples are marked with an opening and closing set of 3 tildes (`~~~`). Shell and SQL commands should be syntax high-lighted where appropriate using the following info.
+
+#### Shell Code Samples
+Start shell code samples with `~~~ shell` followed by a line break. The first character of the next line must be the terminal marker `$`.
+
+#### SQL Code Samples
+SQL code samples are broken into two sections: commands and responses.
+
+- **Commands** (e.g., `SELECT`, `CREATE TABLE`) should begin with `~~~ sql` followed by a line break. The first character of the next line must be the terminal marker `>`.
+- **Responses** (e.g., retrieved tables) should begin with `~~~` but should *not* be syntax highlighted.
 
 ## Build and Test the Docs Locally
 

--- a/bool.md
+++ b/bool.md
@@ -27,10 +27,12 @@ A `BOOL` value is 1 byte in width, but the total storage size is likely to be la
 
 ## Examples
 
-~~~
-CREATE TABLE bool (a INT PRIMARY KEY, b BOOL, c BOOLEAN);
+~~~ sql
+> CREATE TABLE bool (a INT PRIMARY KEY, b BOOL, c BOOLEAN);
 
-SHOW COLUMNS FROM bool;
+> SHOW COLUMNS FROM bool;
+~~~
+~~~
 +-------+------+-------+---------+
 | Field | Type | Null  | Default |
 +-------+------+-------+---------+
@@ -38,10 +40,13 @@ SHOW COLUMNS FROM bool;
 | b     | BOOL | true  | NULL    |
 | c     | BOOL | true  | NULL    |
 +-------+------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO bool VALUES (12345, true, CAST(0 AS BOOL));
 
-INSERT INTO bool VALUES (12345, true, CAST(0 AS BOOL));
-
-SELECT * FROM bool;
+> SELECT * FROM bool;
+~~~
+~~~
 +-------+------+-------+
 |   a   |  b   |   c   |
 +-------+------+-------+

--- a/bytes.md
+++ b/bytes.md
@@ -28,10 +28,12 @@ The size of a `BYTES` value is variable, but it's recommended to keep values und
 
 ## Examples
 
-~~~
-CREATE TABLE bytes (a INT PRIMARY KEY, b BYTES, c BLOB);
+~~~ sql
+> CREATE TABLE bytes (a INT PRIMARY KEY, b BYTES, c BLOB);
 
-SHOW COLUMNS FROM bytes;
+> SHOW COLUMNS FROM bytes;
+~~~
+~~~
 +-------+-------+-------+---------+
 | Field | Type  | Null  | Default |
 +-------+-------+-------+---------+
@@ -39,10 +41,13 @@ SHOW COLUMNS FROM bytes;
 | b     | BYTES | true  | NULL    |
 | c     | BYTES | true  | NULL    |
 +-------+-------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO bytes VALUES (12345, b'\141\061\142\062\143\063', b'\x61\x31\x62\x32\x63\x33');
 
-INSERT INTO bytes VALUES (12345, b'\141\061\142\062\143\063', b'\x61\x31\x62\x32\x63\x33');
-
-SELECT * FROM bytes;
+> SELECT * FROM bytes;
+~~~
+~~~
 +-------+--------+--------+
 |   a   |   b    |   c    |
 +-------+--------+--------+

--- a/column-families.md
+++ b/column-families.md
@@ -35,15 +35,17 @@ To manually assign a column family on [table creation](create-table.html), use t
 
 For example, let's say we want to create a `users` table to store user IDs (`id INT`), date and time when users joined (`joined TIMESTAMP`), and user names (`name STRING`). We don't know how long a name will be, so we leave it unbounded. However, since names are generally short, we use the `FAMILY` keyword to group `name` with the other columns:
 
-~~~
-CREATE TABLE users (
+~~~ sql
+> CREATE TABLE users (
     id INT PRIMARY KEY, 
     joined TIMESTAMP,
     name STRING,
     FAMILY f1 (id, joined, name)
 );
 
-SHOW CREATE TABLE users;
+> SHOW CREATE TABLE users;
+~~~
+~~~
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
@@ -66,20 +68,20 @@ When using the [`ALTER TABLE`](alter-table.html) statement to add a column to a 
 
 - Use the `CREATE FAMILY` keyword to assign a new column to a **new family**. For example, the following would add a `data BYTES` column to the `users` table above and assign it to a new column family: 
 
-  ~~~
-  ALTER TABLE users ADD COLUMN data BYTES CREATE FAMILY f2;
+  ~~~ sql
+  > ALTER TABLE users ADD COLUMN data BYTES CREATE FAMILY f2;
   ~~~
 
 - Use the `FAMILY` keyword to assign a new column to an **existing family**. For example, the following would add a `data BYTES` colum to the `users` table above and assign it to family `f1`:
 
-  ~~~
-  ALTER TABLE users ADD COLUMN data BYTES FAMILY f1;
+  ~~~ sql
+  > ALTER TABLE users ADD COLUMN data BYTES FAMILY f1;
   ~~~
 
 - Use the `CREATE IF NOT EXISTS FAMILY` keyword to assign a new column to an **existing family or, if the family doesn't exist, to a new family**. For example, the following would assign the new column to the existing `f1` family; if that family didn't exist, it would create a new family and assign the column to it:
 
-  ~~~
-  ALTER TABLE users ADD COLUMN data BYTES CREATE IF NOT EXISTS FAMILY f1;
+  ~~~ sql
+  > ALTER TABLE users ADD COLUMN data BYTES CREATE IF NOT EXISTS FAMILY f1;
   ~~~
 
 ## Compatibility with Past Releases

--- a/constraints.md
+++ b/constraints.md
@@ -32,15 +32,17 @@ The different types of constraints are:
 
 A NOT NULL constraint is specified using `NOT NULL` at the column level. It requires that the column's value is mandatory and must contain a value that is not *NULL*. You can also explicitly just say `NULL` which means the column's value is optional and the column may contain a *NULL* value. If nothing is specified, the default is `NULL`.
 
-~~~sql
-CREATE TABLE customers
+~~~ sql
+> CREATE TABLE customers
 (
   customer_id INT         PRIMARY KEY,
   cust_name   STRING(30)  NULL,
   cust_email  STRING(100) NOT NULL
 );
 
-INSERT INTO customers (customer_id, cust_name, cust_email) VALUES (1, 'Smith', NULL);
+> INSERT INTO customers (customer_id, cust_name, cust_email) VALUES (1, 'Smith', NULL);
+~~~
+~~~
 pq: null value in column "cust_email" violates not-null constraint
 ~~~
 
@@ -56,8 +58,8 @@ The Primary Key for a table can only be specified in the [`CREATE TABLE`](create
 
 A Primary Key constraint can be specified at the column level if it has only one column.
 
-~~~sql
-CREATE TABLE orders
+~~~ sql
+> CREATE TABLE orders
 (
   order_id        INT PRIMARY KEY NOT NULL,
   order_date      TIMESTAMP NOT NULL,
@@ -69,8 +71,8 @@ CREATE TABLE orders
 
 It needs to be specified at the table level if it has more than one column.
 
-~~~sql
-CREATE TABLE inventories
+~~~ sql
+> CREATE TABLE inventories
 (
   product_id        INT NOT NULL,
   warehouse_id      INT NOT NULL,
@@ -85,8 +87,8 @@ A Unique constraint is specified using `UNIQUE` at either the column or table le
 
 A Unique constraint can be specified at the column level if it has only one column.
 
-~~~sql
-CREATE TABLE warehouses
+~~~ sql
+> CREATE TABLE warehouses
 (
   warehouse_id    INT        PRIMARY KEY NOT NULL,
   warehouse_name  STRING(35) UNIQUE,
@@ -96,8 +98,8 @@ CREATE TABLE warehouses
 
 It needs to be specified at the table level if it has more than one column.
 
-~~~sql
-CREATE TABLE logon
+~~~ sql
+> CREATE TABLE logon
 (
   login_id	INT PRIMARY KEY, 
   customer_id   INT,
@@ -108,8 +110,8 @@ CREATE TABLE logon
 
 Be aware that if a table has a `UNIQUE` constraint on column(s) that are optional (nullable), it is still possible to insert duplicate rows that appear to violate the constraint if they contain a *NULL* value in at least one of the columns. This is because *NULL*s are never considered equal and hence don't violate the uniqueness constraint.
 
-~~~sql
-CREATE TABLE logon
+~~~ sql
+> CREATE TABLE logon
 (
   login_id INT PRIMARY KEY, 
   customer_id   INT NOT NULL,
@@ -117,11 +119,12 @@ CREATE TABLE logon
   UNIQUE (customer_id, sales_id)
 );
 
-INSERT INTO logon (login_id, customer_id, sales_id) VALUES (1, 2, NULL);
+> INSERT INTO logon (login_id, customer_id, sales_id) VALUES (1, 2, NULL);
+> INSERT INTO logon (login_id, customer_id, sales_id) VALUES (2, 2, NULL);
 
-INSERT INTO logon (login_id, customer_id, sales_id) VALUES (2, 2, NULL);
-
-select * from logon;
+> SELECT * FROM logon;
+~~~
+~~~
 +----------+-------------+----------+
 | login_id | customer_id | sales_id |
 +----------+-------------+----------+
@@ -136,19 +139,19 @@ A Check constraint is specified using `CHECK` at the column or table level. It r
 
 You can have multiple Check constraints on a single column but ideally these should be combined using the logical operators. So, for example, 
 
-~~~sql
+~~~ sql
 warranty_period INT CHECK (warranty_period >= 0) CHECK (warranty_period <= 24)
 ~~~
 should be specified as 
 
-~~~sql
+~~~ sql
 warranty_period INT CHECK (warranty_period BETWEEN 0 AND 24)
 ~~~
 
 Check constraints that refer to multiple columns should be specified at the table level. 
 
-~~~sql
-CREATE TABLE inventories
+~~~ sql
+> CREATE TABLE inventories
 (
   product_id        INT NOT NULL,
   warehouse_id      INT NOT NULL,
@@ -160,8 +163,8 @@ CREATE TABLE inventories
 
 Check constraints may be specified at the column or table level and can reference other columns within the table. Internally, all column level Check constrints are converted to table level constraints so they can be handled in a consistent fashion.
 
-~~~sql
-CREATE TABLE inventories
+~~~ sql
+> CREATE TABLE inventories
 (
   product_id        INT NOT NULL,
   warehouse_id      INT NOT NULL,
@@ -169,7 +172,9 @@ CREATE TABLE inventories
   PRIMARY KEY (product_id, warehouse_id)
 );
 
-INSERT INTO inventories (product_id, warehouse_id, quantity_on_hand) VALUES (1, 2, -20);
+> INSERT INTO inventories (product_id, warehouse_id, quantity_on_hand) VALUES (1, 2, -20);
+~~~
+~~~
 pq: failed to satisfy CHECK constraint (quantity_on_hand > 0)
 ~~~
 
@@ -179,8 +184,8 @@ A Default Value constraint is specified using `DEFAULT` at the column level. It 
 The Datatype of the DEFAULT value or expression should be the same as the Datatype of the column.
 The DEFAULT constraint only applies on insert if the column is not specified in the INSERT statement. You can still insert a *NULL* into an optional (nullable) column by explicitly stating the column and the *NULL* value.
 
-~~~sql
-CREATE TABLE inventories
+~~~ sql
+> CREATE TABLE inventories
 (
   product_id        INT NOT NULL,
   warehouse_id      INT NOT NULL,
@@ -188,11 +193,13 @@ CREATE TABLE inventories
   PRIMARY KEY (product_id, warehouse_id)
 );
 
-INSERT INTO inventories (product_id, warehouse_id) VALUES (1,20);
+> INSERT INTO inventories (product_id, warehouse_id) VALUES (1,20);
 
-INSERT INTO inventories (product_id, warehouse_id, quantity_on_hand) VALUES (2,30, NULL);
+> INSERT INTO inventories (product_id, warehouse_id, quantity_on_hand) VALUES (2,30, NULL);
 
-SELECT * FROM inventories;
+> SELECT * FROM inventories;
+~~~
+~~~
 +------------+--------------+------------------+
 | product_id | warehouse_id | quantity_on_hand |
 +------------+--------------+------------------+
@@ -247,10 +254,10 @@ We're currently working to improve the performance of these statements, though.
 
 #### Example
 
-~~~sql
-CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
+~~~ sql
+> CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
 
-CREATE TABLE orders 
+> CREATE TABLE orders 
 (
   id INT PRIMARY KEY,
   customer INT NOT NULL REFERENCES customers (id),
@@ -258,19 +265,25 @@ CREATE TABLE orders
   INDEX (customer)
 );
 
-INSERT INTO customers VALUES (1001, 'a@co.tld');
-INSERT 1
+> INSERT INTO customers VALUES (1001, 'a@co.tld');
 
-INSERT INTO orders VALUES (1, 1002, 29.99);
+> INSERT INTO orders VALUES (1, 1002, 29.99);
+~~~
+~~~
 pq: foreign key violation: value [1002] not found in customers@primary [id]
+~~~
+~~~ sql
+> INSERT INTO orders VALUES (1, 1001, 29.99);
 
-INSERT INTO orders VALUES (1, 1001, 29.99);
-INSERT 1
-
-UPDATE customers SET id = 1002 WHERE id = 1001;
+> UPDATE customers SET id = 1002 WHERE id = 1001;
+~~~
+~~~
 pq: foreign key violation: value(s) [1001] in columns [id] referenced in table "orders"
-
-DELETE FROM customers WHERE id = 1001;
+~~~
+~~~ sql
+> DELETE FROM customers WHERE id = 1001;
+~~~
+~~~
 pq: foreign key violation: value(s) [1001] in columns [id] referenced in table "orders"
 ~~~
 
@@ -280,26 +293,34 @@ The Foreign Key constraint depends on [the index of foreign key columns](#rules-
 
 {{site.data.alerts.callout_danger}}<code>CASCADE</code> also drops any other objects that depend on the index.{{site.data.alerts.end}}
 
-~~~sql
-SHOW CONSTRAINTS FROM orders;
+~~~ sql
+> SHOW CONSTRAINTS FROM orders;
+~~~
+~~~
 +--------+---------------------------+-------------+------------+----------------+
 | Table  |           Name            |    Type     | Column(s)  |    Details     |
 +--------+---------------------------+-------------+------------+----------------+
 | orders | fk_customer_ref_customers | FOREIGN KEY | [customer] | customers.[id] |
 | orders | primary                   | PRIMARY KEY | [id]       | NULL           |
 +--------+---------------------------+-------------+------------+----------------+
-
-SHOW INDEX FROM orders;
+~~~
+~~~ sql
+> SHOW INDEX FROM orders;
+~~~
+~~~
 +--------+---------------------+--------+-----+----------+-----------+---------+
 | Table  |        Name         | Unique | Seq |  Column  | Direction | Storing |
 +--------+---------------------+--------+-----+----------+-----------+---------+
 | orders | primary             | true   |   1 | id       | ASC       | false   |
 | orders | orders_customer_idx | false  |   1 | customer | ASC       | false   |
 +--------+---------------------+--------+-----+----------+-----------+---------+
+~~~
+~~~ sql
+> DROP INDEX orders@orders_customer_idx CASCADE;
 
-DROP INDEX orders@orders_customer_idx CASCADE;
-
-SHOW CONSTRAINTS FROM orders;
+> SHOW CONSTRAINTS FROM orders;
+~~~
+~~~
 +--------+---------+-------------+-----------+---------+
 | Table  |  Name   |    Type     | Column(s) | Details |
 +--------+---------+-------------+-----------+---------+

--- a/create-database.md
+++ b/create-database.md
@@ -28,11 +28,12 @@ Parameter | Description
 
 
 ### Create a Database
-~~~
+~~~ sql
 > CREATE DATABASE bank;
-CREATE DATABASE
 
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+
@@ -44,18 +45,24 @@ CREATE DATABASE
 
 ### Create Fails (Name Already In Use)
 
+~~~ sql
+> SHOW DATABASES;
 ~~~
-> SHOW DATABASES;
+~~~
 +----------+
 | Database |
 +----------+
 | bank     |
 | system   |
 +----------+
-
+~~~
+~~~ sql
 > CREATE DATABASE bank;
+~~~
+~~~
 pq: database "bank" already exists
-
+~~~
+~~~ sql
 > SHOW DATABASES;
 +----------+
 | Database |
@@ -63,11 +70,19 @@ pq: database "bank" already exists
 | bank     |
 | system   |
 +----------+
+~~~
 
+~~~ sql
 > CREATE DATABASE IF NOT EXISTS bank;
-CREATE DATABASE
+~~~
 
+SQL does not generate an error, but instead responds `CREATE DATABASE` even though a new database wasn't created.
+
+~~~ sql
 > SHOW DATABASES;
+~~~
+
+~~~
 +----------+
 | Database |
 +----------+

--- a/create-index.md
+++ b/create-index.md
@@ -49,8 +49,8 @@ To create the most efficient indexes, we recommend reviewing:
 
 Single-column indexes sort the values of a single column.
 
-~~~sql
-CREATE INDEX ON products (price);
+~~~ sql
+> CREATE INDEX ON products (price);
 ~~~
 
 Because each query can only use one index, single-column indexes are not typically as useful as multiple-column indexes.
@@ -59,8 +59,8 @@ Because each query can only use one index, single-column indexes are not typical
 
 Multiple-column indexes sort columns in the order you list them.
 
-~~~sql
-CREATE INDEX ON products (price, stock);
+~~~ sql
+> CREATE INDEX ON products (price, stock);
 ~~~
 
 To create the most useful multiple-column indexes, we recommend reviewing our [best practices](indexes.html#indexing-columns).
@@ -69,22 +69,22 @@ To create the most useful multiple-column indexes, we recommend reviewing our [b
 
 Unique indexes do not allow duplicate values among their columns.
 
-~~~sql
-CREATE UNIQUE INDEX ON products (name, manufacturer_id);
+~~~ sql
+> CREATE UNIQUE INDEX ON products (name, manufacturer_id);
 ~~~
 
 This also applies the [`UNIQUE`](constraints.html#unique) constraint at the table level, similarly to [`ALTER TABLE`](alter-table.html). The above example is equivalent to:
 
-~~~sql
-ALTER TABLE products ADD CONSTRAINT products_name_manufacturer_id_key UNIQUE (name, manufacturer_id);
+~~~ sql
+> ALTER TABLE products ADD CONSTRAINT products_name_manufacturer_id_key UNIQUE (name, manufacturer_id);
 ~~~
 
 ### Store Columns
 
 Storing a column improves the performance of queries that retrieve (but don’t filter) its values.
 
-~~~sql
-CREATE INDEX ON products (price) STORING (name);
+~~~ sql
+> CREATE INDEX ON products (price) STORING (name);
 ~~~
 
 However, to use stored columns, queries must filter another column in the same index. For example, SQL can retrieve `name` values from the above index only when a query's `WHERE` clause filters `price`.
@@ -93,8 +93,8 @@ However, to use stored columns, queries must filter another column in the same i
 
 To sort columns in descending order, you must explicitly set the option when creating the index. (Ascending order is the default.)
 
-~~~sql
-CREATE INDEX ON products (price DESC, stock);
+~~~ sql
+> CREATE INDEX ON products (price DESC, stock);
 ~~~
 
 How columns are sorted impacts the order of rows returned by queries using the index, which particularly affects queries using `LIMIT`.
@@ -103,8 +103,10 @@ How columns are sorted impacts the order of rows returned by queries using the i
 
 Normally, CockroachDB selects the index that it calculates will scan the fewest rows. However, you can override that selection and specify the name of the index you want to use. To find the name, use [`SHOW INDEX`](show-index.html).
 
-~~~sql
-SHOW INDEX FROM products;
+~~~ sql
+> SHOW INDEX FROM products;
+~~~
+~~~
 +----------+--------------------+--------+-----+--------+-----------+---------+
 |  Table   |        Name        | Unique | Seq | Column | Direction | Storing |
 +----------+--------------------+--------+-----+--------+-----------+---------+
@@ -112,8 +114,9 @@ SHOW INDEX FROM products;
 | products | products_price_idx | false  |   1 | name   | N/A       | true    |
 | products | products_price_idx | false  |   2 | price  | ASC       | false   |
 +----------+--------------------+--------+-----+--------+-----------+---------+
-
-SELECT name FROM products@products_price_idx WHERE price > 10;
+~~~
+~~~ sql
+> SELECT name FROM products@products_price_idx WHERE price > 10;
 ~~~
 
 ## See Also

--- a/create-table.md
+++ b/create-table.md
@@ -90,13 +90,15 @@ In CockroachDB, every table requires a [`PRIMARY KEY`](constraints.html#primary-
 
 {{site.data.alerts.callout_info}}Strictly speaking, a primary key's unique index is not created; it is derived from the key(s) under which the data is stored, so it takes no additional space. However, it appears as a normal unique index when using commands like <code>SHOW INDEX</code>.{{site.data.alerts.end}}
 
-~~~ 
-CREATE TABLE logon (
+~~~ sql
+> CREATE TABLE logon (
     user_id INT, 
     logon_date DATE
 );
 
-SHOW COLUMNS FROM logon;
+> SHOW COLUMNS FROM logon;
+~~~
+~~~
 +------------+------+-------+----------------+
 |   Field    | Type | Null  |    Default     |
 +------------+------+-------+----------------+
@@ -105,8 +107,11 @@ SHOW COLUMNS FROM logon;
 | rowid      | INT  | false | unique_rowid() |
 +------------+------+-------+----------------+
 (3 rows)
-
-SHOW INDEX FROM logon;
+~~~
+~~~ sql
+> SHOW INDEX FROM logon;
+~~~
+~~~
 +-------+---------+--------+-----+--------+-----------+---------+
 | Table |  Name   | Unique | Seq | Column | Direction | Storing |
 +-------+---------+--------+-----+--------+-----------+---------+
@@ -121,7 +126,7 @@ In this example, we create a table with three columns. One column is the [`PRIMA
 
 By default, CockroachDB would assign the `user_id` and `logoff_date` columns to a single column family, since they're of a fixed size, and `user_email` to its own column family, since it's unbounded. We know that `user_email` will be relatively small, however, so we use the `FAMILY` keyword to group it with the other columns. As a result, each new row in the table would correspond to a single underlying key-value pair. For more deails about how columns are assigned to column families, see [Column Families](column-families.html).
 
-~~~ 
+~~~ sql
 CREATE TABLE logoff (
     user_id INT PRIMARY KEY, 
     user_email STRING UNIQUE, 
@@ -129,7 +134,9 @@ CREATE TABLE logoff (
     FAMILY f1 (user_id, user_email, logoff_date)
 );
 
-SHOW COLUMNS FROM logoff;
+> SHOW COLUMNS FROM logoff;
+~~~
+~~~
 +-------------+------------+-------+---------+
 |    Field    |    Type    | Null  | Default |
 +-------------+------------+-------+---------+
@@ -138,8 +145,11 @@ SHOW COLUMNS FROM logoff;
 | logoff_date | DATE       | true  | NULL    |
 +-------------+------------+-------+---------+
 (3 rows)
-
-SHOW INDEX FROM logoff;
+~~~
+~~~ sql
+> SHOW INDEX FROM logoff;
+~~~
+~~~
 +--------+-----------------------+--------+-----+------------+-----------+---------+
 | Table  |         Name          | Unique | Seq |   Column   | Direction | Storing |
 +--------+-----------------------+--------+-----+------------+-----------+---------+
@@ -153,8 +163,8 @@ SHOW INDEX FROM logoff;
 
 In this example, we create two secondary indexes during table creation. Secondary indexes allow efficient access to data with keys other than the primary key. This example also demonstrates a number of column-level and table-level [constraints](constraints.html).
 
-~~~ 
-CREATE TABLE product_information (
+~~~ sql
+> CREATE TABLE product_information (
     product_id           INT PRIMARY KEY NOT NULL,
     product_name         STRING(50) UNIQUE NOT NULL,
     product_description  STRING(2000),
@@ -172,7 +182,9 @@ CREATE TABLE product_information (
     INDEX supp_id_prod_status_idx (supplier_id, product_status)
 );
 
-SHOW INDEX FROM product_information;
+> SHOW INDEX FROM product_information;
+~~~
+~~~
 +---------------------+--------------------------------------+--------+-----+----------------+-----------+---------+
 |        Table        |                 Name                 | Unique | Seq |     Column     | Direction | Storing |
 +---------------------+--------------------------------------+--------+-----+----------------+-----------+---------+
@@ -202,12 +214,12 @@ There are a [number of rules](constraints.html#rules-for-creating-foreign-keys) 
 
 In this example, we'll show a series of tables using different formats of foreign keys.
 
-~~~ 
-CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
+~~~ sql
+> CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
 
-CREATE TABLE products (sku STRING PRIMARY KEY, price DECIMAL(9,2));
+> CREATE TABLE products (sku STRING PRIMARY KEY, price DECIMAL(9,2));
 
-CREATE TABLE orders (
+> CREATE TABLE orders (
   id INT PRIMARY KEY,
   product STRING NOT NULL REFERENCES products,
   quantity INT,
@@ -217,7 +229,7 @@ CREATE TABLE orders (
   INDEX (customer)
 );
 
-CREATE TABLE reviews (
+> CREATE TABLE reviews (
   id INT PRIMARY KEY,
   product STRING NOT NULL REFERENCES products,
   customer INT NOT NULL,
@@ -234,8 +246,10 @@ CREATE TABLE reviews (
 
 To show the definition of a table, use the [`SHOW CREATE TABLE`](show-create-table.html) statement. The contents of the `CreateTable` column in the response is a string with embedded line breaks that, when echoed, produces formatted output.
 
-~~~ 
-SHOW CREATE TABLE logoff;
+~~~ sql
+> SHOW CREATE TABLE logoff;
+~~~
+~~~
 +--------+----------------------------------------------------------+
 | Table  |                       CreateTable                        |
 +--------+----------------------------------------------------------+

--- a/css/components/_callout.scss
+++ b/css/components/_callout.scss
@@ -32,12 +32,14 @@
     color: #428bca;
 }
 .bs-callout-success {
+    background-color: rgba(248,245,225,0.4);
     border-left-color: #5cb85c;
 }
 .bs-callout-success h4 {
     color: #5cb85c;
 }
 .bs-callout-danger {
+    background-color: rgba(217,83,79, .07);
     border-left-color: #d9534f;
 }
 .bs-callout-danger h4 {
@@ -45,6 +47,7 @@
 }
 .bs-callout-warning {
     border-left-color: #f0ad4e;
+    background-color: rgba(248,245,225,0.4);
 }
 .bs-callout-warning h4 {
     color: #f0ad4e;

--- a/css/components/_codesamples.scss
+++ b/css/components/_codesamples.scss
@@ -1,0 +1,17 @@
+/* Designed to make items marked as terminal prompts with Rouge syntax highlighter unselectable*/
+.noselect{
+  -webkit-user-select: none;  /* Chrome all / Safari all */
+  -moz-user-select: none;     /* Firefox all */
+  -ms-user-select: none;      /* IE 10+ */
+  user-select: none;          /* Likely future */      
+}
+
+/* Works in conjunction with /js/customscripts.js to make shell terminals prompts ($) totally unselectable */
+.shellterminal::before {
+    content: "$ ";
+}
+
+/* Works in conjunction with /js/customscripts.js to make SQL terminals prompts (>) totally unselectable */
+.sqlterminal::before {
+    content: "> ";
+}

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -132,6 +132,9 @@ p {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale; }
 
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 40px; }
+
 h1 {
   font-family: 'Adelle-Regular', serif;
   font-size: 40px;
@@ -162,6 +165,8 @@ h3 {
   -moz-osx-font-smoothing: grayscale;
   color: #142848;
   text-transform: uppercase; }
+  h3.clickable-header {
+    cursor: pointer; }
   h3 strong, h3 b {
     font-family: 'AvenirLTStd-Black', serif;
     font-size: 20px;
@@ -219,7 +224,7 @@ header {
   background: #fff;
   -webkit-transition: margin 0.4s;
   transition: margin 0.4s;
-  border-bottom: 1px solid #d9dbe2; }
+  border-bottom: 1px solid #D9DBE2; }
   header .logo {
     width: 160px;
     float: left;
@@ -342,8 +347,8 @@ header {
       display: none; } }
 /* navgoco sidebar styles (customized) */
 .col-sidebar {
-  background-color: #f7f7f7;
-  border-bottom: 1px solid #d9dbe2; }
+  background-color: #F7F7F7;
+  border-bottom: 1px solid #D9DBE2; }
   @media screen and (min-width: 768px) {
     .col-sidebar {
       background-color: transparent;
@@ -426,7 +431,7 @@ header {
       color: #46a417; }
 
 .roach {
-  border: 1px solid #d9dbe2;
+  border: 1px solid #D9DBE2;
   margin-bottom: 20px;
   padding: 10px;
   text-align: center;
@@ -455,7 +460,7 @@ header {
     line-height: 20px; }
   .roach:hover {
     border-color: #46a417;
-    background-color: #f7f7f7; }
+    background-color: #F7F7F7; }
   .roach.full-roach .catrina {
     height: 120px; }
   @media screen and (min-width: 992px) {
@@ -468,7 +473,7 @@ header {
         height: auto; } }
 
 .blog-post {
-  border: 1px solid #d9dbe2;
+  border: 1px solid #D9DBE2;
   padding: 10px 20px;
   border-bottom: none;
   overflow: auto; }
@@ -492,9 +497,9 @@ header {
     .blog-post .blog-meta .meta-emphasis {
       color: #46a417; }
   .blog-post.last-entry {
-    border-bottom: 1px solid #d9dbe2; }
+    border-bottom: 1px solid #D9DBE2; }
   .blog-post:hover {
-    background-color: #f7f7f7; }
+    background-color: #F7F7F7; }
   @media screen and (min-width: 768px) {
     .blog-post .blog-title {
       float: left;
@@ -540,7 +545,7 @@ header {
     #content #main-content {
       min-height: 625px; }
       #content #main-content .content-col {
-        border-left: 1px solid #d9dbe2;
+        border-left: 1px solid #D9DBE2;
         min-height: 625px;
         padding-left: 55px; } }
 
@@ -819,17 +824,16 @@ section.footer {
   color: #777 !important; }
 
 /* make room for the nav bar */
-h1[id]::before,
-h2[id]::before,
-h3[id]::before,
-h4[id]::before,
-h5[id]::before,
-h6[id]::before,
-dt[id]::before {
+h1:target:before,
+h2:target:before,
+h3:target:before,
+h4:target:before,
+h5:target:before,
+h6:target:before {
   content: '';
   display: block;
   height: 100px;
-  margin-top: -80px; }
+  margin-top: -100px; }
 
 .post-content img {
   margin: 12px 0px 3px 0px; }
@@ -1357,32 +1361,35 @@ a.accordion-toggle {
   color: #428bca; }
 
 .bs-callout-success {
+  background-color: rgba(248, 245, 225, 0.4);
   border-left-color: #5cb85c; }
 
 .bs-callout-success h4 {
   color: #5cb85c; }
 
 .bs-callout-danger {
+  background-color: rgba(217, 83, 79, 0.07);
   border-left-color: #d9534f; }
 
 .bs-callout-danger h4 {
   color: #d9534f; }
 
 .bs-callout-warning {
-  border-left-color: #f0ad4e; }
+  border-left-color: #f0ad4e;
+  background-color: rgba(248, 245, 225, 0.4); }
 
 .bs-callout-warning h4 {
   color: #f0ad4e; }
 
 .bs-callout-info {
-  background-color: #ecf7ff;
-  border-left-color: #7fbeeb; }
+  background-color: #ECF7FF;
+  border-left-color: #7FBEEB; }
 
 .bs-callout-info h4 {
   color: #5bc0de; }
 
 #toc > ul {
-  background-color: #f0ffe8;
+  background-color: #F0FFE8;
   padding: 20px 30px;
   margin: 0;
   width: 100%; }
@@ -1821,6 +1828,25 @@ a.accordion-toggle {
 
   .hubspot-install-form .install-form .hs_email input {
     width: 250px; } }
+/* Designed to make items marked as terminal prompts with Rouge syntax highlighter unselectable*/
+.noselect {
+  -webkit-user-select: none;
+  /* Chrome all / Safari all */
+  -moz-user-select: none;
+  /* Firefox all */
+  -ms-user-select: none;
+  /* IE 10+ */
+  user-select: none;
+  /* Likely future */ }
+
+/* Works in conjunction with /js/customscripts.js to make shell terminals prompts ($) totally unselectable */
+.shellterminal::before {
+  content: "$ "; }
+
+/* Works in conjunction with /js/customscripts.js to make SQL terminals prompts (>) totally unselectable */
+.sqlterminal::before {
+  content: "> "; }
+
 @namespace "http://www.w3.org/2000/svg";
 .line {
   fill: none;
@@ -2001,11 +2027,11 @@ polygon.regexp {
 
 /* Literal.String */
 .highlight .na {
-  color: teal; }
+  color: #008080; }
 
 /* Name.Attribute */
 .highlight .nb {
-  color: #0086b3; }
+  color: #0086B3; }
 
 /* Name.Builtin */
 .highlight .nc {
@@ -2014,11 +2040,11 @@ polygon.regexp {
 
 /* Name.Class */
 .highlight .no {
-  color: teal; }
+  color: #008080; }
 
 /* Name.Constant */
 .highlight .ni {
-  color: purple; }
+  color: #800080; }
 
 /* Name.Entity */
 .highlight .ne {
@@ -2035,11 +2061,11 @@ polygon.regexp {
 
 /* Name.Namespace */
 .highlight .nt {
-  color: navy; }
+  color: #000080; }
 
 /* Name.Tag */
 .highlight .nv {
-  color: teal; }
+  color: #008080; }
 
 /* Name.Variable */
 /*.highlight .ow { font-weight: bold } /* Operator.Word */
@@ -2064,35 +2090,35 @@ polygon.regexp {
 
 /* Literal.Number.Oct */
 .highlight .sb {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Backtick */
 .highlight .sc {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Char */
 .highlight .sd {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Doc */
 .highlight .s2 {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Double */
 .highlight .se {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Escape */
 .highlight .sh {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Heredoc */
 .highlight .si {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Interpol */
 .highlight .sx {
-  color: #dd1144; }
+  color: #d14; }
 
 /* Literal.String.Other */
 .highlight .sr {
@@ -2112,15 +2138,15 @@ polygon.regexp {
 
 /* Name.Builtin.Pseudo */
 .highlight .vc {
-  color: teal; }
+  color: #008080; }
 
 /* Name.Variable.Class */
 .highlight .vg {
-  color: teal; }
+  color: #008080; }
 
 /* Name.Variable.Global */
 .highlight .vi {
-  color: teal; }
+  color: #008080; }
 
 /* Name.Variable.Instance */
 .highlight .il {
@@ -2131,7 +2157,7 @@ polygon.regexp {
 #feedback-prompt {
   display: inline-block;
   padding: 25px;
-  background-color: #f0ffe8;
+  background-color: #F0FFE8;
   font-size: 0; }
   #feedback-prompt form {
     display: inline-block;
@@ -2155,7 +2181,7 @@ polygon.regexp {
   padding: 0;
   display: inline-block;
   vertical-align: bottom;
-  background-color: #f0ffe8;
+  background-color: #F0FFE8;
   color: #142848 !important;
   font-family: 'AvenirLTStd-Book', serif;
   font-size: 16px;
@@ -2621,3 +2647,5 @@ img.mfp-img {
   .mfp-container {
     padding-left: 6px;
     padding-right: 6px; } }
+
+/*# sourceMappingURL=customstyles.css.map */

--- a/css/customstyles.scss
+++ b/css/customstyles.scss
@@ -16,6 +16,10 @@ p {
   }
 }
 
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 40px;
+}
+
 h1 {
   @include adelle(40px);
   color: $cl_green;
@@ -37,6 +41,10 @@ h2 {
 h3 {
   @include avenir_h(20px);
   color: $cl_blue;
+
+  &.clickable-header {
+    cursor: pointer;
+  }
   
   text-transform: uppercase;
 
@@ -68,18 +76,16 @@ h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 .breadcrumb > .active {color: #777 !important;}
 
 /* make room for the nav bar */
-h1[id]::before,
-h2[id]::before,
-h3[id]::before,
-h4[id]::before,
-h5[id]::before,
-h6[id]::before,
-dt[id]::before {
+h1:target:before,
+h2:target:before,
+h3:target:before,
+h4:target:before,
+h5:target:before,
+h6:target:before {
   content: '';
   display: block;
   height: 100px;
-  margin-top: -80px;
-}
+  margin-top: -100px; }
 
 .post-content {
   img {
@@ -625,9 +631,7 @@ a.accordion-toggle {
 @import "components/toc";
 @import "components/filtertabs";
 @import "components/newsletter";
+@import "components/codesamples";
 @import "syntax/sql";
 @import "syntax/syntax";
 @import "components/feedback-widget";
-
-
-

--- a/date.md
+++ b/date.md
@@ -22,20 +22,25 @@ A `DATE` column supports values up to 8 bytes in width, but the total storage si
 
 ## Examples
 
-~~~
-CREATE TABLE dates (a DATE PRIMARY KEY, b INT);
+~~~ sql
+> CREATE TABLE dates (a DATE PRIMARY KEY, b INT);
 
-SHOW COLUMNS FROM dates;
+> SHOW COLUMNS FROM dates;
+~~~
+~~~
 +-------+------+-------+---------+
 | Field | Type | Null  | Default |
 +-------+------+-------+---------+
 | a     | DATE | false | NULL    |
 | b     | INT  | true  | NULL    |
 +-------+------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO dates VALUES (DATE '2016-03-26', 12345);
 
-INSERT INTO dates VALUES (DATE '2016-03-26', 12345);
-
-SELECT * FROM dates;
+> SELECT * FROM dates;
+~~~
+~~~
 +---------------------------------+-------+
 |                a                |   b   |
 +---------------------------------+-------+

--- a/decimal.md
+++ b/decimal.md
@@ -38,10 +38,12 @@ The size of a `DECIMAL` value is variable, starting at 9 bytes. It's recommended
 
 ## Examples
 
-~~~
-create table decimals (a DECIMAL PRIMARY KEY, b DECIMAL(10,5), c NUMERIC);
+~~~ sql
+> CREATE TABLE decimals (a DECIMAL PRIMARY KEY, b DECIMAL(10,5), c NUMERIC);
 
-SHOW COLUMNS FROM decimals;
+> SHOW COLUMNS FROM decimals;
+~~~
+~~~
 +-------+---------------+-------+---------+
 | Field |     Type      | Null  | Default |
 +-------+---------------+-------+---------+
@@ -49,10 +51,13 @@ SHOW COLUMNS FROM decimals;
 | b     | DECIMAL(10,5) | true  | NULL    |
 | c     | DECIMAL       | true  | NULL    |
 +-------+---------------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO decimals VALUES (1.01234567890123456789, 1.01234567890123456789, CAST(1.01234567890123456789 AS DECIMAL));
 
-INSERT INTO decimals VALUES (1.01234567890123456789, 1.01234567890123456789, CAST(1.01234567890123456789 AS DECIMAL));
-
-SELECT * FROM decimals;
+> SELECT * FROM decimals;
+~~~
+~~~
 +------------------------+---------+--------------------+
 |           a            |    b    |         c          |
 +------------------------+---------+--------------------+

--- a/delete.md
+++ b/delete.md
@@ -49,8 +49,10 @@ Successful `DELETE` statements return one of the following:
 
 You can delete all rows from a table by not including a `WHERE` clause in your `DELETE` statement.
 
-~~~
+~~~ sql
 > DELETE FROM account_details;
+~~~
+~~~
 DELETE 7
 ~~~
 
@@ -58,6 +60,8 @@ This is roughly equivalent to [`TRUNCATE`](truncate.html).
 
 ~~~
 > TRUNCATE account_details;
+~~~
+~~~
 TRUNCATE
 ~~~
 
@@ -73,8 +77,10 @@ Using your table's `PRIMARY KEY` or `UNIQUE` columns to delete rows ensures your
 
 In this example, `account_id` is our `PRIMARY KEY` and we want to delete the row where it equals 1. Because we're positive no other rows have that value in the `account_id` column, there's no risk of accidentally removing another row.
 
-~~~
+~~~ sql
 > DELETE FROM account_details WHERE account_id = 1 RETURNING *;
+~~~
+~~~
 +------------+---------+--------------+
 | account_id | balance | account_type |
 +------------+---------+--------------+
@@ -86,8 +92,10 @@ In this example, `account_id` is our `PRIMARY KEY` and we want to delete the row
 
 Deleting rows using non-unique columns removes _every_ row that returns `TRUE` for the `WHERE` clause's `a_expr`. This can easily result in deleting data you didn't intend to.
 
-~~~
+~~~ sql
 > DELETE FROM account_details WHERE balance = 30000 RETURNING *;
+~~~
+~~~
 +------------+---------+--------------+
 | account_id | balance | account_type |
 +------------+---------+--------------+
@@ -105,8 +113,10 @@ To see which rows your statement deleted, include the `RETURNING` clause to retr
 #### Use All Columns
 By specifying `*`, you retrieve all columns of the delete rows.
 
-~~~
+~~~ sql
 > DELETE FROM account_details WHERE balance < 23000 RETURNING *;
+~~~
+~~~
 +------------+---------+--------------+
 | account_id | balance | account_type |
 +------------+---------+--------------+
@@ -118,8 +128,10 @@ By specifying `*`, you retrieve all columns of the delete rows.
 
 To retrieve specific columns, name them in the `RETURNING` clause.
 
-~~~
+~~~ sql
 > DELETE FROM account_details WHERE account_id = 5 RETURNING account_id, account_type;
+~~~
+~~~
 +------------+--------------+
 | account_id | account_type |
 +------------+--------------+
@@ -131,8 +143,10 @@ To retrieve specific columns, name them in the `RETURNING` clause.
 
 When `RETURNING` specific columns, you can change their labels using `AS`.
 
-~~~
+~~~ sql
 > DELETE FROM account_details WHERE balance < 22500 RETURNING account_id, balance AS final_balance;
+~~~
+~~~
 +------------+---------------+
 | account_id | final_balance |
 +------------+---------------+

--- a/drop-database.md
+++ b/drop-database.md
@@ -21,36 +21,42 @@ The user must have the `DROP` [privilege](privileges.html) on the database and o
 To remove a database from a CockroachDB cluster, use the `DROP DATABASE` statement followed by a database name:
 
 ~~~ sql
-DROP DATABASE db1;
+> DROP DATABASE db1;
 ~~~
 
 To avoid an error in case the database does not exist, you can include `IF EXISTS`:
 
 ~~~ sql
-DROP DATABASE IF EXISTS db1;
+> DROP DATABASE IF EXISTS db1;
 ~~~
 
 ## Example
 
-~~~
+~~~ sql
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+
 | db1      |
 | system   |
 +----------+
-
+~~~
+~~~ sql
 > DROP DATABASE db1;
-DROP DATABASE
 
 > DROP DATABASE db2;
+~~~
+~~~
 pq: database "db2" does not exist
-
+~~~
+~~~ sql
 > DROP DATABASE IF EXISTS db2;
-DROP DATABASE
 
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+

--- a/drop-index.md
+++ b/drop-index.md
@@ -29,18 +29,23 @@ The user must have the `CREATE` [privilege](privileges.html) on each specified t
 ## Examples
 
 ### Remove an Index
-~~~
+~~~ sql
 > SHOW INDEX FROM tbl;
+~~~
+~~~ 
 +-------+------------+--------+-----+--------+-----------+---------+
 | Table |    Name    | Unique | Seq | Column | Direction | Storing |
 +-------+------------+--------+-----+--------+-----------+---------+
 | tbl   | primary    | true   |   1 | id     | ASC       | false   |
 | tbl   | index_name | false  |   1 | name   | ASC       | false   |
 +-------+------------+--------+-----+--------+-----------+---------+
-
+~~~
+~~~ sql
 > DROP INDEX tbl@index_name;
 
 > SHOW INDEX FROM tbl;
+~~~
+~~~ 
 +-------+---------+--------+-----+--------+-----------+---------+
 | Table |  Name   | Unique | Seq | Column | Direction | Storing |
 +-------+---------+--------+-----+--------+-----------+---------+
@@ -52,29 +57,40 @@ The user must have the `CREATE` [privilege](privileges.html) on each specified t
 
 {{site.data.alerts.callout_danger}}<code>CASCADE</code> drops <em>all</em> dependent objects without listing them, which can lead to inadvertent and difficult-to-recover losses. To avoid potential harm, we recommend dropping objects individually in most cases.{{site.data.alerts.end}}
 
-~~~
+~~~ sql
 > SHOW INDEX FROM orders;
+~~~
+~~~ 
 +--------+---------------------+--------+-----+----------+-----------+---------+
 | Table  |        Name         | Unique | Seq |  Column  | Direction | Storing |
 +--------+---------------------+--------+-----+----------+-----------+---------+
 | orders | primary             | true   |   1 | id       | ASC       | false   |
 | orders | orders_customer_idx | false  |   1 | customer | ASC       | false   |
 +--------+---------------------+--------+-----+----------+-----------+---------+
-
+~~~
+~~~ sql
 > DROP INDEX orders@orders_customer_idx;
+~~~
+~~~ 
 pq: index "orders_customer_idx" is in use as a foreign key constraint
-
+~~~
+~~~ sql
 > SHOW CONSTRAINTS FROM orders;
+~~~
+~~~
 +--------+---------------------------+-------------+------------+----------------+
 | Table  |           Name            |    Type     | Column(s)  |    Details     |
 +--------+---------------------------+-------------+------------+----------------+
 | orders | fk_customer_ref_customers | FOREIGN KEY | [customer] | customers.[id] |
 | orders | primary                   | PRIMARY KEY | [id]       | NULL           |
 +--------+---------------------------+-------------+------------+----------------+
-
+~~~
+~~~ sql
 > DROP INDEX orders@orders_customer_idx CASCADE;
 
 > SHOW CONSTRAINTS FROM orders;
+~~~
+~~~
 +--------+---------+-------------+-----------+---------+
 | Table  |  Name   |    Type     | Column(s) | Details |
 +--------+---------+-------------+-----------+---------+

--- a/drop-table.md
+++ b/drop-table.md
@@ -21,19 +21,21 @@ The user must have the `DROP` [privilege](privileges.html) on the table.
 To remove one or more tables from a database, use the `DROP TABLE` statement followed by a comma-separated list of table names, each in `database.table` format:
 
 ~~~ sql
-DROP TABLE db1.table1, db1.table2;
+> DROP TABLE db1.table1, db1.table2;
 ~~~
 
 To avoid an error in case one or more of the tables do not exist, you can include `IF EXISTS`:
 
 ~~~ sql
-DROP TABLE IF EXISTS db1.table1, db1.table2;
+> DROP TABLE IF EXISTS db1.table1, db1.table2;
 ~~~
 
 ## Example
 
-~~~
+~~~ sql
 > SHOW TABLES FROM db1;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+
@@ -41,11 +43,13 @@ DROP TABLE IF EXISTS db1.table1, db1.table2;
 | table2 |
 | table3 |
 +--------+
-
+~~~
+~~~ sql
 > DROP TABLE db1.table1, db1.table2;
-DROP TABLE
 
 > SHOW TABLES FROM db1;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+

--- a/float.md
+++ b/float.md
@@ -31,10 +31,12 @@ A `FLOAT` column supports values up to 8 bytes in width, but the total storage s
 
 ## Examples
 
-~~~
-CREATE TABLE floats (a FLOAT PRIMARY KEY, b REAL, c DOUBLE PRECISION);
+~~~ sql
+> CREATE TABLE floats (a FLOAT PRIMARY KEY, b REAL, c DOUBLE PRECISION);
 
-SHOW COLUMNS FROM floats;
+> SHOW COLUMNS FROM floats;
+~~~
+~~~
 +-------+-------+-------+---------+
 | Field | Type  | Null  | Default |
 +-------+-------+-------+---------+
@@ -42,10 +44,13 @@ SHOW COLUMNS FROM floats;
 | b     | FLOAT | true  | NULL    |
 | C     | FLOAT | true  | NULL    |
 +-------+-------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO floats VALUES (1.012345678901, 2.01234567890123456789, CAST('+Inf' AS FLOAT));
 
-INSERT INTO floats VALUES (1.012345678901, 2.01234567890123456789, CAST('+Inf' AS FLOAT));
-
-SELECT * FROM floats;
+> SELECT * FROM floats;
+~~~
+~~~ 
 +----------------+--------------------+------+
 |       a        |         b          |  c   |
 +----------------+--------------------+------+

--- a/grant.md
+++ b/grant.md
@@ -44,8 +44,8 @@ Privilege | Levels
 
 To grant privileges on one or more databases, use the following syntax:
 
-~~~
-GRANT <privileges> ON DATABASE <databases> TO <users>
+~~~ sql
+> GRANT <privileges> ON DATABASE <databases> TO <users>;
 ~~~
 
 where `<privileges>` is a comma-separated list of [privileges](#supported-privileges); `<databases>` is a comma-separated list of database names; and `<users>` is a comma-separated list of user names.
@@ -56,24 +56,24 @@ The privileges will be inherited by any new tables created in the target databas
 
 To grant privileges on one or more tables in a database, use the following syntax:
 
-~~~
-GRANT <privileges> ON <tables> TO <users>
+~~~ sql
+> GRANT <privileges> ON <tables> TO <users>
 ~~~
 
 where `<privileges>` is a comma-separated list of [privileges](#supported-privileges); `<tables>` is a comma-separated list of table names, each in `database.table` format; and `<users>` is a comma-separated list of user names.
 
 Alternately, you can add the `TABLE` keyword:
 
-~~~
-GRANT <privileges> on TABLE <tables> TO <users>
+~~~ sql
+> GRANT <privileges> on TABLE <tables> TO <users>
 ~~~
 
 ### Grant Privileges on All Tables in a Database
 
 To grant privileges on all current tables in one or more databases, use the following syntax:
 
-~~~
-GRANT <privileges> ON <databases>.* TO <users>
+~~~ sql
+> GRANT <privileges> ON <databases>.* TO <users>
 ~~~
 
 where `<privileges>` is a comma-separated list of [privileges](#supported-privileges); `<databases>` is a comma-separated list of database names, each with the `.*` suffix; and `<users>` is a comma-separated list of user names. 
@@ -82,8 +82,10 @@ where `<privileges>` is a comma-separated list of [privileges](#supported-privil
 
 Let's say you have an `animals` database containing two tables: 
 
-~~~ 
+~~~ sql 
 > SHOW tables FROM animals;
+~~~
+~~~
 +-------------+
 |    Table    |
 +-------------+
@@ -96,11 +98,12 @@ You want the `maxroach` user to have the `SELECT` privilege on both tables, and 
 
 First, you grant the `maxroach` user the `SELECT` privilege on the two current tables:
 
-~~~ 
+~~~ sql
 > GRANT SELECT ON animals.* TO maxroach;
-GRANT
 
 > SHOW GRANTS ON animals.* FOR maxroach;
+~~~
+~~~
 +-----------+----------+------------+
 |   Table   |   User   | Privileges |
 +-----------+----------+------------+
@@ -111,11 +114,12 @@ GRANT
 
 Next, you grant the `betsyroach` user the `ALL` privilege on the two current tables:
 
-~~~ 
+~~~ sql
 > GRANT ALL ON animals.* TO betsyroach;
-GRANT
 
 > SHOW GRANTS ON animals.* FOR betsyroach;
+~~~
+~~~
 +-----------+------------+------------+
 |   Table   |    User    | Privileges |
 +-----------+------------+------------+
@@ -126,11 +130,12 @@ GRANT
 
 Finally, you grant the `betsyroach` user the `ALL` privilege on the `animals` database to ensure that the user retains the privilege for all new tables created in the database:
 
-~~~ 
+~~~ sql
 > GRANT ALL ON DATABASE animals TO betsyroach;
-GRANT
 
 > SHOW GRANTS ON DATABASE animals FOR betsyroach;
+~~~
+~~~
 +----------+------------+------------+
 | Database |    User    | Privileges |
 +----------+------------+------------+
@@ -140,11 +145,12 @@ GRANT
 
 Whenever a new table is created in the `animals` database, the `betsyroach` user will inherit the `ALL` privilege on the table:
 
-~~~ 
+~~~ sql
 > CREATE TABLE animals.cockroaches (name STRING, count INT);
-CREATE TABLE
 
 > SHOW GRANTS ON animals.cockroaches FOR betsyroach;
+~~~
+~~~
 +-------------+------------+------------+
 |    Table    |    User    | Privileges |
 +-------------+------------+------------+

--- a/indexes.md
+++ b/indexes.md
@@ -75,16 +75,16 @@ However, for SQL to use stored columns, queries must filter another column in th
 
 If you wanted to optimize the performance of the following queries:
 
-~~~sql
-SELECT col1 FROM tbl WHERE col1 = 10;
+~~~ sql
+> SELECT col1 FROM tbl WHERE col1 = 10;
 
-SELECT col1, col2, col3 FROM tbl WHERE col1 = 10 AND col2 > 1;
+> SELECT col1, col2, col3 FROM tbl WHERE col1 = 10 AND col2 > 1;
 ~~~
 
 You could create a single index of `col1` and `col2` that stores `col3`:
 
-~~~sql
-CREATE INDEX ON tbl (col1, col2) STORING (col3);
+~~~ sql
+> CREATE INDEX ON tbl (col1, col2) STORING (col3);
 ~~~
 
 ## See Also

--- a/insert.md
+++ b/insert.md
@@ -38,11 +38,12 @@ Parameter | Description
 
 ### Insert a Single Row
 
-~~~
+~~~ sql
 > INSERT INTO accounts (balance, id) VALUES (10000.50, 1);
-INSERT 1
 
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+---------+
 | id | balance |
 +----+---------+
@@ -52,17 +53,19 @@ INSERT 1
 
 If you don't list column names, the statement will use the columns of the table in their declared order:
 
-~~~
+~~~ sql
 > SHOW COLUMNS FROM accounts;
+~~~
+~~~
 +---------+---------+-------+----------------+
 |  Field  |  Type   | Null  |    Default     |
 +---------+---------+-------+----------------+
 | id      | INT     | false | unique_rowid() |
 | balance | DECIMAL | true  | NULL           |
 +---------+---------+-------+----------------+
-
+~~~
+~~~ sql
 > INSERT INTO accounts VALUES (2, 20000.75);
-INSERT 1
 
 > SELECT * FROM accounts;
 +----+----------+
@@ -75,11 +78,12 @@ INSERT 1
 
 ### Insert Multiple Rows
 
-~~~ 
+~~~ sql
 > INSERT INTO accounts (id, balance) VALUES (3, 8100.73), (4, 9400.10);
-INSERT 2
 
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+----------+
 | id | balance  |
 +----+----------+
@@ -92,19 +96,23 @@ INSERT 2
 
 ### Insert from a `SELECT` Statement
 
-~~~
+~~~ sql
 > SHOW COLUMS FROM other_accounts;
+~~~
+~~~
 +--------+---------+-------+---------+
 | Field  |  Type   | Null  | Default |
 +--------+---------+-------+---------+
 | number | INT     | false | NULL    |
 | amount | DECIMAL | true  | NULL    |
 +--------+---------+-------+---------+
-
+~~~
+~~~ sql
 > INSERT INTO accounts (id, balance) SELECT number, amount FROM other_accounts WHERE id > 4;
-INSERT 3
 
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+----------+
 | id | balance  |
 +----+----------+
@@ -120,25 +128,26 @@ INSERT 3
 
 ### Insert Default Values
 
-~~~
+~~~ sql
 > INSERT INTO accounts (id) VALUES (8);
-INSERT 1
-
 > INSERT INTO accounts (id, balance) VALUES (9, DEFAULT);
-INSERT 1
 
 > SELECT * FROM accounts WHERE id in (8, 9);
+~~~
+~~~
 +----+---------+
 | id | balance |
 +----+---------+
 |  8 | NULL    |
 |  9 | NULL    |
 +----+---------+
-
+~~~
+~~~ sql
 > INSERT INTO accounts DEFAULT VALUES;
-INSERT 1
 
 > SELECT * FROM accounts;
+~~~
+~~~
 +--------------------+----------+
 |         id         | balance  |
 +--------------------+----------+
@@ -157,22 +166,30 @@ INSERT 1
 
 ### Insert and Return Values
 
-~~~ 
+~~~ sql
 > INSERT INTO accounts (id, balance) VALUES (DEFAULT, 5000.99) RETURNING id;
+~~~
+~~~
 +--------------------+
 |         id         |
 +--------------------+
 | 142935769332121601 |
 +--------------------+
-
+~~~
+~~~ sql
 > INSERT INTO accounts (id, balance) VALUES (DEFAULT, 250000) RETURNING *;
+~~~
+~~~
 +--------------------+---------+
 |         id         | balance |
 +--------------------+---------+
 | 142935982200750081 |  250000 |
 +--------------------+---------+
-
+~~~
+~~~ sql
 > INSERT INTO accounts (id, balance) VALUES (DEFAULT, 2000) RETURNING balance * 2;
+~~~
+~~~ sql
 +-------------+
 | balance * 2 |
 +-------------+
@@ -184,14 +201,15 @@ INSERT 1
 
 When a uniqueness conflict is detected, CockroachDB stores the row in a temporary table called <code>excluded</code>. This example demonstrates how you use the columns in the temporary <code>excluded</code> table to apply updates on conflict:
 
-~~~ 
+~~~ sql
 > INSERT INTO accounts (id, balance) 
     VALUES (8, 500.50) 
     ON CONFLICT (id) 
     DO UPDATE SET balance = excluded.balance;
-INSERT 1
 
 > SELECT * FROM accounts WHERE id = 8;
+~~~
+~~~
 +----+---------+
 | id | balance |
 +----+---------+
@@ -203,28 +221,34 @@ INSERT 1
 
 In this example, we get an error from a uniqueness conflict:
 
-~~~
+~~~ sql
 > SELECT * FROM accounts WHERE id = 8;
+~~~
+~~~
 +----+---------+
 | id | balance |
 +----+---------+
 |  8 |   500.5 |
 +----+---------+
-
+~~~
+~~~ sql
 > INSERT INTO accounts (id, balance) VALUES (8, 125.50);
+~~~
+~~~
 pq: duplicate key value (id)=(8) violates unique constraint "primary"
 ~~~
 
 In this example, we use `ON CONFLICT DO NOTHING` to ignore the uniqueness error and prevent the affected row from being updated:
 
-~~~
+~~~ sql
 > INSERT INTO accounts (id, balance) 
     VALUES (8, 125.50) 
     ON CONFLICT (id) 
     DO NOTHING;
-INSERT 1
 
 > SELECT * FROM accounts WHERE id = 8;
+~~~
+~~~
 +----+---------+
 | id | balance |
 +----+---------+
@@ -234,14 +258,15 @@ INSERT 1
 
 In this example, `ON CONFLICT DO NOTHING` prevents the first row from updating while allowing the second row to be inserted:
 
-~~~
+~~~ sql
 > INSERT INTO accounts (id, balance)
     VALUES (8, 125.50), (10, 450)
     ON CONFLICT (id)
     DO NOTHING;
-INSERT 2
 
 > SELECT * FROM accounts WHERE id in (8, 10);
+~~~
+~~~
 +----+---------+
 | id | balance |
 +----+---------+

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -124,10 +124,6 @@ $(document).ready(function(){
       </div>
     </li>
   </ol>
-
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="use-homebrew" class="install-option" style="display: none;">
@@ -164,10 +160,6 @@ $(document).ready(function(){
       </div>
     </li>
   </ol>
-
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="build-from-source" class="install-option" style="display: none;">
@@ -230,10 +222,8 @@ $(document).ready(function(){
     </div>
   </li>
 </ol>
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
+
 <div id="use-docker" class="install-option" style="display: none;">
 <h2>Use Docker</h2>
 
@@ -275,9 +265,6 @@ $(document).ready(function(){
     </div>
   </li>
 </ol>
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster-in-docker.html">Quick start</a> a cluster of CockroachDB nodes across multiple Docker containers.</p>
 </div>
 </div>
 
@@ -327,10 +314,6 @@ $(document).ready(function(){
       </div>
     </li>
   </ol>
-
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="build-from-source-linux" class="install-option" style="display: none;">
@@ -393,10 +376,6 @@ $(document).ready(function(){
       </div>
     </li>
 </ol>
-
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="use-docker-linux" class="install-option" style="display: none;">
@@ -442,9 +421,6 @@ $(document).ready(function(){
     </div>
   </li>
 </ol>
-<h2 id="whats-next">What's Next?</h2>
-
-<p><a href="start-a-local-cluster-in-docker.html">Quick start</a> a cluster of CockroachDB nodes across multiple Docker containers.</p>
 </div>
 </div>
 
@@ -489,8 +465,8 @@ $(document).ready(function(){
     </div>
   </li>
 </ol>
+</div>
 
 <h2 id="whats-next">What's Next?</h2>
 
-<p><a href="start-a-local-cluster-in-docker.html">Quick start</a> a cluster of CockroachDB nodes across multiple Docker containers.</p>
-</div>
+<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>

--- a/int.md
+++ b/int.md
@@ -39,10 +39,12 @@ CockroachDB does not offer multiple integer types for different widths; instead,
 
 ## Examples
 
-~~~
-CREATE TABLE ints (a INT PRIMARY KEY, b SMALLINT, c INTEGER);
+~~~ sql
+> CREATE TABLE ints (a INT PRIMARY KEY, b SMALLINT, c INTEGER);
 
-SHOW COLUMNS FROM ints;
+> SHOW COLUMNS FROM ints;
+~~~
+~~~
 +-------+------+-------+---------+
 | Field | Type | Null  | Default |
 +-------+------+-------+---------+
@@ -50,10 +52,13 @@ SHOW COLUMNS FROM ints;
 | b     | INT  | true  | NULL    |
 | c     | INT  | true  | NULL    |
 +-------+------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO ints VALUES (11111, 22222, 33333);
 
-INSERT INTO ints VALUES (11111, 22222, 33333);
-
-SELECT * FROM ints;
+> SELECT * FROM ints;
+~~~
+~~~
 +-------+-------+-------+
 |   a   |   b   |   c   |
 +-------+-------+-------+

--- a/interval.md
+++ b/interval.md
@@ -29,25 +29,27 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 
 ## Example
 
-~~~
+~~~ sql
 > CREATE TABLE intervals (a INT PRIMARY KEY, b INTERVAL);
-CREATE TABLE
 
 > SHOW COLUMNS FROM intervals;
+~~~
+~~~
 +-------+----------+-------+---------+
 | Field |   Type   | Null  | Default |
 +-------+----------+-------+---------+
 | a     | INT      | false | NULL    |
 | b     | INTERVAL | true  | NULL    |
 +-------+----------+-------+---------+
-
+~~~
+~~~ sql
 > INSERT INTO intervals VALUES 
     (1, INTERVAL '1h2m3s4ms5us6ns'), 
     (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'), 
     (3, INTERVAL '4:5:6')
 ;
-INSERT 3
-
+~~~
+~~~
 +---+------------------+
 | a |        b         |
 +---+------------------+

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -1,6 +1,6 @@
 (function($) {
     $(window).load(function() {
-        
+
         var _viewport_width = $(window).width(),
             $mobile_menu = $('nav.mobile_expanded'),
             $sidebar = $('#mysidebar'),
@@ -51,5 +51,24 @@
         });
 
         $(window).scroll();
+
+        // Section makes shell terminal prompt markers ($) totally unselectable in syntax-highlighted code samples
+        terminalMarkers = document.getElementsByClassName("gp");  // Rogue syntax highlighter styles all terminal markers with class gp
+        
+        for(var i = 0; i < terminalMarkers.length; i++){
+            terminalMarkers[i].innerText="";    // Remove the existing on-page terminal marker
+            terminalMarkers[i].className += " noselect shellterminal"; // Add shellterminal class, which then displays the terminal marker as a ::before element
+        }
+
+        // Section makes SQL terminal prompt markers (>) totally unselectable in syntax-highlighted code samples
+        sqlMarkers = document.getElementsByClassName("o");
+        for(var i = 0; i < sqlMarkers.length; i++){
+            if(sqlMarkers[i].innerText===">" && (!sqlMarkers[i].previousSibling || sqlMarkers[i].previousSibling.textContent==="\n"|| sqlMarkers[i].previousSibling.textContent==="\n\n")){
+                sqlMarkers[i].innerText="";    // Remove the existing on-page SQL marker
+                sqlMarkers[i].nextSibling.textContent="";
+                sqlMarkers[i].className += " noselect sqlterminal"; // Add sqlterminal class, which then displays the terminal marker as a ::before element
+            }
+        }
+
     });
 })(jQuery);

--- a/learn-cockroachdb-sql.md
+++ b/learn-cockroachdb-sql.md
@@ -15,19 +15,19 @@ This page walks you through some of the most essential CockroachDB SQL statement
 CockroachDB comes with a single default `system` database, which contains CockroachDB metadata and is read-only. To create a new database, use [`CREATE DATABASE`](create-database.html) followed by a database name:
 
 ~~~ sql
-CREATE DATABASE bank;
+> CREATE DATABASE bank;
 ~~~
 
 Database names must follow [these identifier rules](keywords-and-identifiers.html#identifiers). To avoid an error in case the database already exists, you can include `IF NOT EXISTS`:
 
 ~~~ sql
-CREATE DATABASE IF NOT EXISTS bank;
+> CREATE DATABASE IF NOT EXISTS bank;
 ~~~
 
 When you no longer need a database, use [`DROP DATABASE`](drop-database.html) followed by the database name to remove the database and all its objects:
 
 ~~~ sql
-DROP DATABASE bank;
+> DROP DATABASE bank;
 ~~~
 
 ## Show Databases
@@ -35,7 +35,7 @@ DROP DATABASE bank;
 To see all databases, use the [`SHOW DATABASES`](show-databases.html) statement:
 
 ~~~ sql
-SHOW DATABASES;
+> SHOW DATABASES;
 ~~~
 ~~~
 +----------+
@@ -51,13 +51,13 @@ SHOW DATABASES;
 To set the default database, use the [`SET DATABASE`](set-database.html) statement:
 
 ~~~ sql
-SET DATABASE = bank;
+> SET DATABASE = bank;
 ~~~
 
 When working with the default database, you don't need to reference it explicitly in statements. To see which database is currently the default, use the `SHOW DATABASE` statement (note the singular form):
 
 ~~~ sql
-SHOW DATABASE;
+> SHOW DATABASE;
 ~~~
 ~~~
 +----------+
@@ -72,7 +72,7 @@ SHOW DATABASE;
 To create a table, use [`CREATE TABLE`](create-table.html) followed by a table name, the column names, and the [data type](data-types.html) and [constraint](constraints.html), if any, for each column:
 
 ~~~ sql
-CREATE TABLE accounts (
+> CREATE TABLE accounts (
     id INT PRIMARY KEY,
     balance DECIMAL
 );
@@ -83,7 +83,7 @@ Table and column names must follow [these rules](keywords-and-identifiers.html#i
 To avoid an error in case the table already exists, you can include `IF NOT EXISTS`:
 
 ~~~ sql
-CREATE TABLE IF NOT EXISTS accounts (
+> CREATE TABLE IF NOT EXISTS accounts (
     id INT PRIMARY KEY,
     balance DECIMAL
 );
@@ -92,7 +92,7 @@ CREATE TABLE IF NOT EXISTS accounts (
 To show all of the columns from a table, use [`SHOW COLUMNS FROM`](show-columns.html) followed by the table name:
 
 ~~~ sql
-SHOW COLUMNS FROM accounts;
+> SHOW COLUMNS FROM accounts;
 ~~~
 ~~~
 +---------+---------+-------+---------+
@@ -106,7 +106,7 @@ SHOW COLUMNS FROM accounts;
 When you no longer need a table, use [`DROP TABLE`](drop-table.html) followed by the table name to remove the table and all its data:
 
 ~~~ sql
-DROP TABLE accounts;
+> DROP TABLE accounts;
 ~~~
 
 ## Show Tables
@@ -114,7 +114,7 @@ DROP TABLE accounts;
 To see all tables in the active database, use the [`SHOW TABLES`](show-tables.html) statement:
 
 ~~~ sql
-SHOW TABLES;
+> SHOW TABLES;
 ~~~
 ~~~
 +----------+
@@ -128,7 +128,7 @@ SHOW TABLES;
 To view tables in a database that's not active, use `SHOW TABLES FROM` followed by the name of the database:
 
 ~~~ sql
-SHOW TABLES FROM animals;
+> SHOW TABLES FROM animals;
 ~~~
 ~~~
 +------------+
@@ -148,20 +148,20 @@ SHOW TABLES FROM animals;
 To insert a row into a table, use [`INSERT INTO`](insert.html) followed by the table name and then the column values listed in the order in which the columns appear in the table:
 
 ~~~ sql
-INSERT INTO accounts VALUES (1, 10000.50);
+> INSERT INTO accounts VALUES (1, 10000.50);
 ~~~
 
 If you want to pass column values in a different order, list the column names explicitly and provide the column values in the corresponding order:
 
 ~~~ sql
-INSERT INTO accounts (balance, id) VALUES 
+> INSERT INTO accounts (balance, id) VALUES 
     (25000.00, 2);
 ~~~
 
 To insert multiple rows into a table, use a comma-separated list of parentheses, each containing column values for one row:
 
 ~~~ sql
-INSERT INTO accounts VALUES 
+> INSERT INTO accounts VALUES 
     (3, 8100.73),
     (4, 9400.10);
 ~~~
@@ -169,13 +169,13 @@ INSERT INTO accounts VALUES
 [Defaults values](constraints.html#default-value) are used when you leave specific columns out of your statement, or when you explicitly request default values. For example, both of the following statements would create a row with `balance` filled with its default value, in this case `NULL`:
 
 ~~~ sql
-INSERT INTO accounts (id, balance) VALUES 
+> INSERT INTO accounts (id, balance) VALUES 
     (5);
 
-INSERT INTO accounts (id, balance) VALUES 
+> INSERT INTO accounts (id, balance) VALUES 
     (6, DEFAULT);
 
-SELECT * FROM accounts WHERE id in (5, 6);
+> SELECT * FROM accounts WHERE id in (5, 6);
 ~~~
 ~~~
 +----+---------+
@@ -192,13 +192,13 @@ SELECT * FROM accounts WHERE id in (5, 6);
 To create an index for non-unique columns, use [`CREATE INDEX`](create-index.html) followed by an optional index name and an `ON` clause identifying the table and column(s) to index.  For each column, you can choose whether to sort ascending (`ASC`) or descending (`DESC`).
 
 ~~~ sql
-CREATE INDEX balance_idx ON accounts (balance DESC);
+> CREATE INDEX balance_idx ON accounts (balance DESC);
 ~~~
 
 You can create indexes during table creation as well; just include the `INDEX` keyword followed by an optional index name and the column(s) to index:
 
 ~~~ sql
-CREATE TABLE accounts (
+> CREATE TABLE accounts (
     id INT PRIMARY KEY,
     balance DECIMAL,
     INDEX balance_idx (balance)
@@ -210,7 +210,7 @@ CREATE TABLE accounts (
 To show the indexes on a table, use [`SHOW INDEX FROM`](show-index.html) followed by the name of the table:
 
 ~~~ sql
-SHOW INDEX FROM accounts;
+> SHOW INDEX FROM accounts;
 ~~~
 ~~~
 +----------+-------------+--------+-----+---------+-----------+---------+
@@ -226,7 +226,7 @@ SHOW INDEX FROM accounts;
 To query a table, use [`SELECT`](select.html) followed by a comma-separated list of the columns to be returned and the table from which to retrieve the data:
 
 ~~~ sql
-SELECT balance FROM accounts;
+> SELECT balance FROM accounts;
 ~~~
 ~~~
 +----------+
@@ -244,7 +244,7 @@ SELECT balance FROM accounts;
 To retrieve all columns, use the `*` wildcard:
 
 ~~~ sql
-SELECT * FROM accounts;
+> SELECT * FROM accounts;
 ~~~
 ~~~
 +----+----------+
@@ -262,7 +262,7 @@ SELECT * FROM accounts;
 To filter the results, add a `WHERE` clause identifying the columns and values to filter on: 
 
 ~~~ sql
-SELECT id, balance FROM accounts WHERE balance > 9000;
+> SELECT id, balance FROM accounts WHERE balance > 9000;
 ~~~
 ~~~
 +----+----------+
@@ -277,7 +277,7 @@ SELECT id, balance FROM accounts WHERE balance > 9000;
 To sort the results, add an `ORDER BY` clause identifying the columns to sort by. For each column, you can choose whether to sort ascending (`ASC`) or descending (`DESC`).
 
 ~~~ sql
-SELECT id, balance FROM accounts ORDER BY balance DESC;
+> SELECT id, balance FROM accounts ORDER BY balance DESC;
 ~~~
 ~~~
 +----+----------+
@@ -297,9 +297,9 @@ SELECT id, balance FROM accounts ORDER BY balance DESC;
 To update rows in a table, use [`UPDATE`](update.html) followed by the table name, a `SET` clause identifying the columns to update and their new values, and a `WHERE` clause identifying the rows to update:
 
 ~~~ sql
-UPDATE accounts SET balance = balance - 5.50 WHERE balance < 10000;
+> UPDATE accounts SET balance = balance - 5.50 WHERE balance < 10000;
 
-SELECT * FROM accounts;
+> SELECT * FROM accounts;
 ~~~
 ~~~
 +----+----------+
@@ -321,9 +321,9 @@ If a table has a primary key, you can use that in the `WHERE` clause to reliably
 To delete rows from a table, use [`DELETE FROM`](delete.html) followed by the table name and a `WHERE` clause identifying the rows to delete: 
 
 ~~~ sql
-DELETE FROM accounts WHERE id in (5, 6);
+> DELETE FROM accounts WHERE id in (5, 6);
 
-SELECT * FROM accounts;
+> SELECT * FROM accounts;
 ~~~
 ~~~
 +----+----------+

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -70,20 +70,18 @@ This command uses the `--url` flag to identify the client user and the hostname 
 
 Once you're connected, run some [SQL statements](learn-cockroachdb-sql.html): 
 
-~~~ shell
-root@:26257> CREATE DATABASE bank;
-CREATE DATABASE
+~~~ sql
+> CREATE DATABASE bank;
 
-root@:26257> SET DATABASE = bank;
-SET DATABASE
+> SET DATABASE = bank;
 
-root@:26257> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
-CREATE TABLE
+> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
 
-root@26257> INSERT INTO accounts VALUES (1234, 10000);
-INSERT 1
+> INSERT INTO accounts VALUES (1234, 10000);
 
-root@26257> SELECT * FROM accounts;
+> SELECT * FROM accounts;
+~~~
+~~~
 +------+---------+
 |  id  | balance |
 +------+---------+
@@ -181,20 +179,18 @@ This command uses the `--url` flag to identify the client user, the hostname and
 
 Once you're connected, run some [SQL statements](learn-cockroachdb-sql.html): 
 
-~~~ shell
-root@:26257> CREATE DATABASE bank;
-CREATE DATABASE
+~~~ sql
+> CREATE DATABASE bank;
 
-root@:26257> SET DATABASE = bank;
-SET DATABASE
+> SET DATABASE = bank;
 
-root@:26257> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
-CREATE TABLE
+> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
 
-root@26257> INSERT INTO accounts VALUES (1234, 10000);
-INSERT 1
+> INSERT INTO accounts VALUES (1234, 10000);
 
-root@26257> SELECT * FROM accounts;
+> SELECT * FROM accounts;
+~~~
+~~~
 +------+---------+
 |  id  | balance |
 +------+---------+

--- a/null-handling.md
+++ b/null-handling.md
@@ -14,22 +14,24 @@ This page summarizes how `NULL` values are handled in CockroachDB SQL. Each topi
 
 Any comparison between a value and `NULL` results in `NULL`. This behavior is consistent with PostgresSQL as well as all other major RDBMS's.
 
-~~~sql
-CREATE TABLE t1(
+~~~ sql
+> CREATE TABLE t1(
   a INT, 
   b INT, 
   c INT
 );
 
-INSERT INTO t1 VALUES(1, 0, 0);
-INSERT INTO t1 VALUES(2, 0, 1);
-INSERT INTO t1 VALUES(3, 1, 0);
-INSERT INTO t1 VALUES(4, 1, 1);
-INSERT INTO t1 VALUES(5, NULL, 0);
-INSERT INTO t1 VALUES(6, NULL, 1);
-INSERT INTO t1 VALUES(7, NULL, NULL);
+> INSERT INTO t1 VALUES(1, 0, 0);
+> INSERT INTO t1 VALUES(2, 0, 1);
+> INSERT INTO t1 VALUES(3, 1, 0);
+> INSERT INTO t1 VALUES(4, 1, 1);
+> INSERT INTO t1 VALUES(5, NULL, 0);
+> INSERT INTO t1 VALUES(6, NULL, 1);
+> INSERT INTO t1 VALUES(7, NULL, NULL);
 
-SELECT * FROM t1;
+> SELECT * FROM t1;
+~~~
+~~~
 +---+------+------+
 | a |  b   |  c   |
 +---+------+------+
@@ -41,8 +43,11 @@ SELECT * FROM t1;
 | 6 | NULL |    1 |
 | 7 | NULL | NULL |
 +---+------+------+
-
-SELECT * FROM t1 WHERE b < 10;
+~~~
+~~~ sql
+> SELECT * FROM t1 WHERE b < 10;
+~~~
+~~~
 +---+---+---+
 | a | b | c |
 +---+---+---+
@@ -51,8 +56,11 @@ SELECT * FROM t1 WHERE b < 10;
 | 3 | 1 | 0 |
 | 4 | 1 | 1 |
 +---+---+---+
-
-SELECT * FROM t1 WHERE NOT b > 10;
+~~~
+~~~ sql
+> SELECT * FROM t1 WHERE NOT b > 10;
+~~~
+~~~
 +---+---+---+
 | a | b | c |
 +---+---+---+
@@ -61,8 +69,11 @@ SELECT * FROM t1 WHERE NOT b > 10;
 | 3 | 1 | 0 |
 | 4 | 1 | 1 |
 +---+---+---+
-
-SELECT * FROM t1 WHERE b < 10 OR c = 1;
+~~~
+~~~ sql
+> SELECT * FROM t1 WHERE b < 10 OR c = 1;
+~~~
+~~~
 +---+------+---+
 | a |  b   | c |
 +---+------+---+
@@ -72,16 +83,22 @@ SELECT * FROM t1 WHERE b < 10 OR c = 1;
 | 4 |    1 | 1 |
 | 6 | NULL | 1 |
 +---+------+---+
-
-SELECT * FROM t1 WHERE b < 10 AND c = 1;
+~~~
+~~~ sql
+> SELECT * FROM t1 WHERE b < 10 AND c = 1;
+~~~
+~~~
 +---+---+---+
 | a | b | c |
 +---+---+---+
 | 2 | 0 | 1 |
 | 4 | 1 | 1 |
 +---+---+---+
-
-SELECT * FROM t1 WHERE NOT (b < 10 AND c = 1);
+~~~
+~~~ sql
+> SELECT * FROM t1 WHERE NOT (b < 10 AND c = 1);
+~~~
+~~~
 +---+------+---+
 | a |  b   | c |
 +---+------+---+
@@ -89,8 +106,10 @@ SELECT * FROM t1 WHERE NOT (b < 10 AND c = 1);
 | 3 |    1 | 0 |
 | 5 | NULL | 0 |
 +---+------+---+
-
-SELECT * FROM t1 WHERE NOT (c = 1 AND b < 10);
+~~~
+~~~ sql
+> SELECT * FROM t1 WHERE NOT (c = 1 AND b < 10);
+~~~
 +---+------+---+
 | a |  b   | c |
 +---+------+---+
@@ -98,13 +117,14 @@ SELECT * FROM t1 WHERE NOT (c = 1 AND b < 10);
 | 3 |    1 | 0 |
 | 5 | NULL | 0 |
 +---+------+---+
-
 ~~~
 
 Use the `IS NULL` or `IS NOT NULL` clauses when checking for `NULL` values.
 
-~~~sql
-SELECT * FROM t1 WHERE b IS NULL AND c IS NOT NULL;
+~~~ sql
+> SELECT * FROM t1 WHERE b IS NULL AND c IS NOT NULL;
+~~~
+~~~
 +---+------+---+
 | a |  b   | c |
 +---+------+---+
@@ -117,8 +137,10 @@ SELECT * FROM t1 WHERE b IS NULL AND c IS NOT NULL;
 
 Arithmetic operations involving a `NULL` value will yield a `NULL` result.
 
-~~~sql
-SELECT a, b, c, b*0, b*c, b+c FROM t1;
+~~~ sql
+> SELECT a, b, c, b*0, b*c, b+c FROM t1;
+~~~
+~~~
 +---+------+------+-------+-------+-------+
 | a |  b   |  c   | b * 0 | b * c | b + c |
 +---+------+------+-------+-------+-------+
@@ -136,8 +158,10 @@ SELECT a, b, c, b*0, b*c, b+c FROM t1;
 
 Aggregate [functions](functions-and-operators.html) are those that operate on a set of rows and return a single value. The example data has been repeated here to make it easier to understand the results.
 
-~~~sql
-SELECT * FROM t1;
+~~~ sql
+> SELECT * FROM t1;
+~~~
+~~~
 +---+------+------+
 | a |  b   |  c   |
 +---+------+------+
@@ -149,8 +173,11 @@ SELECT * FROM t1;
 | 6 | NULL |    1 |
 | 7 | NULL | NULL |
 +---+------+------+
-
-SELECT COUNT(*), COUNT(b), SUM(b), AVG(b), MIN(b), MAX(b) FROM t1;
+~~~
+~~~ sql
+> SELECT COUNT(*), COUNT(b), SUM(b), AVG(b), MIN(b), MAX(b) FROM t1;
+~~~
+~~~
 +----------+----------+--------+--------------------+--------+--------+
 | COUNT(*) | COUNT(b) | SUM(b) |       AVG(b)       | MIN(b) | MAX(b) |
 +----------+----------+--------+--------------------+--------+--------+
@@ -171,8 +198,10 @@ Note the following:
 
 `NULL` values are considered distinct from other values and are included in the list of distinct values from a column.
 
-~~~sql
-SELECT DISTINCT b FROM t1;
+~~~ sql
+> SELECT DISTINCT b FROM t1;
+~~~
+~~~
 +------+
 |  b   |
 +------+
@@ -184,8 +213,10 @@ SELECT DISTINCT b FROM t1;
 
 However, counting the number of distinct values excludes `NULL`s, which is consistent with the `COUNT()` function.
 
-~~~sql
-SELECT COUNT(DISTINCT b) FROM t1;
+~~~ sql
+> SELECT COUNT(DISTINCT b) FROM t1;
+~~~
+~~~
 +-------------------+
 | count(DISTINCT b) |
 +-------------------+
@@ -199,8 +230,10 @@ In some cases, you may want to include `NULL` values in arithmetic or aggregate 
 
 For example, let's say you want to calculate the average value of column `b` as being the `SUM()` of all numbers in `b` divided by the total number of rows, regardless of whether `b`'s value is `NULL`. In this case, you would use `AVG(IFNULL(b, 0))`, where `IFNULL(b, 0)` substitutes a value of zero (0) for `NULL`s during the calculation.
 
-~~~sql
- SELECT COUNT(*), COUNT(b), SUM(b), AVG(b), AVG(IFNULL(b, 0)), MIN(b), MAX(b) FROM t1;
+~~~ sql
+> SELECT COUNT(*), COUNT(b), SUM(b), AVG(b), AVG(IFNULL(b, 0)), MIN(b), MAX(b) FROM t1;
+~~~
+~~~
 +----------+----------+--------+--------------------+--------------------+--------+--------+
 | COUNT(*) | COUNT(b) | SUM(b) |       AVG(b)       | AVG(IFNULL(b, 0))  | MIN(b) | MAX(b) |
 +----------+----------+--------+--------------------+--------------------+--------+--------+
@@ -212,8 +245,10 @@ For example, let's say you want to calculate the average value of column `b` as 
 
 `NULL` values are considered as part of a `UNION` set operation.
 
-~~~sql
-SELECT b FROM t1 UNION SELECT b FROM t1;
+~~~ sql
+> SELECT b FROM t1 UNION SELECT b FROM t1;
+~~~
+~~~
 +------+
 |  b   |
 +------+
@@ -230,8 +265,10 @@ When sorting a column containing `NULL` values, CockroachDB orders `NULL`s lower
 
 Note that the `NULLS FIRST` and `NULLS LAST` options of the `ORDER BY` clause are not implemented in CockroachDB, so you cannot change where `NULL` values appear in the sort order.
 
-~~~sql
-SELECT * FROM t1 ORDER BY b;
+~~~ sql
+> SELECT * FROM t1 ORDER BY b;
+~~~
+~~~
 +---+------+------+
 | a |  b   |  c   |
 +---+------+------+
@@ -243,8 +280,11 @@ SELECT * FROM t1 ORDER BY b;
 | 4 |    1 |    1 |
 | 3 |    1 |    0 |
 +---+------+------+
-
-SELECT * FROM t1 ORDER BY b DESC;
+~~~
+~~~ sql
+> SELECT * FROM t1 ORDER BY b DESC;
+~~~
+~~~
 +---+------+------+
 | a |  b   |  c   |
 +---+------+------+
@@ -262,14 +302,16 @@ SELECT * FROM t1 ORDER BY b DESC;
 
 `NULL` values are not considered unique. Therefore, if a table has a `UNIQUE` constraint on one or more columns that are optional (nullable), it is possible to insert multiple rows with `NULL` values in those columns, as shown in the example below.
 
-~~~sql
-CREATE TABLE t2(a INT, b INT UNIQUE);
+~~~ sql
+> CREATE TABLE t2(a INT, b INT UNIQUE);
 
-INSERT INTO t2 VALUES(1, 1);
-INSERT INTO t2 VALUES(2, NULL);
-INSERT INTO t2 VALUES(3, NULL);
+> INSERT INTO t2 VALUES(1, 1);
+> INSERT INTO t2 VALUES(2, NULL);
+> INSERT INTO t2 VALUES(3, NULL);
 
-SELECT * FROM t2;
+> SELECT * FROM t2;
+~~~
+~~~
 +---+------+
 | a |  b   |
 +---+------+
@@ -285,23 +327,31 @@ A [`CHECK`](constraints.html#check) constraint expression that evaluates to `NUL
 used along side a `CHECK` expression.
 
 
-~~~sql
-CREATE TABLE products (id STRING PRIMARY KEY, price INT NOT NULL CHECK (price > 0), discount INT, CHECK (discount <= price));
+~~~ sql
+> CREATE TABLE products (id STRING PRIMARY KEY, price INT NOT NULL CHECK (price > 0), discount INT, CHECK (discount <= price));
 
-INSERT INTO products (id, price) VALUES ('ncc-1701-d', 100);
-INSERT INTO products (id, price, discount) VALUES ('ncc-1701-a', 100, 50);
+> INSERT INTO products (id, price) VALUES ('ncc-1701-d', 100);
+> INSERT INTO products (id, price, discount) VALUES ('ncc-1701-a', 100, 50);
 
-SELECT * FROM products;
+> SELECT * FROM products;
+~~~
+~~~
 +----------+-------+----------+
 |    id    | price | discount |
 +----------+-------+----------+
 | ncc1701a |   100 |       50 |
 | ncc1701d |   100 | NULL     |
 +----------+-------+----------+
-
-INSERT INTO products (id, price) VALUES ('ncc-1701-b', -5);
+~~~
+~~~ sql
+> INSERT INTO products (id, price) VALUES ('ncc-1701-b', -5);
+~~~
+~~~
 failed to satisfy CHECK constraint (price > 0)
-
-INSERT INTO products (id, price, discount) VALUES ('ncc-1701-b', 100, 150);
+~~~
+~~~ sql
+> INSERT INTO products (id, price, discount) VALUES ('ncc-1701-b', 100, 150);
+~~~
+~~~
 failed to satisfy CHECK constraint (discount <= price)
 ~~~

--- a/privileges.md
+++ b/privileges.md
@@ -20,24 +20,24 @@ For a full list of supported privileges, see the [`GRANT`](grant.html) documenta
 
 To grant privileges to a user, use the [`GRANT`](grant.html) statement, for example: 
 
-~~~
-GRANT SELECT, INSERT ON bank.accounts TO maxroach;
+~~~ sql
+> GRANT SELECT, INSERT ON bank.accounts TO maxroach;
 ~~~
 
 ## Showing Privileges
 
 To show privileges granted to users, use the [`SHOW GRANTS`](show-grants.html) statement, for example:
 
-~~~
-SHOW GRANTS ON DATABASE bank FOR maxroach;
+~~~ sql
+> SHOW GRANTS ON DATABASE bank FOR maxroach;
 ~~~
 
 ## Revoking Privileges
 
 To revoke privileges from users, use the [`REVOKE`](revoke.html) statement, for example:
 
-~~~
-REVOKE INSERT ON bank.accounts FROM maxroach;
+~~~ sql
+> REVOKE INSERT ON bank.accounts FROM maxroach;
 ~~~
 
 ## See Also

--- a/rename-database.md
+++ b/rename-database.md
@@ -26,8 +26,10 @@ Parameter | Description
 
 ### Rename a Database
 
-~~~
+~~~ sql
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+
@@ -35,11 +37,17 @@ Parameter | Description
 | db2      |
 | system   |
 +----------+
-
+~~~
+~~~ sql
 > ALTER DATABASE db1 RENAME TO db3;
+~~~
+~~~
 RENAME DATABASE
-
+~~~
+~~~ sql
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+
@@ -51,8 +59,10 @@ RENAME DATABASE
 
 ### Rename Fails (New Name Already In Use)
 
-~~~
+~~~ sql
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+
@@ -60,8 +70,11 @@ RENAME DATABASE
 | db3      |
 | system   |
 +----------+
-
+~~~
+~~~ sql
 > ALTER DATABASE db2 RENAME TO db3;
+~~~
+~~~
 pq: the new database name "db3" already exists
 ~~~
 

--- a/rename-table.md
+++ b/rename-table.md
@@ -21,38 +21,46 @@ The user must have the `DROP` [privilege](privileges.html) on the table and the 
 To rename a table, use the `ALTER TABLE` statement followed by the current table name in `database.table` format, the `RENAME TO` statement, and the new table name in `database.table` format:
 
 ~~~ sql
-ALTER TABLE db1.table1 RENAME TO db1.table2  
+> ALTER TABLE db1.table1 RENAME TO db1.table2;
 ~~~
 
 To avoid an error in case the table does not exist, you can include `IF EXISTS`:
 
 ~~~ sql
-ALTER TABLE IF EXISTS db1.table1 RENAME TO db1.table2  
+> ALTER TABLE IF EXISTS db1.table1 RENAME TO db1.table2;
 ~~~
 
 To move a table from one database to another, use the above syntax but specify the source database after `ALTER TABLE` and the target database after `RENAME TO`:
 
 ~~~ sql
-ALTER TABLE db1.table1 RENAME TO db2.table1  
+> ALTER TABLE db1.table1 RENAME TO db2.table1;
 ~~~
 
 ## Examples
 
 ### Rename a table
 
-~~~ 
+~~~ sql
 > SHOW TABLES FROM db1;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+
 | table1 |
 | table2 |
 +--------+
-
+~~~
+~~~ sql
 > ALTER TABLE db1.table1 RENAME TO db1.tablea
+~~~
+~~~
 RENAME TABLE
-
+~~~
+~~~ sql
 > SHOW TABLES FROM db1;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+
@@ -63,8 +71,10 @@ RENAME TABLE
 
 ### Move a table
 
-~~~ 
+~~~ sql 
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+
@@ -72,32 +82,47 @@ RENAME TABLE
 | db2      |
 | system   |
 +----------+
-
+~~~
+~~~ sql
 > SHOW TABLES FROM db1;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+
 | table2 |
 | tablea |
 +--------+
-
+~~~
+~~~ sql
 > SHOW TABLES FROM db2;
+~~~
+~~~
 +-------+
 | Table |
 +-------+
 +-------+
-
+~~~
+~~~ sql
 > ALTER TABLE db1.tablea RENAME TO db2.tablea
+~~~
+~~~
 RENAME TABLE
-
+~~~
+~~~ sql
 > SHOW TABLES FROM db1;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+
 | table2 |
 +--------+
-
+~~~
+~~~ sql
 > SHOW TABLES FROM db2;
+~~~
+~~~
 +--------+
 | Table  |
 +--------+

--- a/secure-a-cluster.md
+++ b/secure-a-cluster.md
@@ -64,21 +64,24 @@ This command is the same as before, but now uses the additional `--ca-cert`, `--
 
 ## Step 5.  Run more [CockroachDB SQL statements](learn-cockroachdb-sql.html)
 
-~~~ shell
-root@:26257> SET DATABASE = bank;
-SET DATABASE
+~~~ sql
+> SET DATABASE = bank;
 
-root@26257> SELECT * FROM accounts;
+> SELECT * FROM accounts;
+~~~
+~~~
 +------+----------+
 |  id  | balance  |
 +------+----------+
 | 1234 | 10000.50 |
 +------+----------+
+~~~
+~~~ sql
+> INSERT INTO accounts VALUES (5678, 250.75);
 
-root@26257> INSERT INTO accounts VALUES (5678, 250.75);
-INSERT 1
-
-root@26257> SELECT * FROM accounts;
+> SELECT * FROM accounts;
+~~~
+~~~
 +------+----------+
 |  id  | balance  |
 +------+----------+

--- a/serial.md
+++ b/serial.md
@@ -33,15 +33,16 @@ A `SERIAL` column supports values up to 8 bytes in width, but the total storage 
 
 In this example, we create a table with the `SERIAL` column as the `PRIMARY KEY` so we can auto-generate unique IDs on insert.
 
-~~~
+~~~ sql
 > CREATE TABLE serial (a SERIAL PRIMARY KEY, b STRING(30), c BOOL);
-CREATE TABLE
 ~~~
 
 The [`SHOW COLUMNS`](show-columns.html) statement shows that the `SERIAL` type is just an alias for `INT` with `unique_rowid()` as the default. 
 
-~~~
+~~~ sql
 > SHOW COLUMNS FROM serial;
+~~~
+~~~
 +-------+------------+-------+----------------+
 | Field |    Type    | Null  |    Default     |
 +-------+------------+-------+----------------+
@@ -53,8 +54,10 @@ The [`SHOW COLUMNS`](show-columns.html) statement shows that the `SERIAL` type i
 
 When we insert 3 rows without values in column `a` and return the new rows, we see that each row has defaulted to a unique value in column `a`. 
 
-~~~
+~~~ sql
 > INSERT INTO serial (b,c) VALUES ('red', true), ('yellow', false), ('pink', true) RETURNING *;
+~~~
+~~~
 +--------------------+--------+-------+
 |         a          |   b    |   c   |
 +--------------------+--------+-------+
@@ -72,23 +75,25 @@ To experience this for yourself, run through the following example in PostgreSQL
 
 1. Create a table with a `SERIAL` column.
 
-   ~~~
-   CREATE TABLE increment (a SERIAL PRIMARY KEY);
+   ~~~ sql
+   > CREATE TABLE increment (a SERIAL PRIMARY KEY);
    ~~~ 
 
 2. Run four transactions for inserting rows. 
 
-   ~~~
-   BEGIN; INSERT INTO increment DEFAULT VALUES; ROLLBACK;
-   BEGIN; INSERT INTO increment DEFAULT VALUES; COMMIT;
-   BEGIN; INSERT INTO increment DEFAULT VALUES; ROLLBACK;
-   BEGIN; INSERT INTO increment DEFAULT VALUES; COMMIT;
+   ~~~ sql
+   > BEGIN; INSERT INTO increment DEFAULT VALUES; ROLLBACK;
+   > BEGIN; INSERT INTO increment DEFAULT VALUES; COMMIT;
+   > BEGIN; INSERT INTO increment DEFAULT VALUES; ROLLBACK;
+   > BEGIN; INSERT INTO increment DEFAULT VALUES; COMMIT;
    ~~~ 
 
 3. View the rows created.
 
+   ~~~ sql
+   > SELECT * from increment;
    ~~~
-   SELECT * from increment;
+   ~~~
    +---+
    | a |
    +---+

--- a/show-columns.md
+++ b/show-columns.md
@@ -35,7 +35,7 @@ Field | Description
 
 ## Example
 
-~~~ shell
+~~~ sql
 > CREATE TABLE orders (
     id INT PRIMARY KEY DEFAULT unique_rowid(),
     date TIMESTAMP NOT NULL,
@@ -48,6 +48,8 @@ Field | Description
 );
 
 > SHOW COLUMNS FROM orders;
+~~~
+~~~
 +-------------+-----------+-------+----------------+
 |    Field    |   Type    | Null  |    Default     |
 +-------------+-----------+-------+----------------+

--- a/show-constraints.md
+++ b/show-constraints.md
@@ -44,7 +44,7 @@ Field | Description
 
 ## Example
 
-~~~ shell
+~~~ sql
 > CREATE TABLE orders (
     id INT PRIMARY KEY,
     date TIMESTAMP NOT NULL,
@@ -57,6 +57,8 @@ Field | Description
 );
 
 > SHOW CONSTRAINTS FROM orders;
+~~~
+~~~
 +--------+------------------------+-------------+---------------+--------------------------------------------------------+
 | Table  |          Name          |    Type     |   Column(s)   |                        Details                         |
 +--------+------------------------+-------------+---------------+--------------------------------------------------------+

--- a/show-create-table.md
+++ b/show-create-table.md
@@ -31,7 +31,7 @@ Field | Description
 
 ## Example
 
-~~~ shell
+~~~ sql
 > CREATE TABLE orders (
     id INT PRIMARY KEY DEFAULT unique_rowid(),
     date TIMESTAMP NOT NULL,
@@ -44,6 +44,8 @@ Field | Description
 );
 
 > SHOW CREATE TABLE orders;
+~~~
+~~~
 +--------+--------------------------------------------------------------------------------------------------+
 | Table  |                                           CreateTable                                            |
 +--------+--------------------------------------------------------------------------------------------------+

--- a/show-databases.md
+++ b/show-databases.md
@@ -19,8 +19,10 @@ No [privileges](privileges.html) are required to list the databases in the Cockr
 
 ## Example
 
-~~~
+~~~ sql
 > SHOW DATABASES;
+~~~
+~~~
 +----------+
 | Database |
 +----------+

--- a/show-index.md
+++ b/show-index.md
@@ -52,12 +52,12 @@ Field | Description
     c TIMESTAMP,
     d STRING
   );
-CREATE TABLE
 
 > CREATE INDEX b_c_idx ON t1 (b, c) STORING (d);
-CREATE INDEX
 
 > SHOW INDEX FROM t1;
+~~~
+~~~
 +--------+---------+--------+-----+--------+-----------+---------+
 | Table  |  Name   | Unique | Seq | Column | Direction | Storing |
 +--------+---------+--------+-----+--------+-----------+---------+

--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -44,7 +44,9 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
 ## Step 2. Start your first container/node
 
 ~~~ shell
-$ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080 -v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data" cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
+$ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080  \
+-v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data"  
+cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
 ~~~
 
 This command creates a container and starts the first CockroachDB node inside it. Let's look at each part:
@@ -61,8 +63,13 @@ This command creates a container and starts the first CockroachDB node inside it
 ## Step 3. Start additional containers/nodes
 
 ~~~ shell
-$ docker run -d --name=roach2 --hostname=roach2 --net=roachnet -P -v "${PWD}/cockroach-data/roach2:/cockroach/cockroach-data" cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
-$ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P -v "${PWD}/cockroach-data/roach3:/cockroach/cockroach-data" cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+$ docker run -d --name=roach2 --hostname=roach2 --net=roachnet -P -v \
+"${PWD}/cockroach-data/roach2:/cockroach/cockroach-data" cockroachdb/cockroach:{{site.data.strings.version}} \
+start --insecure --join=roach1
+
+$ docker run -d --name=roach3 --hostname=roach3 --net=roachnet -P -v  \
+"${PWD}/cockroach-data/roach3:/cockroach/cockroach-data" cockroachdb/cockroach:{{site.data.strings.version}} \
+start --insecure --join=roach1
 ~~~
 
 These commands add two more containers and start CockroachDB nodes inside them, joining them to the first node. There are only a few differences to note from step 2:
@@ -90,20 +97,18 @@ root@roach1:/cockroach# ./cockroach sql --insecure
 
 Then run some [CockroachDB SQL statements](learn-cockroachdb-sql.html):
 
-~~~ shell
-root@:26257> CREATE DATABASE bank;
-CREATE DATABASE
+~~~ sql
+> CREATE DATABASE bank;
 
-root@:26257> SET DATABASE = bank;
-SET
+> SET DATABASE = bank;
 
-root@:26257> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
-CREATE TABLE
+> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
 
-root@26257> INSERT INTO accounts VALUES (1234, 10000.50);
-INSERT 1
+> INSERT INTO accounts VALUES (1234, 10000.50);
 
-root@26257> SELECT * FROM accounts;
+> SELECT * FROM accounts;
+~~~
+~~~
 +------+----------+
 |  id  | balance  |
 +------+----------+
@@ -121,7 +126,10 @@ root@roach1:/cockroach# ./cockroach sql --insecure
 # Welcome to the cockroach SQL interface.
 # All statements must be terminated by a semicolon.
 # To exit: CTRL + D.
-root@:26257> SHOW DATABASES;
+~~~
+~~~ sql
+> SHOW DATABASES;
+~~~
 +----------+
 | Database |
 +----------+

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -57,7 +57,10 @@ This command starts a node, accepting all [`cockroach start`](start-a-node.html)
 ## Step 2. Join additional nodes to the cluster
    
 ~~~ shell
+# Start your second node
 $ cockroach start --store=node2 --port=26258 --http-port=8081 --join=localhost:26257 --background
+
+# Start your third node
 $ cockroach start --store=node3 --port=26259 --http-port=8082 --join=localhost:26257 --background
 ~~~
 
@@ -86,20 +89,18 @@ $ cockroach sql
 
 Then run some [CockroachDB SQL statements](learn-cockroachdb-sql.html):
 
-~~~ shell
-root@:26257> CREATE DATABASE bank;
-CREATE DATABASE
+~~~ sql
+> CREATE DATABASE bank;
 
-root@:26257> SET DATABASE = bank;
-SET
+> SET DATABASE = bank;
 
-root@:26257> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
-CREATE TABLE
+> CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL);
 
-root@26257> INSERT INTO accounts VALUES (1234, 10000.50);
-INSERT 1
+> INSERT INTO accounts VALUES (1234, 10000.50);
 
-root@26257> SELECT * FROM accounts;
+> SELECT * FROM accounts;
+~~~
+~~~
 +------+----------+
 |  id  | balance  |
 +------+----------+

--- a/start-a-node.md
+++ b/start-a-node.md
@@ -94,6 +94,14 @@ $ cockroach start --store=node3 --port=26259 --http-port=8082 --http-addr=localh
 
 This example demonstrates starting up three nodes on different machines. Because each is on a different machine, default ports can be used without causing conflict. See [Manual Deployment](manual-deployment.html) for a detailed walkthrough.
 
+<style>
+.pg::before {
+    content: "test";
+}
+.pg::after {
+    content: "test2";
+}
+</style>
 ~~~ shell
 # Insecure:
 $ cockroach start --insecure --host=<node1-hostname>
@@ -101,9 +109,9 @@ $ cockroach start --insecure --host=<node2-hostname> --join=<node1-hostname>:262
 $ cockroach start --insecure --host=<node3-hostname> --join=<node1-hostname>:26257
 
 # Secure:
-$ cockroach start --host=<node1-hostname> --http-addr=<private-address> --ca-cert=ca.cert --cert=node1.cert --key=node1.key
-$ cockroach start --host=<node2-hostname> --http-addr=<private-address> --join=<node1-hostname>:26257 --ca-cert=ca.cert --cert=node2.cert --key=node2.key 
-$ cockroach start --host=<node3-hostname> --http-addr=<private-address> --join=<node1-hostname>:26257 --ca-cert=ca.cert --cert=node3.cert --key=node3.key 
+$ cockroach start --ca-cert=ca.cert --cert=node1.cert --key=node1.key --host=<node1-hostname> --http-addr=<private-address>
+$ cockroach start --ca-cert=ca.cert --cert=node2.cert --key=node2.key --host=<node2-hostname> --http-addr=<private-address> --join=<node1-hostname>:26257
+$ cockroach start --ca-cert=ca.cert --cert=node3.cert --key=node3.key --host=<node3-hostname> --http-addr=<private-address> --join=<node1-hostname>:26257 --ca-cert=ca.cert --cert=node3.cert --key=node3.key
 ~~~
 
 ## See Also

--- a/string.md
+++ b/string.md
@@ -73,10 +73,12 @@ The size of a `STRING` value is variable, but it's recommended to keep values un
 
 ## Examples
 
-~~~
-CREATE TABLE strings (a STRING PRIMARY KEY, b STRING(4), c TEXT);
+~~~ sql
+> CREATE TABLE strings (a STRING PRIMARY KEY, b STRING(4), c TEXT);
 
-SHOW COLUMNS FROM strings;
+> SHOW COLUMNS FROM strings;
+~~~
+~~~
 +-------+-----------+-------+---------+
 | Field |  Type     | Null  | Default |
 +-------+-----------+-------+---------+
@@ -84,10 +86,13 @@ SHOW COLUMNS FROM strings;
 | b     | STRING(4) | true  | NULL    |
 | c     | STRING    | true  | NULL    |
 +-------+-----------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO strings VALUES ('a1b2c3d4', 'e5f6', 'g7h8i9');
 
-INSERT INTO strings VALUES ('a1b2c3d4', 'e5f6', 'g7h8i9');
-
-SELECT * FROM strings;
+> SELECT * FROM strings;
+~~~
+~~~
 +----------+------+--------+
 |    a     |  b   |   c    |
 +----------+------+--------+

--- a/timestamp.md
+++ b/timestamp.md
@@ -38,20 +38,25 @@ A `TIMESTAMP` column supports values up to 12 bytes in width, but the total stor
 
 ## Examples
 
-~~~
-CREATE TABLE timestamps (a INT PRIMARY KEY, b TIMESTAMP);
+~~~ sql
+> CREATE TABLE timestamps (a INT PRIMARY KEY, b TIMESTAMP);
 
-SHOW COLUMNS FROM timestamps;
+> SHOW COLUMNS FROM timestamps;
+~~~
+~~~
 +-------+-----------+-------+---------+
 | Field |   Type    | Null  | Default |
 +-------+-----------+-------+---------+
 | a     | INT       | false | NULL    |
 | b     | TIMESTAMP | true  | NULL    |
 +-------+-----------+-------+---------+
+~~~
+~~~ sql
+> INSERT INTO timestamps VALUES (1, TIMESTAMP '2016-03-26 10:10:10-05:00'), (2, TIMESTAMP '2016-03-26');
 
-INSERT INTO timestamps VALUES (1, TIMESTAMP '2016-03-26 10:10:10-05:00'), (2, TIMESTAMP '2016-03-26');
-
-SELECT * FROM timestamps;
+> SELECT * FROM timestamps;
+~~~
+~~~
 +------+---------------------------------+
 |  a   |                b                |
 +------+---------------------------------+

--- a/transactions.md
+++ b/transactions.md
@@ -15,9 +15,9 @@ CockroachDB supports bundling multiple SQL statements into a single all-or-nothi
 In CockroachDB, a transaction is set up by surrounding SQL statements with the [`BEGIN`](begin-transaction.html) and [`COMMIT`](commit-transaction.html) statements:
 
 ~~~ sql
-BEGIN
+> BEGIN;
 <other statements>
-COMMIT
+> COMMIT;
 ~~~
 
 If at any point in the transaction you decide to abort all updates, you can issue the [`ROLLBACK`](rollback-transaction.html) statement instead of the `COMMIT` statement.
@@ -53,13 +53,13 @@ To assist with client-side retries, CockroachDB provides a generic **retry funct
 Every transaction in CockroachDB is assigned an initial **priority**. By default, that priority is `NORMAL`, but for transactions that should be given preference in high-contention scenarios, the client can set the priority within the [`BEGIN`](begin-transaction.html) statement:
 
 ~~~ sql
-BEGIN PRIORITY <LOW, NORMAL, HIGH>
+> BEGIN PRIORITY <LOW, NORMAL, HIGH>;
 ~~~
 
 Alternately, the client can set the priority immediately after the transaction is started as follows:
 
 ~~~ sql
-SET TRANSACTION PRIORITY <LOW, NORMAL, HIGH>
+> SET TRANSACTION PRIORITY <LOW, NORMAL, HIGH>;
 ~~~
 
 {{site.data.alerts.callout_info}}When two transactions contend for the same resource, the one with the lower priority loses and is retried. On retry, the transaction inherits the priority of the winner. This means that each retry makes a transaction stronger and more likely to succeed.{{site.data.alerts.end}}
@@ -69,13 +69,13 @@ SET TRANSACTION PRIORITY <LOW, NORMAL, HIGH>
 CockroachDB supports two transaction isolation levels: `SNAPSHOT ISOLATION` and `SERIALIZABLE`. By default, transactions use the `SERIALIZABLE` isolation level, but the client can explicitly set a transaction's isolation when starting the transaction:
 
 ~~~ sql
-BEGIN ISOLATION LEVEL <ANSI SQL ISOLATION LEVEL>
+> BEGIN ISOLATION LEVEL <ANSI SQL ISOLATION LEVEL>;
 ~~~
 
 Alternately, the client can set the isolation level immediately after the transaction is started:
 
 ~~~ sql
-SET TRANSACTION ISOLATION LEVEL <ANSI SQL ISOLATION LEVEL>
+> SET TRANSACTION ISOLATION LEVEL <ANSI SQL ISOLATION LEVEL>;
 ~~~
 
 {{site.data.alerts.callout_info}}For a detailed discussion of isolation in CockroachDB transactions, see <a href="https://www.cockroachlabs.com/blog/serializable-lockless-distributed-isolation-cockroachdb/">Serializable, Lockless, Distributed: Isolation in CockroachDB</a>.{{site.data.alerts.end}}

--- a/truncate.md
+++ b/truncate.md
@@ -24,8 +24,10 @@ The user must have the `DROP` [privilege](privileges.html) on the table.
 
 ## Example
 
-~~~sql
+~~~ sql
 > SELECT * FROM tbl;
+~~~
+~~~
 +----+
 | id |
 +----+
@@ -33,11 +35,13 @@ The user must have the `DROP` [privilege](privileges.html) on the table.
 |  2 |
 |  3 |
 +----+
-
+~~~
+~~~ sql
 > TRUNCATE tbl;
-TRUNCATE
 
 > SELECT * FROM tbl;
+~~~
+~~~
 +----+
 | id |
 +----+

--- a/upsert.md
+++ b/upsert.md
@@ -32,10 +32,10 @@ Parameter | Description
 
 `UPSERT` considers uniqueness only for [`PRIMARY KEY`](constraints.html#primary-key) columns. For example, assuming that columns `a` and `b` are the primary key, the following `UPSERT` and `INSERT ON CONFLICT` statements are equivalent:
 
-~~~
-UPSERT INTO t (a, b, c) VALUES (1, 2, 3);
+~~~ sql
+> UPSERT INTO t (a, b, c) VALUES (1, 2, 3);
 
-INSERT INTO t (a, b, c) 
+> INSERT INTO t (a, b, c) 
     VALUES (1, 2, 3)
     ON CONFLICT (a, b)
     DO UPDATE SET c = excluded.c;
@@ -49,19 +49,23 @@ INSERT INTO t (a, b, c)
 
 In this example, the `id` column is the primary key. Because the inserted `id` value does not conflict with the `id` value of any existing row, the `UPSERT` statement inserts a new row into the table.
 
-~~~
+~~~ sql
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+----------+
 | id | balance  |
 +----+----------+
 |  1 |  10000.5 |
 |  2 | 20000.75 |
 +----+----------+
-
+~~~
+~~~ sql
 > UPSERT INTO accounts (id, balance) VALUES (3, 6325.20);
-INSERT 1
 
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+----------+
 | id | balance  |
 +----+----------+
@@ -75,8 +79,10 @@ INSERT 1
 
 In this example, the `id` column is the primary key. Because the inserted `id` value is not unique, the `UPSERT` statement updates the row with the new `balance`.
 
-~~~
+~~~ sql
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+----------+
 | id | balance  |
 +----+----------+
@@ -84,11 +90,13 @@ In this example, the `id` column is the primary key. Because the inserted `id` v
 |  2 | 20000.75 |
 |  3 |   6325.2 |
 +----+----------+
-
+~~~
+~~~ sql
 > UPSERT INTO accounts (id, balance) VALUES (3, 7500.83);
-INSERT 1
 
 > SELECT * FROM accounts;
+~~~
+~~~
 +----+----------+
 | id | balance  |
 +----+----------+
@@ -102,8 +110,10 @@ INSERT 1
 
 `UPSERT` will not update rows when the uniquness conflict is on columns not in the primary key. In this example, the `a` column is the primary key, but the `b` column also has the [`UNIQUE`](constraints.html#unique) constraint. Because the inserted `b` value is not unique, the `UPSERT` fails.
 
-~~~
+~~~ sql
 > SELECT * FROM unique_test;
+~~~
+~~~
 +---+---+
 | a | b |
 +---+---+
@@ -111,18 +121,22 @@ INSERT 1
 | 2 | 2 |
 | 3 | 3 |
 +---+---+
-
+~~~
+~~~ sql
 > UPSERT INTO unique_test VALUES (4, 1);
+~~~
+~~~
 pq: duplicate key value (b)=(1) violates unique constraint "unique_test_b_key"
 ~~~
 
 In such a case, you would need to use the [`INSERT ON CONFLICT`](insert.html) statement to specify the `b` column as the column with the `UNIQUE` constraint.
 
-~~~
+~~~ sql
 > INSERT INTO unique_test VALUES (4, 1) ON CONFLICT (b) DO UPDATE SET a = excluded.a;
-INSERT 1
 
 > SELECT * FROM unique_test;
+~~~
+~~~
 +---+---+
 | a | b |
 +---+---+

--- a/use-the-built-in-sql-client.md
+++ b/use-the-built-in-sql-client.md
@@ -85,14 +85,14 @@ $ cockroach sql --url=postgresql://maxroach@roachnode1.com:26257/critterdb?sslmo
 
 This example assume that we have already started the SQL shell (see examples above).
 
-~~~ shell
+~~~ sql
 > CREATE TABLE animals (id SERIAL PRIMARY KEY, name STRING);
-CREATE TABLE
 
 > INSERT INTO animals (name) VALUES ('bobcat'), ('🐢 '), ('barn owl');
-INSERT 3
 
 > SELECT * FROM animals;
+~~~
+~~~
 +--------------------+----------+
 |         id         |   name   |
 +--------------------+----------+
@@ -174,18 +174,21 @@ INSERT 2
 
 In this example, we use `\!` to look at the rows in a csv file before creating a table and then using `\|` to insert those rows into the table.
 
-~~~ shell
+~~~ sql
 > \! cat test.csv
+~~~
+~~~
 12, 13, 14
 10, 20, 30
-
+~~~
+~~~ sql
 > CREATE TABLE csv (x INT, y INT, z INT);
-CREATE TABLE
 
 > \| IFS=","; while read a b c; do echo "insert into csv values ($a, $b, $c);"; done < test.csv;
-INSERT 1
 
 > SELECT * FROM csv;
+~~~
+~~~
 +----+----+----+
 | x  | y  | z  |
 +----+----+----+
@@ -196,14 +199,14 @@ INSERT 1
 
 In this example, we create a table and then use `\|` to programmatically insert values.
 
-~~~ shell
+~~~ sql
 > CREATE TABLE for_loop (x INT);
-CREATE TABLE
 
 > \| for ((i=0;i<10;++i)); do echo "INSERT INTO for_loop VALUES ($i);"; done
-INSERT 1
 
 > SELECT * FROM for_loop;
+~~~
+~~~
 +---+
 | x |
 +---+


### PR DESCRIPTION
- When using syntax highlighting, made terminal identifier (e.g. "$" for shell) unselectable (#525)
- Fixed bug with over-large area for anchors (#575)
- Included background color for all bs-callout styles (same for all callouts); color choice driven by need to accommodate green link text and medium-gray code formatting

### Related issues
Fixes #525
Fixes #575

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/585)
<!-- Reviewable:end -->
