### PR TITLE
clarify timestamp time zone details

### DIFF
--- a/v1.0/set-vars.md
+++ b/v1.0/set-vars.md
@@ -115,10 +115,13 @@ The following demonstrates how to assign a list of values:
 
 ## `SET TIME ZONE`
 
-The statement `SET TIME ZONE` can configure the default time zone for
-the current session. This is a special syntax form used to configure
-the `"time zone"` session parameter; the special syntax is necessary
-because `SET` cannot assign to parameter names containing spaces.
+{{site.data.alerts.callout_danger}}As a best practice, we recommend not using this setting and avoid setting a session time for your database. We instead recommend converting UTC values to the appropriate time zone on the client side.{{site.data.alerts.end}}
+
+You can control your client's default time zone for the current session with `SET TIME ZONE`. This will apply a session offset to all [`TIMESTAMP WITH TIME ZONE`](timestamp.html) values.
+
+{{site.data.alerts.callout_info}}With setting `SET TIME ZONE`, CockroachDB uses UTC as the default time zone.{{site.data.alerts.end}}
+
+`SET TIME ZONE` uses a special syntax form used to configure the `"time zone"` session parameter because `SET` cannot assign to parameter names containing spaces.
 
 ### Parameters
 

--- a/v1.0/timestamp.md
+++ b/v1.0/timestamp.md
@@ -4,13 +4,34 @@ summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIM
 toc: false
 ---
 
-The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC, whereas `TIMESTAMPTZ` stores a date and time pair with a time zone offset from UTC. 
+The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC.
 
 <div id="toc"></div>
 
+## Time Zone Details
+
+`TIMESTAMP` has two variants:
+
+- `TIMESTAMP WITH TIME ZONE` converts `TIMESTAMP` values from UTC to the client's session time zone (unless another time zone is specified for the value). However, it is conceptually important to note that `TIMESTAMP WITH TIME ZONE` *does not* store any time zone data.
+
+   {{site.data.alerts.callout_info}}The default session time zone is UTC, which means that by default `TIMESTAMP WITH TIME ZONE` values display in UTC.{{site.data.alerts.end}}
+
+- `TIMESTAMP WITHOUT TIME ZONE` presents all `TIMESTAMP` values in UTC.
+
+The difference between these two types is that `TIMESTAMP WITH TIME ZONE` uses the client's session time zone, while the other simply does not. This behavior extends to functions like `now()` and `extract()` on `TIMESTAMP WITH TIME ZONE` values.
+
+### Best Practices
+
+We recommend always using the `...WITH TIME ZONE` variant because the `...WITHOUT TIME ZONE` variant can sometimes lead to unexpected behaviors when it ignores a session offset. 
+
+However, we also recommend you avoid setting a session time for your database. Instead, convert values from the default time zone (UTC) on the client side.
+
 ## Aliases
 
-In CockroachDB, `TIMESTAMP WITHOUT TIME ZONE` is an alias for `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` is an alias for `TIMESTAMPTZ`.
+In CockroachDB, the following are aliases:
+
+- `TIMESTAMP`, `TIMESTAMP WITHOUT TIME ZONE`
+- `TIMESTAMPTZ`, `TIMESTAMP WITH TIME ZONE`
 
 ## Syntax
 

--- a/v1.1/set-vars.md
+++ b/v1.1/set-vars.md
@@ -114,7 +114,26 @@ The following demonstrates how to assign a list of values:
 (1 row)
 ~~~
 
-### Set the default time zone via `SET TIME ZONE`
+## `SET TIME ZONE`
+
+{{site.data.alerts.callout_danger}}As a best practice, we recommend not using this setting and avoid setting a session time for your database. We instead recommend converting UTC values to the appropriate time zone on the client side.{{site.data.alerts.end}}
+
+You can control your client's default time zone for the current session with `SET TIME ZONE`. This will apply a session offset to all [`TIMESTAMP WITH TIME ZONE`](timestamp.html) values.
+
+{{site.data.alerts.callout_info}}With setting `SET TIME ZONE`, CockroachDB uses UTC as the default time zone.{{site.data.alerts.end}}
+
+`SET TIME ZONE` uses a special syntax form used to configure the `"time zone"` session parameter because `SET` cannot assign to parameter names containing spaces.
+
+### Parameters
+
+The time zone value indicates the time zone for the current session.
+
+This value can be a string representation of a local system-defined
+time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or
+negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`,
+`LOCAL`, or `0` sets the session time zone to `UTC`.
+
+### Example: Set the Default Time Zone via `SET TIME ZONE`
 
 ~~~ sql
 > SET TIME ZONE 'EST'; -- same as SET "time zone" = 'EST'

--- a/v1.1/timestamp.md
+++ b/v1.1/timestamp.md
@@ -4,13 +4,32 @@ summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIM
 toc: false
 ---
 
-The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC, whereas `TIMESTAMPTZ` stores a date and time pair with a time zone offset from UTC. 
+The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC.
 
 <div id="toc"></div>
 
+## Time Zone Details
+
+`TIMESTAMP` has two variants:
+
+- `TIMESTAMP WITH TIME ZONE` converts `TIMESTAMP` values from UTC to the client's session time zone (unless another time zone is specified for the value). However, it is conceptually important to note that `TIMESTAMP WITH TIME ZONE` *does not* store any time zone data.
+
+   {{site.data.alerts.callout_info}}The default session time zone is UTC, which means that by default `TIMESTAMP WITH TIME ZONE` values display in UTC.{{site.data.alerts.end}}
+
+- `TIMESTAMP WITHOUT TIME ZONE` presents all `TIMESTAMP` values in UTC.
+
+The difference between these two types is that `TIMESTAMP WITH TIME ZONE` uses the client's session time zone, while the other simply does not. This behavior extends to functions like `now()` and `extract()` on `TIMESTAMP WITH TIME ZONE` values.
+
+### Best Practices
+
+We recommend always using the `...WITH TIME ZONE` variant because the `...WITHOUT TIME ZONE` variant can sometimes lead to unexpected behaviors when it ignores a session offset. However, we also recommend you avoid setting a session time for your database.
+
 ## Aliases
 
-In CockroachDB, `TIMESTAMP WITHOUT TIME ZONE` is an alias for `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` is an alias for `TIMESTAMPTZ`.
+In CockroachDB, the following are aliases:
+
+- `TIMESTAMP`, `TIMESTAMP WITHOUT TIME ZONE`
+- `TIMESTAMPTZ`, `TIMESTAMP WITH TIME ZONE`
 
 ## Syntax
 


### PR DESCRIPTION
closes #685

Chose not to link to docs for setting session time zone because it is apparently not a best practice.