### PR TITLE
Fix typo: connection -> connecting

### DIFF
--- a/_includes/app/basic-sample.go
+++ b/_includes/app/basic-sample.go
@@ -12,7 +12,7 @@ func main() {
 	// Connect to the "bank" database.
 	db, err := sql.Open("postgres", "postgresql://maxroach@localhost:26257/bank?sslmode=disable")
 	if err != nil {
-		log.Fatalf("error connection to the database: %s", err)
+		log.Fatalf("error connecting to the database: %s", err)
 	}
 
 	// Create the "accounts" table.

--- a/_includes/app/txn-sample.go
+++ b/_includes/app/txn-sample.go
@@ -35,7 +35,7 @@ func transferFunds(tx *sql.Tx, from int, to int, amount int) error {
 func main() {
 	db, err := sql.Open("postgres", "postgresql://maxroach@localhost:26257/bank?sslmode=disable")
 	if err != nil {
-		log.Fatal("error connection to the database: ", err)
+		log.Fatal("error connecting to the database: ", err)
 	}
 
 	// Run a transfer in a transaction.

--- a/insert.md
+++ b/insert.md
@@ -314,7 +314,7 @@ func main() {
                 "postgresql://root@localhost:26257/bank?sslmode=disable"
         )
         if err != nil {
-                log.Fatalf("error connection to the database: %s", err)
+                log.Fatalf("error connecting to the database: %s", err)
         }
 
         // Insert two rows into the "accounts" table


### PR DESCRIPTION
I notice that there's a little inconsistency in the use of `log.Fatal` vs. `log.Fatalf`, not a big deal but might be something worth standardizing in the docs on a larger scale at some point?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1272)
<!-- Reviewable:end -->
