### PR TITLE
Draft release notes for beta-20161117

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -399,6 +399,9 @@ entries:
     - title: Release Notes
       items:
 
+        - title: beta-20161117
+          url: /beta-20161117.html
+
         - title: beta-20161110
           url: /beta-20161110.html
 
@@ -407,9 +410,6 @@ entries:
 
         - title: beta-20161027
           url: /beta-20161027.html
-
-        - title: beta-20161013
-          url: /beta-20161013.html
 
         - title: Older Beta Versions
           url: /older-versions.html

--- a/beta-20161117.md
+++ b/beta-20161117.md
@@ -1,0 +1,85 @@
+---
+title: What's New in beta-20161117
+toc: false
+summary: Additions and changes in CockroachDB version beta-20161117.
+---
+
+## Nov 17, 2016
+
+### Binaries
+
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20161117.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-beta-20161117.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+</div>
+
+
+### Upgrade Notes
+
+Due to changes in the on-disk format of internal range leases, this release cannot be run concurrently with any prior release. All servers running older versions must be stopped before starting any node with this version. [#10420](https://github.com/cockroachdb/cockroach/pull/10420)
+
+We realize that "stop the world" upgrades are overly interruptive and are actively working on infrastructure improvements to drastically reduce the need for such upgrades in the future.
+
+### SQL Language Changes
+
+- The SQL standard interval format `Y-M-D` is now supported. [#10499](https://github.com/cockroachdb/cockroach/pull/10499)
+- The functions `array_length`, `array_upper`, and `array_lower` are now available. [#10565](https://github.com/cockroachdb/cockroach/pull/10565)
+- The functions `to_uuid` and `from_uuid` are now available. [#10541](https://github.com/cockroachdb/cockroach/pull/10541)
+- The `pow()` and `div()` functions now work when both arguments are integers. [#10538](https://github.com/cockroachdb/cockroach/pull/10538)
+- The `ARRAY[]` constructor syntax is now supported. [#10585](https://github.com/cockroachdb/cockroach/pull/10585)
+- The `COLLATE` operator is now supported. Collation support is still incomplete and will be improved in upcoming releases. [#10605](https://github.com/cockroachdb/cockroach/pull/10605)
+- Keys in the `pg_catalog.pg_settings` table are now lowercase. [#10548](https://github.com/cockroachdb/cockroach/pull/10548)
+- The `pg_catalog.pg_settings` now contains an entry for `max_index_keys`. [#10548](https://github.com/cockroachdb/cockroach/pull/10548)
+- The `pg_catalog.pg_depend` table is now partially supported (just enough to support `pgjdbc`). [#10696](https://github.com/cockroachdb/cockroach/pull/10696)
+
+### Command-Line Interface Changes
+
+- The `cockroach user set` command no longer prompts for passwords in insecure mode. [#10547](https://github.com/cockroachdb/cockroach/pull/10547)
+
+### Admin UI Changes
+
+- The design of the navigation elements has been updated. [#10611](https://github.com/cockroachdb/cockroach/pull/10611)
+- The design of the Database tab has been updated. [#10552](https://github.com/cockroachdb/cockroach/pull/10552)
+- Syntax highlighting is now used when displaying `CREATE TABLE` statements. [#10579](https://github.com/cockroachdb/cockroach/pull/10579)
+
+### Bug Fixes
+
+- Fixed a bug that caused data corruption when upgrading from `beta-20161103` to `beta-20161110`. [#10681](https://github.com/cockroachdb/cockroach/pull/10681)
+- Fixed bugs that prevented communication with a node that was previously down. [#10642](https://github.com/cockroachdb/cockroach/pull/10642) [#10652](https://github.com/cockroachdb/cockroach/pull/10652)
+- It is now possible for a new node to start up using the same network address as a node that had previously existed. [#10544](https://github.com/cockroachdb/cockroach/pull/10544)
+- Fixed a panic "range lookup of meta key found only non-matching ranges". [#10583](https://github.com/cockroachdb/cockroach/pull/10583)
+- The consistency checker now runs to completion instead of canceling itself before finishing. [#10625](https://github.com/cockroachdb/cockroach/pull/10625)
+- Internal retries no longer cause transaction replay errors. [#10639](https://github.com/cockroachdb/cockroach/pull/10639)
+- More fixes for very large `DECIMAL` values. [#10559](https://github.com/cockroachdb/cockroach/pull/10559)
+
+### Performance Improvements
+
+- The rebalancing system now attempts to balance range leases in addition to storage capacity. [#10464](https://github.com/cockroachdb/cockroach/pull/10464)
+- The rebalancing system now prioritizes adding new replicas to underreplicated ranges over removing replicas from nodes that have died. [#10683](https://github.com/cockroachdb/cockroach/pull/10683)
+- Time series pruning is now more efficient. [#10682](https://github.com/cockroachdb/cockroach/pull/10682)
+- Reduced memory allocations when encoding dates and times. [#10531](https://github.com/cockroachdb/cockroach/pull/10531)
+
+### Contributors
+
+This release includes 72 merged PRs by 20 authors. We would like to thank the following contributors from the CockroachDB community, including first-time contributor kiran.
+
+- Haines Chan
+- kiran
+- songhao
+
+
+### Stay Up-to-Date
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>

--- a/older-versions.md
+++ b/older-versions.md
@@ -6,6 +6,7 @@ toc: false
 
 Release Date | Version
 -------------|--------
+Oct 13, 2016 | [beta-20161013](beta-20161013.html)
 Oct 6, 2016 | [beta-20161006](beta-20161006.html)
 Sep 29, 2016 | [beta-20160929](beta-20160929.html)
 Sep 15, 2016 | [beta-20160915](beta-20160915.html)


### PR DESCRIPTION
As of cockroachdb/cockroach@183f7c017. 

We may not do a release this week given the state of the test clusters, in which case this will be a start for the following release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/862)
<!-- Reviewable:end -->
