### PR TITLE
Remove unnecessary pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ baseurl: "/docs"
 highlighter: rouge
 markdown: kramdown
 
-exclude: ["choose-a-deployment-profile.md", "recommended-environments.md", "vendor"]
+exclude: ["set-application-name.md", "vendor"]
 
 defaults:
   -

--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -144,9 +144,6 @@ entries:
                 - title: <code>SELECT</code>
                   url: /select.html
 
-                - title: <code>SET APPLICATION_NAME</code>
-                  url: /set-application-name.html
-
                 - title: <code>SET DATABASE</code>
                   url: /set-database.html
 

--- a/beta-20161201.md
+++ b/beta-20161201.md
@@ -40,7 +40,7 @@ We realize that "stop the world" upgrades are overly interruptive and are active
 - The `ARRAY[]` constructor syntax is now supported. [#10585](https://github.com/cockroachdb/cockroach/pull/10585)
 - The `COLLATE` operator is now supported. Collation support is still incomplete and will be improved in upcoming releases. [#10605](https://github.com/cockroachdb/cockroach/pull/10605)
 - The `current_schema` [function](functions-and-operators.html) is now supported. [#10707](https://github.com/cockroachdb/cockroach/pull/10707)
-- The [`SET APPLICATION_NAME`](set-application-name.html) statement is now supported. This is a write-only variable which is used by some frameworks but has no effect. [#10725](https://github.com/cockroachdb/cockroach/pull/10725)
+- The `SET APPLICATION_NAME` statement is now supported. This is a write-only variable which is used by some frameworks but has no effect. [#10725](https://github.com/cockroachdb/cockroach/pull/10725)
 - The [`CREATE DATABASE`](create-database.html) statement now accepts the options `TEMPLATE`, `LC_COLLATE`, and `LC_CTYPE` for compatibility with PostgreSQL, although the values available for these options are limited. [#10775](https://github.com/cockroachdb/cockroach/pull/10775)
 - The [`SELECT`](select.html) statement now supports the `WITH ORDINALITY` modifier to generate row numbers. [#10558](https://github.com/cockroachdb/cockroach/pull/10558)
 

--- a/choose-a-deployment-profile.md
+++ b/choose-a-deployment-profile.md
@@ -1,4 +1,0 @@
----
-title: Choose a Deployment Profile
-toc: false
----

--- a/recommended-environments.md
+++ b/recommended-environments.md
@@ -1,4 +1,0 @@
----
-title: Recommended Environments
-toc: false
----

--- a/set-database.md
+++ b/set-database.md
@@ -90,7 +90,6 @@ $ cockroach sql --database=db1
 
 ## See Also
 
-- [`SET APPLICATION_NAME`](set-application-name.html)
 - [`SET TIME ZONE`](set-time-zone.html)
 - [`SET TRANSACTION`](set-transaction.html)
  

--- a/sql-statements.md
+++ b/sql-statements.md
@@ -34,7 +34,6 @@ Statement | Usage
 [`REVOKE`](revoke.html) | Revoke privileges from users. 
 [`ROLLBACK`](rollback-transaction.html) | Discard all updates made by the current [transaction](transactions.html) or, when using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), rollback to the `cockroach_restart` savepoint and retry the transaction.  
 [`SELECT`](select.html) | Select rows from a table.
-[`SET APPLICATION_NAME`](set-application-name.html) | Set the default applicaiton name for the session.
 [`SET DATABASE`](set-database.html) | Set the default database for the session.
 [`SET TIME ZONE`](set-time-zone.html) | Set the default time zone for the session.
 [`SET TRANSACTION`](set-transaction.html) | Set the isolation level or priority for the session or for an individual [transaction](transactions.html).


### PR DESCRIPTION
This PR removes mention of `SET APPLICATION_NAME` in favor of adding it later with other such variables. It also removes a few old stub pages.

Partially addresses #918

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/919)
<!-- Reviewable:end -->
