### PR TITLE
Adjust formatting in Clojure example

### DIFF
--- a/_includes/app/basic-sample.clj
+++ b/_includes/app/basic-sample.clj
@@ -1,6 +1,6 @@
 (ns test.test
-  (:require   [clojure.java.jdbc :as j]
-              [test.util :as util]))
+  (:require [clojure.java.jdbc :as j]
+            [test.util :as util]))
 
 ;; Define the connection parameters to the cluster.
 (def db-spec {:subprotocol "postgresql"
@@ -24,10 +24,8 @@
          doall)
 
     ;; The database connection is automatically closed by with-db-connection.
-    )
-  )
+    ))
 
 
 (defn -main [& args]
-  (test-basic)
-  )
+  (test-basic))

--- a/_includes/app/txn-sample.clj
+++ b/_includes/app/txn-sample.clj
@@ -1,13 +1,12 @@
 (ns test.test
-  (:require   [clojure.java.jdbc :as j]
-              [test.util :as util]))
+  (:require [clojure.java.jdbc :as j]
+            [test.util :as util]))
 
 ;; Define the connection parameters to the cluster.
 (def db-spec {:subprotocol "postgresql"
               :subname "//localhost:26257/bank"
               :user "maxroach"
               :password ""})
-
 
 ;; The transaction we want to run.
 (defn transferFunds
@@ -22,8 +21,7 @@
 
   ;; Perform the transfer.
   (j/execute! txn [(str "UPDATE accounts SET balance = balance - " amount " WHERE id = " from)])
-  (j/execute! txn [(str "UPDATE accounts SET balance = balance + " amount " WHERE id = " to)])
-  )
+  (j/execute! txn [(str "UPDATE accounts SET balance = balance + " amount " WHERE id = " to)]))
 
 (defn test-txn []
   ;; Connect to the cluster and run the code below with
@@ -39,10 +37,7 @@
     (println "Balances after transfer:")
     (->> (j/query conn ["SELECT id, balance FROM accounts"])
          (map println)
-         (doall))
-    )
-  )
+         (doall))))
 
 (defn -main [& args]
-  (test-txn)
-  )
+  (test-txn))


### PR DESCRIPTION
* It's customary in Clojure to group parentheses at the end of a line
* Predicates in Clojure are named with a `?` suffix, rather than a `p`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1339)
<!-- Reviewable:end -->
