### PR TITLE
Turn on optimizely on comparison matrix, faq, and docs home

### DIFF
--- a/cockroachdb-in-comparison.md
+++ b/cockroachdb-in-comparison.md
@@ -2,6 +2,7 @@
 title: CockroachDB in Comparison
 summary: Learn how CockroachDB compares to other popular databases.
 toc: false
+optimizely: true
 ---
 
 <script>

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -2,6 +2,7 @@
 title: Frequently Asked Questions
 summary: Get answers to frequently asked questions about CockroachDB.
 toc: false
+optimizely: true
 ---
 
 <div id="toc"></div>

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ summary: Read the documentation for CockroachDB, a distributed SQL database buil
 type: first_page
 homepage: true
 toc: false
+optimizely: true
 ---
 
 CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. It scales horizontally; survives disk, machine, rack, and even datacenter failures with minimal latency disruption and no manual intervention; supports strongly-consistent ACID transactions; and provides a familiar SQL API for structuring, manipulating, and querying data. 


### PR DESCRIPTION
At @swatikumar16's request, this PR adds the optimizely script to `cockroachdb-in-comparison`, `frequently-asked-questions`, and `index`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/980)
<!-- Reviewable:end -->
