### PR TITLE
fix typo of unique_rowid(). Was unique_row(id)

### DIFF
--- a/create-table.md
+++ b/create-table.md
@@ -86,7 +86,7 @@ Parameter | Description
 
 ### Create a Table (No Primary Key Defined)
 
-In CockroachDB, every table requires a [`PRIMARY KEY`](constraints.html#primary-key). If one is not explicitly defined, a column called `rowid` of the type `INT` is added automatically as the primary key, with the `unique_row(id)` function used to ensure that new rows always default to unique `rowid` values. The primary key is automatically indexed. 
+In CockroachDB, every table requires a [`PRIMARY KEY`](constraints.html#primary-key). If one is not explicitly defined, a column called `rowid` of the type `INT` is added automatically as the primary key, with the `unique_rowid()` function used to ensure that new rows always default to unique `rowid` values. The primary key is automatically indexed. 
 
 {{site.data.alerts.callout_info}}Strictly speaking, a primary key's unique index is not created; it is derived from the key(s) under which the data is stored, so it takes no additional space. However, it appears as a normal unique index when using commands like <code>SHOW INDEX</code>.{{site.data.alerts.end}}
 


### PR DESCRIPTION
I'm assuming this is a typo a show columns uses the method of  unique_rowid() and not unique_row(id)

```
root@:26257> show columns from urlmap;
+--------------------+--------------+-------+------------------+
|       Field        |     Type     | Null  |     Default      |
+--------------------+--------------+-------+------------------+
| geturl_name        | STRING(50)   | false | NULL             |
| geturl_description | STRING(2048) | true  | NULL             |
| date_added         | DATE         | true  | "CURRENT_DATE"() |
| true_url           | STRING(2048) | true  | NULL             |
| rowid              | INT          | false | unique_rowid()   |
+--------------------+--------------+-------+------------------+
(5 rows)
root@:26257>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/623)
<!-- Reviewable:end -->
