### PR TITLE
replace all references to `gh-pages` with `master`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,22 +48,20 @@ We'll review your changes, providing feedback and guidance as necessary. Also, T
 
 If you want to regularly contribute to the CockroachDB docs, there are a few things we recommend:
 
-1. Note that our "master" branch is called `gh-pages`.
-
-2. Make it easy to bring updated docs into your fork by tracking us upstream:
+1. Make it easy to bring updated docs into your fork by tracking us upstream:
 
     ``` shell
-    $ git remote add --track gh-pages upstream https://github.com/cockroachdb/docs.git
+    $ git remote add --track master upstream https://github.com/cockroachdb/docs.git
     ```
 
-3. When you're ready to make your next round of changes, get our latest docs:
+2. When you're ready to make your next round of changes, get our latest docs:
 
     ``` shell
     $ git fetch upstream
-    $ git merge upstream/gh-pages
+    $ git merge upstream/master
     ```
 
-4. Repeat the write, build, push, pull flow from the [Get Started](#get-started) section above.
+3. Repeat the write, build, push, pull flow from the [Get Started](#get-started) section above.
 
 ## Docs Structure
 

--- a/_includes/contribute-options.html
+++ b/_includes/contribute-options.html
@@ -5,7 +5,7 @@
       <span class="arrow-down"></span>
     </button>
     <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-      <li><a href="https://github.com/cockroachdb/docs/edit/gh-pages{{ page.url | replace: '.html', '.md'}}" target="blank" id="edit-this-page" data-proofer-ignore>Edit This Page</a></li>
+      <li><a href="https://github.com/cockroachdb/docs/edit/master{{ page.url | replace: '.html', '.md'}}" target="blank" id="edit-this-page" data-proofer-ignore>Edit This Page</a></li>
       <li><a href="https://github.com/cockroachdb/docs/issues/new?title={{page.title}}%20Doc%20Update%20&amp;body=Re%3A%20%5B{{page.title}}%5D(https%3A%2F%2Fcockroachlabs.com/docs/{{page.url}})%0A%0A%23%23%20Issue%20Description%0A%0A%23%23%20Suggested%20Resolution%20%0A&amp;labels=community" target="blank" id="report-doc-issue" data-proofer-ignore>Report Doc Issue</a></li>
       <li><a href="https://github.com/cockroachdb/docs/issues/new?title=New%20Doc%20Proposal%20&amp;body=%23%23%20Title%0A%0A%0A%23%23%20Description%0A%0A%0A%23%23%20Outline%0A%0A%0A%23%23%20Expected%20Audience%0A&amp;labels=community" target="blank" id="suggest-new-content" data-proofer-ignore>Suggest New Content</a></li>
     </ul>

--- a/asciicasts/build-a-python-app-with-driver.json
+++ b/asciicasts/build-a-python-app-with-driver.json
@@ -1472,7 +1472,7 @@
     ],
     [
       0.005086,
-      "--2017-02-08 17:33:01--  https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.py\r\n"
+      "--2017-02-08 17:33:01--  https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.py\r\n"
     ],
     [
       0.013878,
@@ -1912,7 +1912,7 @@
     ],
     [
       0.004864,
-      "--2017-02-08 17:33:21--  https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.py\r\n"
+      "--2017-02-08 17:33:21--  https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.py\r\n"
     ],
     [
       0.011853,

--- a/beta-20160602.md
+++ b/beta-20160602.md
@@ -48,7 +48,7 @@ Get future release notes emailed to you:
 
 - Added a tutorial on [building an Application with CockroachDB and SQLAlchemy](https://www.cockroachlabs.com/blog/building-application-cockroachdb-sqlalchemy-2/) 
 - Added docs on [how CockroachDB handles `NULL` values](null-handling.html) in various contexts. [#333](https://github.com/cockroachdb/docs/pull/333)
-- Improved guidance on [Contributing to CockroachDB docs](https://github.com/cockroachdb/docs/blob/gh-pages/CONTRIBUTING.md). [#344](https://github.com/cockroachdb/docs/pull/344)
+- Improved guidance on [Contributing to CockroachDB docs](https://github.com/cockroachdb/docs/blob/master/CONTRIBUTING.md). [#344](https://github.com/cockroachdb/docs/pull/344)
 - Improved [zone configuration examples](configure-replication-zones.html#basic-examples). [#327](https://github.com/cockroachdb/docs/pull/327) 
 
 ### Contributors

--- a/build-a-c++-app-with-cockroachdb.md
+++ b/build-a-c++-app-with-cockroachdb.md
@@ -28,7 +28,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.cpp" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.cpp" download>download it directly</a>.
 
 ~~~ cpp
 {% include app/basic-sample.cpp %}
@@ -40,7 +40,7 @@ Next, use the following code to again connect as the `maxroach` user but this ti
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 
-You can copy the code or <a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.cpp" download>download it directly</a>.
+You can copy the code or <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.cpp" download>download it directly</a>.
 
 ~~~ cpp
 {% include app/txn-sample.cpp %}

--- a/build-a-clojure-app-with-cockroachdb.md
+++ b/build-a-clojure-app-with-cockroachdb.md
@@ -37,19 +37,19 @@ Now that you have a database and a user, you'll run code to create a table and i
 ### Create a basic Clojure/JDBC project
 
 1. Create a new directory `myapp`.
-2. Create a file `myapp/project.clj` and populate it with the following code, or <a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/project.clj" download>download it directly</a>. Be sure to place the file in the subdirectory `src/test` in your project.
+2. Create a file `myapp/project.clj` and populate it with the following code, or <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/project.clj" download>download it directly</a>. Be sure to place the file in the subdirectory `src/test` in your project.
 
     ~~~ clojure
     {% include app/project.clj %}
     ~~~
 
-3. Create a file `myapp/src/test/util.clj` and populate it with the code from <a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/util.clj" download>this file</a>. Be sure to place the file in the subdirectory `src/test` in your project.
+3. Create a file `myapp/src/test/util.clj` and populate it with the code from <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/util.clj" download>this file</a>. Be sure to place the file in the subdirectory `src/test` in your project.
 
 ### Basic Statements
 
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, inserting rows and reading and printing the rows.
 
-Create a file `myapp/src/test/test.clj` and copy the code below to it, or <a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.clj" download>download it directly</a>. Be sure to rename this file to `test.clj` in the subdirectory `src/test` in your project.
+Create a file `myapp/src/test/test.clj` and copy the code below to it, or <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.clj" download>download it directly</a>. Be sure to rename this file to `test.clj` in the subdirectory `src/test` in your project.
 
 ~~~ clojure
 {% include app/basic-sample.clj %}
@@ -66,7 +66,7 @@ lein run
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 Copy the code below to `myapp/src/test/test.clj` or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.clj" download>download it directly</a>. Again, preserve the file name `test.clj`.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.clj" download>download it directly</a>. Again, preserve the file name `test.clj`.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/build-a-go-app-with-cockroachdb-gorm.md
+++ b/build-a-go-app-with-cockroachdb-gorm.md
@@ -35,7 +35,7 @@ $ go get -u github.com/jinzhu/gorm
 The following code uses the [GORM](http://jinzhu.me/gorm/) ORM to map Go-specific objects to SQL operations. Specifically, `db.AutoMigrate(&Account{})` creates an `accounts` table based on the Account model, `db.Create(&Account{})` inserts rows into the table, and `db.Find(&accounts)` selects from the table so that balances can be printed.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/gorm-basic-sample.go" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/gorm-basic-sample.go" download>download it directly</a>.
 
 ~~~ go
 {% include app/gorm-basic-sample.go %}

--- a/build-a-go-app-with-cockroachdb.md
+++ b/build-a-go-app-with-cockroachdb.md
@@ -37,7 +37,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.go" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.go" download>download it directly</a>.
 
 ~~~ go
 {% include app/basic-sample.go %}
@@ -62,7 +62,7 @@ Initial balances:
 Next, use the following code to again connect as the `maxroach` user but this time will execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.go" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.go" download>download it directly</a>.
 
 ~~~ go
 {% include app/txn-sample.go %}

--- a/build-a-java-app-with-cockroachdb-hibernate.md
+++ b/build-a-java-app-with-cockroachdb-hibernate.md
@@ -38,13 +38,13 @@ For other ways to install Gradle, see the [official documentation](https://gradl
 
 ## Step 5. Run the Java code
 
-[Downlod and extract this tarball](https://github.com/cockroachdb/docs/raw/gh-pages/_includes/app/hibernate-basic-sample/hibernate-basic-sample.tgz), which includes three files that work together:
+[Downlod and extract this tarball](https://github.com/cockroachdb/docs/raw/master/_includes/app/hibernate-basic-sample/hibernate-basic-sample.tgz), which includes three files that work together:
 
 File | Description
 -----|------------
-[`hibernate.cfg.xml`](https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/hibernate-basic-sample/hibernate.cfg.xml) | This file specifies how to connect to the database and that the database schema will be deleted and recreated each time the app is run. It must be in the `src/main/resources` directory.
-[`Sample.java`](https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/hibernate-basic-sample/Sample.java) | This file uses the Hibernate ORM to map Java-specific objects to SQL operations. It must be in the `src/main/java/com/cockroachlabs/` directory.
-[`build.gradle`](https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/hibernate-basic-sample/build.gradle) | This is the file you run to execute your app.
+[`hibernate.cfg.xml`](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/hibernate-basic-sample/hibernate.cfg.xml) | This file specifies how to connect to the database and that the database schema will be deleted and recreated each time the app is run. It must be in the `src/main/resources` directory.
+[`Sample.java`](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/hibernate-basic-sample/Sample.java) | This file uses the Hibernate ORM to map Java-specific objects to SQL operations. It must be in the `src/main/java/com/cockroachlabs/` directory.
+[`build.gradle`](https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/hibernate-basic-sample/build.gradle) | This is the file you run to execute your app.
 
 For more insight into this sample application, review the `Sample.java` file, which uses the [Hibernate ORM](http://hibernate.org/orm/) to map Java-specific objects to SQL operations. Specifically, an `accounts` table gets created based on the `Account` class, `session.save(new Account())` inserts rows into the table, and the `CriteriaQuery<Account> query` object defines the SQL query for selecting from the table so that balances can be printed.
 

--- a/build-a-java-app-with-cockroachdb.md
+++ b/build-a-java-app-with-cockroachdb.md
@@ -33,7 +33,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/BasicSample.java" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/BasicSample.java" download>download it directly</a>.
 
 ~~~ java
 {% include app/BasicSample.java %}
@@ -44,7 +44,7 @@ You can copy the code or
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/TxnSample.java" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/TxnSample.java" download>download it directly</a>.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -35,7 +35,7 @@ $ npm install sequelize sequelize-cockroachdb
 The following code uses the [Sequelize](http://docs.sequelizejs.com/en/v3/) ORM to map Node.js-specific objects to SQL operations. Specifically, `Account.sync({force: true})` creates an `accounts` table based on the Account model (or drops and recreates the table if it already exists), `Account.bulkCreate([...])` inserts rows into the table, and `Account.findAll()` selects from the table so that balances can be printed.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/sequelize-basic-sample.js" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/sequelize-basic-sample.js" download>download it directly</a>.
 
 ~~~ js
 {% include app/sequelize-basic-sample.js %}

--- a/build-a-nodejs-app-with-cockroachdb.md
+++ b/build-a-nodejs-app-with-cockroachdb.md
@@ -44,7 +44,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.js" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.js" download>download it directly</a>.
 
 ~~~ js
 {% include app/basic-sample.js %}
@@ -55,7 +55,7 @@ You can copy the code or
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.js" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.js" download>download it directly</a>.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/build-a-php-app-with-cockroachdb.md
+++ b/build-a-php-app-with-cockroachdb.md
@@ -39,7 +39,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, inserting rows and reading and printing the rows.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.php" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.php" download>download it directly</a>.
 
 ~~~ php
 {% include app/basic-sample.php %}
@@ -50,7 +50,7 @@ You can copy the code or
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.php" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.php" download>download it directly</a>.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -38,7 +38,7 @@ The following code uses the [SQLAlchemy ORM](https://docs.sqlalchemy.org/en/late
 ])` inserts rows into the table, and `session.query(Account)` selects from the table so that balances can be printed. Also note that the [cockroachdb python package](https://github.com/cockroachdb/cockroachdb-python) installed earlier is triggered by the `cockroachdb://` prefix in the engine URL.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/sqlalchemy-basic-sample.py" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/sqlalchemy-basic-sample.py" download>download it directly</a>.
 
 ~~~ python
 {% include app/sqlalchemy-basic-sample.py %}

--- a/build-a-python-app-with-cockroachdb.md
+++ b/build-a-python-app-with-cockroachdb.md
@@ -46,7 +46,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use he following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.py" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.py" download>download it directly</a>.
 
 ~~~ python
 {% include app/basic-sample.py %}
@@ -71,7 +71,7 @@ Initial balances:
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.py" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.py" download>download it directly</a>.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/build-a-ruby-app-with-cockroachdb-activerecord.md
+++ b/build-a-ruby-app-with-cockroachdb-activerecord.md
@@ -35,7 +35,7 @@ $ gem install activerecord pg activerecord-cockroachdb-adapter
 The following code uses the [ActiveRecord](http://guides.rubyonrails.org/active_record_basics.html) ORM to map Ruby-specific objects to SQL operations. Specifically, `Schema.new.change()` creates an `accounts` table based on the Account model (or drops and recreates the table if it already exists), `Account.create()` inserts rows into the table, and `Account.all` selects from the table so that balances can be printed.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/activerecord-basic-sample.rb" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/activerecord-basic-sample.rb" download>download it directly</a>.
 
 ~~~ ruby
 {% include app/activerecord-basic-sample.rb %}

--- a/build-a-ruby-app-with-cockroachdb.md
+++ b/build-a-ruby-app-with-cockroachdb.md
@@ -37,7 +37,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.rb" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.rb" download>download it directly</a>.
 
 ~~~ ruby
 {% include app/basic-sample.rb %}
@@ -62,7 +62,7 @@ Initial balances:
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 Copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.rb" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.rb" download>download it directly</a>.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/build-a-rust-app-with-cockroachdb.md
+++ b/build-a-rust-app-with-cockroachdb.md
@@ -39,7 +39,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, inserting rows and reading and printing the rows.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/basic-sample.rs" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/basic-sample.rs" download>download it directly</a>.
 
 ~~~ rust
 {% include app/basic-sample.rs %}
@@ -50,7 +50,7 @@ You can copy the code or
 Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
 
 You can copy the code or
-<a href="https://raw.githubusercontent.com/cockroachdb/docs/gh-pages/_includes/app/txn-sample.rs" download>download it directly</a>.
+<a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/app/txn-sample.rs" download>download it directly</a>.
 
 {{site.data.alerts.callout_info}}With the default <code>SERIALIZABLE</code> isolation level, CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
 

--- a/improve-the-docs.md
+++ b/improve-the-docs.md
@@ -10,7 +10,7 @@ The CockroachDB docs are open source just like the database itself. We welcome y
 
 Want to contribute to the docs?
 
-Find an issue with the [help-wanted](https://github.com/cockroachdb/docs/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted) label and then review [CONTRIBUTING.md](https://github.com/cockroachdb/docs/blob/gh-pages/CONTRIBUTING.md) to set yourself up and get started. You can also select **Contribute > Edit This Page** directly on a page.
+Find an issue with the [help-wanted](https://github.com/cockroachdb/docs/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted) label and then review [CONTRIBUTING.md](https://github.com/cockroachdb/docs/blob/master/CONTRIBUTING.md) to set yourself up and get started. You can also select **Contribute > Edit This Page** directly on a page.
 
 ## Suggest Improvements
 


### PR DESCRIPTION
We no longer use GitHub pages directly; we run Jekyll ourselves and push
the built site to another repository. Stop using the `gh-pages` branch
so that GitHub stops trying to build this repository as a GitHub pages
site (and warning about how the redcarpet gem is no longer supported).

This completes the transition by replacing all references to `gh-pages`
with `master`.

---

@sploiselle @jseldess if this PR successfully builds, we're good to go!