### PR TITLE
Regenerate func docs

### DIFF
--- a/_includes/sql/aggregates.md
+++ b/_includes/sql/aggregates.md
@@ -1,53 +1,54 @@
 Function &rarr; Returns | Description
 --- | ---
-<code>array_agg(<a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Aggregates the selected values into an array.</span>
-<code>array_agg(<a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Aggregates the selected values into an array.</span>
-<code>avg(<a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
-<code>avg(<a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
-<code>avg(<a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
-<code>bool_and(<a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Calculates the boolean value of `AND`ing all selected values.</span>
-<code>bool_or(<a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Calculates the boolean value of `OR`ing all selected values.</span>
-<code>concat_agg(<a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Concatenates all selected values.</span>
-<code>concat_agg(<a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Concatenates all selected values.</span>
-<code>count(<a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="float.html">float</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(<a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count(tuple) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>max(<a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(<a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>min(<a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(<a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>stddev(<a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
-<code>stddev(<a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
-<code>stddev(<a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
-<code>sum(<a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum(<a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum(<a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum_int(<a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>variance(<a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
-<code>variance(<a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
-<code>variance(<a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
+<code>array_agg(arg: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Aggregates the selected values into an array.</span>
+<code>array_agg(arg: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Aggregates the selected values into an array.</span>
+<code>avg(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
+<code>avg(arg: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
+<code>avg(arg: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
+<code>bool_and(arg: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Calculates the boolean value of `AND`ing all selected values.</span>
+<code>bool_or(arg: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Calculates the boolean value of `OR`ing all selected values.</span>
+<code>concat_agg(arg: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Concatenates all selected values.</span>
+<code>concat_agg(arg: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Concatenates all selected values.</span>
+<code>count(arg: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="float.html">float</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>count(arg: tuple) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
+<code>max(arg: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>max(arg: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
+<code>min(arg: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>min(arg: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
+<code>stddev(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
+<code>stddev(arg: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
+<code>stddev(arg: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
+<code>sum(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
+<code>sum(arg: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
+<code>sum(arg: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
+<code>sum(arg: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
+<code>sum_int(arg: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
+<code>variance(arg: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
+<code>variance(arg: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
+<code>variance(arg: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
 

--- a/_includes/sql/functions.md
+++ b/_includes/sql/functions.md
@@ -55,6 +55,7 @@ Function &rarr; Returns | Description
 <code>ceiling(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the smallest integer greater than `val`.</span>
 <code>cos(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the cosine of `val`.</span>
 <code>cot(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the cotangent of `val`.</span>
+<code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>, txnID: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
 <code>degrees(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Converts `val` as a radian value to a degree value.</span>
 <code>div(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the integer quotient of `x`/`y`.</span>
 <code>div(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the integer quotient of `x`/`y`.</span>
@@ -164,11 +165,19 @@ Function &rarr; Returns | Description
 
 Function &rarr; Returns | Description
 --- | ---
-<code>pg_catalog.generate_series(<a href="int.html">int</a>, <a href="int.html">int</a>) &rarr; setof tuple{<a href="int.html">int</a>}</code> | <span class="funcdesc">Not usable; supported only for ORM compatibility.</span>
-<code>pg_catalog.generate_series(<a href="int.html">int</a>, <a href="int.html">int</a>, <a href="int.html">int</a>) &rarr; setof tuple{<a href="int.html">int</a>}</code> | <span class="funcdesc">Not usable; supported only for ORM compatibility.</span>
-<code>pg_catalog.pg_get_expr(pg_node_tree: <a href="string.html">string</a>, relation_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; supported only for ORM compatibility</span>
-<code>pg_catalog.pg_get_expr(pg_node_tree: <a href="string.html">string</a>, relation_oid: <a href="int.html">int</a>, pretty_<a href="bool.html">bool</a>: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; supported only for ORM compatibility</span>
-<code>pg_catalog.pg_get_indexdef(index_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; supported only for ORM compatibility</span>
-<code>pg_catalog.pg_get_userbyid(role_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; supported only for ORM compatibility</span>
-<code>pg_catalog.pg_typeof(val: anyelement) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; supported only for ORM compatibility</span>
+<code>pg_catalog.array_in(<a href="string.html">string</a>: <a href="string.html">string</a>, element_oid: <a href="int.html">int</a>, element_typmod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.col_description(table_oid: <a href="int.html">int</a>, column_number: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.format_type(type_oid: <a href="int.html">int</a>, typemod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the SQL name of a data type that is identified by its type OID and possibly a type modifier. Currently, the type modifier is ignored.</span>
+<code>pg_catalog.generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>) &rarr; setof tuple{<a href="int.html">int</a>}</code> | <span class="funcdesc">Produces a virtual table containing the integer values from `start` to `end`, inclusive.</span>
+<code>pg_catalog.generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>, step: <a href="int.html">int</a>) &rarr; setof tuple{<a href="int.html">int</a>}</code> | <span class="funcdesc">Produces a virtual table containing the integer values from `start` to `end`, inclusive, by increment of `step`.</span>
+<code>pg_catalog.obj_description(object_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.pg_backend_pid() &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.pg_get_expr(pg_node_tree: <a href="string.html">string</a>, relation_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.pg_get_expr(pg_node_tree: <a href="string.html">string</a>, relation_oid: <a href="int.html">int</a>, pretty_<a href="bool.html">bool</a>: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.pg_get_indexdef(index_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.pg_get_userbyid(role_oid: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.pg_typeof(val: anyelement) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>pg_catalog.shobj_description(object_oid: <a href="int.html">int</a>, catalog_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Not usable; exposed only for ORM compatibility.</span>
+<code>unnest(input: <a href="int.html">int</a>[]) &rarr; setof tuple{<a href="int.html">int</a>}</code> | <span class="funcdesc">Returns the input array as a set of rows</span>
+<code>unnest(input: <a href="string.html">string</a>[]) &rarr; setof tuple{<a href="string.html">string</a>}</code> | <span class="funcdesc">Returns the input array as a set of rows</span>
 


### PR DESCRIPTION
Regenerate built-in function docs to add:
- `col_description()`
- `format_type()`
- `unnest()`

And a bunch of `pg_catalog` compatibility functions. Note: I'll open a cockroach PR to update some descriptions and the regenerate these before merging.

Fixes #1045 
Fixes #1044 
Fixes #1041 
Fixes #1039 
Fixes #1038

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1047)
<!-- Reviewable:end -->
