### PR TITLE
update sql standard interval format

### DIFF
--- a/interval.md
+++ b/interval.md
@@ -17,7 +17,7 @@ Format | Description
 Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'` 
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
-SQL Standard | `INTERVAL 'H:M:S'`<br><br>Using a single field defines seconds only, and using two fields defines hours and minutes. Also, all fields support both integers and floats.
+SQL Standard | `INTERVAL 'Y-M-D H:M:S'`<br><br>`Y-M-D`: Using a single value defines days only; using two values defines years and months. Values must be integers.<br><br>`H:M:S`: Using a single value defines seconds only; using two values defines hours and minutes. Values can be integers or floats.<br><br>Note that each side is optional.
 
 Alternatively, you can use a string literal, e.g., `'1h2m3s4ms5us6ns'` or`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`, which CockroachDB will resolve into the `INTERVAL` type.
 
@@ -31,9 +31,16 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 
 ~~~ sql
 > CREATE TABLE intervals (a INT PRIMARY KEY, b INTERVAL);
+~~~
 
+~~~
+CREATE TABLE
+~~~
+
+~~~ sql
 > SHOW COLUMNS FROM intervals;
 ~~~
+
 ~~~
 +-------+----------+-------+---------+
 | Field |   Type   | Null  | Default |
@@ -42,20 +49,29 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 | b     | INTERVAL | true  | NULL    |
 +-------+----------+-------+---------+
 ~~~
+
 ~~~ sql
 > INSERT INTO intervals VALUES 
-    (1, INTERVAL '1h2m3s4ms5us6ns'), 
-    (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'), 
-    (3, INTERVAL '4:5:6')
-;
+  (1, INTERVAL '1h2m3s4ms5us6ns'), 
+  (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'), 
+  (3, INTERVAL '1-2-3 4:5:6');
 ~~~
+
+~~~
+INSERT 3
+~~~
+
+~~~ sql
+> SELECT * FROM intervals;
+~~~
+
 ~~~
 +---+------------------+
 | a |        b         |
 +---+------------------+
 | 1 | 1h2m3.004005006s |
 | 2 | 14m3d4h5m6s      |
-| 3 | 4h5m6s           |
+| 3 | 14m3d4h5m6s      |
 +---+------------------+
 (3 rows)
 ~~~


### PR DESCRIPTION
Update docs on the sql standard interval format to `Y-M-D H:M:S`.

Fixes #831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/867)
<!-- Reviewable:end -->
