### PR TITLE
adding VALUES clause to INSERT diagram

### DIFF
--- a/_includes/sql/diagrams/insert.html
+++ b/_includes/sql/diagrams/insert.html
@@ -1,4 +1,4 @@
-<svg width="504" height="384">
+<svg width="552" height="384">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -9,57 +9,60 @@
          <rect x="119" y="1" width="54" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="129" y="21">INTO</text>
          <a xlink:href="sql-grammar.html#qualified_name" xlink:title="qualified_name">
-            <rect x="195" y="3" width="116" height="32"></rect>
-            <rect x="193" y="1" width="116" height="32" class="nonterminal"></rect>
+            <rect x="195" y="3" width="108" height="32"></rect>
+            <rect x="193" y="1" width="108" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="203" y="21">qualified_name</text>
          </a>
-         <rect x="351" y="35" width="38" height="32" rx="10"></rect>
-         <rect x="349" y="33" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="359" y="53">AS</text>
+         <rect x="343" y="35" width="38" height="32" rx="10"></rect>
+         <rect x="341" y="33" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="351" y="53">AS</text>
          <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="409" y="35" width="54" height="32"></rect>
-            <rect x="407" y="33" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="417" y="53">name</text>
+            <rect x="401" y="35" width="54" height="32"></rect>
+            <rect x="399" y="33" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="409" y="53">name</text>
          </a>
-         <rect x="81" y="133" width="26" height="32" rx="10"></rect>
-         <rect x="79" y="131" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="89" y="151">(</text>
+         <rect x="65" y="133" width="26" height="32" rx="10"></rect>
+         <rect x="63" y="131" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="151">(</text>
          <a xlink:href="sql-grammar.html#qualified_name_list" xlink:title="qualified_name_list">
-            <rect x="127" y="133" width="142" height="32"></rect>
-            <rect x="125" y="131" width="142" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="135" y="151">qualified_name_list</text>
+            <rect x="111" y="133" width="132" height="32"></rect>
+            <rect x="109" y="131" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="119" y="151">qualified_name_list</text>
          </a>
-         <rect x="289" y="133" width="26" height="32" rx="10"></rect>
-         <rect x="287" y="131" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="297" y="151">)</text>
+         <rect x="263" y="133" width="26" height="32" rx="10"></rect>
+         <rect x="261" y="131" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="271" y="151">)</text>
+         <rect x="329" y="101" width="72" height="32" rx="10"></rect>
+         <rect x="327" y="99" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="119">VALUES</text>
          <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-            <rect x="355" y="101" width="92" height="32"></rect>
-            <rect x="353" y="99" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="363" y="119">select_stmt</text>
+            <rect x="421" y="101" width="90" height="32"></rect>
+            <rect x="419" y="99" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="429" y="119">select_stmt</text>
          </a>
-         <rect x="61" y="177" width="80" height="32" rx="10"></rect>
-         <rect x="59" y="175" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="69" y="195">DEFAULT</text>
-         <rect x="161" y="177" width="72" height="32" rx="10"></rect>
-         <rect x="159" y="175" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="169" y="195">VALUES</text>
-         <rect x="213" y="263" width="100" height="32" rx="10"></rect>
-         <rect x="211" y="261" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="221" y="281">RETURNING</text>
+         <rect x="45" y="177" width="80" height="32" rx="10"></rect>
+         <rect x="43" y="175" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="195">DEFAULT</text>
+         <rect x="145" y="177" width="72" height="32" rx="10"></rect>
+         <rect x="143" y="175" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="195">VALUES</text>
+         <rect x="263" y="263" width="100" height="32" rx="10"></rect>
+         <rect x="261" y="261" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="271" y="281">RETURNING</text>
          <a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
-            <rect x="353" y="263" width="84" height="32"></rect>
-            <rect x="351" y="261" width="84" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="361" y="281">target_list</text>
+            <rect x="403" y="263" width="80" height="32"></rect>
+            <rect x="401" y="261" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="411" y="281">target_list</text>
          </a>
-         <rect x="353" y="307" width="84" height="32" rx="10"></rect>
-         <rect x="351" y="305" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="361" y="325">NOTHING</text>
+         <rect x="403" y="307" width="82" height="32" rx="10"></rect>
+         <rect x="401" y="305" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="411" y="325">NOTHING</text>
          <a xlink:href="sql-grammar.html#on_conflict" xlink:title="on_conflict">
-            <rect x="213" y="351" width="86" height="32"></rect>
-            <rect x="211" y="349" width="86" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="221" y="369">on_conflict</text>
+            <rect x="263" y="351" width="84" height="32"></rect>
+            <rect x="261" y="349" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="271" y="369">on_conflict</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-486 98 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m26 0 h10 m0 0 h10 m142 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m92 0 h10 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v56 m426 0 v-56 m-426 56 q0 10 10 10 m406 0 q10 0 10 -10 m-416 10 h10 m80 0 h10 m0 0 h10 m72 0 h10 m0 0 h214 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-318 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h254 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v12 m284 0 v-12 m-284 12 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m100 0 h10 m20 0 h10 m84 0 h10 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m-254 -54 v20 m284 0 v-20 m-284 20 v68 m284 0 v-68 m-284 68 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m86 0 h10 m0 0 h158 m23 -120 h-3"></path>
-         <polygon points="495 245 503 241 503 249"></polygon>
-         <polygon points="495 245 487 241 487 249"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m108 0 h10 m20 0 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-494 98 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m26 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m72 0 h10 m0 0 h10 m90 0 h10 m-506 0 h20 m486 0 h20 m-526 0 q10 0 10 10 m506 0 q0 -10 10 -10 m-516 10 v56 m506 0 v-56 m-506 56 q0 10 10 10 m486 0 q10 0 10 -10 m-496 10 h10 m80 0 h10 m0 0 h10 m72 0 h10 m0 0 h294 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-332 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m100 0 h10 m20 0 h10 m80 0 h10 m0 0 h2 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m-252 -54 v20 m282 0 v-20 m-282 20 v68 m282 0 v-68 m-282 68 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m84 0 h10 m0 0 h158 m23 -120 h-3"></path>
+         <polygon points="543 245 551 241 551 249"></polygon>
+         <polygon points="543 245 535 241 535 249"></polygon>
       </svg>

--- a/generate/main.go
+++ b/generate/main.go
@@ -366,9 +366,10 @@ func main() {
 				},
 				{name: "index_def", inline: []string{"opt_storing", "storing", "index_params", "opt_name"}},
 				{
-					name:   "insert_stmt",
-					inline: []string{"insert_target", "insert_rest", "returning_clause"},
-					match:  []*regexp.Regexp{regexp.MustCompile("'INSERT'")},
+					name:    "insert_stmt",
+					inline:  []string{"insert_target", "insert_rest", "returning_clause"},
+					match:   []*regexp.Regexp{regexp.MustCompile("'INSERT'")},
+					replace: map[string]string{"select_stmt": "'VALUES' select_stmt"},
 				},
 				{name: "iso_level"},
 				{name: "interleave", stmt: "create_table_stmt", inline: []string{"opt_interleave"}, replace: map[string]string{"any_name": "table_name", "opt_table_elem_list": "table_definition", "name_list": "interleave_prefix", " name": " parent_table"}, unlink: []string{"table_name", "table_definition", "parent_table", "child_columns"}},


### PR DESCRIPTION
`INSERT` page was missing `VALUES` clause in diagram, so added it back in

@mjibson Is there a way to check to see if the `VALUES` clause in this diagram disappeared because of a change to the `sql.y` file? If not, feel free to unassign yourself from the review. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1223)
<!-- Reviewable:end -->
