### PR TITLE
Fix the example error message for retryable transactions.

### DIFF
--- a/transactions.md
+++ b/transactions.md
@@ -38,7 +38,7 @@ To assist with client-side retries, CockroachDB provides a generic **retry funct
 
 3. The statements in the transaction are executed. 
 
-4. If a statement returns a retryable error (identified via the `40001` error code or `retry transaction` string in the error message), the [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html) statement restarts the transaction. Alternately, the original `SAVEPOINT cockroach_restart` statement can be reissued to restart the transaction.
+4. If a statement returns a retryable error (identified via the `40001` error code or `restart transaction` string at the start of the error message), the [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html) statement restarts the transaction. Alternately, the original `SAVEPOINT cockroach_restart` statement can be reissued to restart the transaction.
 
    In cases where you do not want the application to retry the transaction, you can adapt the wrapper function to simply `ROLLBACK` at this point. Any other statements will be rejected by the server, as is generally the case after an error has been encountered and the transaction has not been closed.
 


### PR DESCRIPTION
Addresses the docs part of #646.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/647)
<!-- Reviewable:end -->
