### PR TITLE
List views via pg_catalog.pg_views

### DIFF
--- a/create-view.md
+++ b/create-view.md
@@ -64,7 +64,24 @@ Alternatively, to make it much easier to run this complex query, you could creat
 CREATE VIEW
 ~~~
 
-Then, executing the query is as easy as `SELECT`ing from the view:
+The view is then represented as a virtual table alongside other tables in the database:
+
+~~~ sql
+> SHOW TABLES FROM startrek;
+~~~
+
+~~~
++-------------------+
+|       Table       |
++-------------------+
+| episodes          |
+| quotes            |
+| quotes_per_season |
++-------------------+
+(4 rows)
+~~~
+
+Executing the query is as easy as `SELECT`ing from the view, as you would from a standard table:
 
 ~~~ sql
 > SELECT * FROM startrek.quotes_per_season;

--- a/show-create-view.md
+++ b/show-create-view.md
@@ -29,7 +29,9 @@ Field | Description
 `View` | The name of the view.
 `CreateView` | The [`CREATE VIEW`](create-view.html) statement for creating a carbon copy of the specified view. 
 
-## Example
+## Examples
+
+### Show the `CREATE VIEW` statement for a view
 
 ~~~ sql
 > SHOW CREATE VIEW bank.user_accounts;
@@ -41,6 +43,25 @@ Field | Description
 +--------------------+---------------------------------------------------------------------------+
 | bank.user_accounts | CREATE VIEW "bank.user_accounts" AS SELECT type, email FROM bank.accounts |
 +--------------------+---------------------------------------------------------------------------+
+(1 row)
+~~~
+
+### Show just a view's `SELECT` statement
+
+To get just a view's `SELECT` statement, you can query the `views` table in the built-in `information_schema` database and filter on the view name: 
+
+~~~ sql
+> SELECT view_definition 
+  FROM information_schema.views 
+  WHERE table_name = 'user_accounts';
+~~~
+
+~~~
++---------------------------------------+
+|            view_definition            |
++---------------------------------------+
+| SELECT type, email FROM bank.accounts |
++---------------------------------------+
 (1 row)
 ~~~
 

--- a/views.md
+++ b/views.md
@@ -196,7 +196,9 @@ To create a view, use the [`CREATE VIEW`](create-view.html) statement:
 CREATE VIEW
 ~~~
 
-The view is then represented as a table alongside other virtual and standard tables in the database:
+### Listing Views
+
+Once created, views are represented as virtual tables alongside other virtual and standard tables in the database:
 
 ~~~ sql
 > SHOW TABLES FROM bank;
@@ -212,7 +214,23 @@ The view is then represented as a table alongside other virtual and standard tab
 (2 rows)
 ~~~
 
-It's also possible to list views by querying `information_schema.tables`:
+To list just views, you can query the `pg_views` table in the built-in `pg_catalog` database: 
+
+~~~ sql
+> SELECT * FROM pg_catalog.pg_views;
+~~~
+
+~~~
++-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|    schemaname     |       viewname       | viewowner |                                                                                definition                                                                                 |
++-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| bank              | user_accounts        | NULL      | SELECT type, email FROM bank.accounts                                                                                                                                     |
+| startrek          | quotes_per_season    | NULL      | SELECT startrek.episodes.season, count(*) FROM startrek.quotes JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id GROUP BY startrek.episodes.season |
++-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+(2 rows)
+~~~
+
+Alternatively, you can query the `tables` table in the built-in `information_schema` database and filter for views:
 
 ~~~ sql
 > SELECT * FROM information_schema.tables WHERE table_type = 'VIEW';
@@ -222,7 +240,7 @@ It's also possible to list views by querying `information_schema.tables`:
 +---------------+-------------------+----------------------+------------+---------+
 | TABLE_CATALOG |   TABLE_SCHEMA    |      TABLE_NAME      | TABLE_TYPE | VERSION |
 +---------------+-------------------+----------------------+------------+---------+
-| def           | bank              | user_accounts        | VIEW       |       3 |
+| def           | bank              | user_accounts        | VIEW       |       1 |
 | def           | startrek          | quotes_per_episode   | VIEW       |       1 |
 +---------------+-------------------+----------------------+------------+---------+
 (2 rows)
@@ -262,6 +280,22 @@ To query a view, target it with a [`SELECT`](select.html) statement just as you 
 | bank.user_accounts | CREATE VIEW "bank.user_accounts" AS SELECT type, email FROM bank.accounts |
 +--------------------+---------------------------------------------------------------------------+
 (1 row)
+~~~
+
+You can also inspect the `SELECT` statement executed by a view by querying `pg_views` table in the built-in `pg_catalog` database: 
+
+~~~ sql
+> SELECT * FROM pg_catalog.pg_views;
+~~~
+
+~~~
++-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|    schemaname     |       viewname       | viewowner |                                                                                definition                                                                                 |
++-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| bank              | user_accounts        | NULL      | SELECT type, email FROM bank.accounts                                                                                                                                     |
+| startrek          | quotes_per_season    | NULL      | SELECT startrek.episodes.season, count(*) FROM startrek.quotes JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id GROUP BY startrek.episodes.season |
++-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+(2 rows)
 ~~~
 
 ### View Dependencies

--- a/views.md
+++ b/views.md
@@ -328,7 +328,7 @@ pq: cannot drop table "accounts" because view "user_accounts" depends on it
 pq: cannot drop column email because view "bank.user_accounts" depends on it
 ~~~
 
-There is an exception to the rule above, however: It is possible to drop a table or view referenced in a view's `SELECT` statement if you delete the view at the same time. To do so, use `DROP TABLE ... CASCADE` or `DROP VIEW ... CASCADE`:
+There is an exception to the rule above, however: When [dropping a table](drop-table.html) or [dropping a view](drop-view.html), you can use the `CASCADE` keyword to drop all dependent objects as well:
 
 ~~~ sql
 > DROP TABLE bank.accounts CASCADE;
@@ -337,6 +337,8 @@ There is an exception to the rule above, however: It is possible to drop a table
 ~~~
 DROP TABLE
 ~~~
+
+{{site.data.alerts.callout_danger}}<code>CASCADE</code> drops <em>all</em> dependent objects without listing them, which can lead to inadvertent and difficult-to-recover losses. To avoid potential harm, we recommend dropping objects individually in most cases.{{site.data.alerts.end}}
 
 ### Renaming Views
 

--- a/views.md
+++ b/views.md
@@ -214,7 +214,23 @@ Once created, views are represented as virtual tables alongside other virtual an
 (2 rows)
 ~~~
 
-To list just views, you can query the `pg_views` table in the built-in `pg_catalog` database: 
+To list just views, you can query the `views` table in the built-in `information_schema` database: 
+
+~~~ sql
+> SELECT * FROM information_schema.views;
+~~~
+
+~~~
++---------------+-------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+--------------+--------------------+----------------------+----------------------+----------------------------+
+| TABLE_CATALOG |   TABLE_SCHEMA    |      TABLE_NAME      |                                                                              VIEW_DEFINITION                                                                              | CHECK_OPTION | IS_UPDATABLE | IS_INSERTABLE_INTO | IS_TRIGGER_UPDATABLE | IS_TRIGGER_DELETABLE | IS_TRIGGER_INSERTABLE_INTO |
++---------------+-------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+--------------+--------------------+----------------------+----------------------+----------------------------+
+| def           | bank              | user_accounts        | SELECT type, email FROM bank.accounts                                                                                                                                     | NULL         | NULL         | NULL               | NULL                 | NULL                 | NULL                       |
+| def           | startrek          | quotes_per_season    | SELECT startrek.episodes.season, count(*) FROM startrek.quotes JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id GROUP BY startrek.episodes.season | NULL         | NULL         | NULL               | NULL                 | NULL                 | NULL                       |
++---------------+-------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+--------------+--------------------+----------------------+----------------------+----------------------------+
+(2 rows)
+~~~
+
+Alternatively, you can query the `pg_views` table in the built-in `pg_catalog` database: 
 
 ~~~ sql
 > SELECT * FROM pg_catalog.pg_views;
@@ -227,22 +243,6 @@ To list just views, you can query the `pg_views` table in the built-in `pg_catal
 | bank              | user_accounts        | NULL      | SELECT type, email FROM bank.accounts                                                                                                                                     |
 | startrek          | quotes_per_season    | NULL      | SELECT startrek.episodes.season, count(*) FROM startrek.quotes JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id GROUP BY startrek.episodes.season |
 +-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-(2 rows)
-~~~
-
-Alternatively, you can query the `tables` table in the built-in `information_schema` database and filter for views:
-
-~~~ sql
-> SELECT * FROM information_schema.tables WHERE table_type = 'VIEW';
-~~~
-
-~~~ 
-+---------------+-------------------+----------------------+------------+---------+
-| TABLE_CATALOG |   TABLE_SCHEMA    |      TABLE_NAME      | TABLE_TYPE | VERSION |
-+---------------+-------------------+----------------------+------------+---------+
-| def           | bank              | user_accounts        | VIEW       |       1 |
-| def           | startrek          | quotes_per_episode   | VIEW       |       1 |
-+---------------+-------------------+----------------------+------------+---------+
 (2 rows)
 ~~~
 
@@ -282,19 +282,19 @@ To query a view, target it with a [`SELECT`](select.html) statement just as you 
 (1 row)
 ~~~
 
-You can also inspect the `SELECT` statement executed by a view by querying `pg_views` table in the built-in `pg_catalog` database: 
+You can also inspect the `SELECT` statement executed by a view by querying the `views` table in the built-in `information_schema` database: 
 
 ~~~ sql
-> SELECT * FROM pg_catalog.pg_views;
+> SELECT * FROM information_schema.views;
 ~~~
 
 ~~~
-+-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-|    schemaname     |       viewname       | viewowner |                                                                                definition                                                                                 |
-+-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| bank              | user_accounts        | NULL      | SELECT type, email FROM bank.accounts                                                                                                                                     |
-| startrek          | quotes_per_season    | NULL      | SELECT startrek.episodes.season, count(*) FROM startrek.quotes JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id GROUP BY startrek.episodes.season |
-+-------------------+----------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++---------------+-------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+--------------+--------------------+----------------------+----------------------+----------------------------+
+| TABLE_CATALOG |   TABLE_SCHEMA    |      TABLE_NAME      |                                                                              VIEW_DEFINITION                                                                              | CHECK_OPTION | IS_UPDATABLE | IS_INSERTABLE_INTO | IS_TRIGGER_UPDATABLE | IS_TRIGGER_DELETABLE | IS_TRIGGER_INSERTABLE_INTO |
++---------------+-------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+--------------+--------------------+----------------------+----------------------+----------------------------+
+| def           | bank              | user_accounts        | SELECT type, email FROM bank.accounts                                                                                                                                     | NULL         | NULL         | NULL               | NULL                 | NULL                 | NULL                       |
+| def           | startrek          | quotes_per_season    | SELECT startrek.episodes.season, count(*) FROM startrek.quotes JOIN startrek.episodes ON startrek.quotes.episode = startrek.episodes.id GROUP BY startrek.episodes.season | NULL         | NULL         | NULL               | NULL                 | NULL                 | NULL                       |
++---------------+-------------------+----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+--------------+--------------------+----------------------+----------------------+----------------------------+
 (2 rows)
 ~~~
 


### PR DESCRIPTION
This PR updates our views overview and `CREATE VIEW` doc to mention that you can list views by querying `pg_catalog.pg_views`.

Fixes #807
Fixes #812 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/811)
<!-- Reviewable:end -->
