### PR TITLE
Remove flag to use markdown inside alerts

### DIFF
--- a/_data/alerts.yml
+++ b/_data/alerts.yml
@@ -4,12 +4,12 @@ important: '<div class="alert alert-warning" role="alert"><i class="fa fa-warnin
 warning: '<div class="alert alert-danger" role="alert"><i class="fa fa-exclamation-circle"></i> <b>Warning: </b>'
 end: '</div>'
 
-callout_danger: '<div class="bs-callout bs-callout-danger" markdown="1">'
-callout_default: '<div class="bs-callout bs-callout-default" markdown="1">'
-callout_primary: '<div class="bs-callout bs-callout-primary" markdown="1">'
-callout_success: '<div class="bs-callout bs-callout-success" markdown="1">'
-callout_info: '<div class="bs-callout bs-callout-info" markdown="1">'
-callout_warning: '<div class="bs-callout bs-callout-warning" markdown="1">'
+callout_danger: '<div class="bs-callout bs-callout-danger">'
+callout_default: '<div class="bs-callout bs-callout-default">'
+callout_primary: '<div class="bs-callout bs-callout-primary">'
+callout_success: '<div class="bs-callout bs-callout-success">'
+callout_info: '<div class="bs-callout bs-callout-info">'
+callout_warning: '<div class="bs-callout bs-callout-warning">'
 
 hr_faded: '<hr class="faded"/>'
 hr_shaded: '<hr class="shaded"/>'

--- a/sql-grammar.md
+++ b/sql-grammar.md
@@ -18,7 +18,7 @@ a[name]:focus {
 </style>
 
 {{site.data.alerts.callout_success}}
-This page describes the full CockroachDB SQL grammar. However, as a starting point, it's best to reference our [sql-statements pages](sql-statements.html) first, which provide detailed explanations and examples.
+This page describes the full CockroachDB SQL grammar. However, as a starting point, it's best to reference our <a href="sql-statements.html">SQL statements pages</a> first, which provide detailed explanations and examples.
 {{site.data.alerts.end}}
 
 {% include sql/diagrams/grammar.html %}


### PR DESCRIPTION
In https://github.com/cockroachdb/docs/pull/1017, we changed the "alerts" to allow markdown in addition to HTML, but I missed that this change has caused alerts to not close properly. Reverting to allow only HTML inside alerts to fix the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1020)
<!-- Reviewable:end -->
