### PR TITLE
fixing typo for secure DO deployment

### DIFF
--- a/deploy-cockroachdb-on-digital-ocean.md
+++ b/deploy-cockroachdb-on-digital-ocean.md
@@ -5,7 +5,7 @@ toc: false
 toc_not_nested: true
 ---
 
-This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Digital Ocean.
+This page shows you how to manually deploy a secure multi-node CockroachDB cluster on Digital Ocean.
 
 If you plan to use CockroachDB in production, we recommend using a secure cluster *(documented on this page)*. However, if you are not concerned with protecting your data with SSL encryption, you can use the **Insecure** instructions below.
 


### PR DESCRIPTION
Secure deployment instructions for DigitalOcean mistakenly say that they're for an insecure deployment. Fixing typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1128)
<!-- Reviewable:end -->
