### PR TITLE
shorten Homebrew link by using our new tap

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -138,7 +138,7 @@ $(document).ready(function(){
     <li>
       <p>Run our brew recipe to get the CockroachDB code and build the binary:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-homebrew-step2"><span class="gp" data-eventcategory="mac-homebrew-step2">$ </span>brew install https://raw.githubusercontent.com/cockroachdb/cockroach/master/build/cockroach.rb</code></pre>
+      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-homebrew-step2"><span class="gp" data-eventcategory="mac-homebrew-step2">$ </span>brew install cockroachdb/cockroach/cockroach</code></pre>
       </div>
     </li>
     <li>


### PR DESCRIPTION
If cockroachdb/cockroach#14082 lands, this will update the docs with the new,
shorter URL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1177)
<!-- Reviewable:end -->
