### PR TITLE
change sql standard format for postgres compatibility

### DIFF
--- a/interval.md
+++ b/interval.md
@@ -17,7 +17,7 @@ Format | Description
 Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 Traditional Postgres | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'` 
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
-SQL Standard | `INTERVAL 'Y-M-D H:M:S'`<br><br>`Y-M-D`: Using a single value defines days only; using two values defines years and months. Values must be integers.<br><br>`H:M:S`: Using a single value defines seconds only; using two values defines hours and minutes. Values can be integers or floats.<br><br>Note that each side is optional.
+SQL Standard | `INTERVAL 'Y-M D H:M:S'`<br><br>`Y-M D`: Using a single value defines days only; using two values defines years and months. Values must be integers.<br><br>`H:M:S`: Using a single value defines seconds only; using two values defines hours and minutes. Values can be integers or floats.<br><br>Note that each side is optional.
 
 Alternatively, you can use a string literal, e.g., `'1h2m3s4ms5us6ns'` or`'1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`, which CockroachDB will resolve into the `INTERVAL` type.
 
@@ -54,7 +54,7 @@ CREATE TABLE
 > INSERT INTO intervals VALUES 
   (1, INTERVAL '1h2m3s4ms5us6ns'), 
   (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'), 
-  (3, INTERVAL '1-2-3 4:5:6');
+  (3, INTERVAL '1-2 3 4:5:6');
 ~~~
 
 ~~~


### PR DESCRIPTION
This PR simply changes the SQL standard interval format from `INTERVAL 'Y-M-D H:M:S'` to `INTERVAL 'Y-M D H:M:S'` for postgres compatibility. 

@knz, PTAL and let me know if any additional details need to be added.

Fixes #951

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/963)
<!-- Reviewable:end -->
