### PR TITLE
client certificate doc improvements

### DIFF
--- a/create-and-manage-users.md
+++ b/create-and-manage-users.md
@@ -9,7 +9,7 @@ To create and manage your cluster's users (which lets you control SQL-level [pri
 When creating users, it's also important to note:
 
 - After creating users, you must [grant them privileges to databases and tables](grant.html).
-- On secure clusters, users must [authenticate their access to the cluster](#user-authentication).
+- On secure clusters, you must [create client certificates for users](create-security-certificates.html#create-the-certificate-and-key-for-a-client) and users must [authenticate their access to the cluster](#user-authentication).
 
 {{site.data.alerts.callout_info}}You can also create users through the <a href="create-user.html"><code>CREATE USER</code></a> statement.{{site.data.alerts.end}}
 
@@ -87,12 +87,17 @@ After creating users, you must [grant them privileges to databases](grant.html).
 
 ~~~ shell
 $ cockroach user set jpointsman \
---ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key --password
+--ca-cert=certs/ca.cert \
+--cert=certs/root.cert \
+--key=certs/root.key
 ~~~
 
 {{site.data.alerts.callout_success}}If you want to allow password authentication for the user, include the <code>--password</code> flag and then enter and confirm the password at the command prompt.{{site.data.alerts.end}}
 
-After creating users, you must [grant them privileges to databases](grant.html).
+After creating users, you must:
+
+- [Create their client certificates](create-security-certificates.html#create-the-certificate-and-key-for-a-client).
+- [Grant them privileges to databases](grant.html).
 
 ### Authenticate as a Specific User
 
@@ -107,7 +112,10 @@ $ cockroach sql --user=jpointsman
 All users can authenticate their access to a secure cluster using [a client certificate](create-security-certificates.html#create-the-certificate-and-key-for-a-client) issued to their username.
 
 ~~~ shell
-$ cockroach sql --user=jpointsman --ca-cert=certs/ca.cert --cert=jpointsman.cert --key=jpointsman.key
+$ cockroach sql --user=jpointsman \
+--ca-cert=certs/ca.cert \
+--cert=jpointsman.cert \
+--key=jpointsman.key
 ~~~
 
 #### Secure Clusters with Passwords
@@ -125,7 +133,9 @@ After issuing this command, you must enter the password for `jpointsman` twice.
 ~~~ shell
 $ cockroach user set jpointsman \
 --password \
---ca-cert=certs/ca.cert --cert=certs/root.cert --key=certs/root.key
+--ca-cert=certs/ca.cert \
+--cert=certs/root.cert \
+--key=certs/root.key
 ~~~
 
 After issuing this command, enter and confirm the user's new password at the command prompt.

--- a/create-security-certificates.md
+++ b/create-security-certificates.md
@@ -25,10 +25,22 @@ Subcommand | Usage
 $ cockroach cert create-ca --ca-cert=<path-to-ca-cert> --ca-key=<path-to-ca-key> 
 
 # Create a node certificate and key, specifying all addresses at which the node can be reached:
-$ cockroach cert create-node <node-hostname> <node-other-hostname> <node-yet-another-hostname> --ca-cert=<path-to-ca-cert> --ca-key=<path-to-ca-key> --cert=<path-to-node-cert> --key=<path-to-node-key> 
+$ cockroach cert create-node \
+ <node-hostname> \
+ <node-other-hostname> \
+ <node-yet-another-hostname> \
+ --ca-cert=<path-to-ca-cert> \
+ --ca-key=<path-to-ca-key> \
+ --cert=<path-to-node-cert> \
+ --key=<path-to-node-key> 
 
 # Create a client certificate and key:
-$ cockroach cert create-client <username> --ca-cert=<path-to-ca-cert> --ca-key=<path-to-ca-key> --cert=<path-to-client-cert> --key=<path-to-client-key>
+$ cockroach cert create-client \
+ <username> \
+ --ca-cert=<path-to-ca-cert> \
+ --ca-key=<path-to-ca-key> \
+ --cert=<path-to-client-cert> \
+ --key=<path-to-client-key>
 
 # View help:
 $ cockroach cert --help
@@ -56,19 +68,32 @@ Flag | Description
 ### Create the CA certificate and key
 
 ~~~ shell
-$ cockroach cert create-ca --ca-cert=certs/ca.cert --ca-key=certs/ca.key 
+$ cockroach cert create-ca \
+--ca-cert=certs/ca.cert \
+--ca-key=certs/ca.key 
 ~~~
 
 ### Create the certificate and key for a node
 
 ~~~ shell
-$ cockroach cert create-node node1.example.com node1.another-example.com --ca-cert=certs/ca.cert --ca-key=certs/ca.key --cert=certs/node.cert --key=certs/node.key
+$ cockroach cert create-node \
+node1.example.com \
+node1.another-example.com \
+--ca-cert=certs/ca.cert \
+--ca-key=certs/ca.key \
+--cert=certs/node.cert \
+--key=certs/node.key
 ~~~
 
 ### Create the certificate and key for a client
 
 ~~~ shell
-$ cockroach cert create-client maxroach --ca-cert=certs/ca.cert --ca-key=certs/ca.key --cert=certs/maxroach.cert --key=certs/maxroach.key
+$ cockroach cert create-client \
+maxroach \
+--ca-cert=certs/ca.cert \
+--ca-key=certs/ca.key \
+--cert=certs/maxroach.cert \
+--key=certs/maxroach.key
 ~~~
 
 ## See Also


### PR DESCRIPTION
Improvements for client certificate documentation including:

- Mention that client certificates must be created for users
- Easier-to-read synopsis and examples for creating certs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1186)
<!-- Reviewable:end -->
