### PR TITLE
fixing scroll issue with mobile nav

### DIFF
--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -7,9 +7,10 @@
             $footer = $('section.footer'),
             footertotop, scrolltop, difference;
 
-
-        $mobile_menu.css('visibility', 'visible');
-
+        if(_viewport_width <= 768) {
+            $mobile_menu.css('visibility', 'visible');
+        }
+        
         $('header nav.mobile').on('click', '.hamburger', function(e){
             e.preventDefault();
             if($('body').hasClass('menu_open')){
@@ -25,6 +26,9 @@
 
             if(_viewport_width > 768) {
                 $('body').removeClass('menu_open');     
+            }
+            else {
+                $mobile_menu.css('visibility', 'visible');
             }
 
             $(window).scroll();


### PR DESCRIPTION
Adds conditional checks for mobile nav to be rendered on page at all; prevents scrolling issue that was causing it to flicker on page as identified in #69.

Closes #69

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/910)
<!-- Reviewable:end -->
