### PR TITLE
Fix Rust samples with changes to postgres driver

### DIFF
--- a/_includes/app/basic-sample.rs
+++ b/_includes/app/basic-sample.rs
@@ -1,9 +1,9 @@
 extern crate postgres;
 
-use postgres::{Connection, SslMode};
+use postgres::{Connection, TlsMode};
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", SslMode::None)
+    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
         .unwrap();
 
     // Insert two rows into the "accounts" table.

--- a/_includes/app/txn-sample.rs
+++ b/_includes/app/txn-sample.rs
@@ -1,6 +1,7 @@
 extern crate postgres;
 
-use postgres::{Connection, SslMode, Transaction, Result};
+use postgres::{Connection, TlsMode, Result};
+use postgres::transaction::Transaction;
 use postgres::error::{Error, SqlState};
 
 /// Runs op inside a transaction and retries it as needed.
@@ -39,7 +40,7 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
 }
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", SslMode::None)
+    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
         .unwrap();
 
     // Run a transfer in a transaction.


### PR DESCRIPTION
The current postgres driver for Rust has some changes that break the current Rust example.

SslMode has been replaced with TlsMode.
Transaction has been moved into the transaction module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/863)
<!-- Reviewable:end -->
