### PR TITLE
Answer more FAQs in the docs

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -458,14 +458,44 @@ entries:
         - title: Troubleshoot
           url: /troubleshoot.html
 
-    - title: Learn How It Works
+    - title: Contribute
       items:
 
-        - title: Frequently Asked Questions
+        - title: Contribute to CockroachDB
+          url: /contribute-to-cockroachdb.html
+
+        - title: Improve the Docs
+          url: /improve-the-docs.html
+
+    - title: Release Notes
+      items:
+
+        - title: beta-20170420
+          url: /beta-20170420.html
+
+        - title: beta-20170413
+          url: /beta-20170413.html
+
+        - title: beta-20170406
+          url: /beta-20170406.html
+
+        - title: beta-20170330
+          url: /beta-20170330.html
+
+        - title: beta-20170323
+          url: /beta-20170323.html
+
+        - title: Older Beta Versions
+          url: /older-versions.html
+
+    - title: FAQs
+      items:
+
+        - title: General FAQs
           url: /frequently-asked-questions.html
 
-        - title: Tech Talks
-          external_url: https://www.cockroachlabs.com/community/tech-talks/
+        - title: SQL FAQs
+          url: /sql-faqs.html
 
         - title: CockroachDB in Comparison
           url: /cockroachdb-in-comparison.html
@@ -501,32 +531,3 @@ entries:
                 - title: Go Implementation
                   url: /go-implementation.html
 
-    - title: Contribute
-      items:
-
-        - title: Contribute to CockroachDB
-          url: /contribute-to-cockroachdb.html
-
-        - title: Improve the Docs
-          url: /improve-the-docs.html
-
-    - title: Release Notes
-      items:
-
-        - title: beta-20170420
-          url: /beta-20170420.html
-
-        - title: beta-20170413
-          url: /beta-20170413.html
-
-        - title: beta-20170406
-          url: /beta-20170406.html
-
-        - title: beta-20170330
-          url: /beta-20170330.html
-
-        - title: beta-20170323
-          url: /beta-20170323.html
-
-        - title: Older Beta Versions
-          url: /older-versions.html

--- a/_includes/faq/auto-generate-unique-ids.html
+++ b/_includes/faq/auto-generate-unique-ids.html
@@ -1,0 +1,15 @@
+To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
+
+~~~ sql
+> CREATE TABLE test (id SERIAL PRIMARY KEY, name STRING);
+~~~
+
+On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead:
+
+~~~ sql
+> CREATE TABLE test (id BYTES PRIMARY KEY DEFAULT uuid_v4(), name STRING);
+~~~
+
+Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
+
+The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.

--- a/_includes/faq/simulate-key-value-store.html
+++ b/_includes/faq/simulate-key-value-store.html
@@ -1,0 +1,13 @@
+CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. Although it is not possible to access the key-value store directly, you can mirror direct access using a "simple" table of two columns, with one set as the primary key:
+
+~~~ sql
+> CREATE TABLE kv (k INT PRIMARY KEY, v BYTES);
+~~~
+
+When such a "simple" table has no indexes or foreign keys, [`INSERT`](insert.html)/[`UPSERT`](upsert.html)/[`UPDATE`](update.html)/[`DELETE`](delete.html) statements translate to key-value operations with minimal overhead (single digit percent slowdowns). For example, the following `UPSERT` to add or replace a row in the table would translate into a single key-value Put operation:
+
+~~~ sql
+> UPSERT INTO kv VALUES (1, b'hello')
+~~~
+
+This SQL table approach also offers you a well-defined query language, a known transaction model, and the flexibility to add more columns to the table if the need arises.

--- a/_includes/faq/when-to-interleave-tables.html
+++ b/_includes/faq/when-to-interleave-tables.html
@@ -1,0 +1,5 @@
+You're most likely to benefit from interleaved tables when:
+
+  - Your tables form a [hierarchy](interleave-in-parent.html#interleaved-hierarchy)
+  - Queries maximize the [benefits of interleaving](interleave-in-parent.html#benefits)
+  - Queries do not suffer too greatly from interleaving's [tradeoffs](interleave-in-parent.html#tradeoffs)

--- a/beta-20170309.md
+++ b/beta-20170309.md
@@ -69,7 +69,7 @@ Get future release notes emailed to you:
 
 ### Doc Updates
 
-- Added an FAQ on [auto-generating unique IDs in CockroachDB](frequently-asked-questions.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb). [#1126](https://github.com/cockroachdb/docs/pull/1126)
+- Added an FAQ on [auto-generating unique IDs in CockroachDB](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb). [#1126](https://github.com/cockroachdb/docs/pull/1126)
 - Expanded guidance on [using a SQL table as an alternative to direct key-value access](frequently-asked-questions.html#can-i-use-cockroachdb-as-a-key-value-store). [#1122](https://github.com/cockroachdb/docs/pull/1122)
 - Added details about [using the `BIT` type to constrain integers](int.html#size) based on their corresponding binary values. [#1116](https://github.com/cockroachdb/docs/pull/1116)
 - Added details about [building a binary](install-cockroachdb.html) that excludes enterprise functionality covered by the CockroachDB Community License (CCL). [#1130](https://github.com/cockroachdb/docs/pull/1130)

--- a/create-table.md
+++ b/create-table.md
@@ -192,27 +192,7 @@ We also have other resources on indexes:
 
 ### Create a Table with Auto-Generated Unique Row IDs
 
-To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
-
-~~~ sql
-> CREATE TABLE test (
-    id SERIAL PRIMARY KEY,
-    name STRING
-);
-~~~
-
-On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead:
-
-~~~ sql
-> CREATE TABLE test (
-    id BYTES PRIMARY KEY DEFAULT uuid_v4(),
-    name STRING
-);
-~~~
-
-Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
-
-The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.
+{% include faq/auto-generate-unique-ids.html %}
 
 ### Create a Table with Foreign Keys
 
@@ -256,7 +236,7 @@ In this example, we'll show a series of tables using different formats of foreig
 
 ### Create a Table that Mirrors Key-Value Storage
 
-CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. Although it is not possible to access the key-value store directly, you can mirror direct access using a "simple" table of two columns, with one set as the primary key. See this [FAQ](frequently-asked-questions.html#can-i-use-cockroachdb-as-a-key-value-store) for more details.
+{% include faq/simulate-key-value-store.html %}
 
 ### Show the Definition of a Table
 

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -154,19 +154,7 @@ Not yet, but this is on our long-term roadmap.
 
 ## Can I use CockroachDB as a key-value store?
 
-CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. Although it is not possible to access the key-value store directly, you can mirror direct access using a "simple" table of two columns, with one set as the primary key:
-
-~~~ sql
-> CREATE TABLE kv (k INT PRIMARY KEY, v BYTES);
-~~~
-
-When such a "simple" table has no indexes or foreign keys, [`INSERT`](insert.html)/[`UPSERT`](upsert.html)/[`UPDATE`](update.html)/[`DELETE`](delete.html) statements translate to key-value operations with minimal overhead (single digit percent slowdowns). For example, the following `UPSERT` to add or replace a row in the table would translate into a single key-value Put operation:
-
-~~~ sql
-> UPSERT INTO kv VALUES (1, b'hello')
-~~~
-
-This SQL table approach also offers you a well-defined query language, a known transaction model, and the flexibility to add more columns to the table if the need arises.
+{% include faq/simulate-key-value-store.html %}
 
 ## Have questions that weren’t answered?
 

--- a/frequently-asked-questions.md
+++ b/frequently-asked-questions.md
@@ -152,40 +152,6 @@ The current version of CockroachDB is intended for use with new applications. Th
 
 Not yet, but this is on our long-term roadmap.
 
-## How do I bulk insert data into CockroachDB?
-
-Currently, you can bulk insert data with batches of [`INSERT`](insert.html) statements not exceeding a few MB. The size of your rows determines how many you can use, but 1,000 - 10,000 rows typically works best. For more details, see [Import Data](https://www.cockroachlabs.com/docs/import-data.html).
-
-## How do I auto-generate unique row IDs in CockroachDB?
-
-To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
-
-~~~ sql
-> CREATE TABLE test (id SERIAL PRIMARY KEY, name STRING);
-~~~
-
-On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead:
-
-~~~ sql
-> CREATE TABLE test (id BYTES PRIMARY KEY DEFAULT uuid_v4(), name STRING);
-~~~
-
-Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
-
-The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.
-
-## Does CockroachDB support `JOIN`?
-
-CockroachDB has basic, non-optimized support for SQL `JOIN`, whose performance we're working to improve.
-
-To learn more, see our blog posts on CockroachDB's JOINs:
-- [Modesty in Simplicity: CockroachDB's JOIN](https://www.cockroachlabs.com/blog/cockroachdbs-first-join/).
-- [On the Way to Better SQL Joins](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/)
-
-## Does CockroachDB support JSON or Protobuf datatypes?
-
-Not currently, but [we plan to offer JSON/Protobuf datatypes](https://github.com/cockroachdb/cockroach/issues/2969).
-
 ## Can I use CockroachDB as a key-value store?
 
 CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. Although it is not possible to access the key-value store directly, you can mirror direct access using a "simple" table of two columns, with one set as the primary key:

--- a/interleave-in-parent.md
+++ b/interleave-in-parent.md
@@ -45,11 +45,7 @@ By writing data in this way, related data is more likely to remain on the same k
 
 ## When to Interleave Tables
 
-You're most likely to benefit from interleaved tables when:
-
-  - Your tables form a [hierarchy](#interleaved-hierarchy)
-  - Queries maximize the [benefits of interleaving](#benefits)
-  - Queries do not suffer too greatly from interleaving's [tradeoffs](#tradeoffs)
+{% include faq/when-to-interleave-tables.html %}
 
 ### Interleaved Hierarchy
 
@@ -107,10 +103,10 @@ This example creates an interleaved hierarchy between `customers`, `orders`, and
   );
 
 > CREATE TABLE orders (
-    customer INT, 
+    customer INT,
     id INT,
-    total DECIMAL(20, 5), 
-    PRIMARY KEY (customer, id), 
+    total DECIMAL(20, 5),
+    PRIMARY KEY (customer, id),
     CONSTRAINT fk_customer FOREIGN KEY (customer) REFERENCES customers
     ) INTERLEAVE IN PARENT customers (customer)
   ;
@@ -133,13 +129,13 @@ This example creates an interleaved hierarchy between `customers`, `orders`, and
 It can be easier to understand what interleaving tables does by seeing what it looks like in the key-value store. For example, using the above example of interleaving `orders` in `customers`, we could insert the following values:
 
 ~~~ sql
-> INSERT INTO customers 
-  (id, name) VALUES 
+> INSERT INTO customers
+  (id, name) VALUES
   (1, 'Ha-Yun'),
   (2, 'Emanuela');
 
-> INSERT INTO orders 
-  (customer, id, total) VALUES 
+> INSERT INTO orders
+  (customer, id, total) VALUES
   (1, 1000, 100.00),
   (2, 1001, 90.00),
   (1, 1002, 80.00),

--- a/sql-faqs.md
+++ b/sql-faqs.md
@@ -12,43 +12,7 @@ Currently, you can bulk insert data with batches of [`INSERT`](insert.html) stat
 
 ## How do I auto-generate unique row IDs in CockroachDB?
 
-To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
-
-~~~ sql
-> CREATE TABLE test (id SERIAL PRIMARY KEY, name STRING);
-~~~
-
-On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead:
-
-~~~ sql
-> CREATE TABLE test (id BYTES PRIMARY KEY DEFAULT uuid_v4(), name STRING);
-~~~
-
-Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
-
-The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.
-
-## Does CockroachDB support `JOIN`?
-
-CockroachDB has basic, non-optimized support for SQL `JOIN`, whose performance we're working to improve.
-
-To learn more, see our blog posts on CockroachDB's JOINs:
-- [Modesty in Simplicity: CockroachDB's JOIN](https://www.cockroachlabs.com/blog/cockroachdbs-first-join/).
-- [On the Way to Better SQL Joins](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/)
-
-## When should I use interleaved tables?
-
-Interleaving tables improves query performance by optimizing the key-value structure of closely related tables, attempting to keep data on the same key-value range if it's likely to be read and written together.
-
-You're most likely to benefit from interleaved tables when:
-
-  - Your tables form a [hierarchy](interleave-in-parent.html#interleaved-hierarchy)
-  - Queries maximize the [benefits of interleaving](interleave-in-parent.html#benefits)
-  - Queries do not suffer too greatly from interleaving's [tradeoffs](interleave-in-parent.html#tradeoffs)
-
-## Does CockroachDB support JSON or Protobuf datatypes?
-
-Not currently, but [we plan to offer JSON/Protobuf datatypes](https://github.com/cockroachdb/cockroach/issues/2969).
+{% include faq/auto-generate-unique-ids.html %}
 
 ## How do I get the last ID/SERIAL value inserted into a table?
 
@@ -61,6 +25,24 @@ For example, this is how you’d use `RETURNING` to return an auto-generated [`S
 
 > INSERT INTO users (name) VALUES ('mike') RETURNING id;
 ~~~
+
+## Does CockroachDB support `JOIN`?
+
+CockroachDB has basic, non-optimized support for SQL `JOIN`, whose performance we're working to improve.
+
+To learn more, see our blog posts on CockroachDB's JOINs:
+- [Modesty in Simplicity: CockroachDB's JOIN](https://www.cockroachlabs.com/blog/cockroachdbs-first-join/).
+- [On the Way to Better SQL Joins](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/)
+
+## When should I use interleaved tables?
+
+[Interleaving tables](interleave-in-parent.html) improves query performance by optimizing the key-value structure of closely related tables, attempting to keep data on the same key-value range if it's likely to be read and written together.
+
+{% include faq/when-to-interleave-tables.html %}
+
+## Does CockroachDB support JSON or Protobuf datatypes?
+
+Not currently, but [we plan to offer JSON/Protobuf datatypes](https://github.com/cockroachdb/cockroach/issues/2969).
 
 ## How do I know which index CockroachDB will select for a query?
 

--- a/sql-faqs.md
+++ b/sql-faqs.md
@@ -1,0 +1,81 @@
+---
+title: SQL FAQs
+summary: Get answers to frequently asked questions about CockroachDB SQL.
+toc: false
+---
+
+<div id="toc"></div>
+
+## How do I bulk insert data into CockroachDB?
+
+Currently, you can bulk insert data with batches of [`INSERT`](insert.html) statements not exceeding a few MB. The size of your rows determines how many you can use, but 1,000 - 10,000 rows typically works best. For more details, see [Import Data](https://www.cockroachlabs.com/docs/import-data.html).
+
+## How do I auto-generate unique row IDs in CockroachDB?
+
+To auto-generate unique row IDs, use the [`SERIAL`](serial.html) data type, which is an alias for [`INT`](int.html) with the `unique_rowid()` [function](functions-and-operators.html#id-generation-functions) as the [default value](default-value.html):
+
+~~~ sql
+> CREATE TABLE test (id SERIAL PRIMARY KEY, name STRING);
+~~~
+
+On insert, the `unique_rowid()` function generates a default value from the timestamp and ID of the node executing the insert, a combination that is likely to be globally unique except in extreme cases where a very large number of IDs (100,000+) are generated per node per second. In such cases, you should use a [`BYTES`](bytes.html) column with the `uuid_v4()` function as the default value instead:
+
+~~~ sql
+> CREATE TABLE test (id BYTES PRIMARY KEY DEFAULT uuid_v4(), name STRING);
+~~~
+
+Because `BYTES` values are 128-bit, much larger than `INT` values at 64-bit, there is virtually no chance of generating non-unique values.
+
+The distribution of IDs at the key-value level may also be a consideration. When using `BYTES` with `uuid_v4()` as the default value, consecutively generated IDs will be spread across different key-value ranges (and therefore likely across different nodes), whereas when using `INT` with `unique_rowid()` as the default value, consecutively generated IDs may end up in the same key-value range.
+
+## Does CockroachDB support `JOIN`?
+
+CockroachDB has basic, non-optimized support for SQL `JOIN`, whose performance we're working to improve.
+
+To learn more, see our blog posts on CockroachDB's JOINs:
+- [Modesty in Simplicity: CockroachDB's JOIN](https://www.cockroachlabs.com/blog/cockroachdbs-first-join/).
+- [On the Way to Better SQL Joins](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/)
+
+## When should I use interleaved tables?
+
+Interleaving tables improves query performance by optimizing the key-value structure of closely related tables, attempting to keep data on the same key-value range if it's likely to be read and written together.
+
+You're most likely to benefit from interleaved tables when:
+
+  - Your tables form a [hierarchy](interleave-in-parent.html#interleaved-hierarchy)
+  - Queries maximize the [benefits of interleaving](interleave-in-parent.html#benefits)
+  - Queries do not suffer too greatly from interleaving's [tradeoffs](interleave-in-parent.html#tradeoffs)
+
+## Does CockroachDB support JSON or Protobuf datatypes?
+
+Not currently, but [we plan to offer JSON/Protobuf datatypes](https://github.com/cockroachdb/cockroach/issues/2969).
+
+## How do I get the last ID/SERIAL value inserted into a table?
+
+There’s no function in CockroachDB for returning last inserted values, but you can use the [`RETURNING` clause](insert.html#insert-and-return-values) of the `INSERT` statement.
+
+For example, this is how you’d use `RETURNING` to return an auto-generated [`SERIAL`](serial.html) value:
+
+~~~ sql
+> CREATE TABLE users (id SERIAL, name STRING);
+
+> INSERT INTO users (name) VALUES ('mike') RETURNING id;
+~~~
+
+## How do I know which index CockroachDB will select for a query?
+
+To see which indexes CockroachDB is using for a given query, you can use the [`EXPLAIN`](explain.html) statement, which will print out the query plan, including any indexes that are being used:
+
+~~~ sql
+> EXPLAIN SELECT col1 FROM tbl1;
+~~~
+
+If you'd like to tell the query planner which index to use, you can do so via some [special syntax for index hints](select.html#force-index-selection-index-hints):
+
+~~~ sql
+> SELECT col1 FROM tbl1@idx1;
+~~~
+
+## Does CockroachDB support a UUID type?
+
+Not at this time, but storing a 16-byte array in a [`BYTES`](bytes.html) column should perform just as well.


### PR DESCRIPTION
As we identify more and more FAQs, we need a good way
to make answers to these questions easily accessible/searchable
in the docs. This PR offers one possible approach: Adding
an FAQs section to the sidenav, with categories of FAQs broken
into distinct pages. For example, in addition to the general
FAQ we've had for some time, I've added a page on SQL-specific
FAQs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1315)
<!-- Reviewable:end -->
