### PR TITLE
Update beta-20160915 release notes

### DIFF
--- a/_data/strings.yml
+++ b/_data/strings.yml
@@ -1,5 +1,5 @@
 search_placeholder_text: Search
 search_no_results_text: No results found.
 copyright_line: "&copy;2016 Cockroach Labs. All rights reserved."
-version: beta-20160908
-build_time: 2016/09/08 15:37:08 (go1.7)
+version: beta-20160915
+build_time: 2016/09/15 14:59:17 (go1.7.1)

--- a/beta-20160915.md
+++ b/beta-20160915.md
@@ -34,6 +34,13 @@ summary: Additions and changes in CockroachDB version beta-20160915.
 - The internal replica queues can now time out and recover from a replica that gets stuck. [#9312](https://github.com/cockroachdb/cockroach/pull/9312)
 - Removed a redundant verification process that periodically scanned over all data. [#9333](https://github.com/cockroachdb/cockroach/pull/9333)
 
+### Doc Updates
+
+- Added docs for [deploying CockroachDB on AWS](deploy-cockroachdb-on-aws.html). [#640](https://github.com/cockroachdb/docs/pull/640)
+- Added a "back to top" feature to improve the usability of longer pages. [#638](https://github.com/cockroachdb/docs/pull/638)
+- Updated [Start a Local Cluster](start-a-local-cluster.html) to suggest manually setting each node's cache size to avoid memory errors when testing against a local cluster in a serious way. [#652](https://github.com/cockroachdb/docs/pull/652)
+- Updated docs on [transaction retries](transactions.html#transaction-retries) to provide the correct error code. [#647](https://github.com/cockroachdb/docs/pull/647) 
+
 ### Contributors
 
 This release includes 66 merged PRs by 17 authors.

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -176,7 +176,7 @@ $(document).ready(function(){
         <p>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.6.2. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code class="highlighter-rouge">$GOPATH</code> and <code class="highlighter-rouge">$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</p>
       </li>
       <li>
-        <p>Git 2.5+</p>
+        <p>Git 1.8+</p>
       </li>
       <li>
         <p><a href="https://www.gnu.org/software/bash/">Bash</a></p>
@@ -330,7 +330,7 @@ $(document).ready(function(){
         <p>A <a href="http://golang.org/doc/code.html">Go environment</a> with a 64-bit version of Go 1.6.2. You can download the <a href="https://golang.org/dl/">Go binary</a> directly from the official site. Be sure to set the <code class="highlighter-rouge">$GOPATH</code> and <code class="highlighter-rouge">$PATH</code> environment variables as described <a href="https://golang.org/doc/code.html#GOPATH">here</a>.</p>
       </li>
       <li>
-        <p>Git 2.5+</p>
+        <p>Git 1.8+</p>
       </li>
       <li>
         <p><a href="https://www.gnu.org/software/bash/">Bash</a></p>


### PR DESCRIPTION
This PR adds doc updates to the release notes and reverts the minimum required Git version for building from source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/662)
<!-- Reviewable:end -->
