### PR TITLE
Fix typo in Automatic Rebalancing docs page

### DIFF
--- a/demo-automatic-rebalancing.md
+++ b/demo-automatic-rebalancing.md
@@ -4,7 +4,7 @@ summary: Use a local cluster to explore how CockroachDB automatically rebalances
 toc: false
 ---
 
-This page walks you through a simple demonstration of how CockroachDB automatically rebalances data as you scale. Starting with a 3-node local cluster, you'll lower the maximum size for a single range, the unit of data that is replicated in CockorachDB. You'll then download and run the `block_writer` example program, which continuously inserts data into your cluster, and watch the replica count quickly increase as ranges split. You'll then add 2 more nodes and watch how CockroachDB automatically rebalances replicas to efficiently use all available capacity.
+This page walks you through a simple demonstration of how CockroachDB automatically rebalances data as you scale. Starting with a 3-node local cluster, you'll lower the maximum size for a single range, the unit of data that is replicated in CockroachDB. You'll then download and run the `block_writer` example program, which continuously inserts data into your cluster, and watch the replica count quickly increase as ranges split. You'll then add 2 more nodes and watch how CockroachDB automatically rebalances replicas to efficiently use all available capacity.
 
 <div id="toc"></div>
 


### PR DESCRIPTION
`CockorachDB` -> `CockroachDB`
cc @jseldess 