### PR TITLE
Window Functions are SQL standard

### DIFF
--- a/sql-feature-support.md
+++ b/sql-feature-support.md
@@ -158,7 +158,7 @@ table tr td:nth-child(2) {
 | Interleaved tables | ✓ | CockroachDB Extension | [Interleaved Tables documentation](interleave-in-parent.html) |
 | Information Schema | ✓ | Standard | [Information Schema documentation](information-schema.html)
 | Views | ✓ | Standard | [Views documentation](views.html) |
-| Window functions | Partial | Common Extension | Perform calculations related on a selected row. |
+| Window functions | Partial | Standard | Perform calculations related on a selected row. |
 | Common Table Expressions | Planned | Common Extension | Similar to Views, though they are not stored. |
 | Stored Procedures | Planned | Common Extension | Execute a procedure explicitly. |
 | Cursors | ✗ | Standard | Traverse a table's rows. |


### PR DESCRIPTION
Fix #1395 by stating that window functions are a standard feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1396)
<!-- Reviewable:end -->
