### PR TITLE
Remove nanoseconds and add INT8 alias

### DIFF
--- a/develop-branch.md
+++ b/develop-branch.md
@@ -7,5 +7,6 @@ These features and changes are available only when you <a href="install-cockroac
 
 Feature | Merge Date
 --------|-----------
+`INT8` is treated as an alias for the [`INT`](int.html) data type. | [8/29/16](https://github.com/cockroachdb/cockroach/pull/8858) 
 [`TIMESTAMP`](timestamp.html) values can no longer be created with nanoseconds. | [8/29/16](https://github.com/cockroachdb/cockroach/pull/8864) 
 [`INTERVAL`](interval.html) columns accept the SQL Standard format. | [8/18/16](https://github.com/cockroachdb/cockroach/pull/8657)

--- a/develop-branch.md
+++ b/develop-branch.md
@@ -3,8 +3,9 @@ title: Features on Develop Branch
 toc: false
 ---
 
-These features are available only when you <a href="install-cockroachdb.html">build a CockroachDB binary</a> from the code on our <code>develop</code> branch. They are not yet included in an official beta release.
+These features and changes are available only when you <a href="install-cockroachdb.html">build a CockroachDB binary</a> from the code on our <code>develop</code> branch. They are not yet included in an official beta release.
 
 Feature | Merge Date
 --------|-----------
+[`TIMESTAMP`](timestamp.html) values can no longer be created with nanoseconds. | [8/29/16](https://github.com/cockroachdb/cockroach/pull/8864) 
 [`INTERVAL`](interval.html) columns accept the SQL Standard format. | [8/18/16](https://github.com/cockroachdb/cockroach/pull/8657)

--- a/int.md
+++ b/int.md
@@ -15,7 +15,8 @@ The `INT` [data type](data-types.html) stores 64-bit signed integers, that is, w
 In CockroachDB, the following are aliases for `INT`: 
 
 - `SMALLINT` 
-- `INTEGER` 
+- `INTEGER`
+- `INT8` (This alias is available only when you [build a CockroachDB binary](install-cockroachdb.html) from the code on our `develop` branch. For a list of other features available only when building from source, see [Features on the Develop Branch](develop-branch.html).) 
 - `INT64` 
 - `BIGINT`
 

--- a/timestamp.md
+++ b/timestamp.md
@@ -26,11 +26,7 @@ Alternatively, you can use a string literal, e.g., `'2016-01-25T10:10:10'` or `'
 
 Note that the fractional portion is optional and is rounded to
 microseconds (6 digits after decimal) for compatibility with the
-PostgreSQL wire protocol. To create a timestamp with nanoseconds, use the
-`parse_timestamp_ns(string)` [function](functions-and-operators.html),
-which creates a timestamp with nanoseconds from a string. To create a string
-with nanosecond precision, use `format_timestamp_ns(ts)`. The `extract`
-function supports nanoseconds as well: `extract(nanosecond from ts)`.
+PostgreSQL wire protocol. 
 
 ## Size
 


### PR DESCRIPTION
This PR removes mention of the ability to create timestamps with nanoseconds, adds the `INT8` alias for the `INT` data type, and adds this change to the list of features/changes only on `develop`. 

Fixes #559
Fixes #597 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/603)
<!-- Reviewable:end -->
