### PR TITLE
update homebrew install to use core formula instead of tap

### DIFF
--- a/install-cockroachdb.md
+++ b/install-cockroachdb.md
@@ -141,10 +141,9 @@ $(document).ready(function(){
       <p><a href="http://brew.sh/">Install Homebrew</a>.</p>
     </li>
     <li>
-      <p>Run our brew recipe to get the CockroachDB code and build the binary:</p>
+      <p>Instruct Homebrew to install CockroachDB:</p>
 
-      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-homebrew-step2"><span class="gp" data-eventcategory="mac-homebrew-step2">$ </span>brew install cockroachdb/cockroach/cockroach</code></pre></div>
-      <p>The build process can take 10+ minutes, so please be patient.</p>
+      <div class="highlighter-rouge"><pre class="highlight"><code data-eventcategory="mac-homebrew-step2"><span class="gp" data-eventcategory="mac-homebrew-step2">$ </span>brew install cockroach</code></pre></div>
     </li>
     <li>
       <p>Make sure the CockroachDB executable works:</p>


### PR DESCRIPTION
As of homebrew/homebrew-core#13431, CockroachDB is now in Homebrew
proper! Point the install instructions at the core cockroach formula
(`cockroach`) instead of our tap's cockroach formula
(`cockroachdb/cockroach/cockroach`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1420)
<!-- Reviewable:end -->
