### PR TITLE
build from source should use `make build`, not `make`

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -207,9 +207,9 @@ $(document).ready(function(){
     <p>Extract the sources:</p>
     <p><div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>tar xfz cockroach-latest.src.tgz</code></pre></div></p>
   </li>
-  <li><p>In the extracted directory, run <code>make</code>:</p>
+  <li><p>In the extracted directory, run <code>make build</code>:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-latest<br><span class="gp noselect shellterminal"></span>make</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-latest<br><span class="gp noselect shellterminal"></span>make build</code></pre></div>
 
     <p>The build process can take 10+ minutes, so please be patient.</p>
 
@@ -393,9 +393,9 @@ $(document).ready(function(){
     <p>Extract the sources:</p>
     <p><div class="language-bash highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>tar xfz cockroach-latest.src.tgz</code></pre></div></p>
   </li>
-  <li><p>In the extracted directory, run <code>make</code>:</p>
+  <li><p>In the extracted directory, run <code>make build</code>:</p>
 
-    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-latest<br><span class="gp noselect shellterminal"></span>make</code></pre></div>
+    <div class="highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span><span class="nb">cd </span>cockroach-latest<br><span class="gp noselect shellterminal"></span>make build</code></pre></div>
 
     <p>The build process can take 10+ minutes, so please be patient.</p>
 


### PR DESCRIPTION
A bare `make` tries to run linters that fail in a source tarball. This will be fixed upstream eventually, but point users at the `make build` command for now, which actually does what it should.

See cockroachdb/cockroach#15909 and cockroachdb/cockroach#15923.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1413)
<!-- Reviewable:end -->
