### PR TITLE
Update binary URL for Azure

### DIFF
--- a/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -104,7 +104,7 @@ When creating the VMs, make sure to select the **Resource Group**, **Virtual Net
 	
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
 
 	# Extract the binary.
 	$ tar -xf cockroach-latest.linux-amd64.tgz  \

--- a/deploy-cockroachdb-on-microsoft-azure.md
+++ b/deploy-cockroachdb-on-microsoft-azure.md
@@ -178,7 +178,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
 
 	# Extract the binary.
 	$ tar -xf cockroach-latest.linux-amd64.tgz  \


### PR DESCRIPTION
`binaries.cockroachdb.com` is not consistently working on Microsoft Azure; @mberhault suggests changing URL to point directly to Amazing S3 where binaries are hosted.

@jseldess PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1011)
<!-- Reviewable:end -->
