### PR TITLE
Add binary links to release notes

### DIFF
--- a/beta-20160407.md
+++ b/beta-20160407.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160407.
 
 ## Apr 7, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160407.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160407.linux-amd64.tgz)
+ 
 ### Backwards-incompatible Changes
 
 * Any databases using the [`DECIMAL`](decimal.html) type will need to be deleted and

--- a/beta-20160414.md
+++ b/beta-20160414.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160414.
 
 ## Apr 14, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160414.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160414.linux-amd64.tgz)
+ 
 ### Backwards-incompatible Changes
 
 * Any databases using the [`DECIMAL`](decimal.html) type will need to be deleted and created from scratch. Columns of this type were encoded incorrectly in older beta releases. (Again! We apologize for the inconvenience.) [#5994](https://github.com/cockroachdb/cockroach/pull/5994)

--- a/beta-20160421.md
+++ b/beta-20160421.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160421.
 
 ## Apr 21, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160421.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160421.linux-amd64.tgz)
+ 
 ### Upgrade Procedure
 
 * This release cannot be run concurrently with older beta releases.

--- a/beta-20160428.md
+++ b/beta-20160428.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160428.
 
 ## Apr 28, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160428.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160428.linux-amd64.tgz)
+ 
 ### Backwards-Incompatible Changes
 
 * Time zone offsets are no longer shown when querying columns of type

--- a/beta-20160505.md
+++ b/beta-20160505.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160505.
 
 ## May 5, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160505.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160505.linux-amd64.tgz)
+ 
 ### New Features
 
 * New SQL command `UPSERT` is available. This is syntactically similar

--- a/beta-20160512.md
+++ b/beta-20160512.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160512.
 
 ## May 12, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160512.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160512.linux-amd64.tgz)
+ 
 ### Upgrade Procedure
 
 - This release cannot be run concurrently with older beta releases. Please stop all nodes running older releases before restarting any node with this version.

--- a/beta-20160519.md
+++ b/beta-20160519.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160519.
 
 ## May 19, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160519.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160519.linux-amd64.tgz)
+ 
 ### Backwards-Incompatible Changes
 
 - [`TIMESTAMP`](timestamp.html) values are now truncated to microsecond resolution when sent over the network for compatibility with the PostgreSQL protocol. The `format_timestamp_ns(ts)` or `extract(nanosecond from ts)` [functions](functions-and-operators.html) can be used to access the full nanosecond precision of a timestamp. The `now()`, `current_timestamp()`, and `statement_timestamp()` functions are truncated to microsecond resolution to avoid confusion when timestamp values are used in unique indexes; the new `current_timestamp_ns()` function can be used to get a non-truncated timestamp. [#6604](https://github.com/cockroachdb/cockroach/pull/6604)

--- a/beta-20160526.md
+++ b/beta-20160526.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160526.
 
 ## May 26, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160526.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160526.linux-amd64.tgz)
+ 
 ### Backwards-Incompatible Changes
 
 - Numeric literals containing a decimal point are now treated as type [`DECIMAL`](decimal.html) instead of type [`FLOAT`](float.html), unless type inference determines that `FLOAT` should be used. In some cases, an explicit `CAST(x AS FLOAT)` may be needed. [#6752](https://github.com/cockroachdb/cockroach/pull/6752)

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160602.
 
 ## Jun 2, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160602.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160602.linux-amd64.tgz)
+ 
 ### New Features
 
 - String literals can now be parsed as [`DATE`](date.html), [`TIMESTAMP`](timestamp.html), [`TIMESTAMPTZ`](timestamp.html), or [`INTERVAL`](interval.html) without an explicit cast. [#6925](https://github.com/cockroachdb/cockroach/pull/6925)

--- a/beta-20160609.md
+++ b/beta-20160609.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160609.
 
 ## Jun 9, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160609.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160609.linux-amd64.tgz)
+ 
 ### New Features
 
 - The [`SERIAL`](serial.html) column type is now supported as an alias for `INT DEFAULT unique_rowid()`. In CockroachDB, this type defaults to a unique 64-bit signed integer that is the combination of the insert timestamp and the ID of the node executing the insert. It therefore differs from similar types in PostgreSQL and MySQL, which auto-increment integers in an approximate sequence. [#7032](https://github.com/cockroachdb/cockroach/pull/7032)

--- a/beta-20160616.md
+++ b/beta-20160616.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160616.
 
 ## Jun 16, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160616.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160616.linux-amd64.tgz)
+
 ### Deprecation Notice
 
 - Integers with a leading zero (e.g., `0755`) are currently treated as octal. In a future release, leading zeros will be ignored and the numbers will be treated as decimal. [#7205](https://github.com/cockroachdb/cockroach/pull/7205)

--- a/beta-20160629.md
+++ b/beta-20160629.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160629.
 
 ## Jun 29, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160629.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160629.linux-amd64.tgz)
+
 ### New Features
 
 - A prototype implementation of `JOIN` (non-optimized) is now available. [#7202](https://github.com/cockroachdb/cockroach/pull/7202)

--- a/beta-20160714.md
+++ b/beta-20160714.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160714.
 
 ## Jul 14, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160714.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160714.linux-amd64.tgz)
+
 ### Upgrade Notes
 
 - This release cannot be run concurrently with older beta releases. Please stop all nodes running older releases before restarting any node with this version.

--- a/beta-20160721.md
+++ b/beta-20160721.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160721.
 
 ## Jul 21, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160721.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160721.linux-amd64.tgz)
+
 ### New Features
 
 - Metrics are now exported on `/_status/vars` in a format suitable for aggregation by Prometheus. [#7895](https://github.com/cockroachdb/cockroach/pull/7895)

--- a/beta-20160728.md
+++ b/beta-20160728.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160728.
 
 ## Jul 28, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160728.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160728.linux-amd64.tgz)
+
 ### New Features
 
 - Foreign keys can now reference multiple columns. [#8033](https://github.com/cockroachdb/cockroach/pull/8033)

--- a/beta-20160829.md
+++ b/beta-20160829.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version beta-20160829.
 
 ## Aug 29, 2016
 
+### Binaries
+
+- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160829.darwin-10.9-amd64.tgz)
+- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160829.linux-amd64.tgz)
+
 ### General Changes
 
 - CockroachDB now uses Go 1.7. [#8579](https://github.com/cockroachdb/cockroach/pull/8579)


### PR DESCRIPTION
This PR adds mac and linux binary links to each beta release notes page.

Fixes #604 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/604)
<!-- Reviewable:end -->
