### PR TITLE
reference serial from sequences

### DIFF
--- a/sql-feature-support.md
+++ b/sql-feature-support.md
@@ -163,4 +163,4 @@ table tr td:nth-child(2) {
 | Stored Procedures | Planned | Common Extension | Execute a procedure explicitly. |
 | Cursors | ✗ | Standard | Traverse a table's rows. |
 | Triggers | ✗ | Standard | Execute a set of commands whenever a specified event occurs. |
-| Sequences | ✗ | Common Extension | Create a numeric sequence. Given CockroachDB's distributed architecture, sequences are not viable. |
+| Sequences | ✗ | Common Extension | Create a numeric sequence. Given CockroachDB's distributed architecture, sequences would be expensive. For fast, globally unique key generation, see [`SERIAL`](serial.html). |


### PR DESCRIPTION
User gave negative docs feedback on search results for `sequence`. That keyword shows up in the `SERIAL` docs, but on our SQL Feature Support list, we don't reference `SERIAL` in the `Sequences` entry. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1102)
<!-- Reviewable:end -->
