### PR TITLE
Fix typo in sidenav

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -44,7 +44,7 @@ entries:
                 - title: Data Replication
                   url: /demo-data-replication.html
 
-                - title: Fault Toleranace & Recovery
+                - title: Fault Tolerance & Recovery
                   url: /demo-fault-tolerance-and-recovery.html
 
                 - title: Scalability


### PR DESCRIPTION
Fixes a typo in the docs sidenav.

Fixes #1003

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1005)
<!-- Reviewable:end -->
