### PR TITLE
Proposal for a new sidebar organisation for sql docs.

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -57,198 +57,62 @@ entries:
           url: /install-client-drivers.html
 
           thirdlevel:
-            - title: SQL Statements
+            - title: Program SQL queries
+              thirdlevelitems:
+
+                - title: Query and Update Statements
+                  url: /sql-statements.html#query-and-update-statements
+
+                - title: Table Expressions
+                  url: /table-expressions.html
+
+                - title: Constant Values
+                  url: /sql-constants.html
+
+                - title: Value Expressions
+                  url: /sql-expressions.html
+
+                - title: Built-in Functions and Operators
+                  url: /functions-and-operators.html
+
+                - title: Data Types
+                  url: /data-types.html
+
+                - title: Information Schema
+                  url: /information-schema.html
+
+                - title: Keywords & Identifiers
+                  url: /keywords-and-identifiers.html
+
+                - title: SQL Grammar
+                  url: /sql-grammar.html
+
+            - title: Use Transactions
               thirdlevelitems:
 
                 - title: Overview
-                  url: /sql-statements.html
+                  url: /transactions.html
 
-                - title: <code>ADD COLUMN</code>
-                  url: /add-column.html
+                - title: Transaction Management Statements
+                  url: /sql-statements.html#transaction-management-statements
 
-                - title: <code>ADD CONSTRAINT</code>
-                  url: /add-constraint.html
+                - title: Automatic and Manual Retries
+                  url: /transactions.html#transaction-retries
 
-                - title: <code>ALTER COLUMN</code>
-                  url: /alter-column.html
+                - title: Priorities
+                  url: /transactions.html#transaction-priorities
 
-                - title: <code>ALTER TABLE</code>
-                  url: /alter-table.html
-
-                - title: <code>ALTER VIEW</code>
-                  url: /alter-view.html
-
-                - title: <code>BEGIN</code>
-                  url: /begin-transaction.html
-
-                - title: <code>COMMIT</code>
-                  url: /commit-transaction.html
-
-                - title: <code>CREATE DATABASE</code>
-                  url: /create-database.html
-
-                - title: <code>CREATE INDEX</code>
-                  url: /create-index.html
-
-                - title: <code>CREATE TABLE</code>
-                  url: /create-table.html
-
-                - title: <code>CREATE TABLE AS</code>
-                  url: /create-table-as.html
-
-                - title: <code>CREATE USER</code>
-                  url: /create-user.html
-
-                - title: <code>CREATE VIEW</code>
-                  url: /create-view.html
-
-                - title: <code>DELETE</code>
-                  url: /delete.html
-
-                - title: <code>DROP COLUMN</code>
-                  url: /drop-column.html
-                  
-                - title: <code>DROP CONSTRAINT</code>
-                  url: /drop-constraint.html
-
-                - title: <code>DROP DATABASE</code>
-                  url: /drop-database.html
-
-                - title: <code>DROP INDEX</code>
-                  url: /drop-index.html
-
-                - title: <code>DROP TABLE</code>
-                  url: /drop-table.html
-
-                - title: <code>DROP VIEW</code>
-                  url: /drop-view.html
-              
-                - title: <code>EXPLAIN</code>
-                  url: /explain.html
-
-                - title: <code>GRANT</code>
-                  url: /grant.html
-
-                - title: <code>INSERT</code>
-                  url: /insert.html
-
-                - title: <code>RENAME COLUMN</code>
-                  url: /rename-column.html
-
-                - title: <code>RENAME DATABASE</code>
-                  url: /rename-database.html
-
-                - title: <code>RENAME INDEX</code>
-                  url: /rename-index.html
-
-                - title: <code>RENAME TABLE</code>
-                  url: /rename-table.html
-
-                - title: <code>RELEASE SAVEPOINT</code>
-                  url: /release-savepoint.html
-
-                - title: <code>REVOKE</code>
-                  url: /revoke.html
-
-                - title: <code>ROLLBACK</code>
-                  url: /rollback-transaction.html
-
-                - title: <code>SAVEPOINT</code>
-                  url: /savepoint.html
-
-                - title: <code>SELECT</code>
-                  url: /select.html
-
-                - title: <code>SET DATABASE</code>
-                  url: /set-database.html
-
-                - title: <code>SET TIME ZONE</code>
-                  url: /set-time-zone.html
-
-                - title: <code>SET TRANSACTION</code>
-                  url: /set-transaction.html
-
-                - title: <code>SHOW ALL</code>
-                  url: /show-all.html
-
-                - title: <code>SHOW COLUMNS</code>
-                  url: /show-columns.html
-
-                - title: <code>SHOW CONSTRAINTS</code>
-                  url: /show-constraints.html
-
-                - title: <code>SHOW CREATE TABLE</code>
-                  url: /show-create-table.html
-
-                - title: <code>SHOW CREATE VIEW</code>
-                  url: /show-create-view.html
-
-                - title: <code>SHOW DATABASE</code>
-                  url: /show-database.html
-
-                - title: <code>SHOW DATABASES</code>
-                  url: /show-databases.html
-
-                - title: <code>SHOW GRANTS</code>
-                  url: /show-grants.html
-
-                - title: <code>SHOW INDEX</code>
-                  url: /show-index.html
-
-                - title: <code>SHOW TABLES</code>
-                  url: /show-tables.html
-
-                - title: <code>SHOW TIME ZONE</code>
-                  url: /show-time-zone.html
-
-                - title: <code>SHOW TRANSACTION</code>
-                  url: /show-transaction.html
-
-                - title: <code>SHOW USERS</code>
-                  url: /show-users.html
-
-                - title: <code>TRUNCATE</code>
-                  url: /truncate.html
-
-                - title: <code>UPDATE</code>
-                  url: /update.html
-
-                - title: <code>UPSERT</code>
-                  url: /upsert.html
-
-        - title: SQL Grammar
-          url: /sql-grammar.html
-
-          thirdlevel:
-            - title: Constraints
-              thirdlevelitems:
-
-                - title: Overview
-                  url: /constraints.html
-
-                - title: Check
-                  url: /check.html
-
-                - title: Default Value
-                  url: /default-value.html
-
-                - title: Foreign Keys
-                  url: /foreign-key.html
-
-                - title: Not Null
-                  url: /not-null.html
-
-                - title: Primary Key
-                  url: /primary-key.html
-
-                - title: Unique
-                  url: /unique.html
+                - title: Isolation Levels
+                  url: /transactions.html#isolation-levels
 
             - title: Data Definition
               thirdlevelitems:
 
-                - title: Keywords & Identifiers
-                  url: /keywords-and-identifiers.html
+                - title: Data Definition Statements
+                  url: /sql-statements.html#data-definition-statements
+
+                - title: Column Constraints
+                  url: /constraints.html
 
                 - title: Indexes
                   url: /indexes.html
@@ -265,56 +129,20 @@ entries:
                 - title: <code>NULL</code> Handling
                   url: /null-handling.html
 
-            - title: Data Types
+                - title: Information Schema
+                  url: /information-schema.html
+
+            - title: Privileges
               thirdlevelitems:
 
                 - title: Overview
-                  url: /data-types.html
+                  url: /privileges.html
 
-                - title: <code>INT</code>
-                  url: /int.html
+                - title: Privilege Management Statements
+                  url: /sql-statements.html#privilege-management-statements
 
-                - title: <code>SERIAL</code>
-                  url: /serial.html
-
-                - title: <code>DECIMAL</code>
-                  url: /decimal.html
-
-                - title: <code>FLOAT</code>
-                  url: /float.html
-
-                - title: <code>BOOL</code>
-                  url: /bool.html
-
-                - title: <code>DATE</code>
-                  url: /date.html
-
-                - title: <code>TIMESTAMP</code>
-                  url: /timestamp.html
-
-                - title: <code>INTERVAL</code>
-                  url: /interval.html
-
-                - title: <code>STRING</code>
-                  url: /string.html
-
-                - title: <code>COLLATE</code>
-                  url: /collate.html
-
-                - title: <code>BYTES</code>
-                  url: /bytes.html
-
-        - title: Privileges
-          url: /privileges.html
-          
-        - title: Functions and Operators
-          url: /functions-and-operators.html
-
-        - title: Transactions
-          url: /transactions.html
-
-        - title: Information Schema
-          url: /information-schema.html
+                - title: Create and Manage Users
+                  url: /create-and-manage-users.html
 
     - title: Deploy
       items:
@@ -349,7 +177,7 @@ entries:
 
                 - title: Overview
                   url: /orchestration.html
-                  
+
                 - title: Kubernetes
                   url: /orchestrate-cockroachdb-with-kubernetes.html
 
@@ -428,7 +256,7 @@ entries:
 
                 - title: SQL
                   url: /sql.html
-                  
+
                 - title: Distributed Transactions
                   url: /distributed-transactions.html
 

--- a/sql-statements.md
+++ b/sql-statements.md
@@ -6,55 +6,81 @@ toc: false
 
 CockroachDB supports the following SQL statements. Click a statement for more details.
 
-Statement | Usage 
+## Query and Update Statements
+
+Statement | Usage
+----------|------------
+[`CREATE TABLE AS`](create-table-as.html) | Create a new table in a database using the results from a `SELECT` statement.
+[`DELETE`](delete.html) | Delete specific rows from a table.
+[`EXPLAIN`](explain.html) | View debugging and analysis details for a `SELECT`, `INSERT`, `UPDATE`, or `DELETE` statement.
+[`INSERT`](insert.html) | Insert rows into a table.
+[`SELECT`](select.html) | Select rows from a table.
+[`TRUNCATE`](truncate.html) | Deletes all rows from specified tables.
+[`UPDATE`](update.html) | Update rows in a table.
+[`UPSERT`](upsert.html) | Insert rows that do not violate uniqueness constraints; update rows that do.
+
+## Data Definition Statements
+
+Statement | Usage
 ----------|------------
 [`ADD COLUMN`](add-column.html) | Add columns to a table.
 [`ADD CONSTRAINT`](add-constraint.html) | Add a constraint to a column.
 [`ALTER COLUMN`](alter-column.html) | Change a column's [Default constraint](default-value.html) or drop the [Not Null constraint](not-null.html).
 [`ALTER TABLE`](alter-table.html) | Apply a schema change to a table.
 [`ALTER VIEW`](alter-view.html) | Rename a view.
-[`BEGIN`](begin-transaction.html)| Initiate a [transaction](transactions.html).
-[`COMMIT`](commit-transaction.html) | Commit the current [transaction](transactions.html).
 [`CREATE DATABASE`](create-database.html) | Create a new database.
 [`CREATE INDEX`](create-index.html) | Create an index for a table.
-[`CREATE TABLE`](create-table.html) | Create a new table in a database. 
+[`CREATE TABLE`](create-table.html) | Create a new table in a database.
 [`CREATE TABLE AS`](create-table-as.html) | Create a new table in a database using the results from a `SELECT` statement.
-[`CREATE USER`](create-user.html) | Creates a SQL user, which lets you control [privileges](privileges.html) on your databases and tables.
 [`CREATE VIEW`](create-view.html) | Create a new [view](views.html) in a database.
-[`DELETE`](delete.html) | Delete specific rows from a table.
 [`DROP COLUMN`](drop-column.html) | Remove columns from a table.
 [`DROP CONSTRAINT`](drop-constraint.html) | Remove constraints from a column.
 [`DROP DATABASE`](drop-database.html) | Remove a database and all its objects.
 [`DROP INDEX`](drop-index.html) | Remove an index for a table.
 [`DROP TABLE`](drop-table.html) | Remove a table.
 [`DROP VIEW`](drop-view.html)| Remove a view.
-[`EXPLAIN`](explain.html) | View debugging and analysis details for a `SELECT`, `INSERT`, `UPDATE`, or `DELETE` statement.
-[`GRANT`](grant.html) | Grant privileges to users. 
-[`INSERT`](insert.html) | Insert rows into a table.
 [`RENAME COLUMN`](rename-column.html) | Rename a column in a table.
 [`RENAME DATABASE`](rename-database.html) | Rename a database.
 [`RENAME INDEX`](rename-index.html) | Rename an index for a table.
 [`RENAME TABLE`](rename-table.html) | Rename a table or move a table between databases.
-[`RELEASE SAVEPOINT`](release-savepoint.html) | When using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), commit the transaction's changes once there are no retryable errors.  
-[`REVOKE`](revoke.html) | Revoke privileges from users. 
-[`ROLLBACK`](rollback-transaction.html) | Discard all updates made by the current [transaction](transactions.html) or, when using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), rollback to the `cockroach_restart` savepoint and retry the transaction.  
-[`SELECT`](select.html) | Select rows from a table.
-[`SET DATABASE`](set-database.html) | Set the default database for the session.
-[`SET TIME ZONE`](set-time-zone.html) | Set the default time zone for the session.
-[`SET TRANSACTION`](set-transaction.html) | Set the isolation level or priority for the session or for an individual [transaction](transactions.html).
-[`SHOW ALL`](show-all.html) | List all current run-time settings.
 [`SHOW COLUMNS`](show-columns.html) | View details about columns in a table.
 [`SHOW CONSTRAINTS`](show-constraints.html) | List constraints on a table.
 [`SHOW CREATE TABLE`](show-create-table.html) | View the `CREATE TABLE` statement that would create a carbon copy of the specified table.
 [`SHOW CREATE VIEW`](show-create-view.html) | View the `CREATE VIEW` statement that would create a carbon copy of the specified view.
-[`SHOW DATABASE`](show-database.html) | List the default database for the session.
 [`SHOW DATABASES`](show-databases.html) | List databases in the cluster.
-[`SHOW GRANTS`](show-grants.html) | View privileges granted to users.
-[`SHOW INDEX`](show-index.html) | View index information for a table. 
+[`SHOW INDEX`](show-index.html) | View index information for a table.
 [`SHOW TABLES`](show-tables.html) | List tables in a database.
+
+## Transaction Management Statements
+
+Statement | Usage
+----------|------------
+[`BEGIN`](begin-transaction.html)| Initiate a [transaction](transactions.html).
+[`COMMIT`](commit-transaction.html) | Commit the current [transaction](transactions.html).
+[`RELEASE SAVEPOINT`](release-savepoint.html) | When using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), commit the transaction's changes once there are no retryable errors.
+[`ROLLBACK`](rollback-transaction.html) | Discard all updates made by the current [transaction](transactions.html) or, when using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), rollback to the `cockroach_restart` savepoint and retry the transaction.
+[`SAVEPOINT`](savepoint.html) | When using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), start a retryable transaction.
+[`SET TRANSACTION`](set-transaction.html) | Set the isolation level or priority for the session or for an individual [transaction](transactions.html).
+[`SHOW TRANSACTION`](show-transaction.html) | View the isolation level or priority for the session or for an individual [transaction](transactions.html).
+
+## Privilege Management Statements
+
+Statement | Usage
+----------|------------
+[`CREATE USER`](create-user.html) | Creates a SQL user, which lets you control [privileges](privileges.html) on your databases and tables.
+[`GRANT`](grant.html) | Grant privileges to users.
+[`REVOKE`](revoke.html) | Revoke privileges from users.
+[`SHOW GRANTS`](show-grants.html) | View privileges granted to users.
+[`SHOW USERS`](show-users.html) | Lists the users for all databases.
+
+## Session Management Statements
+
+Statement | Usage
+----------|------------
+[`SET DATABASE`](set-database.html) | Set the default database for the session.
+[`SET TIME ZONE`](set-time-zone.html) | Set the default time zone for the session.
+[`SET TRANSACTION`](set-transaction.html) | Set the isolation level or priority for the session or for an individual [transaction](transactions.html).
+[`SHOW ALL`](show-all.html) | List all current run-time settings.
+[`SHOW DATABASE`](show-database.html) | List the default database for the session.
 [`SHOW TIME ZONE`](show-time-zone.html) | View the default time zone for the session.
 [`SHOW TRANSACTION`](show-transaction.html) | View the isolation level or priority for the session or for an individual [transaction](transactions.html).
-[`SHOW USERS`](show-users.html) | Lists the users for all databases.
-[`TRUNCATE`](truncate.html) | Deletes all rows from specified tables.
-[`UPDATE`](update.html) | Update rows in a table.
-[`UPSERT`](upsert.html) | Insert rows that do not violate uniqueness constraints; update rows that do.


### PR DESCRIPTION
This PR forks off #1008.

This is a proposal to initiate a discussion about the structure of the sidebar.

The motivation from this stems from the observation that the sidebar is hard to navigate in the "develop" section and fails to identify the hierarchical nature of how developers approach documentation about a new programming environment.

The proposal approaches this by defining the following top sections:

- Writing SQL queries (About the SQL language as supported by CockroachDB)
- Using transactions (About how the SQL queries are handled server-side)
- Data definition (About how to organize data)
- Misc: Security ("Privileges" in proposal) and Client Sessions (not yet written, but will need to be)

It further separates the language features that belong to each of these categories. The classification is "clean" in that it partitions the entire set of SQL statements along these lines without overlap (with one exception, "CREATE TABLE AS" which is really "CREATE TABLE" combined with "INSERT" and is a non-standard extension).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1021)
<!-- Reviewable:end -->
