### PR TITLE
Email signup for product release notes

### DIFF
--- a/beta-20160407.md
+++ b/beta-20160407.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160407.
 
 ## Apr 7, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -92,19 +106,3 @@ especially
 
 * Kenji Kaneda
 * Seif Lotfy
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160414.md
+++ b/beta-20160414.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160414.
 
 ## Apr 14, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -101,19 +115,3 @@ especially
 * Kenji Kaneda
 * Seif Lotfy
 * es-chow
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160421.md
+++ b/beta-20160421.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160421.
 
 ## Apr 21, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -106,19 +120,3 @@ especially first-time contributor
 * Kenjiro Nakayama
 * Lu Guanqun
 * Seif Lotfy
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160428.md
+++ b/beta-20160428.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160428.
 
 ## Apr 28, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -73,19 +87,3 @@ especially first-time contributor
 
 * Karl Southern
 * Kenjiro Nakayama
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160505.md
+++ b/beta-20160505.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160505.
 
 ## May 5, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -86,19 +100,3 @@ thank the following contributors from the CockroachDB community, especially firs
 * il9ue
 * Kenji Kaneda
 * Paul Steffensen
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160512.md
+++ b/beta-20160512.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160512.
 
 ## May 12, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -56,19 +70,3 @@ This release includes 87 merged PRs by 18 authors. We would like to
 thank the following contributor from the CockroachDB community:
 
 * Kenji Kaneda
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160519.md
+++ b/beta-20160519.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160519.
 
 ## May 19, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -54,19 +68,3 @@ thank the following contributor from the CockroachDB community:
 
 * Kenji Kaneda
 * Paul Steffensen
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160526.md
+++ b/beta-20160526.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160526.
 
 ## May 26, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -47,19 +61,3 @@ This release includes 58 merged PRs by 16 authors. We would like to
 thank the following contributor from the CockroachDB community:
 
 * Kenji Kaneda
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -6,6 +6,21 @@ summary: Additions and changes in CockroachDB version beta-20160602.
 
 ## Jun 2, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -43,19 +58,3 @@ thank the following contributors from the CockroachDB community, especially firs
 - Sean Loiselle
 - Thanakom Sangnetra
 - Paul Steffensen
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160609.md
+++ b/beta-20160609.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160609.
 
 ## Jun 9, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -47,19 +61,3 @@ thank the following contributors from the CockroachDB community, especially firs
 - Alex Robinson
 - Kenji Kaneda
 - Paul Steffensen
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160616.md
+++ b/beta-20160616.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160616.
 
 ## Jun 16, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -55,19 +69,3 @@ thank the following contributors from the CockroachDB community:
 
 - Kenji Kaneda
 - Paul Steffensen
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160629.md
+++ b/beta-20160629.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160629.
 
 ## Jun 29, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -65,19 +79,3 @@ thank the following contributors from the CockroachDB community, especially firs
 - Jingguo Yao
 - Kenji Kaneda
 - phynalle
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160714.md
+++ b/beta-20160714.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160714.
 
 ## Jul 14, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -77,19 +91,3 @@ thank the following contributors from the CockroachDB community, especially firs
 - Kenji Kaneda
 - Sean Loiselle
 - songhao
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160721.md
+++ b/beta-20160721.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160721.
 
 ## Jul 21, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -54,19 +68,3 @@ summary: Additions and changes in CockroachDB version beta-20160721.
 
 This release includes 76 merged PRs by 21 authors. We would especially like to
 thank first-time contributors [Christian Meunier](https://github.com/cockroachdb/cockroach/pull/7937) and [Dharmesh Kakadia](https://github.com/dharmeshkakadia) from the CockroachDB community.
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160728.md
+++ b/beta-20160728.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160728.
 
 ## Jul 28, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -42,19 +56,3 @@ summary: Additions and changes in CockroachDB version beta-20160728.
 ### Contributors
 
 This release includes 63 merged PRs by 17 authors. We would like to thank first-time contributor [Rushi Agrawal](https://github.com/cockroachdb/cockroach/pull/7876) from the CockroachDB community.
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160829.md
+++ b/beta-20160829.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160829.
 
 ## Aug 29, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -83,19 +97,3 @@ This release includes 280 merged PRs by 26 authors. We would like to thank the f
 - Christian Koep
 - Dolf Schimmel
 - songhao
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160908.md
+++ b/beta-20160908.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160908.
 
 ## Sep 8, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -55,19 +69,3 @@ summary: Additions and changes in CockroachDB version beta-20160908.
 ### Contributors
 
 This release includes 180 merged PRs by 17 authors. We would like to thank first-time contributor [Henry Escobar](https://github.com/HenryEscobar) from the CockroachDB community.
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160915.md
+++ b/beta-20160915.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160915.
 
 ## Sep 15, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -46,19 +60,3 @@ summary: Additions and changes in CockroachDB version beta-20160915.
 ### Contributors
 
 This release includes 66 merged PRs by 17 authors.
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20160929.md
+++ b/beta-20160929.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20160929.
 
 ## Sep 29, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -57,19 +71,3 @@ This release includes 78 merged PRs by 19 authors. We would like to thank the fo
 
 - Haines Chan
 - Jingguo Yao
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161006.md
+++ b/beta-20161006.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20161006.
 
 ## Oct 6, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 There aren't many user-visible changes in this week's release - an artifact of our recent stability efforts, which funneled user-visible changes to a secondary development branch. Our concerted stability effort is nearing its end, and we are preparing to include these features in next week's release.
 
 ### Binaries
@@ -29,20 +43,3 @@ There aren't many user-visible changes in this week's release - an artifact of o
     - [Strict Serializability (Linearizability)](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md#strict-serializability-linearizability) [#9644](https://github.com/cockroachdb/cockroach/pull/9644)
     - [Node and Cluster Metrics](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md#node-and-cluster-metrics) [#9647](https://github.com/cockroachdb/cockroach/pull/9647)
     - [SQL](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md#sql) [#9651](https://github.com/cockroachdb/cockroach/pull/9651)
-
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161013.md
+++ b/beta-20161013.md
@@ -8,6 +8,20 @@ summary: Additions and changes in CockroachDB version beta-20161013.
 
 This week's release includes many user-visible changes and features that have been in development since our [stability-focused "code yellow"](https://www.cockroachlabs.com/blog/cant-run-100-node-cockroachdb-cluster/) started back in August. When we entered "code yellow", all work unrelated to stability was done in a secondary development environment. Since then, we've made great progress, and so have moved many of these new features back into our main development environment.
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({ 
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -122,19 +136,3 @@ thank the following contributors from the CockroachDB community, especially firs
 - Daniel Theophanes
 - Yan Long
 - songhao
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({ 
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161027.md
+++ b/beta-20161027.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20161027.
 
 ## Oct 27, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -64,19 +78,3 @@ This release includes 182 merged PRs by 24 authors. We would like to thank the f
 
 - Haines Chan
 - songhao
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161103.md
+++ b/beta-20161103.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20161103.
 
 ## Nov 3, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -68,19 +82,3 @@ This release includes 68 merged PRs by 24 authors. We would like to thank the fo
 - MaBo
 - Yan Long
 - songhao
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161110.md
+++ b/beta-20161110.md
@@ -11,63 +11,6 @@ feedback: false
 Data corruption has been observed when upgrading to this release from prior versions, so it has been withdrawn.
 {{site.data.alerts.end}}
 
-### Upgrade Notes
-
-Due to changes in the on-disk format of internal range leases, this release cannot be run concurrently with any prior release. All servers running older versions must be stopped before starting any node with this version. [#10420](https://github.com/cockroachdb/cockroach/pull/10420)
-
-We realize that "stop the world" upgrades are overly interruptive and are actively working on infrastructure improvements to drastically reduce the need for such upgrades in the future.
-
-### SQL Language Changes
-
-- Adding a [`FOREIGN KEY`](foreign-key.html) constraint now automatically creates any necessary index. [#9572](https://github.com/cockroachdb/cockroach/pull/9572)
-- The `pg_catalog.pg_roles`, `pg_catalog.pg_description`, and `pg_catalog.pg_settings` tables are now supported. [#10377](https://github.com/cockroachdb/cockroach/pull/10377) [#10381](https://github.com/cockroachdb/cockroach/pull/10381) [#10293](https://github.com/cockroachdb/cockroach/pull/10293)
-- New [functions](functions-and-operators.html) `from_ip()` and `to_ip()` convert between binary and textual IP address formats. [#10349](https://github.com/cockroachdb/cockroach/pull/10349)
-- Tuple types can now be returned by queries. [#10380](https://github.com/cockroachdb/cockroach/pull/10380)
-
-### Command-Line Interface Changes
-
-- `cockroach debug compact` now always rewrites all data, allowing it to pick up configuration changes. [#10532](https://github.com/cockroachdb/cockroach/pull/10532)
-
-### Performance Improvements
-
-- Adding new replicas is now prioritized over removing dead ones. [#10492](https://github.com/cockroachdb/cockroach/pull/10492)
-- Replicating ranges on to a new node is now more reliably performed back-to-back. [#10440](https://github.com/cockroachdb/cockroach/pull/10440)
-- Raft log truncation is now aware of pending snapshots. [#10482](https://github.com/cockroachdb/cockroach/pull/10482)
-- Replica garbage collection is now triggered more reliably by replication changes. [#10500](https://github.com/cockroachdb/cockroach/pull/10500)
-- Old replicas that are blocking other operations are now prioritized for garbage collection. [#10426](https://github.com/cockroachdb/cockroach/pull/10426)
-- Small clusters now run their replica scanners more frequently by default. [#10433](https://github.com/cockroachdb/cockroach/pull/10433)
-- Reduced contention in the command queue for multi-range operations. [#10470](https://github.com/cockroachdb/cockroach/pull/10470)
-- Operations that have already expired are no longer added to the command queue. [#10487](https://github.com/cockroachdb/cockroach/pull/10487)
-- Reduced allocations for SQL row data. [#10534](https://github.com/cockroachdb/cockroach/pull/10534)
-
-### Bug Fixes
-
-- A node that is stopped and restarted quickly can no longer produce inconsistent results. [#10420](https://github.com/cockroachdb/cockroach/pull/10420)
-- Replication snapshots now release their resources earlier, preventing deadlocks. [#10491](https://github.com/cockroachdb/cockroach/pull/10491)
-- Fixed a bug with time series garbage collection when the time series data spans multiple ranges. [#10400](https://github.com/cockroachdb/cockroach/pull/10400)
-- Fixed a bug with very large [`DECIMAL`](decimal.html) values or very small fractions. [#10446](https://github.com/cockroachdb/cockroach/pull/10446)
-- The `pow()` [function](functions-and-operators.html) now returns an error when its arguments are too large. [#10525](https://github.com/cockroachdb/cockroach/pull/10525)
-- Fixed a crash when the number of placeholders in a query doesn't match the number of arguments. [#10474](https://github.com/cockroachdb/cockroach/pull/10474)
-- Improved error handling when a SQL [transaction](transactions.html) exceeds an internal deadline. [#9906](https://github.com/cockroachdb/cockroach/pull/9906)
-- Fixed a panic in raft leadership transfers. [#10530](https://github.com/cockroachdb/cockroach/pull/10530)
-- Fixed a leak in [`CREATE TABLE AS`](create-table-as.html) and [`CREATE VIEW`](create-view.html). [#10527](https://github.com/cockroachdb/cockroach/pull/10527)
-
-### Doc Updates
-
-- Expanded the [cloud deployment](cloud-deployment.html) tutorials to cover secure clusters:
-    - [GCE](deploy-cockroachdb-on-google-cloud-platform.html)
-    - [AWS](deploy-cockroachdb-on-aws.html)
-    - [Digital Ocean](deploy-cockroachdb-on-digital-ocean.html)
-
-### Contributors
-
-This release includes 64 merged PRs by 21 authors. We would like to thank the following contributors from the CockroachDB community, including first-time contributor Nathan Johnson.
-
-- Nathan Johnson
-- songhao
-
-### Stay Up-to-Date
-
 Get future release notes emailed to you:
 <div class="hubspot-install-form install-form-1 clearfix">
     <script>
@@ -81,4 +24,3 @@ Get future release notes emailed to you:
         });
     </script>
 </div>
->>>>>>> constraint pages

--- a/beta-20161201.md
+++ b/beta-20161201.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20161201.
 
 ## Dec 1, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -148,19 +162,3 @@ This release includes 292 merged PRs by 30 authors. We would like to thank the f
 - Nathan Johnson
 - songhao
 - yznming
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161208.md
+++ b/beta-20161208.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20161208.
 
 ## Dec 8, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -61,19 +75,3 @@ This release includes 101 merged PRs by 19 authors. We would like to thank the f
 
 - songhao
 - yznming
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20161215.md
+++ b/beta-20161215.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20161215.
 
 ## Dec 15, 2016
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -49,19 +63,3 @@ summary: Additions and changes in CockroachDB version beta-20161215.
 ### Contributors
 
 This release includes 62 merged PRs by 18 authors.
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/beta-20170105.md
+++ b/beta-20170105.md
@@ -6,6 +6,20 @@ summary: Additions and changes in CockroachDB version beta-20170105.
 
 ## Jan 5, 2017
 
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
 ### Binaries
 
 <div id="os-tabs" class="clearfix">
@@ -89,19 +103,3 @@ Raft traffic to that node is suspended until it becomes responsive again. [#1263
 This release includes 122 merged PRs by 25 authors. We would like to thank the following contributors from the CockroachDB community:
 
 - Haines Chan
-
-### Stay Up-to-Date
-
-Get future release notes emailed to you:
-<div class="hubspot-install-form install-form-1 clearfix">
-    <script>
-        hbspt.forms.create({
-            css: '',
-            cssClass: 'install-form',
-            portalId: '1753393',
-            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
-            formInstanceId: 1,
-            target: '.install-form-1'
-        });
-    </script>
-</div>

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -108,7 +108,7 @@ $(document).ready(function(){
       <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-binary-step4"><span class="gp" data-eventcategory="mac-binary-step4">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
-      <p>Keep up-to-date with software releases and usage best practices:</p>
+      <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-1 clearfix">
         <script>
           hbspt.forms.create({ 
@@ -144,7 +144,7 @@ $(document).ready(function(){
       <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-homebrew-step3"><span class="gp" data-eventcategory="mac-homebrew-step3">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
-      <p>Keep up-to-date with software releases and usage best practices:</p>
+      <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-2 clearfix">
         <script>
           hbspt.forms.create({ 
@@ -204,7 +204,7 @@ $(document).ready(function(){
     <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-source-step5"><span class="gp" data-eventcategory="mac-source-step5">$ </span>cockroach version</code></pre></div>
   </li>
   <li>
-    <p>Keep up-to-date with software releases and usage best practices:</p>
+    <p>Get future release notes emailed to you:</p>
     <div class="hubspot-install-form install-form-3 clearfix">
       <script>
         hbspt.forms.create({ 
@@ -247,7 +247,7 @@ $(document).ready(function(){
     <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-docker-step4"><span class="gp" data-eventcategory="mac-docker-step4">$ </span>docker run --rm cockroachdb/cockroach:{{site.data.strings.version}} version</code></pre></div>
   </li>
   <li>
-    <p>Keep up-to-date with software releases and usage best practices:</p>
+    <p>Get future release notes emailed to you:</p>
     <div class="hubspot-install-form install-form-4 clearfix">
       <script>
         hbspt.forms.create({ 
@@ -296,7 +296,7 @@ $(document).ready(function(){
       <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-binary-step3"><span class="gp" data-eventcategory="linux-binary-step3">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
-      <p>Keep up-to-date with software releases and usage best practices:</p>
+      <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-5 clearfix">
         <script>
           hbspt.forms.create({ 
@@ -356,7 +356,7 @@ $(document).ready(function(){
       <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-source-step5"><span class="gp" data-eventcategory="linux-source-step5">$ </span>cockroach version</code></pre></div>
   </li>
   <li>
-      <p>Keep up-to-date with software releases and usage best practices:</p>
+      <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-6 clearfix">
         <script>
           hbspt.forms.create({ 
@@ -401,7 +401,7 @@ $(document).ready(function(){
       <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-docker-step4"><span class="gp" data-eventcategory="linux-docker-step4">$ </span>sudo docker run --rm cockroachdb/cockroach:{{site.data.strings.version}} version</code></pre></div>
   </li>
   <li>
-    <p>Keep up-to-date with software releases and usage best practices:</p>
+    <p>Get future release notes emailed to you:</p>
     <div class="hubspot-install-form install-form-7 clearfix">
       <script>
         hbspt.forms.create({ 
@@ -445,7 +445,7 @@ $(document).ready(function(){
       <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="win-docker-step4"><span class="gp" data-eventcategory="win-docker-step4">$ </span>docker run --rm cockroachdb/cockroach:{{site.data.strings.version}} version</code></pre></div>
   </li>
   <li>
-    <p>Keep up-to-date with software releases and usage best practices:</p>
+    <p>Get future release notes emailed to you:</p>
     <div class="hubspot-install-form install-form-8 clearfix">
       <script>
         hbspt.forms.create({ 


### PR DESCRIPTION
In an effort to increase email sign up for product release notes, this PR:

- Moves email sign up to the top of each release notes page.
- Revises email sign up copy on the install page.

Fixes #981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/982)
<!-- Reviewable:end -->
