### PR TITLE
convert headerless tables to lists

### DIFF
--- a/restore.md
+++ b/restore.md
@@ -112,19 +112,17 @@ You can include the following options as key-value pairs in the `kv_option_list`
 
 #### `into_db`
 
-----|----------
-**Description** | If you want to restore a table or view into a database other than the one it originally existed in, you can [change the target database](#restore-into-a-different-database). This is useful if you want to restore a table that currently exists, but don't want to drop it.
-**Key** | `into_db`
-**Value** | The name of the database you want to use
-**Example** | `WITH OPTIONS ("into_db" = "newdb")`
+- **Description**: If you want to restore a table or view into a database other than the one it originally existed in, you can [change the target database](#restore-into-a-different-database). This is useful if you want to restore a table that currently exists, but don't want to drop it.
+- **Key**: `into_db`
+- **Value**: The name of the database you want to use
+- **Example**: `WITH OPTIONS ("into_db" = "newdb")`
 
 #### `skip_missing_foreign_keys`
 
-----|----------
-**Description** | If you want to restore a table with a foreign key but don't want to restore the table it references, you can [drop the Foreign Key constraint from the table](#skip_missing_foreign_keys) and then have it restored.
-**Key** | `skip_missing_foreign_keys`
-**Value** | *No value*
-**Example** | `WITH OPTIONS ("skip_missing_foreign_keys")`
+- **Description**: If you want to restore a table with a foreign key but don't want to restore the table it references, you can [drop the Foreign Key constraint from the table](#skip_missing_foreign_keys) and then have it restored.
+- **Key**: `skip_missing_foreign_keys`
+- **Value**: *No value*
+- **Example**: `WITH OPTIONS ("skip_missing_foreign_keys")`
 
 ## Examples
 

--- a/view-version-details.md
+++ b/view-version-details.md
@@ -17,7 +17,7 @@ C Compiler:  4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)
 
 The `cockroach version` command outputs the following fields:
 
-Field | Description 
+Field | Description
 ------|------------
 `Build Tag` | The CockroachDB version.
 `Build Time` | The date and time when the binary was built.


### PR DESCRIPTION
There's no way to make a headerless table render in Redcarpet (using Markdown; could convert to HTML). To alleviate the issue, I converted the table to a list.

Closes #1533