### PR TITLE
Minor fixes to cloud deployment tutorials

### DIFF
--- a/deploy-cockroachdb-on-aws-insecure.md
+++ b/deploy-cockroachdb-on-aws-insecure.md
@@ -181,14 +181,19 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 5.	View the cluster's databases, which will include `insecurenodetest`:
 
 	~~~ sql
-	> SHOW DATABASE;
+	> SHOW DATABASES;
 	~~~
 	~~~
-	+------------------+
-	|     DATABASE     |
-	+------------------+
-	| insecurenodetest |
-	+------------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| insecurenodetest   |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 6. View the Admin UI

--- a/deploy-cockroachdb-on-aws-insecure.md
+++ b/deploy-cockroachdb-on-aws-insecure.md
@@ -40,7 +40,7 @@ You must have SSH access ([key pairs](http://docs.aws.amazon.com/AWSEC2/latest/U
 
 For guidance on cluster topology, clock synchronization, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
 
-{{site.data.alerts.callout_success}}<strong><a href="https://www.terraform.io/">Terraform</a></strong> users can deploy CockroachDB using the <a href="https://github.com/cockroachdb/cockroach/blob/master/cloud/aws">configuration files and instructions in the our GitHub repo's <code>aws</code>directory</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}<strong><a href="https://www.terraform.io/">Terraform</a></strong> users can deploy CockroachDB using the <a href="https://github.com/cockroachdb/cockroach/blob/master/cloud/aws">configuration files and instructions in our GitHub repo's <code>aws</code>directory</a>.{{site.data.alerts.end}}
 
 ## Step 1. Configure Your Network
 
@@ -96,7 +96,7 @@ To connect your application to CockroachDB, use a [PostgreSQL wire protocol driv
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -110,7 +110,7 @@ To connect your application to CockroachDB, use a [PostgreSQL wire protocol driv
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node, which will communicate with other nodes on its internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background
 	~~~
@@ -126,7 +126,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install CockroachDB from our latest binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -140,7 +140,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background --join=<node1 internal IP address>:26257
 	~~~
@@ -158,7 +158,7 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
@@ -173,14 +173,14 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
 
 5.	View the cluster's databases, which will include `insecurenodetest`:
-	
-	~~~ sql 
+
+	~~~ sql
 	> SHOW DATABASE;
 	~~~
 	~~~
@@ -193,7 +193,7 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 
 ## Step 6. View the Admin UI
 
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`. 
+View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
 
 On this page, go to the following tabs on the left:
 

--- a/deploy-cockroachdb-on-aws.md
+++ b/deploy-cockroachdb-on-aws.md
@@ -42,7 +42,7 @@ In AWS, you must have SSH access ([key pairs](http://docs.aws.amazon.com/AWSEC2/
 
 For guidance on cluster topology, clock synchronization, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
 
-{{site.data.alerts.callout_success}}<strong><a href="https://www.terraform.io/">Terraform</a></strong> users can deploy CockroachDB using the <a href="https://github.com/cockroachdb/cockroach/blob/master/cloud/aws">configuration files and instructions in the our GitHub repo's <code>aws</code>directory</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}<strong><a href="https://www.terraform.io/">Terraform</a></strong> users can deploy CockroachDB using the <a href="https://github.com/cockroachdb/cockroach/blob/master/cloud/aws">configuration files and instructions in our GitHub repo's <code>aws</code>directory</a>.{{site.data.alerts.end}}
 
 ## Step 1. Configure Your Network
 
@@ -171,7 +171,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -185,7 +185,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
-	
+
 	~~~ shell
 	$ cockroach start --background \
 	--ca-cert=certs/ca.cert \
@@ -205,7 +205,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install CockroachDB from our latest binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -219,7 +219,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --background  \
 	--ca-cert=certs/ca.cert \
@@ -242,7 +242,7 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
@@ -258,14 +258,14 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
 
 5.	View the cluster's databases, which will include `securenodetest`:
-	
-	~~~ sql 
+
+	~~~ sql
 	> SHOW DATABASE;
 	~~~
 	~~~
@@ -278,7 +278,7 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 
 ## Step 7. View the Admin UI
 
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`. 
+View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
 
 On this page, go to the following tabs on the left:
 

--- a/deploy-cockroachdb-on-aws.md
+++ b/deploy-cockroachdb-on-aws.md
@@ -266,14 +266,19 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 5.	View the cluster's databases, which will include `securenodetest`:
 
 	~~~ sql
-	> SHOW DATABASE;
+	> SHOW DATABASES;
 	~~~
 	~~~
-	+----------------+
-	|    DATABASE    |
-	+----------------+
-	| securenodetest |
-	+----------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| securenodetest     |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 7. View the Admin UI

--- a/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -71,7 +71,7 @@ To control access to these ports, you'll need to modify each of your Droplet's f
 	~~~
 
 2.	Install CockroachDB from our latest binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball:
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -85,7 +85,7 @@ To control access to these ports, you'll need to modify each of your Droplet's f
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node, which will communicate with other nodes on its internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background --advertise-host=<node1 internal IP address>
 	~~~
@@ -99,7 +99,7 @@ To control access to these ports, you'll need to modify each of your Droplet's f
 	~~~
 
 2.	Install CockroachDB from our latest binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball:
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -113,7 +113,7 @@ To control access to these ports, you'll need to modify each of your Droplet's f
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background   \
 	--advertise-host=<this node’s internal IP address>  \
@@ -133,7 +133,7 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
@@ -148,27 +148,32 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
 
 5.	View the cluster's databases, which will include `insecurenodetest`:
-	
-	~~~ sql 
-	> SHOW DATABASE;
+
+	~~~ sql
+	> SHOW DATABASES;
 	~~~
 	~~~
-	+------------------+
-	|     DATABASE     |
-	+------------------+
-	| insecurenodetest |
-	+------------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| insecurenodetest   |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 6. View the Admin UI
 
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`. 
+View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
 
 On this page, go to the following tabs on the left:
 

--- a/deploy-cockroachdb-on-digital-ocean.md
+++ b/deploy-cockroachdb-on-digital-ocean.md
@@ -143,7 +143,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -157,7 +157,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
-	
+
 	~~~ shell
 	$ cockroach start --background \
 	--ca-cert=certs/ca.cert \
@@ -177,7 +177,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -191,7 +191,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --background  \
 	--ca-cert=certs/ca.cert \
@@ -214,7 +214,7 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
@@ -230,22 +230,27 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
 
 5.	View the cluster's databases, which will include `securenodetest`:
-	
-	~~~ sql 
-	> SHOW DATABASE;
+
+	~~~ sql
+	> SHOW DATABASES;
 	~~~
 	~~~
-	+----------------+
-	|    DATABASE    |
-	+----------------+
-	| securenodetest |
-	+----------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| securenodetest     |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 7. View the Admin UI

--- a/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -97,7 +97,7 @@ If you used a tag for your firewall rules, when you create the instance, select 
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.linux-amd64.tgz
@@ -111,7 +111,7 @@ If you used a tag for your firewall rules, when you create the instance, select 
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background
 	~~~
@@ -127,7 +127,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install CockroachDB from our latest binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.linux-amd64.tgz
@@ -141,7 +141,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background --join=<node1 internal IP address>:26257
 	~~~
@@ -159,7 +159,7 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
@@ -174,27 +174,32 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
 
 5.	View the cluster's databases, which will include `insecurenodetest`:
-	
-	~~~ sql 
+
+	~~~ sql
 	> SHOW DATABASE;
 	~~~
 	~~~
-	+------------------+
-	|     DATABASE     |
-	+------------------+
-	| insecurenodetest |
-	+------------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| insecurenodetest   |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 6. View the Admin UI
 
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`. 
+View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
 
 On this page, go to the following tabs on the left:
 

--- a/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/deploy-cockroachdb-on-google-cloud-platform.md
@@ -171,7 +171,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -185,7 +185,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
-	
+
 	~~~ shell
 	$ cockroach start --background \
 	--ca-cert=certs/ca.cert \
@@ -205,7 +205,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -219,7 +219,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --background  \
 	--ca-cert=certs/ca.cert \
@@ -242,7 +242,7 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
@@ -258,22 +258,27 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
 
 5.	View the cluster's databases, which will include `securenodetest`:
-	
-	~~~ sql 
-	> SHOW DATABASE;
+
+	~~~ sql
+	> SHOW DATABASES;
 	~~~
 	~~~
-	+----------------+
-	|    DATABASE    |
-	+----------------+
-	| securenodetest |
-	+----------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| securenodetest     |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 7. View the Admin UI

--- a/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -52,7 +52,7 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 1. [Create a Resource Group](https://azure.microsoft.com/en-us/updates/create-empty-resource-groups/).
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
 3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
-   
+
    - **Admin UI support**:
 
      | Field | Recommended Value |
@@ -101,7 +101,7 @@ When creating the VMs, make sure to select the **Resource Group**, **Virtual Net
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -115,7 +115,7 @@ When creating the VMs, make sure to select the **Resource Group**, **Virtual Net
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background --advertise-host=<node1 internal IP address>
 	~~~
@@ -133,7 +133,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install CockroachDB from our latest binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -147,7 +147,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --insecure --background \
 	--advertise-host=<node internal IP address> \
@@ -167,7 +167,7 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
@@ -182,27 +182,32 @@ To test your distributed, multi-node cluster, access SQL and create a new databa
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql
 	~~~
 
 5.	View the cluster's databases, which will include `insecurenodetest`:
-	
-	~~~ sql 
-	> SHOW DATABASE;
+
+	~~~ sql
+	> SHOW DATABASES;
 	~~~
 	~~~
-	+------------------+
-	|     DATABASE     |
-	+------------------+
-	| insecurenodetest |
-	+------------------+
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| insecurenodetest   |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
 	~~~
 
 ## Step 6. View the Admin UI
 
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`. 
+View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
 
 On this page, go to the following tabs on the left:
 

--- a/deploy-cockroachdb-on-microsoft-azure.md
+++ b/deploy-cockroachdb-on-microsoft-azure.md
@@ -54,7 +54,7 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 1. [Create a Resource Group](https://azure.microsoft.com/en-us/updates/create-empty-resource-groups/).
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
 3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
-   
+
    - **Admin UI support**:
 
      | Field | Recommended Value |
@@ -175,7 +175,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -189,7 +189,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	~~~
 
 3. 	Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
-	
+
 	~~~ shell
 	$ cockroach start --background \
 	--ca-cert=certs/ca.cert \
@@ -209,7 +209,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 2.	Install the latest CockroachDB binary:
-	
+
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
@@ -223,7 +223,7 @@ At this point, your cluster is live and operational but contains only a single n
 	~~~
 
 3. 	Start a new node that joins the cluster using the first node's internal IP address:
-	
+
 	~~~ shell
 	$ cockroach start --background  \
 	--ca-cert=certs/ca.cert \
@@ -246,7 +246,7 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 2.	Launch the built-in SQL client and create a database:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
@@ -262,22 +262,27 @@ To test your distributed, multi-node cluster, access the built-in SQL client and
 	~~~
 
 4.	Launch the built-in SQL client:
-	
+
 	~~~ shell
 	$ cockroach sql --ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
 	~~~
 
 5.	View the cluster's databases, which will include `securenodetest`:
-	
-	~~~ sql 
+
+	~~~ sql
 	> SHOW DATABASE;
 	~~~
 	~~~
-	+----------------+
-	|    DATABASE    |
-	+----------------+
-	| securenodetest |
-	+----------------+
+  +--------------------+
+  |      Database      |
+  +--------------------+
+  | crdb_internal      |
+  | information_schema |
+  | securenodetest     |
+  | pg_catalog         |
+  | system             |
+  +--------------------+
+  (5 rows)
 	~~~
 
 ## Step 7. View the Admin UI


### PR DESCRIPTION
- Remove extra word in aws deployment tutorials.
- Fix `SHOW DATABASES` output in all cloud deployment tutorials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1134)
<!-- Reviewable:end -->
