### PR TITLE
manual rolling upgrade docs

### DIFF
--- a/_data/sidebar_doc.yml
+++ b/_data/sidebar_doc.yml
@@ -462,6 +462,9 @@ entries:
         - title: View Version Details
           url: /view-version-details.html
 
+        - title: Upgrade a Cluster's Version
+          url: /upgrade-cockroach-version.html
+          
         - title: Back up Data
           url: /back-up-data.html
 

--- a/upgrade-cockroach-version.md
+++ b/upgrade-cockroach-version.md
@@ -1,0 +1,95 @@
+---
+title: Upgrade a Cluster's Version
+summary: Learn how to upgrade your CockroachDB cluster to a new version.
+toc: false
+toc_not_nested: true
+---
+
+Because of CockroachDB's multi-active availability design, you can perform a "rolling upgrade" of CockroachDB on your cluster. This means you can upgrade individual nodes in your cluster one at a time without any downtime for your cluster.
+
+However, there are a few things you should keep in mind:
+
+  - For rolling upgrades to work, your cluster must be behind a load balancer or your clients must be configured to talk to multiple nodes. If your application communicates with a single node, bringing it down to upgrade its CockroachDB binary will cause your application to fail when the node goes offline.
+
+  - We recommend creating scripts to upgrade CockroachDB and not attempting to do so by hand.
+
+  - Only bring down only one node at a time, and wait at least one minute after it rejoins the cluster to bring down the next node. This reduces the number of nodes you have offline at any point in time, minimizing the chance you'll lose a majority of the nodes in your cluster which can cause service outages.
+
+## Perform a Rolling Upgrade
+
+For each node in your cluster, complete the following steps.
+
+1. Connect to the node.
+
+2. Download and install the CockroachDB binary you want to use:
+
+   - **Mac**:
+
+     ~~~ shell
+     $ curl -O https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.darwin-10.9-amd64.tgz
+     $ tar xfz cockroach-{{site.data.strings.version}}.darwin-10.9-amd64.tgz
+
+     # Optional: Place cockroach in your $PATH
+     $ cp -i cockroach-{{site.data.strings.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
+     ~~~
+
+   - **Linux**:
+
+     ~~~ shell
+     $ wget https://binaries.cockroachdb.com/cockroach-{{site.data.strings.version}}.linux-amd64.tgz
+     $ tar xfz cockroach-{{site.data.strings.version}}.linux-amd64.tgz 
+
+     # Optional: Place cockroach in your $PATH
+     $ cp -i cockroach-{{site.data.strings.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
+     ~~~
+
+3. If you're running with a process manager, have it stop `cockroach`.
+
+   Without a process manager, use this command:
+
+   ~~~ shell
+   $ pkill cockroach
+   ~~~
+
+4. If you use `cockroach` in your `$PATH`, rename the outdated `cockroach` binary, and then move the new one into its place:
+
+   - **Mac**:
+
+     ~~~ shell
+     $ i="$(which cockroach)"; mv "$i" "$i"_old
+     $ cp -i cockroach-{{site.data.strings.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
+     ~~~
+
+   - **Linux**:
+
+     ~~~ shell
+     $ i="$(which cockroach)"; mv "$i" "$i"_old
+     $ cp -i cockroach-{{site.data.strings.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
+     ~~~
+
+   If you leave versioned binaries on your servers, you don't need to do anything.
+
+5. If you're running with a process manager, have the node rejoin the cluster by starting it.
+
+   Without a process manager, use this command:
+
+   ~~~ shell
+   $ cockroach start --join=[any other node's IP address] [other flags]
+   ~~~
+
+   `[other flags]` includes any flags you [use to a start node](start-a-node.html), such as its `--host`.
+
+6. Verify the node has rejoined the cluster through its output to `stdout` or through the [admin UI](explore-the-admin-ui.html).
+
+7. If you use `cockroach` in your `$PATH`, you can remove the old binary:
+
+   ~~~ shell
+   $ rm /usr/local/bin/cockroach_old
+   ~~~
+
+8. Wait at least one minute after the node has rejoined the cluster, and then repeat these steps for the next node.
+
+## See Also
+
+- [View Version Details](view-version-details.html)
+- [Release notes for our latest version]({{site.data.strings.version}}.html)


### PR DESCRIPTION
Work toward #1182 (not closing because this is only the manual process without any kind of ops-minded automation)

@mberhault or @bdarnell Do either of you have any guidance on improving this process or additional guidance we should include? e.g., if more than 5 minutes passes before rejoining the node to the cluster, wait for 5 more minutes to ensure you don't freeze the cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1338)
<!-- Reviewable:end -->
