### PR TITLE
use versioned tarball in install instructions

### DIFF
--- a/deploy-cockroachdb-on-aws-insecure.md
+++ b/deploy-cockroachdb-on-aws-insecure.md
@@ -110,11 +110,11 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
@@ -141,11 +141,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin

--- a/deploy-cockroachdb-on-aws.md
+++ b/deploy-cockroachdb-on-aws.md
@@ -213,11 +213,11 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     ~~~ shell
     # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
     # Extract the binary.
-    $ tar -xf cockroach-latest.linux-amd64.tgz  \
-    --strip=1 cockroach-latest.linux-amd64/cockroach
+    $ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
@@ -245,11 +245,11 @@ At this point, your cluster is live and operational but contains only a single n
 
     ~~~ shell
     # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
     # Extract the binary.
-    $ tar -xf cockroach-latest.linux-amd64.tgz  \
-    --strip=1 cockroach-latest.linux-amd64/cockroach
+    $ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin

--- a/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -88,11 +88,11 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 
 	~~~ shell
 	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary:
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
@@ -120,11 +120,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary:
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin

--- a/deploy-cockroachdb-on-digital-ocean.md
+++ b/deploy-cockroachdb-on-digital-ocean.md
@@ -189,11 +189,11 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
@@ -221,11 +221,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin

--- a/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/deploy-cockroachdb-on-google-cloud-platform.md
@@ -214,11 +214,11 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
@@ -245,11 +245,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin

--- a/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -114,11 +114,11 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
@@ -148,11 +148,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin

--- a/deploy-cockroachdb-on-microsoft-azure.md
+++ b/deploy-cockroachdb-on-microsoft-azure.md
@@ -213,11 +213,11 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     ~~~ shell
     # Get the latest CockroachDB tarball.
-    $ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+    $ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
     # Extract the binary.
-    $ tar -xf cockroach-latest.linux-amd64.tgz  \
-    --strip=1 cockroach-latest.linux-amd64/cockroach
+    $ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
@@ -246,11 +246,11 @@ At this point, your cluster is live and operational but contains only a single n
 
     ~~~ shell
     # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
     # Extract the binary.
-    $ tar -xf cockroach-latest.linux-amd64.tgz  \
-    --strip=1 cockroach-latest.linux-amd64/cockroach
+    $ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin

--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -79,7 +79,7 @@ $(document).ready(function(){
 </div>
 
 <div id="macinstall">
-<p>There are four ways to install CockroachDB on macOS. See <a href="{{site.data.strings.version}}.html" data-eventcategory=“mac-releasenotes-download”>Release Notes</a> for what's new in the latest version. </p>
+<p>There are four ways to install CockroachDB on macOS. See <a href="{{site.data.strings.version}}.html">Release Notes</a> for what's new in the latest release, {{ site.data.strings.version }}. </p>
 
 <div id="mac-installs" class="clearfix">
 <a href="#download-the-binary" class="install-button mac-button current" data-eventcategory="buttonClick-doc-install" data-eventaction="mac-binary">Download the <div class="c2a">Binary</div></a>
@@ -92,17 +92,17 @@ $(document).ready(function(){
   <h2>Download the Binary</h2>
   <ol>
     <li>
-      <p>Download the latest <a href="https://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz" data-eventcategory="mac-binary-step1">CockroachDB archive for OS X</a>.</p>
+      <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.darwin-10.9-amd64.tgz" data-eventcategory="mac-binary-step1">CockroachDB {{ site.data.strings.version }} archive for OS X</a>.</p>
     </li>
     <li>
       <p>Extract the binary:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-binary-step2"><span class="gp" data-eventcategory="mac-binary-step2">$ </span>tar xfz cockroach-latest.darwin-10.9-amd64.tgz</code></pre></div>
+      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-binary-step2"><span class="gp" data-eventcategory="mac-binary-step2">$ </span>tar xfz cockroach-{{ site.data.strings.version }}.darwin-10.9-amd64.tgz</code></pre></div>
     </li>
     <li>
       <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-latest.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
+      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-{{ site.data.strings.version }}.darwin-10.9-amd64/cockroach /usr/local/bin</code></pre></div>
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>
@@ -200,15 +200,15 @@ $(document).ready(function(){
     <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>
   </li>
   <li>
-    <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-latest.src.tgz" data-eventcategory=“mac-source-download”>latest CockroachDB source archive</a>.</p>
+    <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.src.tgz" data-eventcategory="mac-source-download">CockroachDB {{ site.data.strings.version }} source archive</a>.</p>
   </li>
   <li>
     <p>Extract the sources:</p>
-    <p><div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>tar xfz cockroach-latest.src.tgz</code></pre></div></p>
+    <p><div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>tar xfz cockroach-{{ site.data.strings.version }}.src.tgz</code></pre></div></p>
   </li>
   <li><p>In the extracted directory, run <code>make build</code>:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-latest<br><span class="gp noselect shellterminal"></span>make build</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-{{ site.data.strings.version }}<br><span class="gp noselect shellterminal"></span>make build</code></pre></div>
 
     <p>The build process can take 10+ minutes, so please be patient.</p>
 
@@ -302,7 +302,7 @@ $(document).ready(function(){
 </div>
 
 <div id="linuxinstall" style="display: none;">
-<p>There are three ways to install CockroachDB on Linux. See <a href="{{site.data.strings.version}}.html" data-eventcategory="linux-releasenotes-download">Release Notes</a> for what's new in the latest version.</p>
+<p>There are three ways to install CockroachDB on Linux. See <a href="{{site.data.strings.version}}.html" data-eventcategory="linux-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ site.data.strings.version }}.</p>
 
 <div id="linux-installs" class="clearfix">
 <a href="#download-the-binary-linux" class="install-button linux-button current" data-eventcategory="buttonClick-doc-install" data-eventaction="linux-binary" data-eventlabel="">Download the <div class="c2a">Binary</div></a>
@@ -315,18 +315,18 @@ $(document).ready(function(){
 
   <ol>
     <li>
-      <p>Download the latest <a href="https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz" data-eventcategory="linux-binary-step1">CockroachDB archive for Linux</a>.</p>
+      <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz" data-eventcategory="linux-binary-step1">CockroachDB {{ site.data.strings.version }} archive for Linux</a>.</p>
     </li>
     <li>
       <p>Extract the binary:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-binary-step2"><span class="gp" data-eventcategory="linux-binary-step2">$ </span>tar xfz cockroach-latest.linux-amd64.tgz</code></pre>
+      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="linux-binary-step2"><span class="gp" data-eventcategory="linux-binary-step2">$ </span>tar xfz cockroach-{{ site.data.strings.version }}.linux-amd64.tgz</code></pre>
       </div>
     </li>
     <li>
       <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-latest.linux-amd64/cockroach /usr/local/bin</code></pre></div>
+      <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach /usr/local/bin</code></pre></div>
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>
@@ -388,15 +388,15 @@ $(document).ready(function(){
     <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>
   </li>
   <li>
-    <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-latest.src.tgz" data-eventcategory=“linux-source-download”>latest CockroachDB source archive</a>.</p>
+    <p>Download the <a href="https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.src.tgz" data-eventcategory="linux-source-download">CockroachDB {{ site.data.strings.version }} source archive</a>.</p>
   </li>
   <li>
     <p>Extract the sources:</p>
-    <p><div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>tar xfz cockroach-latest.src.tgz</code></pre></div></p>
+    <p><div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>tar xfz cockroach-{{ site.data.strings.version }}.src.tgz</code></pre></div></p>
   </li>
   <li><p>In the extracted directory, run <code>make build</code>:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-latest<br><span class="gp noselect shellterminal"></span>make build</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-{{ site.data.strings.version }}<br><span class="gp noselect shellterminal"></span>make build</code></pre></div>
 
     <p>The build process can take 10+ minutes, so please be patient.</p>
 
@@ -494,7 +494,7 @@ $(document).ready(function(){
 
 <div id="windowsinstall" style="display: none;">
 
-<p>There are two ways to install CockroachDB on Windows. See <a href="{{site.data.strings.version}}.html" data-eventcategory="windows-releasenotes-download">Release Notes</a> for what's new in the latest version. </p>
+<p>There are two ways to install CockroachDB on Windows. See <a href="{{site.data.strings.version}}.html" data-eventcategory="windows-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ site.data.strings.version }}. </p>
 
 <div id="windows-installs" class="clearfix">
 <a href="#download-the-binary-windows" class="install-button windows-button current" data-eventcategory="buttonClick-doc-install" data-eventaction="windows-binary">Download the <div class="c2a">Binary</div></a>
@@ -508,12 +508,12 @@ $(document).ready(function(){
 
 <ol>
   <li>
-    <p>Download and extract the latest <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.2.windows-6.2-amd64.zip" data-eventcategory="windows-binary-download">CockroachDB archive for Windows</a>.</p>
+    <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.windows-6.2-amd64.zip" data-eventcategory="windows-binary-download">CockroachDB {{ site.data.strings.version }} archive for Windows</a>.</p>
   </li>
   <li>
     <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\cockroach-latest.windows-6.2-amd64> .\cockroach.exe version</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code><span class="nb">PS </span>C:\cockroach-{{ site.data.strings.version }}.windows-6.2-amd64> .\cockroach.exe version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>

--- a/manual-deployment-insecure.md
+++ b/manual-deployment-insecure.md
@@ -40,11 +40,11 @@ This tutorial shows you how to manually deploy an insecure multi-node CockroachD
 
 	~~~ shell
 	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary:
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
@@ -69,11 +69,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary:
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
@@ -160,11 +160,11 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin

--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -138,11 +138,11 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	~~~ shell
 	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary:
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
@@ -168,11 +168,11 @@ At this point, your cluster is live and operational but contains only a single n
 
 	~~~ shell
 	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary:
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
@@ -261,11 +261,11 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 	~~~ shell
 	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz
+	$ wget https://binaries.cockroachdb.com/cockroach-{{ site.data.strings.version }}.linux-amd64.tgz
 
 	# Extract the binary.
-	$ tar -xf cockroach-latest.linux-amd64.tgz  \
-	--strip=1 cockroach-latest.linux-amd64/cockroach
+	$ tar -xf cockroach-{{ site.data.strings.version }}.linux-amd64.tgz  \
+	--strip=1 cockroach-{{ site.data.strings.version }}.linux-amd64/cockroach
 
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin


### PR DESCRIPTION
The `cockroach-latest*.tgz` tarballs have the unfortunate downside of not
including the version in either the filename or the extracted folder.
This was a convenient way to avoid updating the install instructions to
reflect the new filenames for every release. Now, though, we track the
latest release's name in _data/releases.yml, so we can use that to
automatically derive release filenames.

This is an important step in resolving cockroachdb/cockroach#14731.

Closes #1368.

/cc @mberhault @tamird @bdarnell if we land this change, will there be anything else that depends on the these tarballs?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1375)
<!-- Reviewable:end -->
