### PR TITLE
tracking installs from release notes

### DIFF
--- a/beta-20160929.md
+++ b/beta-20160929.md
@@ -8,8 +8,24 @@ summary: Additions and changes in CockroachDB version beta-20160929.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160929.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160929.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160929.darwin-10.9-amd64.tgz" data-eventcategory="mac-binary-release-notes"><button id="mac">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160929.linux-amd64.tgz" data-eventcategory="linux-binary-release-notes"><button id="linux">Linux</button></a>
+</div>
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
 
 ### New Features
 


### PR DESCRIPTION
To track mac and linux binary downloads from release notes pages, I created new Google Tags/Triggers. Here I'm adding the corresponding data-eventcategory attributes to the links on just one release note page so we can verify that the change works. I've also changed the binary links from text to OS buttons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/730)
<!-- Reviewable:end -->
