### PR TITLE
generate raw HTML tables on "Functions and Operators" page

### DIFF
--- a/_includes/sql/operators.md
+++ b/_includes/sql/operators.md
@@ -1,230 +1,252 @@
-`#` | Return
---- | ---
-<a href="int.html">int</a> `#` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`%` | Return
---- | ---
-<a href="decimal.html">decimal</a> `%` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `%` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `%` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `%` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `%` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`&` | Return
---- | ---
-<a href="int.html">int</a> `&` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`*` | Return
---- | ---
-<a href="decimal.html">decimal</a> `*` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `*` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `*` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `*` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `*` <a href="int.html">int</a> | <a href="int.html">int</a>
-<a href="int.html">int</a> `*` <a href="interval.html">interval</a> | <a href="interval.html">interval</a>
-<a href="interval.html">interval</a> `*` <a href="float.html">float</a> | <a href="interval.html">interval</a>
-<a href="interval.html">interval</a> `*` <a href="int.html">int</a> | <a href="interval.html">interval</a>
-
-`+` | Return
---- | ---
-`+`<a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-`+`<a href="float.html">float</a> | <a href="float.html">float</a>
-`+`<a href="int.html">int</a> | <a href="int.html">int</a>
-<a href="date.html">date</a> `+` <a href="int.html">int</a> | <a href="date.html">date</a>
-<a href="date.html">date</a> `+` <a href="interval.html">interval</a> | <a href="timestamp.html">timestamptz</a>
-<a href="decimal.html">decimal</a> `+` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `+` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `+` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `+` <a href="date.html">date</a> | <a href="date.html">date</a>
-<a href="int.html">int</a> `+` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `+` <a href="int.html">int</a> | <a href="int.html">int</a>
-<a href="interval.html">interval</a> `+` <a href="date.html">date</a> | <a href="timestamp.html">timestamptz</a>
-<a href="interval.html">interval</a> `+` <a href="interval.html">interval</a> | <a href="interval.html">interval</a>
-<a href="interval.html">interval</a> `+` <a href="timestamp.html">timestamp</a> | <a href="timestamp.html">timestamp</a>
-<a href="interval.html">interval</a> `+` <a href="timestamp.html">timestamptz</a> | <a href="timestamp.html">timestamptz</a>
-<a href="timestamp.html">timestamp</a> `+` <a href="interval.html">interval</a> | <a href="timestamp.html">timestamp</a>
-<a href="timestamp.html">timestamptz</a> `+` <a href="interval.html">interval</a> | <a href="timestamp.html">timestamptz</a>
-
-`-` | Return
---- | ---
-`-`<a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-`-`<a href="float.html">float</a> | <a href="float.html">float</a>
-`-`<a href="int.html">int</a> | <a href="int.html">int</a>
-`-`<a href="interval.html">interval</a> | <a href="interval.html">interval</a>
-<a href="date.html">date</a> `-` <a href="date.html">date</a> | <a href="int.html">int</a>
-<a href="date.html">date</a> `-` <a href="int.html">int</a> | <a href="date.html">date</a>
-<a href="date.html">date</a> `-` <a href="interval.html">interval</a> | <a href="timestamp.html">timestamptz</a>
-<a href="decimal.html">decimal</a> `-` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `-` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `-` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `-` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `-` <a href="int.html">int</a> | <a href="int.html">int</a>
-<a href="interval.html">interval</a> `-` <a href="interval.html">interval</a> | <a href="interval.html">interval</a>
-<a href="timestamp.html">timestamp</a> `-` <a href="interval.html">interval</a> | <a href="timestamp.html">timestamp</a>
-<a href="timestamp.html">timestamp</a> `-` <a href="timestamp.html">timestamp</a> | <a href="interval.html">interval</a>
-<a href="timestamp.html">timestamp</a> `-` <a href="timestamp.html">timestamptz</a> | <a href="interval.html">interval</a>
-<a href="timestamp.html">timestamptz</a> `-` <a href="interval.html">interval</a> | <a href="timestamp.html">timestamptz</a>
-<a href="timestamp.html">timestamptz</a> `-` <a href="timestamp.html">timestamp</a> | <a href="interval.html">interval</a>
-<a href="timestamp.html">timestamptz</a> `-` <a href="timestamp.html">timestamptz</a> | <a href="interval.html">interval</a>
-
-`/` | Return
---- | ---
-<a href="decimal.html">decimal</a> `/` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `/` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `/` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `/` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `/` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="interval.html">interval</a> `/` <a href="float.html">float</a> | <a href="interval.html">interval</a>
-<a href="interval.html">interval</a> `/` <a href="int.html">int</a> | <a href="interval.html">interval</a>
-
-`//` | Return
---- | ---
-<a href="decimal.html">decimal</a> `//` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `//` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `//` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `//` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `//` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`<` | Return
---- | ---
-<a href="bool.html">bool</a> `<` <a href="bool.html">bool</a> | <a href="bool.html">bool</a>
-<a href="bytes.html">bytes</a> `<` <a href="bytes.html">bytes</a> | <a href="bool.html">bool</a>
-collatedstring{} `<` collatedstring{} | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `<` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `<` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `<` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `<` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `<` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `<` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `<` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `<` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `<` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `<` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `<` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `<` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="interval.html">interval</a> `<` <a href="interval.html">interval</a> | <a href="bool.html">bool</a>
-<a href="string.html">string</a> `<` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `<` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `<` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `<` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `<` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `<` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `<` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-tuple `<` tuple | <a href="bool.html">bool</a>
-
-`<<` | Return
---- | ---
-<a href="int.html">int</a> `<<` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`<=` | Return
---- | ---
-<a href="bool.html">bool</a> `<=` <a href="bool.html">bool</a> | <a href="bool.html">bool</a>
-<a href="bytes.html">bytes</a> `<=` <a href="bytes.html">bytes</a> | <a href="bool.html">bool</a>
-collatedstring{} `<=` collatedstring{} | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `<=` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `<=` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `<=` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `<=` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `<=` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `<=` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `<=` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `<=` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `<=` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `<=` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `<=` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `<=` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="interval.html">interval</a> `<=` <a href="interval.html">interval</a> | <a href="bool.html">bool</a>
-<a href="string.html">string</a> `<=` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `<=` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `<=` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `<=` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `<=` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `<=` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `<=` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-tuple `<=` tuple | <a href="bool.html">bool</a>
-
-`=` | Return
---- | ---
-<a href="bool.html">bool</a> `=` <a href="bool.html">bool</a> | <a href="bool.html">bool</a>
-<a href="bytes.html">bytes</a> `=` <a href="bytes.html">bytes</a> | <a href="bool.html">bool</a>
-collatedstring{} `=` collatedstring{} | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `=` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `=` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `=` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `=` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `=` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `=` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `=` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `=` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `=` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `=` <a href="decimal.html">decimal</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `=` <a href="float.html">float</a> | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `=` <a href="int.html">int</a> | <a href="bool.html">bool</a>
-<a href="interval.html">interval</a> `=` <a href="interval.html">interval</a> | <a href="bool.html">bool</a>
-oid `=` oid | <a href="bool.html">bool</a>
-<a href="string.html">string</a> `=` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `=` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `=` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `=` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `=` <a href="date.html">date</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `=` <a href="timestamp.html">timestamp</a> | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `=` <a href="timestamp.html">timestamptz</a> | <a href="bool.html">bool</a>
-tuple `=` tuple | <a href="bool.html">bool</a>
-
-`>>` | Return
---- | ---
-<a href="int.html">int</a> `>>` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`ILIKE` | Return
---- | ---
-<a href="string.html">string</a> `ILIKE` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-
-`IN` | Return
---- | ---
-<a href="bool.html">bool</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="bytes.html">bytes</a> `IN` tuple | <a href="bool.html">bool</a>
-collatedstring{} `IN` tuple | <a href="bool.html">bool</a>
-<a href="date.html">date</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="decimal.html">decimal</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="float.html">float</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="int.html">int</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="interval.html">interval</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="string.html">string</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamp</a> `IN` tuple | <a href="bool.html">bool</a>
-<a href="timestamp.html">timestamptz</a> `IN` tuple | <a href="bool.html">bool</a>
-tuple `IN` tuple | <a href="bool.html">bool</a>
-
-`LIKE` | Return
---- | ---
-<a href="string.html">string</a> `LIKE` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-
-`SIMILAR TO` | Return
---- | ---
-<a href="string.html">string</a> `SIMILAR TO` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-
-`^` | Return
---- | ---
-<a href="decimal.html">decimal</a> `^` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="decimal.html">decimal</a> `^` <a href="int.html">int</a> | <a href="decimal.html">decimal</a>
-<a href="float.html">float</a> `^` <a href="float.html">float</a> | <a href="float.html">float</a>
-<a href="int.html">int</a> `^` <a href="decimal.html">decimal</a> | <a href="decimal.html">decimal</a>
-<a href="int.html">int</a> `^` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`|` | Return
---- | ---
-<a href="int.html">int</a> `|` <a href="int.html">int</a> | <a href="int.html">int</a>
-
-`||` | Return
---- | ---
-<a href="bytes.html">bytes</a> `||` <a href="bytes.html">bytes</a> | <a href="bytes.html">bytes</a>
-<a href="string.html">string</a> `||` <a href="string.html">string</a> | <a href="string.html">string</a>
-
-`~` | Return
---- | ---
-`~`<a href="int.html">int</a> | <a href="int.html">int</a>
-<a href="string.html">string</a> `~` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-
-`~*` | Return
---- | ---
-<a href="string.html">string</a> `~*` <a href="string.html">string</a> | <a href="bool.html">bool</a>
-
+<table><thead>
+<tr><td><code>#</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="int.html">int</a> <code>#</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>%</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="decimal.html">decimal</a> <code>%</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>%</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>%</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>%</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>%</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>&</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="int.html">int</a> <code>&</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>*</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="decimal.html">decimal</a> <code>*</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>*</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>*</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>*</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>*</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>*</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>*</code> <a href="float.html">float</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>*</code> <a href="int.html">int</a></td><td><a href="interval.html">interval</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>+</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><code>+</code><a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><code>+</code><a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><code>+</code><a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>+</code> <a href="int.html">int</a></td><td><a href="date.html">date</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>+</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>+</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>+</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>+</code> <a href="date.html">date</a></td><td><a href="date.html">date</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>+</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>+</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>+</code> <a href="date.html">date</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>+</code> <a href="timestamp.html">timestamp</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>+</code> <a href="timestamp.html">timestamptz</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>+</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>-</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><code>-</code><a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><code>-</code><a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><code>-</code><a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><code>-</code><a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>-</code> <a href="date.html">date</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>-</code> <a href="int.html">int</a></td><td><a href="date.html">date</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>-</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>-</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>-</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>-</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>-</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamp</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>-</code> <a href="timestamp.html">timestamp</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>-</code> <a href="timestamp.html">timestamptz</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamptz</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>-</code> <a href="timestamp.html">timestamp</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>-</code> <a href="timestamp.html">timestamptz</a></td><td><a href="interval.html">interval</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>/</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="decimal.html">decimal</a> <code>/</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>/</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>/</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>/</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>/</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>/</code> <a href="float.html">float</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>/</code> <a href="int.html">int</a></td><td><a href="interval.html">interval</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>//</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="decimal.html">decimal</a> <code>//</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>//</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>//</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>//</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>//</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code><</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="bool.html">bool</a> <code><</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="bytes.html">bytes</a> <code><</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{} <code><</code> collatedstring{}</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code><</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code><</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code><</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code><</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code><</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code><</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code><</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code><</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code><</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code><</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code><</code> <a href="interval.html">interval</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="string.html">string</a> <code><</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code><</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code><</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>tuple <code><</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code><<</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="int.html">int</a> <code><<</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code><=</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="bool.html">bool</a> <code><=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="bytes.html">bytes</a> <code><=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{} <code><=</code> collatedstring{}</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code><=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code><=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code><=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code><=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code><=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code><=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code><=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code><=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code><=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code><=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code><=</code> <a href="interval.html">interval</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="string.html">string</a> <code><=</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code><=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code><=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>tuple <code><=</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>=</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="bool.html">bool</a> <code>=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="bytes.html">bytes</a> <code>=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{} <code>=</code> collatedstring{}</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>=</code> <a href="interval.html">interval</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>oid <code>=</code> oid</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>=</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>tuple <code>=</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>>></code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="int.html">int</a> <code>>></code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>ILIKE</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="string.html">string</a> <code>ILIKE</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>IN</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="bool.html">bool</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="bytes.html">bytes</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>collatedstring{} <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>tuple <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>LIKE</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="string.html">string</a> <code>LIKE</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>SIMILAR TO</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="string.html">string</a> <code>SIMILAR TO</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>^</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="decimal.html">decimal</a> <code>^</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>^</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>^</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>^</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>^</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>|</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="int.html">int</a> <code>|</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>||</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>~</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><code>~</code><a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
+<tr><td><a href="string.html">string</a> <code>~</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>~*</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td><a href="string.html">string</a> <code>~*</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>

--- a/functions-and-operators.md
+++ b/functions-and-operators.md
@@ -17,7 +17,7 @@ toc: true
 The following table lists all CockroachDB operators from highest to lowest precedence, i.e., the order in which they will be evaluated within a statement. Operators with the same precedence are left associative. This means that those operators are grouped together starting from the left and moving right.
 
 | Order of Precedence | Operator | Name | Operator Arity |
-| --- |
+| ------------------- | -------- | ---- | -------------- |
 | 1 | `.` | Member field access operator | binary |
 | 2 | `::` | Type cast | binary |
 | 3 | `-` | Unary minus | unary |

--- a/generate/funcs.go
+++ b/generate/funcs.go
@@ -45,9 +45,9 @@ type operation struct {
 
 func (o operation) String() string {
 	if o.right == "" {
-		return fmt.Sprintf("`%s`%s", o.op, linkTypeName(o.left))
+		return fmt.Sprintf("<code>%s</code>%s", o.op, linkTypeName(o.left))
 	}
-	return fmt.Sprintf("%s `%s` %s", linkTypeName(o.left), o.op, linkTypeName(o.right))
+	return fmt.Sprintf("%s <code>%s</code> %s", linkTypeName(o.left), o.op, linkTypeName(o.right))
 }
 
 type operations []operation
@@ -116,11 +116,13 @@ func GenerateOperators() []byte {
 	sort.Strings(opstrs)
 	b := new(bytes.Buffer)
 	for _, op := range opstrs {
-		fmt.Fprintf(b, "`%s` | Return\n", op)
-		fmt.Fprintf(b, "--- | ---\n")
+		fmt.Fprintf(b, "<table><thead>\n")
+		fmt.Fprintf(b, "<tr><td><code>%s</code></td><td>Return</td></tr>\n", op)
+		fmt.Fprintf(b, "</thead><tbody>\n")
 		for _, v := range ops[op] {
-			fmt.Fprintf(b, "%s | %s\n", v.String(), linkTypeName(v.ret))
+			fmt.Fprintf(b, "<tr><td>%s</td><td>%s</td></tr>\n", v.String(), linkTypeName(v.ret))
 		}
+		fmt.Fprintf(b, "</tbody></table>")
 		fmt.Fprintln(b)
 	}
 	return b.Bytes()


### PR DESCRIPTION
Due to vmg/redcarpet#477, it's not possible to use pipe characters (`|`)
in tables. This currently breaks several table rows on our "Functions
and Operators" page. Since these tables are auto-generated, fix this by
just directly outputting HTML tables, where pipe characters have no
special meaning.

Fixes #1536.