### PR TITLE
Minor fix to Data Replication tutorial

### DIFF
--- a/demo-data-replication.md
+++ b/demo-data-replication.md
@@ -41,7 +41,7 @@ INSERT 1
 ...
 ~~~
 
-Open the [built-in SQL shell](use-the-built-in-sql-client.html) on any node and verify that the new `intro` database was added with one table, `mytable`:
+Open the [built-in SQL shell](use-the-built-in-sql-client.html) and verify that the new `intro` database was added with one table, `mytable`:
 
 ~~~ shell
 $ cockroach sql --insecure


### PR DESCRIPTION
It's misleading to tell the user to open the sql shell
"on any node" because there's only one node at that point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/docs/1454)
<!-- Reviewable:end -->
