### PR TITLE
update binary links on all past release notes

### DIFF
--- a/beta-20160407.md
+++ b/beta-20160407.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160407.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160407.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160407.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160407.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160407.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Backwards-incompatible Changes
 
@@ -90,3 +92,19 @@ especially
 
 * Kenji Kaneda
 * Seif Lotfy
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160414.md
+++ b/beta-20160414.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160414.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160414.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160414.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160414.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160414.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Backwards-incompatible Changes
 
@@ -99,3 +101,19 @@ especially
 * Kenji Kaneda
 * Seif Lotfy
 * es-chow
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160421.md
+++ b/beta-20160421.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160421.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160421.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160421.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160421.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160421.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Upgrade Procedure
 
@@ -104,3 +106,19 @@ especially first-time contributor
 * Kenjiro Nakayama
 * Lu Guanqun
 * Seif Lotfy
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160428.md
+++ b/beta-20160428.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160428.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160428.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160428.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160428.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160428.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Backwards-Incompatible Changes
 
@@ -71,3 +73,19 @@ especially first-time contributor
 
 * Karl Southern
 * Kenjiro Nakayama
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160505.md
+++ b/beta-20160505.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160505.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160505.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160505.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160505.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160505.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### New Features
 
@@ -84,3 +86,19 @@ thank the following contributors from the CockroachDB community, especially firs
 * il9ue
 * Kenji Kaneda
 * Paul Steffensen
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160512.md
+++ b/beta-20160512.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160512.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160512.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160512.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160512.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160512.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Upgrade Procedure
 
@@ -54,3 +56,19 @@ This release includes 87 merged PRs by 18 authors. We would like to
 thank the following contributor from the CockroachDB community:
 
 * Kenji Kaneda
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160519.md
+++ b/beta-20160519.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160519.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160519.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160519.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160519.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160519.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Backwards-Incompatible Changes
 
@@ -52,3 +54,19 @@ thank the following contributor from the CockroachDB community:
 
 * Kenji Kaneda
 * Paul Steffensen
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160526.md
+++ b/beta-20160526.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160526.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160526.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160526.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160526.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160526.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### Backwards-Incompatible Changes
 
@@ -45,3 +47,19 @@ This release includes 58 merged PRs by 16 authors. We would like to
 thank the following contributor from the CockroachDB community:
 
 * Kenji Kaneda
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160602.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160602.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160602.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160602.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160602.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### New Features
 
@@ -41,3 +43,19 @@ thank the following contributors from the CockroachDB community, especially firs
 - Sean Loiselle
 - Thanakom Sangnetra
 - Paul Steffensen
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160609.md
+++ b/beta-20160609.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160609.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160609.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160609.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160609.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160609.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
  
 ### New Features
 
@@ -45,3 +47,19 @@ thank the following contributors from the CockroachDB community, especially firs
 - Alex Robinson
 - Kenji Kaneda
 - Paul Steffensen
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160616.md
+++ b/beta-20160616.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160616.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160616.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160616.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160616.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160616.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### Deprecation Notice
 
@@ -53,3 +55,19 @@ thank the following contributors from the CockroachDB community:
 
 - Kenji Kaneda
 - Paul Steffensen
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160629.md
+++ b/beta-20160629.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160629.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160629.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160629.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160629.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160629.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### New Features
 
@@ -63,3 +65,19 @@ thank the following contributors from the CockroachDB community, especially firs
 - Jingguo Yao
 - Kenji Kaneda
 - phynalle
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160714.md
+++ b/beta-20160714.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160714.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160714.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160714.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160714.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160714.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### Upgrade Notes
 
@@ -75,3 +77,19 @@ thank the following contributors from the CockroachDB community, especially firs
 - Kenji Kaneda
 - Sean Loiselle
 - songhao
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160721.md
+++ b/beta-20160721.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160721.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160721.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160721.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160721.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160721.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### New Features
 
@@ -52,3 +54,19 @@ summary: Additions and changes in CockroachDB version beta-20160721.
 
 This release includes 76 merged PRs by 21 authors. We would especially like to
 thank first-time contributors [Christian Meunier](https://github.com/cockroachdb/cockroach/pull/7937) and [Dharmesh Kakadia](https://github.com/dharmeshkakadia) from the CockroachDB community.
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160728.md
+++ b/beta-20160728.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160728.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160728.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160728.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160728.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160728.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### New Features
 
@@ -40,3 +42,19 @@ summary: Additions and changes in CockroachDB version beta-20160728.
 ### Contributors
 
 This release includes 63 merged PRs by 17 authors. We would like to thank first-time contributor [Rushi Agrawal](https://github.com/cockroachdb/cockroach/pull/7876) from the CockroachDB community.
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160829.md
+++ b/beta-20160829.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160829.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160829.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160829.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160829.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160829.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### General Changes
 
@@ -81,3 +83,19 @@ This release includes 280 merged PRs by 26 authors. We would like to thank the f
 - Christian Koep
 - Dolf Schimmel
 - songhao
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160908.md
+++ b/beta-20160908.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160908.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160908.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160908.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160908.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160908.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### General Changes
 
@@ -53,3 +55,19 @@ summary: Additions and changes in CockroachDB version beta-20160908.
 ### Contributors
 
 This release includes 180 merged PRs by 17 authors. We would like to thank first-time contributor [Henry Escobar](https://github.com/HenryEscobar) from the CockroachDB community.
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160915.md
+++ b/beta-20160915.md
@@ -8,8 +8,10 @@ summary: Additions and changes in CockroachDB version beta-20160915.
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20160915.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20160915.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160915.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20160915.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### General Changes
 
@@ -44,3 +46,19 @@ summary: Additions and changes in CockroachDB version beta-20160915.
 ### Contributors
 
 This release includes 66 merged PRs by 17 authors.
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20160929.md
+++ b/beta-20160929.md
@@ -13,20 +13,6 @@ summary: Additions and changes in CockroachDB version beta-20160929.
     <a href="https://binaries.cockroachdb.com/cockroach-beta-20160929.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
 </div>
 
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>
-
 ### New Features
 
 - The [`--advertise-host`](start-a-node.html#flags) flag can now be used to override the address to advertise to other CockroachDB nodes. [#9503](https://github.com/cockroachdb/cockroach/pull/9503)
@@ -71,3 +57,19 @@ This release includes 78 merged PRs by 19 authors. We would like to thank the fo
 
 - Haines Chan
 - Jingguo Yao
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/beta-20161006.md
+++ b/beta-20161006.md
@@ -10,8 +10,10 @@ There aren't many user-visible changes in this week's release - an artifact of o
 
 ### Binaries
 
-- [Mac](https://binaries.cockroachdb.com/cockroach-beta-20161006.darwin-10.9-amd64.tgz)
-- [Linux](https://binaries.cockroachdb.com/cockroach-beta-20161006.linux-amd64.tgz)
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20161006.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20161006.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
 
 ### Internal Changes
 
@@ -27,3 +29,20 @@ There aren't many user-visible changes in this week's release - an artifact of o
     - [Strict Serializability (Linearizability)](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md#strict-serializability-linearizability) [#9644](https://github.com/cockroachdb/cockroach/pull/9644)
     - [Node and Cluster Metrics](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md#node-and-cluster-metrics) [#9647](https://github.com/cockroachdb/cockroach/pull/9647)
     - [SQL](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md#sql) [#9651](https://github.com/cockroachdb/cockroach/pull/9651)
+
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>


### PR DESCRIPTION
This PR updates the binary links on all past release notes. The links are now OS buttons with a `data-eventcategory` attribute that lets us track left-click and right-click installs.

Fixes #731

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/733)
<!-- Reviewable:end -->
