### PR TITLE
Canonical URL to include domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@ homepage_title: CockroachDB Docs
 site_title: Cockroach Labs
 google_analytics: UA-63775601-1
 
+url: "https://www.cockroachlabs.com"
 baseurl: "/docs"
 
 highlighter: rouge

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="canonical" href="{{ site.baseurl }}{% if page.url != '/index.html' %}{{ page.url }}{% endif %}" data-proofer-ignore>
+<link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{% if page.url != '/index.html' %}{{ page.url }}{% endif %}" data-proofer-ignore>
 <link rel="shortcut icon" href="images/favicon.png" type="image/png">
 
 <link rel="stylesheet" type="text/css" href="css/font-awesome.min.css">


### PR DESCRIPTION
Adding `https://www.cockroachlabs.com` to canonical URL, per [Google's advice](https://support.google.com/webmasters/answer/139066?hl=en).

@jess-edwards first step in fixing URLs. The other work items will be moved into Team City.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/725)
<!-- Reviewable:end -->
