### PR TITLE
Add stop-the-world warning to this week's release notes.

### DIFF
--- a/beta-20170112.md
+++ b/beta-20170112.md
@@ -27,6 +27,10 @@ Get future release notes emailed to you:
     <a href="https://binaries.cockroachdb.com/cockroach-beta-20170112.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
 </div>
 
+### Upgrade Notes
+
+- This release cannot be run concurrently with older beta releases. Please stop all nodes running older releases before restarting any node with this version.
+
 ### SQL Language Changes
 
 - The `ALTER TABLE VALIDATE CONSTRAINT` statement can now be used to validate foreign keys in the `UNVALIDATED` state. [#12682](https://github.com/cockroachdb/cockroach/pull/12682)


### PR DESCRIPTION
The change to MaxOffset requires a stop-the-world upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/997)
<!-- Reviewable:end -->
