### PR TITLE
No sudo in command to move binary into PATH

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -101,7 +101,8 @@ $(document).ready(function(){
     <li>
       <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>sudo cp -i cockroach-latest.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
+      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-latest.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
+      <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>
       <p>Make sure CockroachDB installed successfully:</p>
@@ -303,7 +304,8 @@ $(document).ready(function(){
     <li>
       <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>sudo cp -i cockroach-latest.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
+      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-latest.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
+      <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>
       <p>Make sure CockroachDB installed successfully:</p>

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -304,7 +304,7 @@ $(document).ready(function(){
     <li>
       <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-latest.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
+      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-latest.linux-amd64/cockroach /usr/local/bin</code></pre></div>
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>


### PR DESCRIPTION
In install from binary instructions,
suggest using `sudo` only if permissions require it.

Fixes #1175

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1205)
<!-- Reviewable:end -->
