### PR TITLE
Add 1.0 callout to docs home

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,17 @@ optimizely: true
 twitter: true
 ---
 
-CockroachDB is a distributed SQL database built on a transactional and strongly-consistent key-value store. It scales horizontally; survives failures with minimal latency disruption and no manual intervention; supports ACID transactions; and provides a familiar SQL API.
+CockroachDB is an open source database for building global, scalable cloud services that survive disasters.
+
+<style>
+    #party {
+        font-size: 30px;
+        padding-right: 10px;
+        vertical-align: -20%;
+    }
+</style>
+
+{{site.data.alerts.callout_info}}<span id="party">🎉</span>CockroachDB 1.0 is now available! Get more details in <a href="https://www.cockroachlabs.com/blog/cockroachdb-1-0-release">this blog post</a>.{{site.data.alerts.end}}
 
 <div class="row">
     <div class="col-md-4">


### PR DESCRIPTION
@jess-edwards, @sploiselle, @kuanluo, I added a very basic 1.0 callout to the docs homepage. Due to ongoing conversations about whether or not to have detailed 1.0 release notes, I'm not yet sure where the link will take users, perhaps to Spencer's blog post. 

In any case, thoughts about the callout working and styling? 

You'll notice that I also updated the product summary to match our main homepage. Happy to change that back if you all prefer the older text here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1382)
<!-- Reviewable:end -->
