### PR TITLE
Clarify bytes format

### DIFF
--- a/bytes.md
+++ b/bytes.md
@@ -17,42 +17,37 @@ In CockroachDB, the following are aliases for `BYTES`:
 
 ## Formats
 
-When inserting into a `BYTES` column, use either of the following byte escape formats:
+When inserting into a `BYTES` column, use any of the following formats:
 
 - 1 octet per byte: `b'\141\061\142\062\143\063'`
 - 2 hexadecimal digits per byte: `b'\x61\x31\x62\x32\x63\x33'`. 
+- String literal: `'a1b2c3'`
+
+You can also use these in combination, for example, `b'\141\061\x62\x32\c3'`.
 
 ## Size
 
 The size of a `BYTES` value is variable, but it's recommended to keep values under 64 kilobytes to ensure performance. Above that threshold, [write amplification](https://en.wikipedia.org/wiki/Write_amplification) and other considerations may cause significant performance degredation.  
 
-## Examples
+## Example
 
 ~~~ sql
-> CREATE TABLE bytes (a INT PRIMARY KEY, b BYTES, c BLOB);
+> CREATE TABLE bytes (a INT PRIMARY KEY, b BYTES);
 
-> SHOW COLUMNS FROM bytes;
-~~~
-~~~
-+-------+-------+-------+---------+
-| Field | Type  | Null  | Default |
-+-------+-------+-------+---------+
-| a     | INT   | false | NULL    |
-| b     | BYTES | true  | NULL    |
-| c     | BYTES | true  | NULL    |
-+-------+-------+-------+---------+
-~~~
-~~~ sql
-> INSERT INTO bytes VALUES (12345, b'\141\061\142\062\143\063', b'\x61\x31\x62\x32\x63\x33');
+> INSERT INTO bytes VALUES (1, 'abc'), (2, b'\141\142\143'), (3, b'\x61\x62\x63'), (4, b'\141\x62\c');
 
 > SELECT * FROM bytes;
 ~~~
 ~~~
-+-------+--------+--------+
-|   a   |   b    |   c    |
-+-------+--------+--------+
-| 12345 | a1b2c3 | a1b2c3 |
-+-------+--------+--------+
++---+-----+
+| a |  b  |
++---+-----+
+| 1 | abc |
+| 2 | abc |
+| 3 | abc |
+| 4 | abc |
++---+-----+
+(4 rows)
 ~~~
 
 ## See Also


### PR DESCRIPTION
This PR clarifies that `BYTES` columns accept string literals as well as octets and hex digits.

Fixes #427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/606)
<!-- Reviewable:end -->
