### PR TITLE
canonical link fix

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="canonical" href="{{ site.baseurl }}{{ page.url | replace:'index.html',''}}" data-proofer-ignore>
+<link rel="canonical" href="{{ site.baseurl }}{% if page.url != '/index.html' %}{{ page.url }}{% endif %}" data-proofer-ignore>
 <link rel="shortcut icon" href="images/favicon.png" type="image/png">
 
 <link rel="stylesheet" type="text/css" href="css/font-awesome.min.css">


### PR DESCRIPTION
pages with index.html in url have incomplete urls for the canonical links

/docs/create-index.html
/docs/drop-index.html
/docs/rename-index.html
/docs/show-index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/702)
<!-- Reviewable:end -->
