### PR TITLE
mark generated css as binary in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+css/customstyles.css.map binary
+css/customstyles.css -merge


### PR DESCRIPTION
this prevents it from diffing or trying to merge changes in the generated map, since it should be re-generated via sass to handle merging.

`-merge` tells git not to try to merges changes to a file on its own, but rather to mark it conflicted if two commits both try to change it and let the human fix it -- since these are generated from another file, changes to them generally should not be merged, but rather the changes in the source files merged and the derivative file re-generated in its entirety. 

`binary` implies `-merge` as well as `-diff`, which prevents showing diffs by default, which makes sense for the `.map` since it isn't human readable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/921)
<!-- Reviewable:end -->