### PR TITLE
mark beta-20170406 as withdrawn on releases page

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -16,6 +16,7 @@
 - date: Apr 06, 2017
   version: beta-20170406
   source: true
+  withdrawn: true
 - date: Mar 30, 2017
   version: beta-20170330
   source: true


### PR DESCRIPTION
This was an oversight when landing the new releases page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1374)
<!-- Reviewable:end -->
