### PR TITLE
Remove unnecessary column family suggestion

### DIFF
--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -160,7 +160,7 @@ Not currently, but [we plan to offer JSON/Protobuf datatypes](https://github.com
 
 ## Can I use CockroachDB as a key-value store?
 
-CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. At this time, it is not possible to access the key-value store directly. As an alternative, you can [create a SQL table](create-table.html) with two columns, `k` and `v`, and set `k` as the primary key. Note that if you group these columns into a single [column family](column-families.html), each row will be stored as a single key-value pair in the underlying key-value store.
+CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. At this time, it is not possible to access the key-value store directly. As an alternative, you can [create a SQL table](create-table.html) with two columns, `k` and `v`, and set `k` as the primary key.
 
 ## Have questions that weren’t answered? 
 


### PR DESCRIPTION
In [this FAQ](https://www.cockroachlabs.com/docs/frequently-asked-questions.html#can-i-use-cockroachdb-as-a-key-value-store) about using a SQL table as an alternative to direct access to the key value store, we unnecessarily suggest grouping the columns into a single column family. It's unnecessary because when creating a two column table with one column as the primary key, both columns get placed in the same primary key family automatically. This PR therefore removes the unnecessary suggestion.
 
Fixes #966

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/968)
<!-- Reviewable:end -->
