### PR TITLE
Remove LOCAL from set diagrams

### DIFF
--- a/_includes/sql/diagrams/grammar.html
+++ b/_includes/sql/diagrams/grammar.html
@@ -819,44 +819,41 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="set_stmt" href="#set_stmt">set_stmt:</a></p>
-      <svg width="750" height="222">
+      <svg width="750" height="190">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
          <rect x="33" y="3" width="44" height="32" rx="10"></rect>
          <rect x="31" y="1" width="44" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="41" y="21">SET</text>
-         <rect x="65" y="101" width="64" height="32" rx="10"></rect>
-         <rect x="63" y="99" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="73" y="119">LOCAL</text>
          <a xlink:href="#set_rest" xlink:title="set_rest">
-            <rect x="169" y="69" width="72" height="32"></rect>
-            <rect x="167" y="67" width="72" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="177" y="87">set_rest</text>
+            <rect x="45" y="69" width="72" height="32"></rect>
+            <rect x="43" y="67" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="87">set_rest</text>
          </a>
-         <rect x="45" y="145" width="82" height="32" rx="10"></rect>
-         <rect x="43" y="143" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="163">SESSION</text>
-         <rect x="167" y="145" width="146" height="32" rx="10"></rect>
-         <rect x="165" y="143" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="175" y="163">CHARACTERISTICS</text>
-         <rect x="333" y="145" width="38" height="32" rx="10"></rect>
-         <rect x="331" y="143" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="341" y="163">AS</text>
-         <rect x="391" y="145" width="118" height="32" rx="10"></rect>
-         <rect x="389" y="143" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="399" y="163">TRANSACTION</text>
+         <rect x="45" y="113" width="82" height="32" rx="10"></rect>
+         <rect x="43" y="111" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="131">SESSION</text>
+         <rect x="167" y="113" width="146" height="32" rx="10"></rect>
+         <rect x="165" y="111" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="175" y="131">CHARACTERISTICS</text>
+         <rect x="333" y="113" width="38" height="32" rx="10"></rect>
+         <rect x="331" y="111" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="341" y="131">AS</text>
+         <rect x="391" y="113" width="118" height="32" rx="10"></rect>
+         <rect x="389" y="111" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="399" y="131">TRANSACTION</text>
          <a xlink:href="#transaction_iso_level" xlink:title="transaction_iso_level">
-            <rect x="529" y="145" width="154" height="32"></rect>
-            <rect x="527" y="143" width="154" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="163">transaction_iso_level</text>
+            <rect x="529" y="113" width="154" height="32"></rect>
+            <rect x="527" y="111" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="537" y="131">transaction_iso_level</text>
          </a>
          <a xlink:href="#set_rest" xlink:title="set_rest">
-            <rect x="167" y="189" width="72" height="32"></rect>
-            <rect x="165" y="187" width="72" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="175" y="207">set_rest</text>
+            <rect x="167" y="157" width="72" height="32"></rect>
+            <rect x="165" y="155" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="175" y="175">set_rest</text>
          </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-96 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h10 m72 0 h10 m0 0 h462 m-698 0 h20 m678 0 h20 m-718 0 q10 0 10 10 m698 0 q0 -10 10 -10 m-708 10 v56 m698 0 v-56 m-698 56 q0 10 10 10 m678 0 q10 0 10 -10 m-688 10 h10 m82 0 h10 m20 0 h10 m146 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m154 0 h10 m-556 0 h20 m536 0 h20 m-576 0 q10 0 10 10 m556 0 q0 -10 10 -10 m-566 10 v24 m556 0 v-24 m-556 24 q0 10 10 10 m536 0 q10 0 10 -10 m-546 10 h10 m72 0 h10 m0 0 h444 m43 -120 h-3"></path>
+         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-96 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m72 0 h10 m0 0 h586 m-698 0 h20 m678 0 h20 m-718 0 q10 0 10 10 m698 0 q0 -10 10 -10 m-708 10 v24 m698 0 v-24 m-698 24 q0 10 10 10 m678 0 q10 0 10 -10 m-688 10 h10 m82 0 h10 m20 0 h10 m146 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m154 0 h10 m-556 0 h20 m536 0 h20 m-576 0 q10 0 10 10 m556 0 q0 -10 10 -10 m-566 10 v24 m556 0 v-24 m-556 24 q0 10 10 10 m536 0 q10 0 10 -10 m-546 10 h10 m72 0 h10 m0 0 h444 m43 -88 h-3"></path>
          <polygon points="741 83 749 79 749 87"></polygon>
          <polygon points="741 83 733 79 733 87"></polygon>
       </svg>

--- a/_includes/sql/diagrams/set_transaction.html
+++ b/_includes/sql/diagrams/set_transaction.html
@@ -5,55 +5,52 @@
          <rect x="33" y="3" width="44" height="32" rx="10"></rect>
          <rect x="31" y="1" width="44" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="41" y="21">SET</text>
-         <rect x="65" y="101" width="64" height="32" rx="10"></rect>
-         <rect x="63" y="99" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="73" y="119">LOCAL</text>
-         <rect x="169" y="69" width="118" height="32" rx="10"></rect>
-         <rect x="167" y="67" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="177" y="87">TRANSACTION</text>
-         <rect x="327" y="69" width="98" height="32" rx="10"></rect>
-         <rect x="325" y="67" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="335" y="87">ISOLATION</text>
-         <rect x="445" y="69" width="60" height="32" rx="10"></rect>
-         <rect x="443" y="67" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="453" y="87">LEVEL</text>
+         <rect x="45" y="69" width="118" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">TRANSACTION</text>
+         <rect x="203" y="69" width="98" height="32" rx="10"></rect>
+         <rect x="201" y="67" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="211" y="87">ISOLATION</text>
+         <rect x="321" y="69" width="60" height="32" rx="10"></rect>
+         <rect x="319" y="67" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="329" y="87">LEVEL</text>
          <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="525" y="69" width="74" height="32"></rect>
-            <rect x="523" y="67" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="533" y="87">iso_level</text>
+            <rect x="401" y="69" width="74" height="32"></rect>
+            <rect x="399" y="67" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="409" y="87">iso_level</text>
          </a>
-         <rect x="639" y="101" width="24" height="32" rx="10"></rect>
-         <rect x="637" y="99" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="647" y="119">,</text>
-         <rect x="683" y="101" width="88" height="32" rx="10"></rect>
-         <rect x="681" y="99" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="691" y="119">PRIORITY</text>
+         <rect x="515" y="101" width="24" height="32" rx="10"></rect>
+         <rect x="513" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="523" y="119">,</text>
+         <rect x="559" y="101" width="88" height="32" rx="10"></rect>
+         <rect x="557" y="99" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="567" y="119">PRIORITY</text>
          <a xlink:href="sql-grammar.html#user_priority" xlink:title="user_priority">
-            <rect x="791" y="101" width="100" height="32"></rect>
-            <rect x="789" y="99" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="799" y="119">user_priority</text>
+            <rect x="667" y="101" width="100" height="32"></rect>
+            <rect x="665" y="99" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="675" y="119">user_priority</text>
          </a>
-         <rect x="327" y="145" width="88" height="32" rx="10"></rect>
-         <rect x="325" y="143" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="335" y="163">PRIORITY</text>
+         <rect x="203" y="145" width="88" height="32" rx="10"></rect>
+         <rect x="201" y="143" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="211" y="163">PRIORITY</text>
          <a xlink:href="sql-grammar.html#user_priority" xlink:title="user_priority">
-            <rect x="435" y="145" width="100" height="32"></rect>
-            <rect x="433" y="143" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="443" y="163">user_priority</text>
+            <rect x="311" y="145" width="100" height="32"></rect>
+            <rect x="309" y="143" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="319" y="163">user_priority</text>
          </a>
-         <rect x="575" y="177" width="24" height="32" rx="10"></rect>
-         <rect x="573" y="175" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="583" y="195">,</text>
-         <rect x="619" y="177" width="98" height="32" rx="10"></rect>
-         <rect x="617" y="175" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="627" y="195">ISOLATION</text>
-         <rect x="737" y="177" width="60" height="32" rx="10"></rect>
-         <rect x="735" y="175" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="745" y="195">LEVEL</text>
+         <rect x="451" y="177" width="24" height="32" rx="10"></rect>
+         <rect x="449" y="175" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="459" y="195">,</text>
+         <rect x="495" y="177" width="98" height="32" rx="10"></rect>
+         <rect x="493" y="175" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="503" y="195">ISOLATION</text>
+         <rect x="613" y="177" width="60" height="32" rx="10"></rect>
+         <rect x="611" y="175" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="621" y="195">LEVEL</text>
          <a xlink:href="sql-grammar.html#iso_level" xlink:title="iso_level">
-            <rect x="817" y="177" width="74" height="32"></rect>
-            <rect x="815" y="175" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="825" y="195">iso_level</text>
+            <rect x="693" y="177" width="74" height="32"></rect>
+            <rect x="691" y="175" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="701" y="195">iso_level</text>
          </a>
          <rect x="45" y="221" width="82" height="32" rx="10"></rect>
          <rect x="43" y="219" width="82" height="32" class="terminal" rx="10"></rect>
@@ -125,7 +122,7 @@
             <rect x="813" y="371" width="74" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="823" y="391">iso_level</text>
          </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-96 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -32 h10 m118 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-282 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m100 0 h10 m-604 -32 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v56 m624 0 v-56 m-624 56 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m88 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m40 -108 h18 m-944 0 h20 m924 0 h20 m-964 0 q10 0 10 10 m944 0 q0 -10 10 -10 m-954 10 v132 m944 0 v-132 m-944 132 q0 10 10 10 m924 0 q10 0 10 -10 m-934 10 h10 m82 0 h10 m20 0 h10 m146 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m0 0 h128 m-802 0 h20 m782 0 h20 m-822 0 q10 0 10 10 m802 0 q0 -10 10 -10 m-812 10 v24 m802 0 v-24 m-802 24 q0 10 10 10 m782 0 q10 0 10 -10 m-792 10 h10 m118 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-282 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m100 0 h10 m-604 -32 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v56 m624 0 v-56 m-624 56 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m88 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m83 -304 h-3"></path>
+         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-96 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m118 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-282 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m100 0 h10 m-604 -32 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v56 m624 0 v-56 m-624 56 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m88 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m40 -108 h142 m-944 0 h20 m924 0 h20 m-964 0 q10 0 10 10 m944 0 q0 -10 10 -10 m-954 10 v132 m944 0 v-132 m-944 132 q0 10 10 10 m924 0 q10 0 10 -10 m-934 10 h10 m82 0 h10 m20 0 h10 m146 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m0 0 h128 m-802 0 h20 m782 0 h20 m-822 0 q10 0 10 10 m802 0 q0 -10 10 -10 m-812 10 v24 m802 0 v-24 m-802 24 q0 10 10 10 m782 0 q10 0 10 -10 m-792 10 h10 m118 0 h10 m20 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-282 10 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m100 0 h10 m-604 -32 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v56 m624 0 v-56 m-624 56 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m88 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h326 m-356 0 h20 m336 0 h20 m-376 0 q10 0 10 10 m356 0 q0 -10 10 -10 m-366 10 v12 m356 0 v-12 m-356 12 q0 10 10 10 m336 0 q10 0 10 -10 m-346 10 h10 m24 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m74 0 h10 m83 -304 h-3"></path>
          <polygon points="987 83 995 79 995 87"></polygon>
          <polygon points="987 83 979 79 979 87"></polygon>
       </svg>


### PR DESCRIPTION
`LOCAL` was marked as unimplemented in https://github.com/cockroachdb/cockroach/pull/10289. This PR removes `LOCAL` from the full grammar and from the `SET TRANSACTION` diagram. 

Fixes #802

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/803)
<!-- Reviewable:end -->
