### PR TITLE
Use single quotes throughout JS example

### DIFF
--- a/_includes/app/basic-sample.js
+++ b/_includes/app/basic-sample.js
@@ -25,11 +25,11 @@ pg.connect(config, function (err, client, done) {
   async.waterfall([
     function (next) {
       // Create the "accounts" table.
-      client.query("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT);", next);
+      client.query('CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT);', next);
     },
     function (results, next) {
       // Insert two rows into the "accounts" table.
-      client.query("INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250);", next);
+      client.query('INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250);', next);
     },
     function (results, next) {
       // Print out the balances.


### PR DESCRIPTION
There's no functional difference here, but it's a bit more consistent
with all the other uses to change these ones, especially because the
styling on the page highlights double-quoted strings a different colour
than single-quoted strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1341)
<!-- Reviewable:end -->
