### PR TITLE
Use single quotes throughout ruby example

### DIFF
--- a/_includes/app/activerecord-basic-sample.rb
+++ b/_includes/app/activerecord-basic-sample.rb
@@ -5,11 +5,11 @@ require 'activerecord-cockroachdb-adapter'
 # Connect to CockroachDB through ActiveRecord.
 # In Rails, this configuration would go in config/database.yml as usual.
 ActiveRecord::Base.establish_connection(
-  adapter:  "cockroachdb",
-  username: "maxroach",
-  password: "",
-  database: "bank",
-  host:     "localhost",
+  adapter:  'cockroachdb',
+  username: 'maxroach',
+  password: '',
+  database: 'bank',
+  host:     'localhost',
   port:     26257,
 )
 
@@ -42,5 +42,5 @@ Account.create(id: 2, balance: 250)
 
 # Retrieve accounts and print out the balances
 Account.all.each do |acct|
-    puts "#{acct.id} #{acct.balance}"
+  puts "#{acct.id} #{acct.balance}"
 end

--- a/_includes/app/basic-sample.rb
+++ b/_includes/app/basic-sample.rb
@@ -5,14 +5,14 @@ require 'pg'
 conn = PG.connect(user: 'maxroach', dbname: 'bank', host: 'localhost', port: 26257)
 
 # Create the "accounts" table.
-conn.exec("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)")
+conn.exec('CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)')
 
 # Insert two rows into the "accounts" table.
-conn.exec("INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)")
+conn.exec('INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)')
 
 # Print out the balances.
-puts "Initial balances:"
-conn.exec("SELECT id, balance FROM accounts") do |res|
+puts 'Initial balances:'
+conn.exec('SELECT id, balance FROM accounts') do |res|
   res.each do |row|
     puts row
   end


### PR DESCRIPTION
There isn't really a standard style for this in Ruby as far as I'm
aware, so I arbitrarily chose standardizing on single quotes because I
like the colour they highlight to on the docs page better. There's one
use of double quotes left because it uses string interpolation (which
single quotes disallow).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1343)
<!-- Reviewable:end -->
