### PR TITLE
Basic sample for GORM

### DIFF
--- a/_includes/app/gorm-basic-sample.go
+++ b/_includes/app/gorm-basic-sample.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	// Import GORM-related packages.
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+)
+
+// Account is our model, which corresponds to a database table.
+type Account struct {
+	ID      int `gorm:"primary_key"`
+	Balance int
+}
+
+func main() {
+	// Connect to the "bank" database as the "maxroach" user.
+	const addr = "postgresql://maxroach@localhost:26257/bank?sslmode=disable"
+	db, err := gorm.Open("postgres", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	// Automatically create the "accounts" table based on the Account model.
+	db.AutoMigrate(&Account{})
+
+	// Insert two rows into the "accounts" table.
+	db.Create(&Account{ID: 1, Balance: 1000})
+	db.Create(&Account{ID: 2, Balance: 250})
+
+	// Print out the balances.
+	var accounts []Account
+	db.Find(&accounts)
+	fmt.Println("Initial balances:")
+	for _, account := range accounts {
+		fmt.Printf("%d %d\n", account.ID, account.Balance)
+	}
+}


### PR DESCRIPTION
As discussed, this is meant to mirror `basic-sample.go`.

I believe the naming convention here should also apply for ORM samples
that require multiple files, such as Hibernate. A Hibernate sample might
be ZIP'ed and be named `hibernate-basic-sample.zip`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1054)
<!-- Reviewable:end -->
