### PR TITLE
Transaction-based SQL docs

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -118,6 +118,9 @@ entries:
                 - title: <code>ROLLBACK</code>
                   url: /rollback-transaction.html
 
+                - title: <code>SAVEPOINT</code>
+                  url: /savepoint.html
+
                 - title: <code>SELECT</code>
                   url: /select.html
 

--- a/_includes/sql/diagrams/begin_transaction.html
+++ b/_includes/sql/diagrams/begin_transaction.html
@@ -1,72 +1,62 @@
-<svg width="694" height="450">
+<svg width="740" height="406">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
-         <rect x="53" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="51" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="61" y="21">BEGIN</text>
-         <rect x="155" y="35" width="118" height="32" rx="10"></rect>
-         <rect x="153" y="33" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="163" y="53">TRANSACTION</text>
-         <rect x="53" y="79" width="62" height="32" rx="10"></rect>
-         <rect x="51" y="77" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="61" y="97">START</text>
-         <rect x="135" y="79" width="118" height="32" rx="10"></rect>
-         <rect x="133" y="77" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="97">TRANSACTION</text>
-         <rect x="45" y="165" width="98" height="32" rx="10"></rect>
-         <rect x="43" y="163" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="183">ISOLATION</text>
-         <rect x="163" y="165" width="60" height="32" rx="10"></rect>
-         <rect x="161" y="163" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="171" y="183">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="243" y="165" width="74" height="32"></rect>
-            <rect x="241" y="163" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="251" y="183">iso_level</text>
-         </a>
-         <rect x="357" y="197" width="24" height="32" rx="10"></rect>
-         <rect x="355" y="195" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="365" y="215">,</text>
-         <rect x="401" y="197" width="88" height="32" rx="10"></rect>
-         <rect x="399" y="195" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="409" y="215">PRIORITY</text>
-         <rect x="529" y="197" width="52" height="32" rx="10"></rect>
-         <rect x="527" y="195" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="537" y="215">LOW</text>
-         <rect x="529" y="241" width="78" height="32" rx="10"></rect>
-         <rect x="527" y="239" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="537" y="259">NORMAL</text>
-         <rect x="529" y="285" width="56" height="32" rx="10"></rect>
-         <rect x="527" y="283" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="537" y="303">HIGH</text>
-         <rect x="45" y="329" width="88" height="32" rx="10"></rect>
-         <rect x="43" y="327" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="347">PRIORITY</text>
-         <rect x="173" y="329" width="52" height="32" rx="10"></rect>
-         <rect x="171" y="327" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="181" y="347">LOW</text>
-         <rect x="173" y="373" width="78" height="32" rx="10"></rect>
-         <rect x="171" y="371" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="181" y="391">NORMAL</text>
-         <rect x="173" y="417" width="56" height="32" rx="10"></rect>
-         <rect x="171" y="415" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="181" y="435">HIGH</text>
-         <rect x="311" y="361" width="24" height="32" rx="10"></rect>
-         <rect x="309" y="359" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="319" y="379">,</text>
-         <rect x="355" y="361" width="98" height="32" rx="10"></rect>
-         <rect x="353" y="359" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="363" y="379">ISOLATION</text>
-         <rect x="473" y="361" width="60" height="32" rx="10"></rect>
-         <rect x="471" y="359" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="481" y="379">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="553" y="361" width="74" height="32"></rect>
-            <rect x="551" y="359" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="561" y="379">iso_level</text>
-         </a>
-         <path class="line" d="m19 17 h2 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m-260 -32 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v56 m280 0 v-56 m-280 56 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m62 0 h10 m0 0 h10 m118 0 h10 m0 0 h40 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-332 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h612 m-642 0 h20 m622 0 h20 m-662 0 q10 0 10 10 m642 0 q0 -10 10 -10 m-652 10 v12 m642 0 v-12 m-642 12 q0 10 10 10 m622 0 q10 0 10 -10 m-632 10 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h280 m-310 0 h20 m290 0 h20 m-330 0 q10 0 10 10 m310 0 q0 -10 10 -10 m-320 10 v12 m310 0 v-12 m-310 12 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m52 0 h10 m0 0 h26 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m56 0 h10 m0 0 h22 m-592 -130 v20 m642 0 v-20 m-642 20 v144 m642 0 v-144 m-642 144 q0 10 10 10 m622 0 q10 0 10 -10 m-632 10 h10 m88 0 h10 m20 0 h10 m52 0 h10 m0 0 h26 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m56 0 h10 m0 0 h22 m40 -88 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m43 -228 h-3"></path>
-         <polygon points="685 147 693 143 693 151"></polygon>
-         <polygon points="685 147 677 143 677 151"></polygon>
+         <rect x="33" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">BEGIN</text>
+         <rect x="135" y="35" width="118" height="32" rx="10"></rect>
+         <rect x="133" y="33" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="53">TRANSACTION</text>
+         <rect x="45" y="121" width="142" height="32" rx="10"></rect>
+         <rect x="43" y="119" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="139">ISOLATION LEVEL</text>
+         <rect x="227" y="121" width="94" height="32" rx="10"></rect>
+         <rect x="225" y="119" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="139">SNAPSHOT</text>
+         <rect x="227" y="165" width="116" height="32" rx="10"></rect>
+         <rect x="225" y="163" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="183">SERIALIZABLE</text>
+         <rect x="403" y="153" width="24" height="32" rx="10"></rect>
+         <rect x="401" y="151" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="411" y="171">,</text>
+         <rect x="447" y="153" width="88" height="32" rx="10"></rect>
+         <rect x="445" y="151" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="455" y="171">PRIORITY</text>
+         <rect x="575" y="153" width="52" height="32" rx="10"></rect>
+         <rect x="573" y="151" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="171">LOW</text>
+         <rect x="575" y="197" width="78" height="32" rx="10"></rect>
+         <rect x="573" y="195" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="215">NORMAL</text>
+         <rect x="575" y="241" width="56" height="32" rx="10"></rect>
+         <rect x="573" y="239" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="259">HIGH</text>
+         <rect x="45" y="285" width="88" height="32" rx="10"></rect>
+         <rect x="43" y="283" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="303">PRIORITY</text>
+         <rect x="173" y="285" width="52" height="32" rx="10"></rect>
+         <rect x="171" y="283" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="303">LOW</text>
+         <rect x="173" y="329" width="78" height="32" rx="10"></rect>
+         <rect x="171" y="327" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="347">NORMAL</text>
+         <rect x="173" y="373" width="56" height="32" rx="10"></rect>
+         <rect x="171" y="371" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="391">HIGH</text>
+         <rect x="311" y="317" width="24" height="32" rx="10"></rect>
+         <rect x="309" y="315" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="319" y="335">,</text>
+         <rect x="355" y="317" width="142" height="32" rx="10"></rect>
+         <rect x="353" y="315" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="363" y="335">ISOLATION LEVEL</text>
+         <rect x="537" y="317" width="94" height="32" rx="10"></rect>
+         <rect x="535" y="315" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="545" y="335">SNAPSHOT</text>
+         <rect x="537" y="361" width="116" height="32" rx="10"></rect>
+         <rect x="535" y="359" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="545" y="379">SERIALIZABLE</text>
+         <path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h658 m-688 0 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v12 m688 0 v-12 m-688 12 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m142 0 h10 m20 0 h10 m94 0 h10 m0 0 h22 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m40 -44 h10 m0 0 h280 m-310 0 h20 m290 0 h20 m-330 0 q10 0 10 10 m310 0 q0 -10 10 -10 m-320 10 v12 m310 0 v-12 m-310 12 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m52 0 h10 m0 0 h26 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m56 0 h10 m0 0 h22 m-638 -130 v20 m688 0 v-20 m-688 20 v144 m688 0 v-144 m-688 144 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m88 0 h10 m20 0 h10 m52 0 h10 m0 0 h26 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m56 0 h10 m0 0 h22 m40 -88 h10 m0 0 h372 m-402 0 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v12 m402 0 v-12 m-402 12 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m24 0 h10 m0 0 h10 m142 0 h10 m20 0 h10 m94 0 h10 m0 0 h22 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m63 -272 h-3"></path>
+         <polygon points="731 103 739 99 739 107"></polygon>
+         <polygon points="731 103 723 99 723 107"></polygon>
       </svg>

--- a/_includes/sql/diagrams/commit_transaction.html
+++ b/_includes/sql/diagrams/commit_transaction.html
@@ -1,17 +1,14 @@
-<svg width="352" height="80">
+<svg width="312" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">COMMIT</text>
-         <rect x="51" y="47" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">END</text>
-         <rect x="187" y="35" width="118" height="32" rx="10"></rect>
-         <rect x="185" y="33" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="195" y="53">TRANSACTION</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m48 0 h10 m0 0 h28 m40 -44 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m23 -32 h-3"></path>
-         <polygon points="343 17 351 13 351 21"></polygon>
-         <polygon points="343 17 335 13 335 21"></polygon>
+         <rect x="31" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">COMMIT</text>
+         <rect x="147" y="35" width="118" height="32" rx="10"></rect>
+         <rect x="145" y="33" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="53">TRANSACTION</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m23 -32 h-3"></path>
+         <polygon points="303 17 311 13 311 21"></polygon>
+         <polygon points="303 17 295 13 295 21"></polygon>
       </svg>

--- a/_includes/sql/diagrams/iso_level.html
+++ b/_includes/sql/diagrams/iso_level.html
@@ -1,29 +1,14 @@
-<svg width="336" height="212">
+<svg width="214" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">READ</text>
-         <rect x="147" y="3" width="122" height="32" rx="10"></rect>
-         <rect x="145" y="1" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="155" y="21">UNCOMMITTED</text>
-         <rect x="147" y="47" width="102" height="32" rx="10"></rect>
-         <rect x="145" y="45" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="155" y="65">COMMITTED</text>
-         <rect x="51" y="91" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">SNAPSHOT</text>
-         <rect x="51" y="135" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">REPEATABLE</text>
-         <rect x="175" y="135" width="56" height="32" rx="10"></rect>
-         <rect x="173" y="133" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="183" y="153">READ</text>
-         <rect x="51" y="179" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">SERIALIZABLE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m20 0 h10 m122 0 h10 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-258 -44 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v68 m278 0 v-68 m-278 68 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m94 0 h10 m0 0 h144 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m104 0 h10 m0 0 h10 m56 0 h10 m0 0 h58 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m116 0 h10 m0 0 h122 m23 -176 h-3"></path>
-         <polygon points="327 17 335 13 335 21"></polygon>
-         <polygon points="327 17 319 13 319 21"></polygon>
+         <rect x="51" y="3" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">SNAPSHOT</text>
+         <rect x="51" y="47" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SERIALIZABLE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m94 0 h10 m0 0 h22 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m23 -44 h-3"></path>
+         <polygon points="205 17 213 13 213 21"></polygon>
+         <polygon points="205 17 197 13 197 21"></polygon>
       </svg>

--- a/_includes/sql/diagrams/release_savepoint.html
+++ b/_includes/sql/diagrams/release_savepoint.html
@@ -1,4 +1,4 @@
-<svg width="368" height="68">
+<svg width="446" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -8,12 +8,12 @@
          <rect x="149" y="35" width="98" height="32" rx="10"></rect>
          <rect x="147" y="33" width="98" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="157" y="53">SAVEPOINT</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="287" y="3" width="54" height="32"></rect>
-            <rect x="285" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="295" y="21">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m20 -32 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="359 17 367 13 367 21"></polygon>
-         <polygon points="359 17 351 13 351 21"></polygon>
+         
+            <rect x="287" y="3" width="132" height="32"></rect>
+            <rect x="285" y="1" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="295" y="21">cockroach_restart</text>
+         
+         <path class="line" d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m20 -32 h10 m132 0 h10 m3 0 h-3"></path>
+         <polygon points="437 17 445 13 445 21"></polygon>
+         <polygon points="437 17 429 13 429 21"></polygon>
       </svg>

--- a/_includes/sql/diagrams/rollback_transaction.html
+++ b/_includes/sql/diagrams/rollback_transaction.html
@@ -1,16 +1,25 @@
-<svg width="302" height="36">
+<svg width="736" height="100">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="92" height="32" rx="10"></rect>
          <rect x="29" y="1" width="92" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">ROLLBACK</text>
-         <a xlink:href="sql-grammar.html#opt_to_savepoint" xlink:title="opt_to_savepoint">
-            <rect x="143" y="3" width="132" height="32"></rect>
-            <rect x="141" y="1" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="151" y="21">opt_to_savepoint</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m92 0 h10 m0 0 h10 m132 0 h10 m3 0 h-3"></path>
-         <polygon points="293 17 301 13 301 21"></polygon>
-         <polygon points="293 17 285 13 285 21"></polygon>
+         <rect x="163" y="35" width="118" height="32" rx="10"></rect>
+         <rect x="161" y="33" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="171" y="53">TRANSACTION</text>
+         <rect x="341" y="35" width="38" height="32" rx="10"></rect>
+         <rect x="339" y="33" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="349" y="53">TO</text>
+         <rect x="419" y="67" width="98" height="32" rx="10"></rect>
+         <rect x="417" y="65" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="427" y="85">SAVEPOINT</text>
+         
+            <rect x="557" y="35" width="132" height="32"></rect>
+            <rect x="555" y="33" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="565" y="53">cockroach_restart</text>
+         
+         <path class="line" d="m17 17 h2 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m40 -32 h10 m0 0 h358 m-388 0 h20 m368 0 h20 m-408 0 q10 0 10 10 m388 0 q0 -10 10 -10 m-398 10 v12 m388 0 v-12 m-388 12 q0 10 10 10 m368 0 q10 0 10 -10 m-378 10 h10 m38 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m20 -32 h10 m132 0 h10 m23 -32 h-3"></path>
+         <polygon points="727 17 735 13 735 21"></polygon>
+         <polygon points="727 17 719 13 719 21"></polygon>
       </svg>

--- a/_includes/sql/diagrams/savepoint.html
+++ b/_includes/sql/diagrams/savepoint.html
@@ -1,19 +1,16 @@
-<svg width="388" height="68">
+<svg width="308" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="98" height="32" rx="10"></rect>
          <rect x="29" y="1" width="98" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">SAVEPOINT</text>
-         <rect x="169" y="35" width="98" height="32" rx="10"></rect>
-         <rect x="167" y="33" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="177" y="53">SAVEPOINT</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="307" y="3" width="54" height="32"></rect>
-            <rect x="305" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="315" y="21">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m98 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m20 -32 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="379 17 387 13 387 21"></polygon>
-         <polygon points="379 17 371 13 371 21"></polygon>
+         
+            <rect x="149" y="3" width="132" height="32"></rect>
+            <rect x="147" y="1" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="21">cockroach_restart</text>
+         
+         <path class="line" d="m17 17 h2 m0 0 h10 m98 0 h10 m0 0 h10 m132 0 h10 m3 0 h-3"></path>
+         <polygon points="299 17 307 13 307 21"></polygon>
+         <polygon points="299 17 291 13 291 21"></polygon>
       </svg>

--- a/_includes/sql/diagrams/set_transaction.html
+++ b/_includes/sql/diagrams/set_transaction.html
@@ -1,128 +1,62 @@
-<svg width="996" height="406">
+<svg width="740" height="354">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
          <rect x="33" y="3" width="44" height="32" rx="10"></rect>
          <rect x="31" y="1" width="44" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="41" y="21">SET</text>
-         <rect x="45" y="69" width="118" height="32" rx="10"></rect>
-         <rect x="43" y="67" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="87">TRANSACTION</text>
-         <rect x="203" y="69" width="98" height="32" rx="10"></rect>
-         <rect x="201" y="67" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="211" y="87">ISOLATION</text>
-         <rect x="321" y="69" width="60" height="32" rx="10"></rect>
-         <rect x="319" y="67" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="329" y="87">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="401" y="69" width="74" height="32"></rect>
-            <rect x="399" y="67" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="409" y="87">iso_level</text>
-         </a>
-         <rect x="515" y="101" width="24" height="32" rx="10"></rect>
-         <rect x="513" y="99" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="523" y="119">,</text>
-         <rect x="559" y="101" width="88" height="32" rx="10"></rect>
-         <rect x="557" y="99" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="567" y="119">PRIORITY</text>
-         <a xlink:href="sql-grammar.html#user_priority" xlink:title="user_priority">
-            <rect x="667" y="101" width="100" height="32"></rect>
-            <rect x="665" y="99" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="675" y="119">user_priority</text>
-         </a>
-         <rect x="203" y="145" width="88" height="32" rx="10"></rect>
-         <rect x="201" y="143" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="211" y="163">PRIORITY</text>
-         <a xlink:href="sql-grammar.html#user_priority" xlink:title="user_priority">
-            <rect x="311" y="145" width="100" height="32"></rect>
-            <rect x="309" y="143" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="319" y="163">user_priority</text>
-         </a>
-         <rect x="451" y="177" width="24" height="32" rx="10"></rect>
-         <rect x="449" y="175" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="459" y="195">,</text>
-         <rect x="495" y="177" width="98" height="32" rx="10"></rect>
-         <rect x="493" y="175" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="503" y="195">ISOLATION</text>
-         <rect x="613" y="177" width="60" height="32" rx="10"></rect>
-         <rect x="611" y="175" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="621" y="195">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="693" y="177" width="74" height="32"></rect>
-            <rect x="691" y="175" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="701" y="195">iso_level</text>
-         </a>
-         <rect x="45" y="221" width="82" height="32" rx="10"></rect>
-         <rect x="43" y="219" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="239">SESSION</text>
-         <rect x="167" y="221" width="146" height="32" rx="10"></rect>
-         <rect x="165" y="219" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="175" y="239">CHARACTERISTICS</text>
-         <rect x="333" y="221" width="38" height="32" rx="10"></rect>
-         <rect x="331" y="219" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="341" y="239">AS</text>
-         <rect x="391" y="221" width="118" height="32" rx="10"></rect>
-         <rect x="389" y="219" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="399" y="239">TRANSACTION</text>
-         <rect x="529" y="221" width="98" height="32" rx="10"></rect>
-         <rect x="527" y="219" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="537" y="239">ISOLATION</text>
-         <rect x="647" y="221" width="60" height="32" rx="10"></rect>
-         <rect x="645" y="219" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="655" y="239">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="727" y="221" width="74" height="32"></rect>
-            <rect x="725" y="219" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="735" y="239">iso_level</text>
-         </a>
-         <rect x="167" y="265" width="118" height="32" rx="10"></rect>
-         <rect x="165" y="263" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="175" y="283">TRANSACTION</text>
-         <rect x="325" y="265" width="98" height="32" rx="10"></rect>
-         <rect x="323" y="263" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="283">ISOLATION</text>
-         <rect x="443" y="265" width="60" height="32" rx="10"></rect>
-         <rect x="441" y="263" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="451" y="283">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="523" y="265" width="74" height="32"></rect>
-            <rect x="521" y="263" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="531" y="283">iso_level</text>
-         </a>
-         <rect x="637" y="297" width="24" height="32" rx="10"></rect>
-         <rect x="635" y="295" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="645" y="315">,</text>
-         <rect x="681" y="297" width="88" height="32" rx="10"></rect>
-         <rect x="679" y="295" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="689" y="315">PRIORITY</text>
-         <a xlink:href="sql-grammar.html#user_priority" xlink:title="user_priority">
-            <rect x="789" y="297" width="100" height="32"></rect>
-            <rect x="787" y="295" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="797" y="315">user_priority</text>
-         </a>
-         <rect x="325" y="341" width="88" height="32" rx="10"></rect>
-         <rect x="323" y="339" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="359">PRIORITY</text>
-         <a xlink:href="sql-grammar.html#user_priority" xlink:title="user_priority">
-            <rect x="433" y="341" width="100" height="32"></rect>
-            <rect x="431" y="339" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="441" y="359">user_priority</text>
-         </a>
-         <rect x="573" y="373" width="24" height="32" rx="10"></rect>
-         <rect x="571" y="371" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="581" y="391">,</text>
-         <rect x="617" y="373" width="98" height="32" rx="10"></rect>
-         <rect x="615" y="371" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="625" y="391">ISOLATION</text>
-         <rect x="735" y="373" width="60" height="32" rx="10"></rect>
-         <rect x="733" y="371" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="743" y="391">LEVEL</text>
-         <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="815" y="373" width="74" height="32"></rect>
-            <rect x="813" y="371" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="823" y="391">iso_level</text>
-         </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-96 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m118 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-282 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m100 0 h10 m-604 -32 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v56 m624 0 v-56 m-624 56 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m88 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m40 -108 h142 m-944 0 h20 m924 0 h20 m-964 0 q10 0 10 10 m944 0 q0 -10 10 -10 m-954 10 v132 m944 0 v-132 m-944 132 q0 10 10 10 m924 0 q10 0 10 -10 m-934 10 h10 m82 0 h10 m20 0 h10 m146 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m0 0 h128 m-802 0 h20 m782 0 h20 m-822 0 q10 0 10 10 m802 0 q0 -10 10 -10 m-812 10 v24 m802 0 v-24 m-802 24 q0 10 10 10 m782 0 q10 0 10 -10 m-792 10 h10 m118 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-282 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m100 0 h10 m-604 -32 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v56 m624 0 v-56 m-624 56 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m88 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m83 -304 h-3"></path>
-         <polygon points="987 83 995 79 995 87"></polygon>
-         <polygon points="987 83 979 79 979 87"></polygon>
+         <rect x="97" y="3" width="118" height="32" rx="10"></rect>
+         <rect x="95" y="1" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="105" y="21">TRANSACTION</text>
+         <rect x="45" y="69" width="142" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">ISOLATION LEVEL</text>
+         <rect x="227" y="69" width="94" height="32" rx="10"></rect>
+         <rect x="225" y="67" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="87">SNAPSHOT</text>
+         <rect x="227" y="113" width="116" height="32" rx="10"></rect>
+         <rect x="225" y="111" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="235" y="131">SERIALIZABLE</text>
+         <rect x="403" y="101" width="24" height="32" rx="10"></rect>
+         <rect x="401" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="411" y="119">,</text>
+         <rect x="447" y="101" width="88" height="32" rx="10"></rect>
+         <rect x="445" y="99" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="455" y="119">PRIORITY</text>
+         <rect x="575" y="101" width="52" height="32" rx="10"></rect>
+         <rect x="573" y="99" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="119">LOW</text>
+         <rect x="575" y="145" width="78" height="32" rx="10"></rect>
+         <rect x="573" y="143" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="163">NORMAL</text>
+         <rect x="575" y="189" width="56" height="32" rx="10"></rect>
+         <rect x="573" y="187" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="207">HIGH</text>
+         <rect x="45" y="233" width="88" height="32" rx="10"></rect>
+         <rect x="43" y="231" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="251">PRIORITY</text>
+         <rect x="173" y="233" width="52" height="32" rx="10"></rect>
+         <rect x="171" y="231" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="251">LOW</text>
+         <rect x="173" y="277" width="78" height="32" rx="10"></rect>
+         <rect x="171" y="275" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="295">NORMAL</text>
+         <rect x="173" y="321" width="56" height="32" rx="10"></rect>
+         <rect x="171" y="319" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="339">HIGH</text>
+         <rect x="311" y="265" width="24" height="32" rx="10"></rect>
+         <rect x="309" y="263" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="319" y="283">,</text>
+         <rect x="355" y="265" width="142" height="32" rx="10"></rect>
+         <rect x="353" y="263" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="363" y="283">ISOLATION LEVEL</text>
+         <rect x="537" y="265" width="94" height="32" rx="10"></rect>
+         <rect x="535" y="263" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="545" y="283">SNAPSHOT</text>
+         <rect x="537" y="309" width="116" height="32" rx="10"></rect>
+         <rect x="535" y="307" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="545" y="327">SERIALIZABLE</text>
+         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m0 0 h10 m118 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-234 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m142 0 h10 m20 0 h10 m94 0 h10 m0 0 h22 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m40 -44 h10 m0 0 h280 m-310 0 h20 m290 0 h20 m-330 0 q10 0 10 10 m310 0 q0 -10 10 -10 m-320 10 v12 m310 0 v-12 m-310 12 q0 10 10 10 m290 0 q10 0 10 -10 m-300 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m52 0 h10 m0 0 h26 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m56 0 h10 m0 0 h22 m-648 -120 h20 m668 0 h20 m-708 0 q10 0 10 10 m688 0 q0 -10 10 -10 m-698 10 v144 m688 0 v-144 m-688 144 q0 10 10 10 m668 0 q10 0 10 -10 m-678 10 h10 m88 0 h10 m20 0 h10 m52 0 h10 m0 0 h26 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m56 0 h10 m0 0 h22 m40 -88 h10 m0 0 h372 m-402 0 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v12 m402 0 v-12 m-402 12 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m24 0 h10 m0 0 h10 m142 0 h10 m20 0 h10 m94 0 h10 m0 0 h22 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m63 -240 h-3"></path>
+         <polygon points="731 83 739 79 739 87"></polygon>
+         <polygon points="731 83 723 79 723 87"></polygon>
       </svg>

--- a/begin-transaction.md
+++ b/begin-transaction.md
@@ -1,19 +1,18 @@
 ---
 title: BEGIN
-summary: Use the BEGIN statement to initiate a CockroachDB transaction.
+summary: Initiate a SQL transaction with the BEGIN statement in CockroachDB.
 toc: false
 ---
 
-The `BEGIN` [statement](sql-statements.html) initiates a [transaction](transactions.html), which bundles multiple SQL statements into a single all-or-nothing transaction. 
+The `BEGIN` [statement](sql-statements.html) initiates a [transaction](transactions.html), which either successfully executes all of the statements it contains or none at all.
+
+{{site.data.alerts.callout_danger}}When using transactions, your application should include logic to <a href="transactions.html#transaction-retries">retry transactions that fail because another concurrent or recent transaction accessed the same values</a>.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
 ## Synopsis
 
 {% include sql/diagrams/begin_transaction.html %}
-
-**iso_level ::=**
-{% include sql/diagrams/iso_level.html %}
 
 ## Required Privileges
 
@@ -24,16 +23,98 @@ No [privileges](privileges.html) are required to initiate a transaction. However
 In CockroachDB, the following are aliases for the `BEGIN` statement:
 
 - `BEGIN TRANSACTION` 
-- `START TRANSACTION` 
+- `START TRANSACTION`
+
+The following aliases also exist for [isolation levels](transactions.html#isolation-levels):
+
+- `REPEATABLE READ` is an alias for `SERIALIZABLE`
+- `READ UNCOMMITTED` and `READ COMMITTED` are aliases for `SNAPSHOT`
+
+For more information on isolation level aliases, see [Comparison to ANSI SQL Isolation Levels](transactions.html#comparison-to-ansi-sql-isolation-levels).
 
 ## Parameters
 
 | Parameter | Description |
 |-----------|-------------|
-|  |  |
+| `ISOLATION LEVEL` | If you don't want the transaction to run as `SERIALIZABLE` (CockroachDB's default, which provides the highest level of isolation), you can specify `SNAPSHOT`, which can provide better performance in high-contention scenarios.<br/><br/>For more information, see [Transactions: Isolation Levels](transactions.html#isolation-levels).<br/><br/>**Default**: `SERIALIZABLE` |
+| `PRIORITY` | If you don't want the transaction to run with `NORMAL` priority, you can set it to `LOW` or `HIGH`.<br/><br/>Transactions with higher priority are less likely to need to be retried.<br/><br/>For more information, see [Transactions: Priorities](transactions.html#transaction-priorities).<br/><br/>**Default**: `NORMAL` |
+
+## Examples
+
+### Begin a Transaction
+
+#### Use Default Settings
+
+Without modifying the `BEGIN` statement, the transaction uses `SERIALIZABLE` isolation and `NORMAL` priority.
+
+~~~ sql
+> BEGIN;
+
+> SAVEPOINT cockroach_restart;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, sku, status) VALUES (1001, '8675309', 'new');
+
+> RELEASE SAVEPOINT cockroach_restart;
+
+> COMMIT;
+~~~
+
+{{site.data.alerts.callout_danger}}This example assumes you're using <a href="transactions.html#client-side-intervention">client-side intervention to handle transaction retries</a>.{{site.data.alerts.end}}
+
+#### Change Isolation Level & Priority
+
+You can set a transaction's isolation level to `SNAPSHOT`, as well as its priority to `LOW` or `HIGH`.
+
+~~~ sql
+> BEGIN ISOLATION LEVEL SNAPSHOT, PRIORITY HIGH;
+
+> SAVEPOINT cockroach_restart;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, sku, status) VALUES (1001, '8675309', 'new');
+
+> RELEASE SAVEPOINT cockroach_restart;
+
+> COMMIT;
+~~~
+
+You can also set a transaction's isolation level and priority with [`SET TRANSACTION`](set-transaction.html).
+
+{{site.data.alerts.callout_danger}}This example assumes you're using <a href="transactions.html#client-side-intervention">client-side intervention to handle transaction retries</a>.{{site.data.alerts.end}}
+
+### Begin a Transaction with Automatic Retries
+
+CockroachDB will [automatically retry](transactions.html#transaction-retries) all transactions that contain both `BEGIN` and `COMMIT` in the same batch. Batching is controlled by your driver or client's behavior, but means that CockroachDB receives all of the statements as a single unit, instead of a number of requests. 
+  
+From the perspective of CockroachDB, a transaction sent as a batch looks like this:
+
+~~~ sql
+> BEGIN; DELETE FROM customers WHERE id = 1; DELETE orders WHERE customer = 1; COMMIT;
+~~~
+
+However, in your application's code, batched transactions are often just multiple statements sent at once. For example, in Go, this transaction would sent as a single batch (and automatically retried):
+  
+~~~ go
+db.Exec(
+  "BEGIN; 
+
+  DELETE FROM customers WHERE id = 1; 
+
+  DELETE orders WHERE customer = 1; 
+
+  COMMIT;"
+)
+~~~
+
+Issuing statements this way signals to CockroachDB that you do not need to change any of the statement's values if the transaction doesn't immediately succeed, so it can continually retry the transaction until it's accepted.
 
 ## See Also
 
 - [Transactions](transactions.html)
 - [`COMMIT`](commit-transaction.html)
+- [`SAVEPOINT`](savepoint.html)
+- [`RELEASE SAVEPOINT`](release-savepoint.html)
 - [`ROLLBACK`](rollback-transaction.html)

--- a/commit-transaction.md
+++ b/commit-transaction.md
@@ -1,10 +1,16 @@
 ---
 title: COMMIT
-summary: Use the COMMIT statement to commit a transaction.
-toc: true
+summary: Commit a transaction with the COMMIT statement in CockroachDB.
+toc: false
 ---
 
-## Description
+The `COMMIT` [statement](sql-statements.html) commits the current [transaction](transactions.html) or, when using [client-side transaction retries](transactions.html#client-side-transaction-retries), clears the connection to allow new transactions to begin.
+
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), statements issued after [`SAVEPOINT cockroach_restart`](savepoint.html) are committed when [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html) is issued instead of `COMMIT`. However, you must still issue a `COMMIT` statement to clear the connection for the next transaction.
+
+For non-retryable transactions, if statements in the transaction [generated any errors](transactions.html#error-handling), `COMMIT` is equivalent to `ROLLBACK`, which aborts the transaction and discards *all* updates made by its statements.
+
+<div id="toc"></div>
 
 ## Synopsis
 
@@ -12,16 +18,50 @@ toc: true
 
 ## Required Privileges
 
-No [privileges](privileges.html) are required to commit a transaction. 
+No [privileges](privileges.html) are required to commit a transaction. However, privileges are required for each statement within a transaction.
 
-## Parameters
+## Aliases
 
-| Parameter | Description |
-|-----------|-------------|
-|  |  |
+In CockroachDB, `END` is an alias for the `COMMIT` statement.
+
+## Example
+
+### Commit a Transaction
+
+How you commit transactions depends on how your application handles [transaction retries](transactions.html#transaction-retries).
+
+#### Client-Side Retryable Transactions
+
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), statements are committed by [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html). `COMMIT` itself only clears the connection for the next transaction.
+
+~~~ sql
+> BEGIN;
+
+> SAVEPOINT cockroach_restart;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, sku, status) VALUES (1001, '8675309', 'new');
+
+> RELEASE SAVEPOINT cockroach_restart;
+
+> COMMIT;
+~~~
+
+{{site.data.alerts.callout_danger}}This example assumes you're using <a href="transactions.html#client-side-intervention">client-side intervention to handle transaction retries</a>.{{site.data.alerts.end}}
+
+#### Automatically Retried Transactions
+
+If you are using transactions that CockroachDB will [automatically retry](transactions.html#automatic-retries) (i.e., all statements sent in a single batch), commit the transaction with `COMMIT`.
+
+~~~ sql
+> BEGIN; UPDATE products SET inventory = 100 WHERE = '8675309'; UPDATE products SET inventory = 100 WHERE = '8675310'; COMMIT;
+~~~
 
 ## See Also
 
 - [Transactions](transactions.html)
-- [BEGIN](begin-transaction.html)
-- [ROLLBACK](rollback-transaction.html)
+- [`BEGIN`](begin-transaction.html)
+- [`RELEASE SAVEPOINT`](release-savepoint.html)
+- [`ROLLBACK`](rollback-transaction.html)
+- [`SAVEPOINT`](savepoint.html)

--- a/generate/main.go
+++ b/generate/main.go
@@ -194,8 +194,10 @@ func main() {
 				{
 					name:   "begin_transaction",
 					stmt:   "transaction_stmt",
-					inline: []string{"opt_transaction", "opt_transaction_mode_list", "transaction_iso_level", "transaction_user_priority", "user_priority"},
-					match:  []*regexp.Regexp{regexp.MustCompile("'BEGIN'|'START'")},
+					inline: []string{"opt_transaction", "opt_transaction_mode_list", "transaction_iso_level", "transaction_user_priority", "user_priority", "iso_level"},
+					match:  []*regexp.Regexp{regexp.MustCompile("'BEGIN'")},
+					exclude: []*regexp.Regexp{regexp.MustCompile("'READ'")},
+					replace: map[string]string{"'ISOLATION' 'LEVEL'": "'ISOLATION LEVEL'"},
 				},
 				{name: "column_def"},
 				{name: "col_qual_list", stmt: "col_qual_list", inline: []string{"col_qualification", "col_qualification_elem"}, replace: map[string]string{"| 'REFERENCES' qualified_name opt_name_parens": ""}},
@@ -309,7 +311,7 @@ func main() {
 					replace: map[string]string{"var_name": "'DATABASE'", "var_list": "database_name"},
 					unlink:  []string{"database_name"},
 				},
-				{name: "set_transaction", stmt: "set_stmt", inline: []string{"set_rest", "transaction_mode_list", "transaction_iso_level", "transaction_user_priority"}, replace: map[string]string{" | set_rest_more": ""}, match: []*regexp.Regexp{regexp.MustCompile("'TRANSACTION'")}},
+				{name: "set_transaction", stmt: "set_stmt", inline: []string{"set_rest", "transaction_mode_list", "transaction_iso_level", "transaction_user_priority", "iso_level", "user_priority"}, match: []*regexp.Regexp{regexp.MustCompile("'SET' 'TRANSACTION'")}, exclude: []*regexp.Regexp{regexp.MustCompile("'READ'")}, replace: map[string]string{"'ISOLATION' 'LEVEL'" : "'ISOLATION LEVEL'"}},
 				{name: "show_all", stmt: "show_stmt", match: []*regexp.Regexp{regexp.MustCompile("'SHOW' 'ALL'")}},
 				{name: "show_columns", stmt: "show_stmt", match: []*regexp.Regexp{regexp.MustCompile("'SHOW' 'COLUMNS'")}, replace: map[string]string{"var_name": "table_name"}, unlink: []string{"table_name"}},
 				{name: "show_constraints", stmt: "show_stmt", match: []*regexp.Regexp{regexp.MustCompile("'SHOW' 'CONSTRAINTS'")}, replace: map[string]string{"var_name": "table_name"}, unlink: []string{"table_name"}},
@@ -364,6 +366,7 @@ func main() {
 					if printBNF {
 						fmt.Printf("%s: (PRE REPLACE)\n\n%s\n", s.name, g)
 					}
+					fmt.Println(s.name, string(g))
 					for from, to := range s.replace {
 						g = bytes.Replace(g, []byte(from), []byte(to), -1)
 					}

--- a/release-savepoint.md
+++ b/release-savepoint.md
@@ -1,10 +1,16 @@
 ---
-title: RELEASE SAVEPOINT
-summary: The RELEASE SAVEPOINT cockroach_restart statement commits a transaction's changes once there are no retryable errors.
+title: RELEASE SAVEPOINT cockroach_restart
+summary: Commit a transaction's changes once there are no retryable errors with the RELEASE SAVEPOINT cockroach_restart statement in CockroachDB.
 toc: false
 ---
 
-When using the CockroachDB-provided function for client-side transaction retries, the `RELEASE SAVEPOINT cockroach_restart` statement commits the transaction's changes once there are no retryable errors. `RELEASE SAVEPOINT` is supported only for this special savepoint. For more details, see [Transaction Retries](transactions.html#transaction-retries).  
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), the `RELEASE SAVEPOINT cockroach_restart` statement commits the transaction.
+
+If statements in the transaction [generated any non-retryable errors](transactions.html#error-handling), `RELEASE SAVEPOINT cockroach_restart` is equivalent to [`ROLLBACK`](rollback-transaction.html), which aborts the transaction and discards *all* updates made by its statements.
+
+Despite committing the transaction, you must still issue a [`COMMIT`](commit-transaction.html) statement to prepare the connection for the next transaction.
+
+{{site.data.alerts.callout_danger}}CockroachDB’s <code>SAVEPOINT</code> implementation only supports the <code>cockroach_restart</code> savepoint and does not support all savepoint functionality, such as nested transactions.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -16,15 +22,32 @@ When using the CockroachDB-provided function for client-side transaction retries
 
 No [privileges](privileges.html) are required to release a savepoint. However, privileges are required for each statement within a transaction.
 
-## Parameters
+## Examples
 
-| Parameter | Description |
-|-----------|-------------|
-|  |  |
+### Commit a Transaction
+
+After declaring `SAVEPOINT cockroach_restart`, commit the transaction with `RELEASE SAVEPOINT cockroach_restart` and then prepare the connection for the next transaction with `COMMIT`.
+
+~~~ sql
+> BEGIN;
+
+> SAVEPOINT cockroach_restart;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, sku, status) VALUES (1001, '8675309', 'new');
+
+> RELEASE SAVEPOINT cockroach_restart;
+
+> COMMIT;
+~~~
+
+{{site.data.alerts.callout_danger}}This example assumes you're using <a href="transactions.html#client-side-intervention">client-side intervention to handle transaction retries</a>.{{site.data.alerts.end}}
 
 ## See Also
 
-- [Transaction Retries](transactions.html#transaction-retries)
+- [Transactions](transactions.html)
+- [`SAVEPOINT`](savepoint.html)
+- [`ROLLBACK`](rollback-transaction.html)
 - [`BEGIN`](begin-transaction.html)
 - [`COMMIT`](commit-transaction.html)
-- [`ROLLBACK`](rollback-transaction.html)

--- a/savepoint.md
+++ b/savepoint.md
@@ -1,19 +1,49 @@
 ---
 title: SAVEPOINT
-toc: true
+summary: Identify your intent to retry aborted transactions with the SAVEPOINT cockroach_restart statement in CockroachDB.
+toc: false
 ---
 
-## Description
+The `SAVEPOINT cockroach_restart` statement defines the intent to retry [transactions](transactions.html) using the CockroachDB-provided function for client-side transaction retries. For more information, see [Transaction Retries](transactions.html#transaction-retries).
+
+{{site.data.alerts.callout_danger}}CockroachDB’s <code>SAVEPOINT</code> implementation only supports the <code>cockroach_restart</code> savepoint and does not support all savepoint functionality, such as nested transactions.{{site.data.alerts.end}}
+
+<div id="toc"></div>
  
 ## Synopsis
 
 {% include sql/diagrams/savepoint.html %}
 
-## Privileges
+## Required Privileges
 
-## Parameters
+No [privileges](privileges.html) are required to create a savepoint. However, privileges are required for each statement within a transaction.
 
-| Parameter | Description |
-|-----------|-------------|
-|  |  |
+## Example
 
+### Create Savepoint
+
+After you `BEGIN` the transaction, you must create the savepoint to identify that if the transaction contends with another transaction for resources and "loses", you intend to use [the function for client-side transaction retries](transactions.html#transaction-retries).
+
+~~~ sql
+> BEGIN;
+
+> SAVEPOINT cockroach_restart;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, sku, status) VALUES (1001, '8675309', 'new');
+
+> RELEASE SAVEPOINT cockroach_restart;
+
+> COMMIT;
+~~~
+
+When using `SAVEPOINT`, your application must also include functions to execute retries with [`ROLLBACK TO cockroach_restart`](rollback-transaction.html#retry-a-transaction).
+
+## See Also
+
+- [Transactions](transactions.html)
+- [`RELEASE SAVEPOINT`](release-savepoint.html)
+- [`ROLLBACK`](rollback-transaction.html)
+- [`BEGIN`](begin-transaction.html)
+- [`COMMIT`](commit-transaction.html)

--- a/set-transaction.md
+++ b/set-transaction.md
@@ -4,7 +4,9 @@ summary: The SET TRANSACTION statement sets the transaction isolation level and/
 toc: false
 ---
 
-The `SET TRANSACTION` [statement](sql-statements.html) sets the transaction isolation level and/or priority for the current session or for an individual [transaction](transactions.html).
+The `SET TRANSACTION` [statement](sql-statements.html) sets the transaction isolation level or priority after you [`BEGIN`](begin-transaction.html) it but before executing the first statement that manipulates a database.
+
+{{site.data.alerts.callout_info}}You can also set the session's default isolation level.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -14,12 +16,71 @@ The `SET TRANSACTION` [statement](sql-statements.html) sets the transaction isol
 
 ## Required Privileges
 
-No [privileges](privileges.html) are required to set the transaction isolation level and/or priority. However, privileges are required for each statement within a transaction.
+No [privileges](privileges.html) are required to set the transaction isolation level or priority. However, privileges are required for each statement within a transaction.
 
 ## Parameters
 
 | Parameter | Description |
 |-----------|-------------|
-|  |  |
+| `ISOLATION LEVEL` | If you don't want the transaction to run as `SERIALIZABLE` (CockroachDB's default, which provides the highest level of isolation), you can set the isolation level to `SNAPSHOT`, which can provide better performance in high-contention scenarios.<br/><br/>For more information, see [Transactions: Isolation Levels](transactions.html#isolation-levels).<br/><br/>**Default**: `SERIALIZABLE` |
+| `PRIORITY` | If you don't want the transaction to run with `NORMAL` priority, you can set it to `LOW` or `HIGH`.<br/><br/>Transactions with higher priority are less likely to need to be retried.<br/><br/>For more information, see [Transactions: Priorities](transactions.html#transaction-priorities).<br/><br/>**Default**: `NORMAL` |
 
+## Examples
 
+### Set Isolation & Priority
+
+You can set a transaction's isolation level to `SNAPSHOT`, as well as its priority to `LOW` or `HIGH`.
+
+~~~ sql
+> BEGIN;
+
+> SET TRANSACTION ISOLATION LEVEL SNAPSHOT, PRIORITY HIGH;
+
+> SAVEPOINT cockroach_restart;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, sku, status) VALUES (1001, '8675309', 'new');
+
+> RELEASE SAVEPOINT cockroach_restart;
+
+> COMMIT;
+~~~
+
+{{site.data.alerts.callout_danger}}This example assumes you're using <a href="transactions.html#client-side-intervention">client-side intervention to handle transaction retries</a>.{{site.data.alerts.end}}
+
+### Set Session's Default Isolation
+
+You can also set the default isolation level for all transactions in the client's current session using `SET DEFAULT_TRANSACTION_ISOLATION TO <isolation level>`.
+
+~~~ sql
+> SHOW TRANSACTION ISOLATION LEVEL;
+~~~
+~~~
++-----------------------------+
+| TRANSACTION ISOLATION LEVEL |
++-----------------------------+
+| SERIALIZABLE                |
++-----------------------------+
+~~~
+~~~ sql
+> SET DEFAULT_TRANSACTION_ISOLATION TO SNAPSHOT
+
+> SHOW TRANSACTION ISOLATION LEVEL;
+~~~
+~~~
++-----------------------------+
+| TRANSACTION ISOLATION LEVEL |
++-----------------------------+
+| SNAPSHOT                    |
++-----------------------------+
+~~~
+
+## See Also
+
+- [Transactions](transactions.html)
+- [`BEGIN`](begin-transaction.html)
+- [`COMMIT`](commit-transaction.html)
+- [`SAVEPOINT`](savepoint.html)
+- [`RELEASE SAVEPOINT`](release-savepoint.html)
+- [`ROLLBACK`](rollback-transaction.html)

--- a/show-transaction.md
+++ b/show-transaction.md
@@ -5,7 +5,9 @@ keywords: reflection
 toc: false
 ---
 
-The `SHOW TRANSACTION` [statement](sql-statements.html) lists the default transaction isolation level or transaction priority for the current session or for an individual [transaction](transactions.html).
+The `SHOW TRANSACTION` [statement](sql-statements.html) shows you the current transaction's [priority](transactions.html#transaction-priorities) or [isolation level](transactions.html#isolation-levels).
+
+{{site.data.alerts.callout_info}}<code>SHOW TRANSACTION</code> can be run outside of transactions but simply returns <code>NORMAL</code> priority and <code>SERIALIZABLE</code> isolation level.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -17,8 +19,48 @@ The `SHOW TRANSACTION` [statement](sql-statements.html) lists the default transa
 
 No [privileges](privileges.html) are required to view transaction isolation level or priority.
 
-## Parameters
+## Examples
 
-| Parameter | Description |
-|-----------|-------------|
-|  |  |
+### Show the Transaction's Isolation Level
+
+~~~ sql
+> BEGIN;
+
+> SET TRANSACTION ISOLATION LEVEL SNAPSHOT, PRIORITY HIGH;
+
+> SHOW TRANSACTION ISOLATION LEVEL;
+~~~
+~~~
++-----------------------------+
+| TRANSACTION ISOLATION LEVEL |
++-----------------------------+
+| SNAPSHOT                    |
++-----------------------------+
+~~~
+
+### Show the Transaction's Priority
+
+~~~ sql
+> BEGIN;
+
+> SET TRANSACTION ISOLATION LEVEL SNAPSHOT, PRIORITY HIGH;
+
+> SHOW TRANSACTION PRIORITY;
+~~~
+~~~
++----------------------+
+| TRANSACTION PRIORITY |
++----------------------+
+| HIGH                 |
++----------------------+
+~~~
+
+## See Also
+
+- [Transactions](transactions.html)
+- [`SET TRANSACTION`](set-transaction.html)
+- [`BEGIN`](begin-transaction.html)
+- [`COMMIT`](commit-transaction.html)
+- [`SAVEPOINT`](savepoint.html)
+- [`RELEASE SAVEPOINT`](release-savepoint.html)
+- [`ROLLBACK`](rollback-transaction.html)

--- a/transactions.md
+++ b/transactions.md
@@ -10,92 +10,229 @@ CockroachDB supports bundling multiple SQL statements into a single all-or-nothi
 
 <div id="toc"></div>
 
+## SQL Statements
+
+Each of the following SQL statements control transactions in some way.
+
+| Statement | Function |
+|-----------|----------|
+| [`BEGIN`](begin-transaction.html) | Initiate a transaction, as well as control its [priority](#transaction-priorities) and [isolation level](#isolation-levels). |
+| [`SET TRANSACTION`](set-transaction.html) | Control a transaction's [priority](#transaction-priorities) and [isolation level](#isolation-levels). |
+| [`SAVEPOINT cockroach_restart`](savepoint.html) | Declare the transaction as [retryable](#client-side-transaction-retries). This lets you retry the transaction if it doesn't succeed because a higher priority transaction concurrently or recently accessed the same values. |
+| [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html) | Commit a [retryable transaction](#client-side-transaction-retries). |
+| [`COMMIT`](commit-transaction.html) | Commit a non-retryable transaction or clear the connection after committing a retryable transaction. |
+| [`ROLLBACK cockroach_restart`](rollback-transaction.html) | Handle [retryable errors](#error-handling) by rolling back a transaction's changes and increasing its priority. |
+| [`ROLLBACK`](rollback-transaction.html) | Abort a transaction and roll the database back to its state before the transaction began. |
+| [`SHOW TRANSACTION`](show-transaction.html) | Retrieve a transaction's [priority](#transaction-priorities) or [isolation level](#isolation-levels). |
+
 ## Syntax
 
-In CockroachDB, a transaction is set up by surrounding SQL statements with the [`BEGIN`](begin-transaction.html) and [`COMMIT`](commit-transaction.html) statements:
+In CockroachDB, a transaction is set up by surrounding SQL statements with the [`BEGIN`](begin-transaction.html) and [`COMMIT`](commit-transaction.html) statements.
+
+To use [client-side transaction retries](#client-side-transaction-retries), you should also include the `cockroach_restart` statements, `SAVEPOINT` and `RELEASE SAVEPOINT`.
 
 ~~~ sql
 > BEGIN;
-<other statements>
+
+> SAVEPOINT cockroach_restart;
+
+<transaction statements>
+
+> RELEASE SAVEPOINT cockroach_restart;
+
 > COMMIT;
 ~~~
 
-If at any point in the transaction you decide to abort all updates, you can issue the [`ROLLBACK`](rollback-transaction.html) statement instead of the `COMMIT` statement.
+At any time before it's committed, you can abort the transaction by executing the [`ROLLBACK`](rollback-transaction.html) statement.
+
+Clients using transactions must also include logic to handle [retries](#transaction-retries).
+
+## Error Handling
+
+To handle errors in transactions, you should listen for the following types of server-side errors:
+
+- **Retryable Errors**: Errors with the code `40001` or string `retry transaction`, which indicate the transaction failed because another concurrent or recent transaction accessed the same values. To handle these errors, you should [retry the transaction](#client-side-transaction-retries).
+
+- **Ambiguous Errors**: Errors with the code `XX000` that are returned in response to `RELEASE SAVEPOINT` (or `COMMIT` when not using `SAVEPOINT`), which indicate that the state of the transaction is ambiguous, i.e., you cannot assume it either committed or failed. How you handle these errors depends on how you want to resolve the ambiguity.
+
+  For example, you might want to read values from the database to see if the transaction successfully wrote values before attempting to write the values again or, alternatively, you might write the data again without seeing if the first write attempt succeeded.
+
+- **SQL Errors**: All other errors, which indicate that a statement in the transaction failed. For example, violating the `UNIQUE` constraint generates an `23505` error. After encountering these errors, you can either issue a `COMMIT` or `ROLLBACK` to abort the transaction and revert the database to its state before the transaction began.
+
+  If you want to attempt the same set of statements again, you must begin a completely new transaction.
 
 ## Transaction Retries
 
-Transactions in CockroachDB do not explicitly lock their data resources. Instead, using [optimistic concurrency control (OCC)](https://en.wikipedia.org/wiki/Optimistic_concurrency_control), CockroachDB proceeds with transactions under the assumption that there’s no contention until commit time. In cases without contention, this results in higher performance than explicit locking would allow. With contention, however, one of the conflicting transactions must be retried or aborted.
+Transactions in CockroachDB do not explicitly lock their data resources. Instead, using [optimistic concurrency control (OCC)](https://en.wikipedia.org/wiki/Optimistic_concurrency_control), CockroachDB proceeds with transactions under the assumption that there’s no contention until commit time. In cases without contention, this results in higher performance than explicit locking would allow. With contention, however, the transaction with the highest priority succeeds and any other transactions must be retried or aborted.
 
-Individual statements, which are treated as implicit transactions, and statements batched between `BEGIN` and `COMMIT`, are retried automatically by the CockroachDB server. Transactions involving business logic, however, must be retried from the client. For example, when a transaction depends on values read from the database, reads after a retry can return different results than before the retry, and so the follow-up logic may be different. 
+For transactions that do not succeed because of contention, CockroachDB has two cases:
 
-To assist with client-side retries, CockroachDB provides a generic **retry function** that runs inside a transaction and retries it as needed. For Go, this function is available as a library. For other languages, it can be copy and pasted directly into your application code. See [Build a Test App](build-a-test-app.html#step-4-execute-transactions-from-a-client) for the code. 
+- [Automatic retries](#automatic-retries), which CockroachDB processes for you.
+- [Client-side intervention](#client-side-intervention), which your application must handle.
 
-**How the retry function works:**
+### Automatic Retries
 
-1. The transaction starts.
+In cases of contention, CockroachDB automatically retries any of the following types of transactions:
 
-2. The `SAVEPOINT cockroach_restart` statement defines the intention to retry the transaction in the case of CockroachDB-retryable errors. Note that CockroachDB's savepoint implementation does not support all savepoint functionality, such as nested transactions. 
+- Individual statements (which are treated as implicit transactions), such as:
+
+  ~~~ sql
+  > DELETE FROM customers WHERE id = 1;
+  ~~~
+
+- Transactions sent from the client as a single batch. Batching is controlled by your driver or client's behavior, but means that CockroachDB receives all of the statements as a single unit, instead of a number of requests. 
+  
+  From the perspective of CockroachDB, a transaction sent as a batch looks like this:
+
+  ~~~ sql
+  > BEGIN; DELETE FROM customers WHERE id = 1; DELETE orders WHERE customer = 1; COMMIT;
+  ~~~
+
+  However, in your application's code, batched transactions are often just multiple statements sent at once. For example, in Go, this transaction would sent as a single batch (and automatically retried):
+  
+  ~~~ go
+  db.Exec(
+    "BEGIN; 
+
+    DELETE FROM customers WHERE id = 1; 
+
+    DELETE orders WHERE customer = 1; 
+
+    COMMIT;"
+  )
+  ~~~
+
+In these cases, CockroachDB infers there is nothing conditional about these values, so it can continue to retry the transaction with the same values it originally received.
+
+However, if the transaction relies on conditional logic, you should instead write your transactions to use [client-side intervention](#client-side-intervention). This provides an opportunity for the client to check the transaction's conditions before deciding whether or not to retry the transaction, as well as update any values.
+
+### Client-Side Intervention
+
+In cases of contention, your application should include error handling when the statements are sent individually, such as:
+
+~~~ sql
+> BEGIN;
+
+> UPDATE products SET inventory = 0 WHERE sku = '8675309';
+
+> INSERT INTO orders (customer, status) VALUES (1, 'new');
+
+> COMMIT;
+~~~
+
+To alert you of failures due to contention, CockroachDB surfaces an error with the code `40001` that begins with the string `retry transaction`.
+
+To handle these types of errors you have two options:
+
+- *Recommended*: Use the `SAVEPOINT cockroach_restart` functions to create retryable transactions. Retryable transactions can improve performance because their priority's increased each time they are retried, making them more likely to succeed the longer they're in your system. 
+
+  For more information, see [Client-Side Transaction Retries](#client-side-transaction-retries).
+
+- Abort the transaction using `ROLLBACK`, and then reissue all of the statements in the transaction. This does *not* automatically increase the transaction's priority, so it's possible in high-contention workloads for transactions to take an incredibly long time to succeed.
+
+#### Client-Side Transaction Retries
+
+To improve the performance of transactions that fail due to contention, CockroachDB includes a set of statements that let you retry those transactions. Retrying transactions has the benefit of increasing their priority each time they're retried, increasing their likelihood to succeed.
+
+Retried transactions are also issued at a later timestamp, so the transaction now operates on a later snapshot of the database, which so the reads might return updated data
+
+Implementing client-side retries requires three statements:
+
+- [`SAVEPOINT cockroach_restart`](savepoint.html) declares the client's intent to retry the transaction if there are contention errors. It must be executed after `BEGIN` but before the first statement that manipulates a database.
+
+- [`ROLLBACK TO cockroach_restart`](rollback-transaction.html#retry-a-transaction) is used when your application detects `40001` / `retry transaction` errors. It provides you a chance to "retry" the transaction by rolling the database's state back to the beginning of the transaction and increasing the transaction's priority. 
+  
+  After issuing `ROLLBACK TO cockroach_restart`, you must issue any statements you want the transaction to contain. Typically, this means recalculating values and reissuing a similar set of statements to the previous attempt.
+
+- [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html) commits the transaction. At this point, CockroachDB checks to see if the transaction contends with others for access to the same values; the highest priority transaction succeeds, and the others return `40001` / `retry transaction` errors.
+  
+  You must also execute `COMMIT` afterward to clear the connection for the next transaction.
+
+You can find examples of this in the [Syntax](#syntax) section of this page or at our page [Build a Test App: Execute transaction from a client](build-a-test-app.html#step-4-execute-transactions-from-a-client).
+
+{{site.data.alerts.callout_success}}If you're building an application in the following languages, we have packages to make client-side retries simpler:
+<ul>
+  <li><strong>Go</strong> developers can use the <code>crdb</code> package of the CockroachDB Go client. For more information, see the <strong>Go</strong> tab of <a href="build-a-test-app.html#step-4-execute-transactions-from-a-client">Build a Test App: Execute transaction from a client</a>.</li>
+  <li><strong>Python</strong> developers can use the <code>sqlalchemy</code> package. For more information, see our blog post <a href="https://www.cockroachlabs.com/blog/building-application-cockroachdb-sqlalchemy-2/">Building an Application With CockroachDB and SQLAlchemy</a>.</li>
+</ul>{{site.data.alerts.end}}
+
+It's also important to note that retried transactions are restarted at a later timestamp. This means that the transaction operates on a later snapshot of the database and related reads might retrieve updated data.
+
+For greater detail, here's the process a retryable transaction goes through.
+
+1. The transaction starts with the `BEGIN` statement.
+
+2. The `SAVEPOINT cockroach_restart` statement declares the intention to retry the transaction in the case of contention errors. Note that CockroachDB's savepoint implementation does not support all savepoint functionality, such as nested transactions. 
 
 3. The statements in the transaction are executed. 
 
-4. If a statement returns a retryable error (identified via the `40001` error code or `restart transaction` string at the start of the error message), the [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html) statement restarts the transaction. Alternately, the original `SAVEPOINT cockroach_restart` statement can be reissued to restart the transaction.
+4. If a statement returns a retryable error (identified via the `40001` error code or `retry transaction` string at the start of the error message), you can issue the [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html) statement to restart the transaction. Alternately, the original `SAVEPOINT cockroach_restart` statement can be reissued to restart the transaction.
+	
+	You must now issue the statements in the transaction again.
 
-   In cases where you do not want the application to retry the transaction, you can adapt the wrapper function to simply `ROLLBACK` at this point. Any other statements will be rejected by the server, as is generally the case after an error has been encountered and the transaction has not been closed.
+	In cases where you do not want the application to retry the transaction, you can simply issue `ROLLBACK` at this point. Any other statements will be rejected by the server, as is generally the case after an error has been encountered and the transaction has not been closed.
 
-5. When there are no retryable errors, the [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html) statement commits the changes. If this succeeds, all changes made by the transaction become visible to subsequent transactions and are guaranteed to be durable if a crash occurs.
+5. Once the transaction executes all statements without encountering contention errors, execute [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html) to commit the changes. If this succeeds, all changes made by the transaction become visible to subsequent transactions and are guaranteed to be durable if a crash occurs.
 
-   In some cases, the `RELEASE SAVEPOINT` statement itself can fail with a retryable error, mainly because transactions in CockroachDB only realize that they need to be restarted when they attempt to commit. If this happens, the retryable error is handled as described in step 4.
-
-{{site.data.alerts.callout_info}}In CockroachDB, individual statements and statements batched between <code>BEGIN</code> and <code>COMMIT</code> are considered implicit transactions and are retried automatically by the server; no special error handling is needed.{{site.data.alerts.end}}
+	In some cases, the `RELEASE SAVEPOINT` statement itself can fail with a retryable error, mainly because transactions in CockroachDB only realize that they need to be restarted when they attempt to commit. If this happens, the retryable error is handled as described in step 4.
 
 ## Transaction Priorities
 
 Every transaction in CockroachDB is assigned an initial **priority**. By default, that priority is `NORMAL`, but for transactions that should be given preference in high-contention scenarios, the client can set the priority within the [`BEGIN`](begin-transaction.html) statement:
 
 ~~~ sql
-> BEGIN PRIORITY <LOW, NORMAL, HIGH>;
+> BEGIN PRIORITY <LOW | NORMAL | HIGH>;
 ~~~
 
 Alternately, the client can set the priority immediately after the transaction is started as follows:
 
 ~~~ sql
-> SET TRANSACTION PRIORITY <LOW, NORMAL, HIGH>;
+> SET TRANSACTION PRIORITY <LOW | NORMAL | HIGH>;
 ~~~
 
 {{site.data.alerts.callout_info}}When two transactions contend for the same resource, the one with the lower priority loses and is retried. On retry, the transaction inherits the priority of the winner. This means that each retry makes a transaction stronger and more likely to succeed.{{site.data.alerts.end}}
 
 ## Isolation Levels
 
-CockroachDB supports two transaction isolation levels: `SNAPSHOT ISOLATION` and `SERIALIZABLE`. By default, transactions use the `SERIALIZABLE` isolation level, but the client can explicitly set a transaction's isolation when starting the transaction:
+CockroachDB supports two transaction isolation levels: `SERIALIZABLE` and `SNAPSHOT`. By default, transactions use the `SERIALIZABLE` isolation level, but the client can explicitly set a transaction's isolation when starting the transaction:
 
 ~~~ sql
-> BEGIN ISOLATION LEVEL <ANSI SQL ISOLATION LEVEL>;
+> BEGIN ISOLATION LEVEL <SERIALIZABLE | SNAPSHOT>;
 ~~~
 
 Alternately, the client can set the isolation level immediately after the transaction is started:
 
 ~~~ sql
-> SET TRANSACTION ISOLATION LEVEL <ANSI SQL ISOLATION LEVEL>;
+> SET TRANSACTION ISOLATION LEVEL <SERIALIZABLE | SNAPSHOT>;
 ~~~
 
 {{site.data.alerts.callout_info}}For a detailed discussion of isolation in CockroachDB transactions, see <a href="https://www.cockroachlabs.com/blog/serializable-lockless-distributed-isolation-cockroachdb/">Serializable, Lockless, Distributed: Isolation in CockroachDB</a>.{{site.data.alerts.end}}
 
-### SERIALIZABLE ISOLATION
+### Serializable Isolation
 
 With `SERIALIZABLE` isolation, a transaction behaves as though it has the entire database all to itself for the duration of its execution. This means that no concurrent writers can affect the transaction unless they commit before it starts, and no concurrent readers can be affected by the transaction until it has successfully committed. This is the strongest level of isolation provided by CockroachDB and it's the default. 
 
-Unlike `SNAPSHOT ISOLATION`, `SERIALIZABLE` isolation permits no anomalies. However, due to CockroachDB's transaction model, `SERIALIZABLE` isolation may require more transaction restarts, especially in the presence of high contention between concurrent transactions. Consider using `SNAPSHOT ISOLATION` for high contention workloads.
+Unlike `SNAPSHOT`, `SERIALIZABLE` isolation permits no anomalies. However, due to CockroachDB's transaction model, `SERIALIZABLE` isolation may require more transaction restarts, especially in the presence of high contention between concurrent transactions. Consider using `SNAPSHOT` isolation for high contention workloads.
 
-### SNAPSHOT ISOLATION
+### Snapshot Isolation
 
-With `SNAPSHOT ISOLATION`, a transaction behaves as if it
-were reading the state of the database consistently at a fixed point in time. Unlike the `SERIALIZABLE` level, `SNAPSHOT ISOLATION` permits the [write skew](https://en.wikipedia.org/wiki/Snapshot_isolation) anomaly, but in cases where write skew conditions are unlikely, this isolation level can be highly performant.  
+With `SNAPSHOT` isolation, a transaction behaves as if it were reading the state of the database consistently at a fixed point in time. Unlike the `SERIALIZABLE` level, `SNAPSHOT` isolation permits the [write skew](https://en.wikipedia.org/wiki/Snapshot_isolation) anomaly, but in cases where write skew conditions are unlikely, this isolation level can be highly performant.
 
-### Comparison to [ANSI SQL Isolation Levels](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Isolation_levels)
+### Comparison to ANSI SQL Isolation Levels
 
-The CockroachDB `SERIALIZABLE` level is stronger than the ANSI SQL `REPEATABLE READ` level and equivalent to the ANSI SQL `SERIALIZABLE` level.
+CockroachDB uses slightly different isolation levels than [ANSI SQL isolation levels](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Isolation_levels).
 
-The CockroachDB `SNAPSHOT ISOLATION` level is stronger than the ANSI SQL `READ UNCOMMITTED` and `READ COMMITTED` levels.
+#### Aliases
+
+- `REPEATABLE READ` is an alias for `SERIALIZABLE`.
+- `READ UNCOMMITTED` and `READ COMMITTED` are aliases for `SNAPSHOT`.
+
+{{site.data.alerts.callout_success}}Despite similarity in names, <code>REPEATABLE READ</code> does <em>not</em> equate to <code>SNAPSHOT</code> in CockroachDB. We made this choice to avoid potential confusion between them and the anomalies they can introduce. <code>REPEATABLE READ</code> permits the <a href="https://en.wikipedia.org/wiki/Isolation_(database_systems)#Phantom_reads">phantom read</a> anomaly, while <code>SNAPSHOT</code> permits the <a href="https://en.wikipedia.org/wiki/Snapshot_isolation">write skew</a> anomaly.{{site.data.alerts.end}}
+
+#### Comparison
+
+- The CockroachDB `SERIALIZABLE` level is stronger than the ANSI SQL `REPEATABLE READ` level and equivalent to the ANSI SQL `SERIALIZABLE` level.
+- The CockroachDB `SNAPSHOT` level is stronger than the ANSI SQL `READ UNCOMMITTED` and `READ COMMITTED` levels. 
 
 For more information about the relationship between these levels, see [this paper](http://arxiv.org/ftp/cs/papers/0701/0701157.pdf).
 
@@ -104,5 +241,6 @@ For more information about the relationship between these levels, see [this pape
 - [`BEGIN`](begin-transaction.html)
 - [`COMMIT`](commit-transaction.html)
 - [`ROLLBACK`](rollback-transaction.html)
+- [`SAVEPOINT`](savepoint.html)
 - [`RELEASE SAVEPOINT`](release-savepoint.html)
 - [Retryable function code samples](build-a-test-app.html#step-4-execute-transactions-from-a-client)


### PR DESCRIPTION
Contains documents for:
- `BEGIN`
- `COMMIT`
- `SET TRANSACTION`
- `SAVEPOINT cockroach_restart`
- `RELEASE SAVEPOINT cockroach_restart`
- `ROLLBACK`
- `SHOW TRANSACTION`

And integrates these links into `transactions.html`

Closes #491, #254, #253

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/672)

<!-- Reviewable:end -->
