### PR TITLE
Note on grammar page

### DIFF
--- a/_data/alerts.yml
+++ b/_data/alerts.yml
@@ -4,12 +4,12 @@ important: '<div class="alert alert-warning" role="alert"><i class="fa fa-warnin
 warning: '<div class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning: </b>'
 end: '</div>'
 
-callout_danger: '<div class="bs-callout bs-callout-danger">'
-callout_default: '<div class="bs-callout bs-callout-default">'
-callout_primary: '<div class="bs-callout bs-callout-primary">'
-callout_success: '<div class="bs-callout bs-callout-success">'
-callout_info: '<div class="bs-callout bs-callout-info">'
-callout_warning: '<div class="bs-callout bs-callout-warning">'
+callout_danger: '<div class="bs-callout bs-callout-danger" markdown="1">'
+callout_default: '<div class="bs-callout bs-callout-default" markdown="1">'
+callout_primary: '<div class="bs-callout bs-callout-primary" markdown="1">'
+callout_success: '<div class="bs-callout bs-callout-success" markdown="1">'
+callout_info: '<div class="bs-callout bs-callout-info" markdown="1">'
+callout_warning: '<div class="bs-callout bs-callout-warning" markdown="1">'
 
 hr_faded: '<hr class="faded"/>'
 hr_shaded: '<hr class="shaded"/>'

--- a/beta-20170112.md
+++ b/beta-20170112.md
@@ -23,8 +23,8 @@ Get future release notes emailed to you:
 {{site.data.alerts.callout_danger}}
 <a href="https://github.com/cockroachdb/cockroach/issues/12875">Data corruption</a> has
 been observed with this release and is still under investigation.
-Until the root cause has been determined we recommend using
-<code>beta-20170105</code> instead of this release.
+Until the root cause has been determined, we recommend using
+<a href="beta-20170105.html"><code>beta-20170105</code></a> instead of this release.
 {{site.data.alerts.end}}
 
 ### Binaries

--- a/sql-grammar.md
+++ b/sql-grammar.md
@@ -17,6 +17,8 @@ a[name]:focus {
 }
 </style>
 
-{{site.data.alerts.callout_success}}This page describes the full CockroachDB SQL grammar. However, as a starting point, it's best to reference our <a href="sql-statements.html">statement-specific pages</a> first, which provide detailed explanations and examples.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}
+This page describes the full CockroachDB SQL grammar. However, as a starting point, it's best to reference our [sql-statements pages](sql-statements.html) first, which provide detailed explanations and examples.
+{{site.data.alerts.end}}
 
 {% include sql/diagrams/grammar.html %}

--- a/sql-grammar.md
+++ b/sql-grammar.md
@@ -17,4 +17,6 @@ a[name]:focus {
 }
 </style>
 
+{{site.data.alerts.callout_success}}This page describes the full CockroachDB SQL grammar. However, as a starting point, it's best to reference our <a href="sql-statements.html">statement-specific pages</a> first, which provide detailed explanations and examples.{{site.data.alerts.end}}
+
 {% include sql/diagrams/grammar.html %}


### PR DESCRIPTION
This PR adds a note to the top of the full SQL grammar page encouraging users to checkout the statement-specific pages first. 

It also adds a link to the warning in the beta-20170112 release notes. 

Fixes #1013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1014)
<!-- Reviewable:end -->
