### PR TITLE
build from source produces binary in source dir

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -218,7 +218,7 @@ $(document).ready(function(){
   <li>
   <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-  <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i ./bin/cockroach /usr/local/bin</code></pre></div>
+  <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i ./src/github.com/cockroachdb/cockroach/cockroach /usr/local/bin</code></pre></div>
   <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
   </li>
   <li>
@@ -404,7 +404,7 @@ $(document).ready(function(){
   <li>
   <p>Move the binary into your <code>PATH</code> so it's easy to execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>
 
-  <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i ./bin/cockroach /usr/local/bin</code></pre></div>
+  <div class="language-shell highlighter-rouge"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i ./src/github.com/cockroachdb/cockroach/cockroach /usr/local/bin</code></pre></div>
   <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
   </li>
   <li>


### PR DESCRIPTION
On my machine `make build` produces a binary in the source directory, there is no `./bin` to be found.  I'm on a Linux machine so I updated that section; I also updated the Mac section on the assumption that it behaves similarly, but feel free to tell me if I'm mistaken.  I can't seem to find any explicit reference in the Makefile that dictates where the binary ends up, so perhaps it's an artifact of my particular go/cmake/make versions/config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1416)
<!-- Reviewable:end -->
