### PR TITLE
Update SHOW ALL docs and sidebar

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -234,6 +234,9 @@ entries:
                 - title: Table Expressions
                   url: /table-expressions.html
 
+                - title: Name Resolution
+                  url: /sql-name-resolution.html
+
                 - title: Full SQL Grammar
                   url: /sql-grammar.html
 

--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -56,6 +56,9 @@ entries:
         - title: Install Client Drivers
           url: /install-client-drivers.html
 
+        - title: SQL Feature Support
+          url: /sql-feature-support.html
+
           thirdlevel:
             - title: SQL Statements
               thirdlevelitems:
@@ -216,10 +219,24 @@ entries:
                 - title: <code>UPSERT</code>
                   url: /upsert.html
 
-        - title: SQL Grammar
-          url: /sql-grammar.html
+            - title: SQL Syntax
+              thirdlevelitems:
 
-          thirdlevel:
+                - title: Keywords & Identifiers
+                  url: /keywords-and-identifiers.html
+
+                - title: Constants
+                  url: /sql-constants.html
+
+                - title: Value Expressions
+                  url: /sql-expressions.html
+
+                - title: Table Expressions
+                  url: /table-expressions.html
+
+                - title: Full SQL Grammar
+                  url: /sql-grammar.html
+
             - title: Constraints
               thirdlevelitems:
 
@@ -246,12 +263,6 @@ entries:
 
             - title: Data Definition
               thirdlevelitems:
-
-                - title: Keywords & Identifiers
-                  url: /keywords-and-identifiers.html
-
-                - title: Constants
-                  url: /sql-constants.html
 
                 - title: Indexes
                   url: /indexes.html
@@ -306,15 +317,6 @@ entries:
 
                 - title: <code>BYTES</code>
                   url: /bytes.html
-
-            - title: Expressions
-              thirdlevelitems:
-
-                - title: Value Expressions
-                  url: /sql-expressions.html
-
-                - title: Table Expressions
-                  url: /table-expressions.html
 
         - title: Privileges
           url: /privileges.html
@@ -421,9 +423,6 @@ entries:
 
         - title: CockroachDB in Comparison
           url: /cockroachdb-in-comparison.html
-
-        - title: SQL Feature Support
-          url: /sql-feature-support.html
 
         - title: CockroachDB Architecture
           url: /cockroachdb-architecture.html

--- a/show-all.md
+++ b/show-all.md
@@ -24,6 +24,9 @@ Variable | Description
 ------|------------
 `DATABASE` | The default database for the current session, as set by [`SET DATABASE`](set-database.html) or the client's connection string. This variable can be viewed with [`SHOW DATABASE`](show-database.html) as well. 
 `DEFAULT_TRANSACTION_ISOLATION` | The default transaction isolation level for the current session, as set by `SET DEFAULT_TRANSACTION_ISOLATION` or the client's connection string. 
+`MAX_INDEX_KEYS` | Not usable; exposed only for ORM compatibility.
+`SEARCH_PATH` | A list of databases or namespaces that will be searched to resolve unqualified table or function names.
+`SERVER_VERSION` | The version of PostgreSQL that CockroachDB emulates.
 `SYNTAX` | The default SQL syntax for the current session, as set by `SET SYNTAX`. This variable can be viewed with `SHOW SYNTAX` as well.
 `TIME ZONE` | The default time zone for the current session, as set by [`SET TIME ZONE`](set-time-zone.html). This variable can be viewed with [`SHOW TIME ZONE`](show-time-zone.html) as well.
 `TRANSACTION ISOLATION LEVEL` | The isolation level of the current transaction, as set by [`SET TRANSACTION ISOLATION LEVEL`](set-transaction.html). When run in the context of a transaction, [`SHOW TRANSACTION ISOLATION LEVEL`](show-transaction.html) returns this variable as well.<br><br>This will differ from `DEFAULT_TRANSACTION_ISOLATION` only when `SHOW ALL` is run in the context of a transaction and `SET TRANSACTION ISOLATION LEVEL` has been used to set a non-default isolation level for the specific transaction.
@@ -34,18 +37,22 @@ Variable | Description
 ~~~ sql
 > SHOW ALL;
 ~~~
+
 ~~~
 +-------------------------------+--------------+
 |           Variable            |    Value     |
 +-------------------------------+--------------+
-| DATABASE                      | bank         |
+| DATABASE                      | test         |
 | DEFAULT_TRANSACTION_ISOLATION | SERIALIZABLE |
+| MAX_INDEX_KEYS                |           32 |
+| SEARCH_PATH                   | pg_catalog   |
+| SERVER_VERSION                | 9.5.0        |
 | SYNTAX                        | Traditional  |
 | TIME ZONE                     | UTC          |
 | TRANSACTION ISOLATION LEVEL   | SERIALIZABLE |
 | TRANSACTION PRIORITY          | NORMAL       |
 +-------------------------------+--------------+
-(6 rows)
+(9 rows)
 ~~~
 
 ## See Also

--- a/show-all.md
+++ b/show-all.md
@@ -25,7 +25,7 @@ Variable | Description
 `DATABASE` | The default database for the current session, as set by [`SET DATABASE`](set-database.html) or the client's connection string. This variable can be viewed with [`SHOW DATABASE`](show-database.html) as well. 
 `DEFAULT_TRANSACTION_ISOLATION` | The default transaction isolation level for the current session, as set by `SET DEFAULT_TRANSACTION_ISOLATION` or the client's connection string. 
 `MAX_INDEX_KEYS` | Not usable; exposed only for ORM compatibility.
-`SEARCH_PATH` | A list of databases or namespaces that will be searched to resolve unqualified table or function names.
+`SEARCH_PATH` | A list of databases or namespaces that will be searched to resolve unqualified table or function names. For more details, see [Name Resolution](sql-name-resolution.html).
 `SERVER_VERSION` | The version of PostgreSQL that CockroachDB emulates.
 `SYNTAX` | The default SQL syntax for the current session, as set by `SET SYNTAX`. This variable can be viewed with `SHOW SYNTAX` as well.
 `TIME ZONE` | The default time zone for the current session, as set by [`SET TIME ZONE`](set-time-zone.html). This variable can be viewed with [`SHOW TIME ZONE`](show-time-zone.html) as well.

--- a/sql-name-resolution.md
+++ b/sql-name-resolution.md
@@ -7,17 +7,17 @@ toc: false
 A SQL client can have access to multiple databases side-by-side. The
 same table name (e.g., `orders`) can exist in multiple
 databases. When a query specifies a table name without a database
-name (e.g., `select * from orders`), how does CockroachDB know
+name (e.g., `SELECT * FROM orders`), how does CockroachDB know
 which `orders` table is being considered?
 
-This page details how CockroachDB performs *name resolution* to answer
+This page details how CockroachDB performs **name resolution** to answer
 this question.
 
 <div id="toc"></div>
 
 ## Overview
 
-The following *name resolution algorithm* is used both to determine
+The following **name resolution algorithm** is used both to determine
 table names in [table expressions](table-expressions.html) and
 function names in [value expressions](sql-expressions.html):
 
@@ -28,23 +28,20 @@ function names in [value expressions](sql-expressions.html):
   - Try to find the name using the [search path](#search-path).
   - If the name is not found, produce an error.
 
-## Search path
+## Search Path
 
-In addition to the default database configurable via [`SET DATABASE`](set-database.html),
-unqualified names are also looked up in the current session's *search path*.
+In addition to the default database configurable via [`SET DATABASE`](set-database.html), unqualified names are also looked up in the current session's *search path*.
 
 The search path is a session variable containing a list of databases,
-or *name spaces*, where names are looked up.
+or *namespaces*, where names are looked up.
 
-The current search path can be inspected using the statement `SHOW
-SEARCH_PATH`, or [`SHOW ALL`](show-all.html).
+The current search path can be inspected using the statement `SHOW SEARCH_PATH`, or [`SHOW ALL`](show-all.html).
 
 By default, the search path for new columns includes just
 `pg_catalog`, so that queries can use PostgreSQL compatibility
 functions and virtual tables in that namespace without the need to
 prefix them with "`pg_catalog.`" every time.
 
-## See also
+## See Also
 
-- [List of predefined databases](predefined-namespaces.html)
 - [`SET DATABASE`](set-database.html)


### PR DESCRIPTION
This PR adds the `MAX_INDEX_KEYS`, `SEARCH_PATH`, and `SERVER_VERSION` variables to the `SHOW ALL` statement documentation. Fixes #933. Fixes #790.

It also changes the **Develop** sidebar a bit:
- New subsection called `SQL Syntax` to better house topics like constants, keywords, expressions, and the full grammar.
- Moved SQL Feature Support from **Learn How It Works** to **Develop** for greater visibility.

@knz, the addition of `search_path` to the `show all` docs goes well with your PR on name resolution. I'll get that reviewed in the morning. If we merge that first, I can link to those docs from the `search_path` description on the `show all` page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1057)
<!-- Reviewable:end -->
