### PR TITLE
Additional docs on view dependencies

### DIFF
--- a/drop-index.md
+++ b/drop-index.md
@@ -28,7 +28,7 @@ The user must have the `CREATE` [privilege](privileges.html) on each specified t
 
 ## Examples
 
-### Remove an Index
+### Remove an Index (No Dependencies)
 ~~~ sql
 > SHOW INDEX FROM tbl;
 ~~~
@@ -53,7 +53,7 @@ The user must have the `CREATE` [privilege](privileges.html) on each specified t
 +-------+---------+--------+-----+--------+-----------+---------+
 ~~~
 
-### Remove Dependent Objects with `CASCADE`
+### Remove an Index and Dependent Objects with `CASCADE`
 
 {{site.data.alerts.callout_danger}}<code>CASCADE</code> drops <em>all</em> dependent objects without listing them, which can lead to inadvertent and difficult-to-recover losses. To avoid potential harm, we recommend dropping objects individually in most cases.{{site.data.alerts.end}}
 

--- a/drop-table.md
+++ b/drop-table.md
@@ -68,7 +68,7 @@ DROP TABLE
 (2 rows)
 ~~~
 
-### Remove a Table (With Dependencies)
+### Remove a Table and Dependent Objects with `CASCADE`
 
 In this example, a view depends on the table being dropped. Therefore, it's only possible to drop the table while simultaneously dropping the dependent view using `CASCADE`.
 

--- a/rename-column.md
+++ b/rename-column.md
@@ -6,6 +6,8 @@ toc: false
 
 The `RENAME COLUMN` [statement](sql-statements.html) changes the name of a column in a table.
 
+{{site.data.alerts.callout_info}}It is not possible to rename a column referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis

--- a/rename-database.md
+++ b/rename-database.md
@@ -6,6 +6,8 @@ toc: false
 
 The `RENAME DATABASE` [statement](sql-statements.html) changes the name of a database.
 
+{{site.data.alerts.callout_info}}It is not possible to rename a database referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis

--- a/rename-index.md
+++ b/rename-index.md
@@ -6,6 +6,8 @@ toc: false
 
 The `RENAME INDEX` [statement](sql-statements.html) changes the name of an index for a table.
 
+{{site.data.alerts.callout_info}}It is not possible to rename an index referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis

--- a/rename-table.md
+++ b/rename-table.md
@@ -6,6 +6,8 @@ toc: false
 
 The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table. It can also be used to move a table from one database to another.
 
+{{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis


### PR DESCRIPTION
This PR updates docs to clarify that you can't rename database, table, column, or index reference by a view.

Will document index hints generally in a separate PR. Still need to document drop column as well.

Fixes #789 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/873)
<!-- Reviewable:end -->
