### PR TITLE
Update Windows archive link

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -465,7 +465,7 @@ $(document).ready(function(){
 
 <ol>
   <li>
-    <p>Download and extract the latest <a href="https://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip">CockroachDB archive for Windows</a>.</p>
+    <p>Download and extract the latest <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.2.windows-6.2-amd64.zip">CockroachDB archive for Windows</a>.</p>
   </li>
   <li>
     <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>


### PR DESCRIPTION
Link directly to the archive instead of using latest. 

Latest is not working. See https://github.com/cockroachdb/cockroach/issues/15727.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1376)
<!-- Reviewable:end -->
