### PR TITLE
Add optimizely script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,14 @@ The syntax for including content is `{% include <filepath> %}`, for example, `{%
   <asciinema-player class="asciinema-demo" src="asciicasts/start-a-local-cluster.json" cols="107" speed="2" theme="solarized-dark" poster="npt:0:30" title="Start a Local Cluster"></asciinema-player>
   ```
 
+### Feedback Widget
+
+"Yes/No" feedback buttons appear toward the bottom of every page by default. On any page for which we don't want feedback (e.g., stub pages), you can remove the feedback buttons by setting `feedback: false` in the page's front-matter.
+
+### A/B Testing
+
+We use [Optimizely](https://www.optimizely.com/) to A/B test changes across our website. To include a page in A/B testing, you must add the necessary JavaScript by setting `optimizely: true` in the page's front-matter.
+
 ## Style Guide
 
 CockroachDB docs should be:

--- a/_includes/expand.html
+++ b/_includes/expand.html
@@ -38,3 +38,9 @@
   margin-bottom: 0px;
 }
 </style>
+
+<script>
+  $('.expandcollapse').on('click', function () {
+    $(this).next().toggle();
+  });
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,5 +20,6 @@
 <script src="js/toc.js"></script>
 <script src="js/customscripts.js"></script>
 <script src="js/anchor.js"></script>
-<script src="js/feedback-widget.js"></script>
 <script src="//js.hsforms.net/forms/v2.js"></script>
+{% if page.optimizely == true %}<script src="https://cdn.optimizely.com/js/7825500667.js"></script>{% endif %}
+{% if page.asciicast == true %}<script src="js/asciinema-player.js"></script>{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,13 +16,6 @@
     </div>
     {% include footer.html %}
   </div>
-  
-  <script>
-  $('.expandcollapse').on('click', function () {
-    $(this).next().toggle();
-  });
-  </script>
-
   {% include back-to-top.html %}
   {% include gitter-sidecar.html %}
   {% include google_tag_manager.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -30,7 +30,3 @@ layout: default
       anchors.add('h2, h3, h4, h5');
    </script>
 {% endif %}
-
-{% if page.asciicast == true %}
-   <script src="js/asciinema-player.js"></script>
-{% endif %}


### PR DESCRIPTION
This PR enables docs pages to be included in Optimizely A/B testing. For now, rather than add the Optimizely JS to every page of the docs, we're using a front-matter label to manage this on a page-by-page basis; when `optimizely: true` is set in a page's front-matter, the Optimizely JS is fetched in the page's header.

This PR also updates `CONTRIBUTING.md` to cover our feedback widget and optimizely, and it simplifies the conditional logic for inclusion of asciicasts and expand/collapse functionality.

Fixes #906

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/909)
<!-- Reviewable:end -->
