### PR TITLE
Add BIT(n) to INT docs

### DIFF
--- a/int.md
+++ b/int.md
@@ -23,41 +23,68 @@ In CockroachDB, the following are aliases for `INT`:
 ## Syntax
 
 A constant value of type `INT` can be entered as a [numeric literal](sql-constants.html#numeric-literals).
-For example: `42`, `-1234` or `0xCAFE`.
+For example: `42`, `-1234`, or `0xCAFE`.
 
 ## Size
 
-An `INT` column supports values up to 8 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata. 
+An `INT` column supports values up to 64 bits (8 bytes) in width, but the total storage size is likely to be larger due to CockroachDB metadata.  
 
-CockroachDB does not offer multiple integer types for different widths; instead, our compression ensures that smaller integers use less disk space than larger integers. 
+CockroachDB does not offer multiple integer types for different widths; instead, our compression ensures that smaller integers use less disk space than larger integers. However, you can use the `BIT(n)` type, with `n` from 1 to 64, to constrain integers based on their corresponding binary values. For example, `BIT(5)` would allow `31` because it corresponds to the five-digit binary integer `11111`, but would not allow `32` because it corresponds to the six-digit binary integer `100000`, which is 1 bit too long. See the [example](#examples) below for a demonstration.
+
+{{site.data.alerts.callout_info}}<code>BIT</code> values are input and displayed in decimal format by default like all other integers, not in binary format. Also note that <code>BIT</code> is equivalent to <code>BIT(1)</code>.{{site.data.alerts.end}}
 
 ## Examples
 
 ~~~ sql
-> CREATE TABLE ints (a INT PRIMARY KEY, b SMALLINT, c INTEGER);
+> CREATE TABLE ints (a INT PRIMARY KEY, b SMALLINT, c BIT(5));
+~~~
 
+~~~
+CREATE TABLE
+~~~
+
+~~~ sql
 > SHOW COLUMNS FROM ints;
 ~~~
-~~~
-+-------+------+-------+---------+
-| Field | Type | Null  | Default |
-+-------+------+-------+---------+
-| a     | INT  | false | NULL    |
-| b     | INT  | true  | NULL    |
-| c     | INT  | true  | NULL    |
-+-------+------+-------+---------+
-~~~
-~~~ sql
-> INSERT INTO ints VALUES (11111, 22222, 33333);
 
+~~~
++-------+--------+-------+---------+-----------+
+| Field |  Type  | Null  | Default |  Indices  |
++-------+--------+-------+---------+-----------+
+| a     | INT    | false | NULL    | {primary} |
+| b     | INT    | true  | NULL    | {}        |
+| c     | BIT(5) | true  | NULL    | {}        |
++-------+--------+-------+---------+-----------+
+(3 rows)
+~~~
+
+~~~ sql
+> INSERT INTO ints VALUES (1, 32, 32);
+~~~
+
+~~~
+pq: bit string too long for type BIT(5) (column "c")
+~~~
+
+~~~ sql
+> INSERT INTO ints VALUES (1, 32, 31);
+~~~
+
+~~~
+INSERT 1
+~~~
+
+~~~ sql
 > SELECT * FROM ints;
 ~~~
+
 ~~~
-+-------+-------+-------+
-|   a   |   b   |   c   |
-+-------+-------+-------+
-| 11111 | 22222 | 33333 |
-+-------+-------+-------+
++---+----+----+
+| a | b  | c  |
++---+----+----+
+| 1 | 32 | 31 |
++---+----+----+
+(1 row)
 ~~~
 
 ## Supported Casting & Conversion

--- a/sql-constants.md
+++ b/sql-constants.md
@@ -146,7 +146,7 @@ where it is used, its literal format, and its numeric value.
 |--------|---------------------|
 | Contains a decimal separator | `FLOAT`, `DECIMAL` |
 | Contains an exponent | `FLOAT`, `DECIMAL` |
-| Contains a value larger than 2^64 in magnitude | `FLOAT`, `DECIMAL` |
+| Contains a value outside of the range -2^63...(2^63)-1 | `FLOAT`, `DECIMAL` |
 | Otherwise | `INT`, `DECIMAL`, `FLOAT` |
 
 Of the possible data types, which one is actually used is then further


### PR DESCRIPTION
This PR adds a `Length` section to our `INT` type docs. That section covers using `BIT(n)` to limit decimal integer values based on the length of their corresponding binary integer values. 

@knz, @bdarnell, did I miss or get anything wrong? Also, @knz, do we need to update the `Supported Casting & Conversion` section?

Fixes #580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1116)
<!-- Reviewable:end -->
