### PR TITLE
Remove ga script

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@ project: cockroachdb
 topnav_title: CockroachDB
 homepage_title: CockroachDB Docs
 site_title: Cockroach Labs
-google_analytics: UA-63775601-1
 
 url: "https://www.cockroachlabs.com"
 baseurl: "/docs"

--- a/_includes/google_tag_manager.html
+++ b/_includes/google_tag_manager.html
@@ -1,16 +1,3 @@
-<!-- the google_analytics_id gets auto inserted from the config file -->
-
-{% if site.google_analytics %}
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{site.google_analytics}}', 'auto');
-    ga('send', 'pageview');
-</script>
-{% endif %}
-
 <!-- Google Tag Manager -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NR8LC4"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
 
   {% include back-to-top.html %}
   {% include gitter-sidecar.html %}
-  {% include google_analytics.html %}
+  {% include google_tag_manager.html %}
   {% include google_remarketing.html %}
   {% include hubspot_analytics.html %}
 </body>


### PR DESCRIPTION
While looking into why the bounce rate on docs pages is off (issue #661), DivisonOf noticed that the docs site has a GA script and Tag Manager. This is duplicative because GA is installed sitewide through Tag Manager. They think this redundancy may affect bounce rate because two pageview events are sent when a page loads.

This PR removes the GA script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/840)
<!-- Reviewable:end -->
