### PR TITLE
Release notes for v1.1 alpha.20170601

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -7,6 +7,9 @@
       version: v1.0
 - title: Testing Releases
   releases:
+    - date: Jun 1, 2017
+      version: v1.1-alpha.20170601
+      latest: true
     - date: May 5, 2017
       version: v1.0-rc.2
     - date: May 1, 2017

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -9,7 +9,6 @@
   releases:
     - date: Jun 1, 2017
       version: v1.1-alpha.20170601
-      latest: true
     - date: May 5, 2017
       version: v1.0-rc.2
     - date: May 1, 2017

--- a/v1.1-alpha.20170601.md
+++ b/v1.1-alpha.20170601.md
@@ -1,0 +1,78 @@
+---
+title: What&#39;s New in v1.1-alpha.20170601
+toc: false
+summary: Additions and changes in CockroachDB version v1.1-alpha.20170601
+---
+
+## Jun 1, 2017
+
+Get future release notes emailed to you:
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
+### Downloads
+
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+### General Changes
+
+- CockroachDB now uses RocksDB 5.3.4 ([#15696](https://github.com/cockroachdb/cockroach/pull/15696)), protobuf 3.3.0 ([#15522](https://github.com/cockroachdb/cockroach/pull/15522)), and a newer version of gRPC ([#15991](https://github.com/cockroachdb/cockroach/pull/15991))
+- Non-release binaries no longer send crash reports. [#15823](https://github.com/cockroachdb/cockroach/pull/15823)
+- Some `make` targets have changed to follow convention. `make` by default now builds the binary without running tests. `make install` defaults to `/usr/local/bin` instead of `$GOPATH/bin` (use `make install prefix=/path/` to change). `make check` is now an alias for `make test`; the former `make check` is now called `make lint`. [#15909](https://github.com/cockroachdb/cockroach/pull/15909) [#16030](https://github.com/cockroachdb/cockroach/pull/16030)
+- The Kubernetes templates now use the latest production release instead of tracking testing releases. [#15878](https://github.com/cockroachdb/cockroach/pull/15878)
+
+### SQL Language Changes
+
+- The `information_schema.user_privileges` table is now supported. [#15745](https://github.com/cockroachdb/cockroach/pull/15745)
+- The `ON UPDATE RESTRICT` and `ON DELETE RESTRICT` modifiers can now be used when creating foreign keys (this behavior is the default, but now it can be specified explicitly). [#15815](https://github.com/cockroachdb/cockroach/pull/15815)
+- The hash functions `sha512()`, `fnv32()`, `fnv32a()`, `fnv64()`, `fnv64a()`, `crc32ieee()`, and `crc32c()` are now supported. All hash functions now accept multiple arguments and arguments of type `BYTES`. [#15828](https://github.com/cockroachdb/cockroach/pull/15828) [#15859](https://github.com/cockroachdb/cockroach/pull/15859)
+- Casts to type `DECIMAL` now respect specified precision and scale. [#15834](https://github.com/cockroachdb/cockroach/pull/15834)
+- A new aggregate function `xor_agg()` is now available. [#15831](https://github.com/cockroachdb/cockroach/pull/15831)
+- Schema change commands now wait until the schema change is complete instead of starting it in the background. [#15598](https://github.com/cockroachdb/cockroach/pull/15598)
+- It is now possible to `SELECT` from the result of a `SHOW` statement with the syntax `SELECT ... FROM [ SHOW ... ] WHERE ...` [#15590](https://github.com/cockroachdb/cockroach/pull/15590)
+- It is now possible to `CREATE` a table and `ALTER` (or `DROP`) it in the same transaction. [#15929](https://github.com/cockroachdb/cockroach/pull/15929)
+- The standard SQL syntax `FETCH FIRST N ROWS ONLY` is now supported as an alias for `LIMIT`. [#16083](https://github.com/cockroachdb/cockroach/pull/16083)
+
+### Command-Line Interface Changes
+
+- A `raw` mode has been added to the SQL shell's `display_format` options. [#15590](https://github.com/cockroachdb/cockroach/pull/15590)
+- `cockroach zone set` with an incomplete config for the special system ranges now merges the given config with the default instead of using zeros. [#16048](https://github.com/cockroachdb/cockroach/pull/16048)
+- Commands that create certificates will fail if asked to create a certificate that would expire after the corresponding CA. [#16055](https://github.com/cockroachdb/cockroach/pull/16055)
+- The default duration of client and node certificates is now 5 years. [#16055](https://github.com/cockroachdb/cockroach/pull/16055)
+
+### Admin UI Changes
+
+- The log viewer now shows more than just the first line of multi-line log entries. [#15949](https://github.com/cockroachdb/cockroach/pull/15949)
+- A new query plan inspector is available at `/queryplan`. [#15908](https://github.com/cockroachdb/cockroach/pull/15908)
+- Metrics are now reported about certificate expiration. [#16045](https://github.com/cockroachdb/cockroach/pull/16045)
+
+### Bug Fixes
+
+- `MAX(bool)` and `MIN(bool)` no longer panic. [#15803](https://github.com/cockroachdb/cockroach/pull/15803)
+- `SHOW GRANTS *` on an empty database now works correctly. [#15881](https://github.com/cockroachdb/cockroach/pull/15881)
+- Fixed a data race involving transaction records. [#15882](https://github.com/cockroachdb/cockroach/pull/15882)
+- `DECIMAL` types now report the correct precision and scale for compatibility with JDBC. [#15927](https://github.com/cockroachdb/cockroach/pull/15927)
+- Fixed a panic when a removed replica attempts to get the range lease. [#15754](https://github.com/cockroachdb/cockroach/pull/15754)
+
+### Performance Improvements
+
+- Raft logs are now cleaned up more aggressively when large commands (such as `RESTORE`) are used. [#15799](https://github.com/cockroachdb/cockroach/pull/15799)
+- Reduced allocations when working with `DECIMAL` values. [#15829](https://github.com/cockroachdb/cockroach/pull/15829)
+- Reduced lock contention during command evaluation. [#15935](https://github.com/cockroachdb/cockroach/pull/15935)
+- Reduced lease durations to improve responsiveness to node failures. [#15331](https://github.com/cockroachdb/cockroach/pull/15331)
+- Improved performance of queries that combine aggregate functions and `WHERE` clauses, such as `SELECT MAX(age) FROM customers WHERE name >= 'Albert' AND name <= 'Bernie'`. [#13194](https://github.com/cockroachdb/cockroach/pull/13194)


### PR DESCRIPTION
An early start on the next testing/unstable release, covering the post-1.0 work so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1423)
<!-- Reviewable:end -->
