### PR TITLE
More docs on auto-generating ids

### DIFF
--- a/create-table.md
+++ b/create-table.md
@@ -178,7 +178,7 @@ CREATE TABLE
 (3 rows)
 ~~~
 
-### Create a Table With Secondary Indexes
+### Create a Table with Secondary Indexes
 
 In this example, we create two secondary indexes during table creation. Secondary indexes allow efficient access to data with keys other than the primary key. This example also demonstrates a number of column-level and table-level [constraints](constraints.html).
 
@@ -221,6 +221,30 @@ We also have other resources on indexes:
 
 - Create indexes for existing tables using [`CREATE INDEX`](create-index.html).
 - [Learn more about indexes](indexes.html).
+
+### Create a Table with Auto-Generated Unique Row IDs
+
+To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
+
+~~~ sql
+> CREATE TABLE test (
+    id SERIAL PRIMARY KEY, 
+    name STRING
+);
+~~~
+
+On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead: 
+
+~~~ sql
+> CREATE TABLE test (
+    id BYTES PRIMARY KEY DEFAULT uuid_v4(), 
+    name STRING
+);
+~~~
+
+Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
+
+The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.
 
 ### Create a Table with Foreign Keys
 

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -160,13 +160,33 @@ Not yet, but this is on our long-term roadmap.
 
 ## How do I bulk insert data into CockroachDB?
 
-Currently, you can bulk insert data with batches of [`INSERT`](insert.html) statements not exceeding a few MB. The size of your rows determines how many you can use, but 1,000 - 10,000 rows typically works best.
+Currently, you can bulk insert data with batches of [`INSERT`](insert.html) statements not exceeding a few MB. The size of your rows determines how many you can use, but 1,000 - 10,000 rows typically works best. For more details, see [Import Data](https://www.cockroachlabs.com/docs/import-data.html).
+
+## How do I auto-generate unique row IDs in CockroachDB?
+
+To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
+
+~~~ sql
+> CREATE TABLE test (id SERIAL PRIMARY KEY, name STRING);
+~~~
+
+On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead:  
+
+~~~ sql
+> CREATE TABLE test (id BYTES PRIMARY KEY DEFAULT uuid_v4(), name STRING);
+~~~
+
+Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
+
+The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.
 
 ## Does CockroachDB support `JOIN`?
 
 CockroachDB has basic, non-optimized support for SQL `JOIN`, whose performance we're working to improve.
 
-To learn more, see our blog post on [CockroachDB's JOIN](https://www.cockroachlabs.com/blog/cockroachdbs-first-join/).
+To learn more, see our blog posts on CockroachDB's JOINs:
+- [Modesty in Simplicity: CockroachDB's JOIN](https://www.cockroachlabs.com/blog/cockroachdbs-first-join/).
+- [On the Way to Better SQL Joins](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/)
 
 ## Does CockroachDB support JSON or Protobuf datatypes?
 

--- a/serial.md
+++ b/serial.md
@@ -4,26 +4,11 @@ summary: The SERIAL data type defaults to a unique 64-bit signed integer that is
 toc: false
 ---
 
-The `SERIAL` [data type](data-types.html) is a column data type which
-generates new integer values on each default insert. The default value
-is the combination of the insert timestamp and the ID of the node
-executing the insert. This combination is guaranteed to be globally
-unique. Also, because value generation does not require talking to
-other nodes, it is much faster than sequentially auto-incrementing a
-value, which requires distributed coordination.
+The `SERIAL` [data type](data-types.html) is a column data type that, on insert, generates a default integer from the timestamp and ID of the node executing the insert. This combination is likely to be globally unique except in extreme cases (see this [example](create-table.html#create-a-table-with-auto-generated-unique-row-ids) for more details). Also, because value generation does not require talking to other nodes, it is much faster than sequentially auto-incrementing a value, which requires distributed coordination.
 
 {{site.data.alerts.callout_info}}
-This data type is <strong>experimental</strong>. We believe it is a better solution
-than PostgeSQL's <code>SERIAL</code> and MySQL's <code>AUTO_INCREMENT</code> types, both of
-which auto-increment integers but not necessarily in a strictly
-sequential fashion (see the
-<a href="#auto-incrementing-is-not-always-sequential">
-Auto-Incrementing Is Not Always Sequential
-</a> example below). However, if you find that this feature is incompatible
-with your application, please
-<a href="https://github.com/cockroachdb/cockroach/issues">open an
-issue</a> or
-<a href="https://gitter.im/cockroachdb/cockroach">chat
+This data type is <strong>experimental</strong>. We believe it is a better solution than PostgeSQL's <code>SERIAL</code> and MySQL's <code>AUTO_INCREMENT</code> types, both of which auto-increment integers but not necessarily in a strictly sequential fashion (see the <a href="#auto-incrementing-is-not-always-sequential"> Auto-Incrementing Is Not Always Sequential </a> example below). However, if you find that this feature is incompatible with your application, please <a href="https://github.com/cockroachdb/cockroach/issues">open an
+issue</a> or <a href="https://gitter.im/cockroachdb/cockroach">chat
 with us on Gitter</a>.
 {{site.data.alerts.end}}
 
@@ -40,9 +25,7 @@ In CockroachDB, the following are aliases for `SERIAL`:
 
 ## Syntax
 
-Any `INT` value is a valid `SERIAL` value; in particular constant
-`SERIAL` values can be expressed using
-[numeric literals](sql-constants.html#numeric-literals).
+Any `INT` value is a valid `SERIAL` value; in particular constant `SERIAL` values can be expressed using [numeric literals](sql-constants.html#numeric-literals).
 
 ## Size
 
@@ -55,7 +38,7 @@ Any `INT` value is a valid `SERIAL` value; in particular constant
 In this example, we create a table with the `SERIAL` column as the primary key so we can auto-generate unique IDs on insert.
 
 ~~~ sql
-> CREATE TABLE serial (a SERIAL PRIMARY KEY, b STRING(30), c BOOL);
+> CREATE TABLE serial (a SERIAL PRIMARY KEY, b STRING, c BOOL);
 ~~~
 
 The [`SHOW COLUMNS`](show-columns.html) statement shows that the `SERIAL` type is just an alias for `INT` with `unique_rowid()` as the default.
@@ -63,24 +46,25 @@ The [`SHOW COLUMNS`](show-columns.html) statement shows that the `SERIAL` type i
 ~~~ sql
 > SHOW COLUMNS FROM serial;
 ~~~
+
 ~~~
 +-------+------------+-------+----------------+
 | Field |    Type    | Null  |    Default     |
 +-------+------------+-------+----------------+
 | a     | INT        | false | unique_rowid() |
-| b     | STRING(30) | true  | NULL           |
+| b     | STRING     | true  | NULL           |
 | c     | BOOL       | true  | NULL           |
 +-------+------------+-------+----------------+
 ~~~
 
-When we insert rows without values in column `a` and display the new
-rows, we see that each row has defaulted to a unique value in column
-`a`.
+When we insert rows without values in column `a` and display the new rows, we see that each row has defaulted to a unique value in column `a`.
 
 ~~~ sql
 > INSERT INTO serial (b,c) VALUES ('red', true), ('yellow', false), ('pink', true);
 > INSERT INTO serial (a,b,c) VALUES (123, 'white', false);
+> SELECT * FROM serial;
 ~~~
+
 ~~~
 +--------------------+--------+-------+
 |         a          |   b    |   c   |


### PR DESCRIPTION
This PR adds an FAQ on auto-generating unique row IDs, and it adds an example to the `CREATE TABLE` doc.

Fixes #188
Fixes #376 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1126)
<!-- Reviewable:end -->
