### PR TITLE
fix UPDATE railroad diagram generation

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -515,7 +515,11 @@ func main() {
 					replace: map[string]string{"stmt_list": "'CREATE' 'TABLE' table_name '(' ( column_def ( ',' column_def )* ) ( 'CONSTRAINT' name | ) 'UNIQUE' '(' ( column_name ( ',' column_name )* ) ')' ( table_constraints | ) ')'"},
 					unlink:  []string{"table_name", "check_expr", "table_constraints"},
 				},
-				{name: "update_stmt", inline: []string{"relation_expr_opt_alias", "set_clause_list", "set_clause", "single_set_clause", "multiple_set_clause", "ctext_row", "ctext_expr_list", "ctext_expr", "from_clause", "from_list", "where_clause", "returning_clause"}},
+				{
+					name:    "update_stmt",
+					inline:  []string{"relation_expr_opt_alias", "set_clause_list", "set_clause", "single_set_clause", "multiple_set_clause", "ctext_row", "ctext_expr_list", "ctext_expr", "from_clause", "from_list", "where_clause", "returning_clause"},
+					nosplit: true,
+				},
 				{name: "upsert_stmt", stmt: "insert_stmt", inline: []string{"insert_target", "insert_rest", "returning_clause"}, match: []*regexp.Regexp{regexp.MustCompile("'UPSERT'")}},
 			}
 


### PR DESCRIPTION
Mark the `update_stmt` as `nosplit`; the update statement is now too complicated for the railroad diagram generator to condense the split form of the grammar.

This commit holds off on actually updating the update railroad digram, because I'm not sure whether it's the same in 1.0 and 1.1.

(CC'ing @knz, just in case he wasn't aware of this neat trick.)