### PR TITLE
Add missing backslash to fix multi-line command

### DIFF
--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -49,7 +49,7 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
 
 ~~~ shell
 $ docker run -d --name=roach1 --hostname=roach1 --net=roachnet -p 26257:26257 -p 8080:8080  \
--v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data"  
+-v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data"  \
 cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
 ~~~
 


### PR DESCRIPTION
Make it so that copying and pasting the command directly into a terminal works, not leaving off the last line.

@jseldess

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/664)
<!-- Reviewable:end -->
