### PR TITLE
Update logging flags intro

### DIFF
--- a/cockroach-commands.md
+++ b/cockroach-commands.md
@@ -28,17 +28,14 @@ Command | Usage
 
 ## Logging Flags
 
-By default, CockroachDB logs all messages to files (see `--log-dir`) and messages are not copied to the standard error stream. 
-
-- To copy messages at or above a severity level to `stderr`, set `--alsologtostderr` to the severity level.
-- To write messages of all severities to `stderr` and not to files, set `--logtostderr` to `true`. 
+By default, `cockroach start` logs all messages to files, and client commands log messages to `stderr` (see `--log-dir`). 
 
 Flag | Description
 -----|------------
-`--alsologtostderr` | Copy log messages at or above this severity level to the standard error stream in addition to log files. Possible values: `info`, `warning`, `error`, `fatal`, and `none`. If this flag is set without a value, it uses the `info` level. <br><br>**Default:** `none`
-`--log-dir` | Write log files in this directory. <br><br> **Default:** `<first-store-dir>/logs` for the `start` command; `$TMPDIR` for all other commands  
-`--logtostderr` |  Write log messages of all severities to the standard error stream and not to log files. If this flag is set to `true`, `--log-dir` and `--alsologtostderr` are ignored. Possible values: `true` or `false`.<br><br>**Default:** `false`
-`--no-color` | Do not colorize the standard error stream based on severity. Possible values: `true` or `false`. <br><br>**Default:** `false`   
+`--alsologtostderr` | Copy log messages at or above this severity level to `stderr` in addition to log files. Possible values: `info`, `warning`, `error`, `fatal`, and `none`. If this flag is set without a value, it uses the `info` level. <br><br>**Default:** `none`
+`--log-dir` | Write log files in this directory. <br><br> **Default:** For the `start` command, this defaults to `<first-store-dir>/logs`; for all client commands, if this flag is empty, CockroachDB logs to `stderr`. 
+`--logtostderr` |  Write log messages of all severities to `stderr` and not to log files. If this flag is set to `true`, `--log-dir` and `--alsologtostderr` are ignored. Possible values: `true` or `false`.<br><br>**Default:** `false`
+`--no-color` | Do not colorize `stderr` based on severity. Possible values: `true` or `false`. <br><br>**Default:** `false`   
 
 The `--log-backtrace-at`, `--verbosity`, and `--vmodule` flags are intended for internal debugging. 
 


### PR DESCRIPTION
Update "Logging Flags" intro to clarify that, when `--log-dir` is not set on a client command, CockroachDB logs to `stderr` instead. We used to log to temp directories in this case.

Fixes #884

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/885)
<!-- Reviewable:end -->
