### PR TITLE
Add --file flag to zone config docs

### DIFF
--- a/configure-replication-zones.md
+++ b/configure-replication-zones.md
@@ -92,13 +92,13 @@ $ cockroach zone get <database> <flags>
 $ cockroach zone get <database.table> <flags>
 
 # Edit the default replication zone for the cluster:
-$ cockroach zone set .default <flags> 'YAML content'
+$ cockroach zone set .default --file=<zone-content.yaml> <flags>
 
 # Create/edit the replication zone for a database:
-$ cockroach zone set <database> <flags> 'YAML content'
+$ cockroach zone set <database> --file=<zone-conent.yaml> <flags>
 
 # Create/edit the replication zone for a table:
-$ cockroach zone set <database.table> <flags> 'YAML content'
+$ cockroach zone set <database.table> --file=<zone-content.yaml> <flags>
 
 # Remove the replication zone for a database:
 $ cockroach zone rm <database> <flags>
@@ -123,6 +123,7 @@ Flag | Description
 `--ca-cert` | The path to the [CA certificate](create-security-certificates.html). This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_CA_CERT`
 `--cert` | The path to the [client certificate](create-security-certificates.html). This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_CERT`
 `--database`<br>`-d` | Not currently implemented. 
+`--file`<br>`-f` | The path to the [YAML file](#replicaton-zone-format) defining the zone configuration. To pass the zone configuration via the standard input, set this flag to `-`.<br><br>This flag is relevant only for the `set` subcommand.
 `--host` | The server host to connect to. This can be the address of any node in the cluster. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** localhost
 `--insecure` | Set this only if the cluster is insecure and running on multiple machines.<br><br>If the cluster is insecure and local, leave this out. If the cluster is secure, leave this out and set the `--ca-cert`, `--cert`, and `-key` flags.<br><br>**Env Variable:** `COCKROACH_INSECURE`
 `--key` | The path to the [client key](create-security-certificates.html) protecting the client certificate. This flag is required if the cluster is secure.<br><br>**Env Variable:** `COCKROACH_KEY`
@@ -141,10 +142,10 @@ Flag | Description
 
 The cluster-wide replication zone (`.default`) is initially set to replicate data to any three nodes in your cluster, with ranges in each replica splitting once they get larger than 67108864 bytes. 
 
-To view the default replication zone, use the `cockroach zone get .default` command with appropriate flags as follows:
+To view the default replication zone, use the `cockroach zone get .default` command with appropriate flags:
 
 ~~~ shell
-$ cockroach zone get .default --insecure
+$ cockroach zone get .default
 .default
 replicas:
 - attrs: []
@@ -158,125 +159,150 @@ gc:
 
 ### Edit the Default Replication Zone
 
-To edit the default replication zone, use the `cockroach zone set .default` command with appropriate flags and the YAML changes specified as a string. 
+Let's say you want to run a three-node cluster across three datacenters, two on the US east coast and one on the US west coast. You want data replicated three times by default, with each replica stored on a specific node in a specific datacenter. 
 
-For example, let's say you want to run a three-node cluster across three datacenters, two on the US east coast and one on the US west coast. You want data replicated three times by default, with each replica stored on a specific node in a specific datacenter. So you start each node with the relevant datacenter location specified in the `--attrs` field. 
+1. Start each node with the relevant datacenter location specified in the `--attrs` field: 
 
-~~~ shell
-# Start node in first US east coast datacenter:
-$ cockroach start --insecure --host=node1-hostname --attrs=us-east-1a
+   ~~~ shell
+   # Start node in first US east coast datacenter:
+   $ cockroach start --host=node1-hostname --attrs=us-east-1a
 
-# Start node in second US east coast datacenter:
-$ cockroach start --insecure --host=node2-hostname --attrs=us-east-1b --join=node1-hostname:27257
+   # Start node in second US east coast datacenter:
+   $ cockroach start --host=node2-hostname --attrs=us-east-1b --join=node1-hostname:27257
 
-# Start node in US west coast datacenter:
-$ cockroach start --insecure --host=node3-hostname --attrs=us-west-1a --join=node1-hostname:27257
-~~~
+   # Start node in US west coast datacenter:
+   $ cockroach start --host=node3-hostname --attrs=us-west-1a --join=node1-hostname:27257
+   ~~~
 
-You then edit the default zone configuration with one datacenter attribute set for each replica.
+2. Create a YAML file with one datacenter attribute set for each replica, and use the file to update the default zone configuration :
 
-~~~ shell
-$ cockroach zone set .default --insecure 'replicas:
-- attrs: [us-east-1a]
-- attrs: [us-east-1b]
-- attrs: [us-west-1a]'
-~~~
+   ~~~ shell
+   $ cat default_update.yaml
+   replicas:
+   - attrs: [us-east-1a] 
+   - attrs: [us-east-1b]
+   - attrs: [us-west-1a]
+   
+   $ cockroach zone set .default -f default_update.yaml
+   UPDATE 1
+   replicas:
+   - attrs: [us-east-1a]
+   - attrs: [us-east-1b]
+   - attrs: [us-west-1a]
+   range_min_bytes: 1048576
+   range_max_bytes: 67108864
+   gc:
+     ttlseconds: 86400
+   ~~~
 
-The `zone set` command automatically echoes the full zone configuration, so you can easily validate your changes without needing to run `zone get`.
+   Alternately, you can pass the YAML content via the standard input:
 
-~~~ shell
-UPDATE 1
-replicas:
-- attrs: [us-east-1a]
-- attrs: [us-east-1b]
-- attrs: [us-west-1a]
-range_min_bytes: 1048576
-range_max_bytes: 67108864
-gc:
-  ttlseconds: 86400
-~~~
+   ~~~ shell
+   $ cockroach zone set .default -f - <<EOF
+   replicas:
+   - attrs: [us-east-1a] 
+   - attrs: [us-east-1b]
+   - attrs: [us-west-1a]
+   EOF
+   ~~~
 
 ### Create a Replication Zone for a Database
 
-To create a replication zone for a specific database, use the `cockroach zone set`, specifying the database name, any appropriate flags, and the zone settings as a YAML string. 
+Let's say you want to run a cluster across five nodes, three of which have ssd storage devices. You want data in the `bank` database replicated to these ssd devices. 
 
-For example, let's say you want to run a cluster across five nodes, three of which have ssd storage devices. You want data in the `bank` database replicated to these ssd devices. So when starting the three nodes with these devices, you specify `ssd` as an attribute of the stores, and when starting the other two nodes, you leave the attribute out.
+1. When starting the three nodes that have ssd storage, specify `ssd` as an attribute of the stores, and when starting the other two nodes, leave the attribute out:
 
-~~~ shell
-# Start nodes with ssd storage devices:
-$ cockroach start --insecure --host=node1-hostname --store=path=node1-data,attr=ssd
-$ cockroach start --insecure --host=node2-hostname --store=path=node2-data,attr=ssd --join=node1-hostname:27257
-$ cockroach start --insecure --host=node3-hostname --store=path=node3-data,attr=ssd --join=node1-hostname:27257
+   ~~~ shell
+   # Start nodes with ssd storage:
+   $ cockroach start --insecure --host=node1-hostname --store=path=node1-data,attr=ssd
+   $ cockroach start --insecure --host=node2-hostname --store=path=node2-data,attr=ssd --join=node1-hostname:27257
+   $ cockroach start --insecure --host=node3-hostname --store=path=node3-data,attr=ssd --join=node1-hostname:27257
 
-# Start nodes without ssd storage devices:
-$ cockroach start --insecure --host=node4-hostname --store=path=node4-data --join=node1-hostname:27257
-$ cockroach start --insecure --host=node5-hostname --store=path=node5-data --join=node1-hostname:27257
-~~~
+   # Start nodes without ssd storage:
+   $ cockroach start --insecure --host=node4-hostname --store=path=node4-data --join=node1-hostname:27257
+   $ cockroach start --insecure --host=node5-hostname --store=path=node5-data --join=node1-hostname:27257
+   ~~~
 
-You then create a zone configuration for the `bank` database with `ssd` set as the attribute for each replica. 
+2. Create a YAML file with `ssd` set as the attribute for each replica, and use the file to update the zone configuration for the `bank` database:
 
-~~~ shell
-$ cockroach zone set bank --insecure 'replicas:
-- attrs: [ssd]
-- attrs: [ssd]
-- attrs: [ssd]
-range_max_bytes: 67108864'
-~~~
+   ~~~ shell
+   $ cat bank_zone.yaml
+   replicas:
+   - attrs: [ssd]
+   - attrs: [ssd]
+   - attrs: [ssd]
 
-The `zone set` command automatically echoes the full zone configuration, so you can easily validate your changes without needing to run `zone get`.
+   $ cockroach zone set bank -f bank_zone.yaml
+   INSERT 1
+   replicas:
+   - attrs: [ssd]
+   - attrs: [ssd]
+   - attrs: [ssd]
+   range_min_bytes: 1048576
+   range_max_bytes: 67108864
+   gc:
+     ttlseconds: 86400
+   ~~~
 
-~~~ shell
-INSERT 1
-replicas:
-- attrs: [ssd]
-- attrs: [ssd]
-- attrs: [ssd]
-range_min_bytes: 1048576
-range_max_bytes: 67108864
-gc:
-  ttlseconds: 86400
-~~~
+   Alternately, you can pass the YAML content via the standard input:
+
+   ~~~ shell
+   $ cockroach zone set bank -f - <<EOF
+   replicas:
+   - attrs: [ssd]
+   - attrs: [ssd]
+   - attrs: [ssd]
+   EOF
+   ~~~
 
 ### Create a Replication Zone for a Table
 
-To create a replication zone for a specific table, use the `cockroach zone set`, specifying the table name in `database.table` format, any appropriate flags, and the zone settings as a YAML string. 
+Let's say you want to run a cluster across five nodes, three of which have ssd storage devices. You want data in the `bank.accounts` table replicated to these ssd devices. 
 
-For example, let's say you want to run a cluster across five nodes, three of which have ssd storage devices. You want data in the `bank.accounts` table replicated to these ssd devices. So when starting the three nodes with these devices, you specify `ssd` as an attribute of the stores. When starting the other two nodes, you leave the attribute out. 
+1. When starting the three nodes that have ssd storage, specify `ssd` as an attribute of the stores, and when starting the other two nodes, leave the attribute out: 
 
-~~~ shell
-# Start nodes with ssd storage devices:
-$ cockroach start --insecure --host=node1-hostname --store=path=node1-data,attr=ssd
-$ cockroach start --insecure --host=node2-hostname --store=path=node2-data,attr=ssd --join=node1-hostname:27257
-$ cockroach start --insecure --host=node3-hostname --store=path=node3-data,attr=ssd --join=node1-hostname:27257
+   ~~~ shell
+   # Start nodes with ssd storage:
+   $ cockroach start --insecure --host=node1-hostname --store=path=node1-data,attr=ssd
+   $ cockroach start --insecure --host=node2-hostname --store=path=node2-data,attr=ssd --join=node1-hostname:27257
+   $ cockroach start --insecure --host=node3-hostname --store=path=node3-data,attr=ssd --join=node1-hostname:27257
 
-# Start nodes without ssd storage devices:
-$ cockroach start --insecure --host=node4-hostname --store=path=node4-data --join=node1-hostname:27257
-$ cockroach start --insecure --host=node5-hostname --store=path=node5-data --join=node1-hostname:27257
-~~~
+   # Start nodes without ssd storage:
+   $ cockroach start --insecure --host=node4-hostname --store=path=node4-data --join=node1-hostname:27257
+   $ cockroach start --insecure --host=node5-hostname --store=path=node5-data --join=node1-hostname:27257
+   ~~~
 
-You then create a zone configuration for the `bank.accounts` table with `ssd` set as the attribute for each replica.
+2. Create a YAML file with `ssd` set as the attribute for each replica, and use the file to update the zone configuration for the `bank.accounts` table:
 
-~~~ shell
-$ cockroach zone set bank.accounts --insecure 'replicas:
-- attrs: [ssd]
-- attrs: [ssd]
-- attrs: [ssd]
-range_max_bytes: 67108864'
-~~~
+   ~~~ shell
+   $ cat accounts_zone.yaml
+   replicas:
+   - attrs: [ssd]
+   - attrs: [ssd]
+   - attrs: [ssd]
 
-The `zone set` command automatically echoes the full zone configuration, so you can easily validate your changes without needing to run `zone get`.
+   $ cockroach zone set bank.accounts -f accounts_zone.yaml
+   INSERT 1
+   replicas:
+   - attrs: [ssd]
+   - attrs: [ssd]
+   - attrs: [ssd]
+   range_min_bytes: 1048576
+   range_max_bytes: 67108864
+   gc:
+     ttlseconds: 86400   
+   ~~~
 
-~~~ shell
-INSERT 1
-replicas:
-- attrs: [ssd]
-- attrs: [ssd]
-- attrs: [ssd]
-range_min_bytes: 1048576
-range_max_bytes: 67108864
-gc:
-  ttlseconds: 86400
-~~~
+   Alternately, you can pass the YAML content via the standard input:
+
+   ~~~ shell
+   $ cockroach zone set bank -f - <<EOF
+   replicas:
+   - attrs: [ssd]
+   - attrs: [ssd]
+   - attrs: [ssd]
+   EOF
+   ~~~
 
 ## See Also
 


### PR DESCRIPTION
Add `--file` flag to `configure-replication-zones.md` and update examples.

I'll open a separate PR to handle the new zone config format and other related changes on `develop`.

Fixes #601

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/602)
<!-- Reviewable:end -->
