### PR TITLE
Improve docs for running CockroachDB in Docker

### DIFF
--- a/_includes/start_in_docker/mac-linux-steps.md
+++ b/_includes/start_in_docker/mac-linux-steps.md
@@ -1,0 +1,160 @@
+## Watch a Demo
+
+Feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.
+
+<asciinema-player class="asciinema-demo" src="asciicasts/start-a-local-cluster-docker.json" cols="107" speed="2" theme="monokai" poster="npt:0:43" title="Start a Local Cluster in Docker"></asciinema-player>
+
+## Step 1. Create a bridge network
+
+Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, you need to create what Docker refers to as a [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The bridge network will enable the containers to communicate as a single cluster while keeping them isolated from external networks. 
+
+~~~ shell
+$ docker network create -d bridge roachnet
+~~~
+
+We've used `roachnet` as the network name here and in subsequent steps, but feel free to give your network any name you like.
+
+## Step 2. Start your first container/node
+
+~~~ shell
+$ docker run -d \
+--name=roach1 \
+--hostname=roach1 \
+--net=roachnet \
+-p 26257:26257 -p 8080:8080  \
+-v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data"  \
+cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
+~~~
+
+This command creates a container and starts the first CockroachDB node inside it. Let's look at each part:
+
+- `docker run`: The Docker command to start a new container.
+- `-d`: This flag runs the container in the background so you can continue the next steps in the same shell. 
+- `--name`: The name for the container. This is optional, but a custom name makes it significantly easier to reference the container in other commands, for example, when opening a Bash session in the container or stopping the container. 
+- `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
+- `--net`: The bridge network for the container to join. See step 1 for more details.
+- `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port of HTTP requests from the Admin UI (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the Admin UI from a browser.
+- `-v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data"`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `${PWD}/cockroach-data/roach1` on the host and will persist after the container is stopped or deleted. For more details, see Docker's <a href="https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume">Mount a host directory as a data volume</a> topic.
+- `cockroachdb/cockroach:{{site.data.strings.version}} start --insecure`: The CockroachDB command to [start a node](start-a-node.html) in the container in insecure mode. 
+
+  {{site.data.alerts.callout_success}}By default, each node's cache is limited to 25% of available memory. This default is reasonable when running one container/node per host. When running multiple containers/nodes on a single host, however, it may lead to out of memory errors, especially when testing against the cluster in a serious way. To avoid such errors, you can manually limit each node's cache size by setting the <a href="start-a-node.html#flags"><code>--cache</code></a> flag in the <code>start</code> command.{{site.data.alerts.end}}
+
+## Step 3. Start additional containers/nodes
+
+~~~ shell
+# Start the second container/node:
+$ docker run -d \
+--name=roach2 \
+--hostname=roach2 \
+--net=roachnet \
+-P \
+-v "${PWD}/cockroach-data/roach2:/cockroach/cockroach-data" \
+cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+
+# Start the third container/node:
+$ docker run -d \
+--name=roach3 \
+--hostname=roach3 \
+--net=roachnet \
+-P \
+-v "${PWD}/cockroach-data/roach3:/cockroach/cockroach-data" \
+cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+~~~
+
+These commands add two more containers and start CockroachDB nodes inside them, joining them to the first node. There are only a few differences to note from step 2:
+
+- `-P`: This flag maps exposed ports to random ports on the host. This random mapping is fine since we've already mapped the relevant ports for the first container.
+- `-v`: This flag mounts a host directory as a data volume. Data and logs for these nodes will be stored in `${PWD}/cockroach-data/roach2` and `${PWD}/cockroach-data/roach3` on the host and will persist after the containers are stopped or deleted.
+- `--join`: This flag joins the new nodes to the cluster, using the first container's `hostname`. Otherwise, all [`cockroach start`](start-a-node.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
+
+## Step 4. Use the built-in SQL client
+
+Use the `docker exec` command to start the [built-in SQL shell](use-the-built-in-sql-client.html) in the first container:
+
+~~~ shell
+$ docker exec -it roach1 ./cockroach sql
+# Welcome to the cockroach SQL interface.
+# All statements must be terminated by a semicolon.
+# To exit: CTRL + D.
+~~~
+
+Then run some [CockroachDB SQL statements](learn-cockroachdb-sql.html):
+
+~~~ sql
+> CREATE DATABASE bank;
+~~~
+
+~~~
+CREATE DATABASE
+~~~
+
+~~~ sql
+> CREATE TABLE bank.accounts (id INT PRIMARY KEY, balance DECIMAL);
+~~~
+
+~~~
+CREATE TABLE
+~~~
+
+~~~ sql
+> INSERT INTO bank.accounts VALUES (1, 1000.50);
+~~~
+
+~~~
+INSERT 1
+~~~
+
+~~~ sql
+> SELECT * FROM bank.accounts;
+~~~
+
+~~~
++----+---------+
+| id | balance |
++----+---------+
+|  1 |  1000.5 |
++----+---------+
+(1 row)
+~~~
+
+When you're done, use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+
+If you want to verify that the containers/nodes are, in fact, part of a single cluster, you can start the SQL shell in one of the other containers and check for the new `bank` database:
+
+~~~ shell
+$ docker exec -it roach2 ./cockroach sql
+# Welcome to the cockroach SQL interface.
+# All statements must be terminated by a semicolon.
+# To exit: CTRL + D.
+~~~
+
+~~~ sql
+> SHOW DATABASES;
+~~~
+
+~~~
++----------+
+| Database |
++----------+
+| bank     |
+| system   |
++----------+
+~~~
+
+## Step 5. Open the Admin UI
+
+When you started the first container/node, you mapped the node's default HTTP port `8080` to port `8080` on the host. To check out the [Admin UI](explore-the-admin-ui.html) for your cluster, point your browser to that port on `localhost`, i.e., `http://localhost:8080`.
+
+<img src="images/admin_ui.png" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
+
+## Step 6.  Stop the cluster
+
+Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster):
+
+~~~ shell
+# Stop the containers:
+$ docker stop roach1 roach2 roach3
+
+# Remove the containers:
+$ docker rm roach1 roach2 roach3
+~~~

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -224,9 +224,11 @@ $(document).ready(function(){
 <div id="use-docker" class="install-option" style="display: none;">
 <h2>Use Docker</h2>
 
+{{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+
 <ol>
   <li>
-    <p>Install <a href="https://docs.docker.com/docker-for-mac/">Docker for Mac</a>.</p>
+    <p>Install <a href="https://docs.docker.com/docker-for-mac/">Docker for Mac</a>. Please carefully check that you meet all prerequisites.</p>
   </li>
   <li>
     <p>Confirm that the Docker daemon is running in the background:</p>
@@ -263,6 +265,9 @@ $(document).ready(function(){
   </li>
 </ol>
 </div>
+<h2 id="whats-next">What's Next?</h2>
+
+<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
 
 <div id="linuxinstall" style="display: none;">
@@ -376,9 +381,11 @@ $(document).ready(function(){
 <div id="use-docker-linux" class="install-option" style="display: none;">
 <h2>Use Docker</h2>
 
+{{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker. Unless you are very experienced with Docker, we recommend starting with a different installation and deployment method.{{site.data.alerts.end}}
+
 <ol>
   <li>
-    <p>Install <a href="https://docs.docker.com/engine/installation/linux/ubuntulinux/">Docker for Linux</a>.</p>
+    <p>Install <a href="https://docs.docker.com/engine/installation/linux/ubuntulinux/">Docker for Linux</a>. Please carefully check that you meet all prerequisites.</p>
   </li>
   <li>
     <p>Confirm that the Docker daemon is running in the background:</p>
@@ -417,32 +424,38 @@ $(document).ready(function(){
   </li>
 </ol>
 </div>
+<h2 id="whats-next">What's Next?</h2>
+
+<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
 </div>
 
-<div id="windowsinstall" style="display: none;">
-<p>At this time, it's possible to run CockroachDB on Windows only from within a Docker virtual environment. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest version of CockroachDB.</p>
+<div id="windowsinstall" style="display: none;" markdown="1">
+
+<p>At this time, it's only possible to run CockroachDB on Windows in a Docker virtual environment. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest version of CockroachDB.</p>
+
+{{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker and is not recommended for production deployments. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See <a href="orchestration.html">Orchestration</a> for more details.{{site.data.alerts.end}}
 
 <ol>
   <li>
-    <p>Install <a href="https://docs.docker.com/docker-for-windows/">Docker for Windows</a>.</p>
+    <p>Install <a href="https://docs.docker.com/docker-for-windows/">Docker for Windows</a>. Please carefully check that you meet all prerequisites.</p> 
   </li>
   <li>
-    <p>Confirm that the Docker daemon is running in the background:</p>
+    <p>Open PowerShell and confirm that the Docker daemon is running in the background:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code>$ docker version</code></pre>
-    </div>
-    <p>If you don't see the server listed, start the <strong>Docker</strong> application.</p>
+    <div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\Users\username&gt; docker version</code></pre></div>
+
+    <p>If you don't see the server listed, start <strong>Docker for Windows</strong>.</p>
   </li>
   <li>
     <p>Pull the official CockroachDB image from <a href="https://hub.docker.com/r/cockroachdb/cockroach/" data-eventcategory="win-docker-step3">Docker Hub</a>:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="win-docker-step3"><span class="gp" data-eventcategory="win-docker-step3">$ </span>docker pull cockroachdb/cockroach:{{site.data.strings.version}}</code></pre>
-    </div>
+    <div class="language-powershell highlighter-rouge"><pre class="highlight"><code data-eventcategory="win-docker-step3"><span class="nb" data-eventcategory="win-docker-step3">PS </span>C:\Users\username&gt; docker pull cockroachdb/cockroach:{{site.data.strings.version}}</code></pre></div>
   </li>
   <li>
       <p>Make sure CockroachDB installed successfully:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="win-docker-step4"><span class="gp" data-eventcategory="win-docker-step4">$ </span>docker run --rm cockroachdb/cockroach:{{site.data.strings.version}} version</code></pre></div>
+      <div class="language-powershell highlighter-rouge"><pre class="highlight"><code data-eventcategory="win-docker-step4"><span class="nb" data-eventcategory="win-docker-step4">PS </span>C:\Users\username&gt; docker run --rm cockroachdb/cockroach:{{site.data.strings.version}} version</code></pre></div>
+
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>
@@ -460,8 +473,7 @@ $(document).ready(function(){
     </div>
   </li>
 </ol>
-</div>
-
 <h2 id="whats-next">What's Next?</h2>
 
-<p><a href="start-a-local-cluster.html">Quick start</a> a single- or multi-node cluster locally and talk to it via the built-in SQL client.</p>
+<p><a href="start-a-local-cluster-in-docker.html">Quick start</a> a multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data, or explore running a physically distributed cluster in containers using <a href="orchestration.html">orchestration</a> tools.</p>
+</div>

--- a/start-a-local-cluster-in-docker.md
+++ b/start-a-local-cluster-in-docker.md
@@ -1,59 +1,116 @@
 ---
-title: Start a Cluster
+title: Start a Cluster in Docker
 summary: Run a multi-node CockroachDB cluster across multiple Docker containers on a single host.
 toc: false
 asciicast: true
 ---
 
-<style>
-.filters .scope-button {
-  width: 20%;
-  height: 65px;
-  margin: 30px 15px 10px 0px;
-}
-.filters a:hover {
-  border-bottom: none;
-}
-</style>
+<script>
+$(document).ready(function(){
+    
+    //detect os and display corresponding tab by default
+    if (navigator.appVersion.indexOf("Mac")!=-1) { 
+        $('#os-tabs').find('button').removeClass('current');
+        $('#mac').addClass('current');
+        toggleMac(); 
+    }
+    if (navigator.appVersion.indexOf("Linux")!=-1) { 
+        $('#os-tabs').find('button').removeClass('current');
+        $('#linux').addClass('current');
+        toggleLinux(); 
+    }
+    if (navigator.appVersion.indexOf("Win")!=-1) { 
+        $('#os-tabs').find('button').removeClass('current');
+        $('#windows').addClass('current');
+        toggleWindows(); 
+    }
 
-<div id="step-three-filters" class="filters clearfix">
-  <a href="start-a-local-cluster.html"><button class="filter-button scope-button">From <strong>Binary</strong></button></a>
-  <button class="filter-button scope-button current">In <strong>Docker</strong></button>
-</div><p></p>
+    var install_option = $('.install-option'), 
+        install_button = $('.install-button');
+
+    install_button.on('click', function(e){
+      e.preventDefault();
+      var hash = $(this).prop("hash");
+
+      install_button.removeClass('current');
+      $(this).addClass('current');
+      install_option.hide();
+      $(hash).show();
+
+    });
+
+    //handle click event for os-tab buttons
+    $('#os-tabs').on('click', 'button', function(){
+        $('#os-tabs').find('button').removeClass('current');
+        $(this).addClass('current');
+
+        if($(this).is('#mac')){ toggleMac(); }
+        if($(this).is('#linux')){ toggleLinux(); }
+        if($(this).is('#windows')){ toggleWindows(); }
+    });
+
+    function toggleMac(){
+        $(".mac-button:first").trigger('click');
+        $("#macinstall").show();
+        $("#linuxinstall").hide();
+        $("#windowsinstall").hide();
+    }
+
+    function toggleLinux(){
+        $(".linux-button:first").trigger('click');
+        $("#linuxinstall").show();
+        $("#macinstall").hide();
+        $("#windowsinstall").hide();
+    }
+
+    function toggleWindows(){
+        $("#windowsinstall").show();
+        $("#macinstall").hide();
+        $("#linuxinstall").hide(); 
+    }
+});
+</script>
+
+<div id="os-tabs" class="clearfix">
+    <button id="mac" class="current">Mac</button>
+    <button id="linux">Linux</button>
+    <button id="windows">Windows</button>
+</div>
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run a multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_info}}Running multiple nodes on a single host is useful for testing out CockroachDB, but it's not recommended for production deployments. To run a physically distributed cluster in production, see <a href="manual-deployment.html">Manual Deployment</a>, <a href="cloud-deployment.html">Cloud Deployment</a>, or <a href="orchestration.html">Orchestration</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_danger}}Running a stateful application like CockroachDB in Docker is more complex and error-prone than most uses of Docker and is not recommended for production deployments. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See <a href="orchestration.html">Orchestration</a> for more details.{{site.data.alerts.end}}
 
-<div id="toc"></div>
+<!--<div id="toc"></div>-->
 
-## Watch a Demo
+<div id="macinstall" markdown="1">
+{% include start_in_docker/mac-linux-steps.md %}
+</div>
 
-Feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.
+<div id="linuxinstall" markdown="1">
+{% include start_in_docker/mac-linux-steps.md %}
+</div>
 
-<asciinema-player class="asciinema-demo" src="asciicasts/start-a-local-cluster-docker.json" cols="107" speed="2" theme="monokai" poster="npt:0:43" title="Start a Local Cluster in Docker"></asciinema-player>
-
+<div id="windowsinstall" markdown="1">
 ## Step 1. Create a bridge network
 
 Since you'll be running multiple Docker containers on a single host, with one CockroachDB node per container, you need to create what Docker refers to as a [bridge network](https://docs.docker.com/engine/userguide/networking/#/a-bridge-network). The bridge network will enable the containers to communicate as a single cluster while keeping them isolated from external networks. 
 
-~~~ shell
-$ docker network create -d bridge roachnet
-~~~
+<div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\Users\username&gt; docker network create -d bridge roachnet</code></pre></div>
 
 We've used `roachnet` as the network name here and in subsequent steps, but feel free to give your network any name you like.
 
 ## Step 2. Start your first container/node
 
-~~~ shell
-$ docker run -d \
---name=roach1 \
---hostname=roach1 \
---net=roachnet \
--p 26257:26257 -p 8080:8080  \
--v "${PWD}/cockroach-data/roach1:/cockroach/cockroach-data"  \
-cockroachdb/cockroach:{{site.data.strings.version}} start --insecure
-~~~
+{{site.data.alerts.callout_info}}Be sure to replace <code>&#60;username&#62;</code> in the <code>-v</code> flag with your actual username.{{site.data.alerts.end}}
+
+<div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\Users\username&gt; docker run -d <span class="sb">`</span>
+--name<span class="o">=</span>roach1 <span class="sb">`</span>
+--hostname<span class="o">=</span>roach1 <span class="sb">`</span>
+--net<span class="o">=</span>roachnet <span class="sb">`</span>
+-p 26257:26257 -p 8080:8080 <span class="sb">`</span>
+-v <span class="s2">"//c/Users/&lt;username&gt;/cockroach-data/roach1:/cockroach/cockroach-data"</span> <span class="sb">`</span>
+cockroachdb/cockroach:beta-20170209 <span class="nb">start</span> --insecure</code></pre></div>
 
 This command creates a container and starts the first CockroachDB node inside it. Let's look at each part:
 
@@ -63,49 +120,47 @@ This command creates a container and starts the first CockroachDB node inside it
 - `--hostname`: The hostname for the container. You will use this to join other containers/nodes to the cluster.
 - `--net`: The bridge network for the container to join. See step 1 for more details.
 - `-p 26257:26257 -p 8080:8080`: These flags map the default port for inter-node and client-node communication (`26257`) and the default port of HTTP requests from the Admin UI (`8080`) from the container to the host. This enables inter-container communication and makes it possible to call up the Admin UI from a browser.
-- `-v ${PWD}/cockroach-data/roach1:/cockroach/cockroach-data`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `${PWD}/cockroach-data/roach1` on the host and will persist after the container is stopped or deleted. For more details about volumes, see Docker's <a href="https://docs.docker.com/engine/tutorials/dockervolumes/">Manage data in containers</a> topic.
+- `-v "//c/Users/<username>/cockroach-data/roach1:/cockroach/cockroach-data"`: This flag mounts a host directory as a data volume. This means that data and logs for this node will be stored in `Users/<username>/cockroach-data/roach1` on the host and will persist after the container is stopped or deleted. For more details, see Docker's <a href="https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume">Mount a host directory as a data volume</a> topic.
 - `cockroachdb/cockroach:{{site.data.strings.version}} start --insecure`: The CockroachDB command to [start a node](start-a-node.html) in the container in insecure mode. 
 
   {{site.data.alerts.callout_success}}By default, each node's cache is limited to 25% of available memory. This default is reasonable when running one container/node per host. When running multiple containers/nodes on a single host, however, it may lead to out of memory errors, especially when testing against the cluster in a serious way. To avoid such errors, you can manually limit each node's cache size by setting the <a href="start-a-node.html#flags"><code>--cache</code></a> flag in the <code>start</code> command.{{site.data.alerts.end}}
 
 ## Step 3. Start additional containers/nodes
 
-~~~ shell
-# Start the second container/node:
-$ docker run -d \
---name=roach2 \
---hostname=roach2 \
---net=roachnet \
--P \
--v "${PWD}/cockroach-data/roach2:/cockroach/cockroach-data" \
-cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
+{{site.data.alerts.callout_info}}Again, be sure to replace <code>&#60;username&#62;</code> in the <code>-v</code> flag with your actual username.{{site.data.alerts.end}}
 
-# Start the third container/node:
-$ docker run -d \
---name=roach3 \
---hostname=roach3 \
---net=roachnet \
--P \
--v "${PWD}/cockroach-data/roach3:/cockroach/cockroach-data" \
-cockroachdb/cockroach:{{site.data.strings.version}} start --insecure --join=roach1
-~~~
+<div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="c1"># Start the second container/node:</span>
+<span class="nb">PS </span>C:\Users\username&gt; docker run -d <span class="sb">`</span>
+--name<span class="o">=</span>roach2 <span class="sb">`</span>
+--hostname<span class="o">=</span>roach2 <span class="sb">`</span>
+--net<span class="o">=</span>roachnet <span class="sb">`</span>
+-P <span class="sb">`</span>
+-v <span class="s2">"//c/Users/&lt;username&gt;/cockroach-data/roach2:/cockroach/cockroach-data"</span> <span class="sb">`</span>
+cockroachdb/cockroach:beta-20170209 <span class="nb">start</span> --insecure --join<span class="o">=</span>roach1
+
+<span class="c1"># Start the third container/node:</span>
+<span class="nb">PS </span>C:\Users\username&gt; docker run -d <span class="sb">`</span>
+--name<span class="o">=</span>roach3 <span class="sb">`</span>
+--hostname<span class="o">=</span>roach3 <span class="sb">`</span>
+--net<span class="o">=</span>roachnet <span class="sb">`</span>
+-P <span class="sb">`</span>
+-v <span class="s2">"//c/Users/&lt;username&gt;/cockroach-data/roach3:/cockroach/cockroach-data"</span> <span class="sb">`</span>
+cockroachdb/cockroach:beta-20170209 <span class="nb">start</span> --insecure --join<span class="o">=</span>roach1</code></pre></div>
 
 These commands add two more containers and start CockroachDB nodes inside them, joining them to the first node. There are only a few differences to note from step 2:
 
 - `-P`: This flag maps exposed ports to random ports on the host. This random mapping is fine since we've already mapped the relevant ports for the first container.
-- `-v`: This flag mounts a host directory as a data volume. Data and logs for these nodes will be stored in `${PWD}/cockroach-data/roach2` and `${PWD}/cockroach-data/roach3` on the host and will persist after the containers are stopped or deleted.
+- `-v`: This flag mounts a host directory as a data volume. Data and logs for these nodes will be stored in `Users/<username>/cockroach-data/roach2` and `Users/<username>/cockroach-data/roach3` on the host and will persist after the containers are stopped or deleted.
 - `--join`: This flag joins the new nodes to the cluster, using the first container's `hostname`. Otherwise, all [`cockroach start`](start-a-node.html) defaults are accepted. Note that since each node is in a unique container, using identical default ports won’t cause conflicts.
 
 ## Step 4. Use the built-in SQL client
 
 Use the `docker exec` command to start the [built-in SQL shell](use-the-built-in-sql-client.html) in the first container:
 
-~~~ shell
-$ docker exec -it roach1 ./cockroach sql
-# Welcome to the cockroach SQL interface.
-# All statements must be terminated by a semicolon.
-# To exit: CTRL + D.
-~~~
+<div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\Users\username&gt; docker <span class="nb">exec</span> -it roach1 ./cockroach sql
+<span class="c1"># Welcome to the cockroach SQL interface.</span>
+<span class="c1"># All statements must be terminated by a semicolon.</span>
+<span class="c1"># To exit: CTRL + D.</span></code></pre></div>
 
 Then run some [CockroachDB SQL statements](learn-cockroachdb-sql.html):
 
@@ -150,12 +205,10 @@ When you're done, use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 If you want to verify that the containers/nodes are, in fact, part of a single cluster, you can start the SQL shell in one of the other containers and check for the new `bank` database:
 
-~~~ shell
-$ docker exec -it roach2 ./cockroach sql
-# Welcome to the cockroach SQL interface.
-# All statements must be terminated by a semicolon.
-# To exit: CTRL + D.
-~~~
+<div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\Users\username&gt; docker <span class="nb">exec</span> -it roach2 ./cockroach sql
+<span class="c1"># Welcome to the cockroach SQL interface.</span>
+<span class="c1"># All statements must be terminated by a semicolon.</span>
+<span class="c1"># To exit: CTRL + D.</span></code></pre></div>
 
 ~~~ sql
 > SHOW DATABASES;
@@ -180,13 +233,13 @@ When you started the first container/node, you mapped the node's default HTTP po
 
 Use the `docker stop` and `docker rm` commands to stop and remove the containers (and therefore the cluster):
 
-~~~ shell
-# Stop the containers:
-$ docker stop roach1 roach2 roach3
+<div class="language-powershell highlighter-rouge"><pre class="highlight"><code><span class="c1"># Stop the containers:</span>
+<span class="nb">PS </span>C:\Users\username&gt; docker stop roach1 roach2 roach3
 
-# Remove the containers:
-$ docker rm roach1 roach2 roach3
-~~~
+<span class="c1"># Remove the containers:</span>
+<span class="nb">PS </span>C:\Users\username&gt; docker <span class="nb">rm </span>roach1 roach2 roach3</code></pre></div>
+
+</div>
 
 ## What's Next?
 

--- a/start-a-local-cluster.md
+++ b/start-a-local-cluster.md
@@ -6,22 +6,6 @@ toc_not_nested: true
 asciicast: true
 ---
 
-<style>
-.filters .scope-button {
-  width: 20%;
-  height: 65px;
-  margin: 15px 15px 10px 0px;
-}
-.filters a:hover {
-  border-bottom: none;
-}
-</style>
-
-<div id="step-three-filters" class="filters clearfix">
-  <button class="filter-button scope-button current">From <strong>Binary</strong></button>
-  <a href="start-a-local-cluster-in-docker.html"><button class="filter-button scope-button">In <strong>Docker</strong></button></a>
-</div><p></p>
-
 Once you've [installed the CockroachDB binary](install-cockroachdb.html), it's simple to start a multi-node cluster locally with each node listening on a different port. 
 
 {{site.data.alerts.callout_info}}Running multiple nodes on a single host is useful for testing out CockroachDB, but it's not recommended for production deployments. To run a physically distributed cluster in production, see <a href="manual-deployment.html">Manual Deployment</a>, <a href="cloud-deployment.html">Cloud Deployment</a>, or <a href="orchestration.html">Orchestration</a>.{{site.data.alerts.end}}


### PR DESCRIPTION
This PR updates `install-cockroachdb.md` and `start-a-local-cluster-in-docker.md` to account for issues reported in https://github.com/cockroachdb/docs/issues/907. Specifically:

- In `start-a-local-cluster-in-docker.md`, we now offer different instructions per OS. Importantly, for Windows, we now provide correct instructions for mounting a host directory as a volume. Also, at the top, we now warn that running CockroachDB in Docker is not easy and not recommended for production; we suggest orchestration tools instead. 
- In `install-cockroachdb.md`, the docker install method for mac and linux now discourages all but Docker experts for running in Docker. The windows install section also starts with a warning about running CockroachDB in Docker and suggests orchestration tools instead.

Fixes #907 

@bdarnell, @BramGruneir, @knz, PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1095)
<!-- Reviewable:end -->
