### PR TITLE
move ci and docker configuration into repository

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+# If you modify this file, you'll need to build a new version of the
+# docs-builder Docker image to keep things speedy in CI. See ci/README.md for
+# instructions.
+
 gem "html-proofer", "~> 3.7"
 gem "jekyll", "~> 3.4"
 gem "rake", "~> 12.0.0"

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ redcarpet:
   - tables
   - with_toc_data
 
-exclude: ["set-application-name.md", "vendor"]
+exclude: ["ci", "set-application-name.md", "vendor"]
 
 defaults:
   -

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.5
+
+COPY Gemfile Gemfile.lock /tmp/bundler/
+
+RUN apk add --update \
+    build-base\
+    groff \
+    less \
+    libcurl \
+    libffi-dev \
+    py-pip \
+    python \
+    ruby \
+    ruby-bundler \
+    ruby-dev \
+    ruby-json \
+    zlib \
+    zlib-dev \
+  && pip install --upgrade awscli \
+  && cd /tmp/bundler && bundle install && rm -rf /tmp/bundler \
+  && apk --purge del \
+    build-base \
+    libffi-dev \
+    py-pip \
+    ruby-dev \
+    zlib-dev \
+  && rm -rf ~/.cache ~/.bundle /var/cache/apk
+
+WORKDIR /docs

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,63 @@
+# Continuous Integration
+
+Every pull request in the docs repository is automatically built, deployed to a
+test S3 bucket (`cockroach-docs-review`), and run through HTML proofer. Only if
+all three of these steps succeed does the PR get a green checkmark from CI.
+
+This process is orchestrated by the `pull-request` script in this directory.
+*Please* do not make changes to the build process in the CI build configuration.
+Versioning the build script along with the code means we can isolate build
+script changes to one branch and atomically update the configuration when that
+branch merges.
+
+The `builder` script and the `Dockerfile` configure a Docker image,
+`cockroachdb/docs-builder`, that bundles all the necessary dependencies to run
+the `pull-request` script. If you're familiar with the [cockroachdb/cockroach]
+repository, `builder` operates much like the [CockroachDB `build/builder`
+script][cockroachdb-builder].
+
+[cockroachdb/cockroach]: https://github.com/cockroachdb/cockroach
+[cockroachdb-builder]: https://github.com/cockroachdb/cockroach/blob/master/build/builder.sh
+
+## Building a new docs-builder
+
+1. Modify `ci/Dockerfile` as necessary.
+
+2. Locally build a new version of the image:
+
+    ```shell
+    $ ci/builder build
+    ```
+
+3. Locally test your changes:
+
+    ```shell
+    $ COCKROACH_DOCS_BUILDER_VERSION=latest ci/builder run [bundle exec jekyll build]
+    ````
+
+4. Push your changes to the Docker repository.
+
+    ```shell
+    $ ci/builder push
+    The push refers to a repository [docker.io/cockroachdb/docs-builder]
+    ...
+    YYYYMMDD-HHMMSS: digest: sha256:ade6c2ff12b2088a3eec903740b769bce1444a245002d2f2cbaadaa34589eea3 size: 1153
+    ```
+
+    You'll need to create a Docker Hub account and ask someone to give you
+    access to the `cockroachdb` repository.
+
+5. Replace the version in `ci/builder` with the version (`YYYYMMDD-HHMMSS`)
+   from above.
+
+## Changing the Gemfile
+
+While we could run `bundle install` at the start of every CI build to pick up
+any changes to the `Gemfile`, this leads to a Docker image that doesn't actually
+bundle the necessary gems. Over time, this slows down CI, as it has to
+re-install the gems for every build.
+
+Instead, whenever you add or update a dependency, you'll need to bake a new
+version of the `docs-builder` image by following the steps above, or the build
+will fail with a missing gem error. Running `./builder build` will
+automatically pick up any changes to the `Gemfile` or `Gemfile.lock`.

--- a/ci/builder
+++ b/ci/builder
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+image=cockroachdb/docs-builder
+version=${COCKROACH_DOCS_BUILDER_VERSION:-20170606-140218}
+
+root=$(cd "$(dirname "$0")" && pwd)
+repo_root=$root/..
+
+usage_and_exit() {
+  echo "usage: $0 <run|build|push>" >&2
+  exit 1
+}
+
+command=${1:-} && shift
+[[ "$command" ]] || usage_and_exit
+
+case "$command" in
+  build)
+    docker build --tag="$image" --file="$root/Dockerfile" "$repo_root"
+    ;;
+  push)
+    tag=$(date +%Y%m%d-%H%M%S)
+    docker tag "$image" "$image:$tag"
+    docker push "$image:$tag"
+    ;;
+  run)
+    [[ -t 0 ]] && tty=--tty
+    docker run --rm --interactive ${tty:-} \
+      --user "$(id -u):$(id -g)" \
+      --env AWS_ACCESS_KEY_ID \
+      --env AWS_SECRET_ACCESS_KEY \
+      --volume="$repo_root:/docs" \
+      "$image:$version" "$@"
+    ;;
+  *)
+    usage_and_exit
+    ;;
+esac

--- a/ci/pull-request
+++ b/ci/pull-request
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# run runs a command in the builder container.
+run() {
+  echo "$@"
+  "$(dirname "$0")"/builder run "$@"
+}
+
+# Step 1. Build the docs.
+run bundle exec jekyll build --baseurl=env.BUILD_VCS_NUMBER
+
+# Step 2. Upload the docs to S3.
+run aws s3 sync --quiet --region=us-east-1 ./_site s3://cockroach-docs-review/"$BUILD_VCS_NUMBER"/
+
+# Step 3. Post a link to the docs on the GitHub pull request. We do this before
+# running HTMLProofer to provide fast feedback. HTMLProofer can take upwards of
+# five minutes to complete. No need to do this in the container.
+curl \
+  --header "Authorization: token $GITHUB_TOKEN" \
+  --data "{\"body\": \"http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/$BUILD_VCS_NUMBER/\"}" \
+  "https://api.github.com/repos/cockroachdb/docs/issues/$BUILD_BRANCH/comments"
+
+# Step 4. Run HTML proofer.
+run bundle exec rake htmlproofer


### PR DESCRIPTION
Move the configuration for CI, which used to leave in the TeamCity build
configuration, and the configuration for Docker, which used to live in
cockroachdb/docs-docker, into the repository. This allows us to
scope CI/Docker configuration changes to one branch and atomically
update the configurations when the branch merges.