### PR TITLE
Convert apostrophes in page titles to HTML rep

### DIFF
--- a/beta-20160407.md
+++ b/beta-20160407.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160407
+title: What&#39;s New in beta-20160407
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160407.
 ---

--- a/beta-20160414.md
+++ b/beta-20160414.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160414
+title: What&#39;s New in beta-20160414
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160414.
 ---

--- a/beta-20160421.md
+++ b/beta-20160421.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160421
+title: What&#39;s New in beta-20160421
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160421.
 ---

--- a/beta-20160428.md
+++ b/beta-20160428.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160428
+title: What&#39;s New in beta-20160428
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160428.
 ---

--- a/beta-20160505.md
+++ b/beta-20160505.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160505
+title: What&#39;s New in beta-20160505
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160505.
 ---

--- a/beta-20160512.md
+++ b/beta-20160512.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160512
+title: What&#39;s New in beta-20160512
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160512.
 ---

--- a/beta-20160519.md
+++ b/beta-20160519.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160519
+title: What&#39;s New in beta-20160519
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160519.
 ---

--- a/beta-20160526.md
+++ b/beta-20160526.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160526
+title: What&#39;s New in beta-20160526
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160526.
 ---

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160602
+title: What&#39;s New in beta-20160602
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160602.
 ---

--- a/beta-20160609.md
+++ b/beta-20160609.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160609
+title: What&#39;s New in beta-20160609
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160609.
 ---

--- a/beta-20160616.md
+++ b/beta-20160616.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160616
+title: What&#39;s New in beta-20160616
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160616.
 ---

--- a/beta-20160629.md
+++ b/beta-20160629.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160629
+title: What&#39;s New in beta-20160629
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160629.
 ---

--- a/beta-20160714.md
+++ b/beta-20160714.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160714
+title: What&#39;s New in beta-20160714
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160714.
 ---

--- a/beta-20160721.md
+++ b/beta-20160721.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160721
+title: What&#39;s New in beta-20160721
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160721.
 ---

--- a/beta-20160728.md
+++ b/beta-20160728.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160728
+title: What&#39;s New in beta-20160728
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160728.
 ---

--- a/beta-20160829.md
+++ b/beta-20160829.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160829
+title: What&#39;s New in beta-20160829
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160829.
 ---

--- a/beta-20160908.md
+++ b/beta-20160908.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160908
+title: What&#39;s New in beta-20160908
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160908.
 ---

--- a/beta-20160915.md
+++ b/beta-20160915.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160915
+title: What&#39;s New in beta-20160915
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160915.
 ---

--- a/beta-20160929.md
+++ b/beta-20160929.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20160929
+title: What&#39;s New in beta-20160929
 toc: false
 summary: Additions and changes in CockroachDB version beta-20160929.
 ---

--- a/beta-20161006.md
+++ b/beta-20161006.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161006
+title: What&#39;s New in beta-20161006
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161006.
 ---

--- a/beta-20161013.md
+++ b/beta-20161013.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161013
+title: What&#39;s New in beta-20161013
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161013.
 ---

--- a/beta-20161027.md
+++ b/beta-20161027.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161027
+title: What&#39;s New in beta-20161027
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161027.
 ---

--- a/beta-20161103.md
+++ b/beta-20161103.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161103
+title: What&#39;s New in beta-20161103
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161103.
 ---

--- a/beta-20161110.md
+++ b/beta-20161110.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161110
+title: What&#39;s New in beta-20161110
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161110.
 feedback: false

--- a/beta-20161201.md
+++ b/beta-20161201.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161201
+title: What&#39;s New in beta-20161201
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161201.
 ---

--- a/beta-20161208.md
+++ b/beta-20161208.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161208
+title: What&#39;s New in beta-20161208
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161208.
 ---

--- a/beta-20161215.md
+++ b/beta-20161215.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20161215
+title: What&#39;s New in beta-20161215
 toc: false
 summary: Additions and changes in CockroachDB version beta-20161215.
 ---

--- a/beta-20170105.md
+++ b/beta-20170105.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20170105
+title: What&#39;s New in beta-20170105
 toc: false
 summary: Additions and changes in CockroachDB version beta-20170105.
 ---

--- a/beta-20170112.md
+++ b/beta-20170112.md
@@ -1,5 +1,5 @@
 ---
-title: What's New in beta-20170112
+title: What&#39;s New in beta-20170112
 toc: false
 summary: Additions and changes in CockroachDB version beta-20170112.
 ---


### PR DESCRIPTION
@jseldess found a bug on release note pages causing the feedback buttons to not work. Culprit was unescaped apostrophes in page titles. Fix is converting those to the HTML representation of an apostrophe (instead of the literal `'`).

Note that this has to be done for all page titles in the future, as well, or those buttons will continue to break. Can discuss another strategy for a permanent fix in person.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1001)
<!-- Reviewable:end -->
