### PR TITLE
Refactor the SHOW/SET documentation; include USE and SET NAMES.

### DIFF
--- a/_includes/sql/v1.1/diagrams/set_var.html
+++ b/_includes/sql/v1.1/diagrams/set_var.html
@@ -1,53 +1,81 @@
-<div><svg width="666" height="256">
+<div><svg width="710" height="454">
          
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <rect x="31" y="47" width="44" height="32" rx="10"></rect>
-         <rect x="29" y="45" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="65">SET</text>
-         <rect x="135" y="79" width="82" height="32" rx="10"></rect>
-         <rect x="133" y="77" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="97">SESSION</text>
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">SET</text>
+         <rect x="65" y="145" width="82" height="32" rx="10"></rect>
+         <rect x="63" y="143" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="163">SESSION</text>
          <a xlink:href="sql-grammar.html#var_name" xlink:title="var_name">
-            <rect x="257" y="47" width="82" height="32"></rect>
-            <rect x="255" y="45" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="265" y="65">var_name</text>
+            <rect x="207" y="113" width="82" height="32"></rect>
+            <rect x="205" y="111" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="215" y="131">var_name</text>
          </a>
-         <rect x="379" y="47" width="38" height="32" rx="10"></rect>
-         <rect x="377" y="45" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="387" y="65">TO</text>
-         <rect x="379" y="91" width="30" height="32" rx="10"></rect>
-         <rect x="377" y="89" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="387" y="109">=</text>
+         <rect x="329" y="113" width="38" height="32" rx="10"></rect>
+         <rect x="327" y="111" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="131">TO</text>
+         <rect x="329" y="157" width="30" height="32" rx="10"></rect>
+         <rect x="327" y="155" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="175">=</text>
          <a xlink:href="sql-grammar.html#var_value" xlink:title="var_value">
-            <rect x="497" y="47" width="82" height="32"></rect>
-            <rect x="495" y="45" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="505" y="65">var_value</text>
+            <rect x="447" y="113" width="82" height="32"></rect>
+            <rect x="445" y="111" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="455" y="131">var_value</text>
          </a>
-         <rect x="497" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="495" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="505" y="21">,</text>
-         <rect x="477" y="91" width="80" height="32" rx="10"></rect>
-         <rect x="475" y="89" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="485" y="109">DEFAULT</text>
-         <rect x="115" y="135" width="52" height="32" rx="10"></rect>
-         <rect x="113" y="133" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="123" y="153">TIME</text>
-         <rect x="187" y="135" width="56" height="32" rx="10"></rect>
-         <rect x="185" y="133" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="195" y="153">ZONE</text>
+         <rect x="447" y="69" width="24" height="32" rx="10"></rect>
+         <rect x="445" y="67" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="455" y="87">,</text>
+         <rect x="427" y="157" width="80" height="32" rx="10"></rect>
+         <rect x="425" y="155" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="435" y="175">DEFAULT</text>
+         <rect x="207" y="201" width="52" height="32" rx="10"></rect>
+         <rect x="205" y="199" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="219">TIME</text>
+         <rect x="279" y="201" width="56" height="32" rx="10"></rect>
+         <rect x="277" y="199" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="219">ZONE</text>
          <a xlink:href="sql-grammar.html#var_value" xlink:title="var_value">
-            <rect x="283" y="135" width="82" height="32"></rect>
-            <rect x="281" y="133" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="291" y="153">var_value</text>
+            <rect x="375" y="201" width="82" height="32"></rect>
+            <rect x="373" y="199" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="383" y="219">var_value</text>
          </a>
-         <rect x="283" y="179" width="80" height="32" rx="10"></rect>
-         <rect x="281" y="177" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="291" y="197">DEFAULT</text>
-         <rect x="283" y="223" width="64" height="32" rx="10"></rect>
-         <rect x="281" y="221" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="291" y="241">LOCAL</text>
-         <path class="line" d="m17 61 h2 m0 0 h10 m44 0 h10 m40 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -32 h10 m82 0 h10 m20 0 h10 m38 0 h10 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m30 0 h10 m0 0 h8 m60 -44 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m-142 44 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m80 0 h10 m0 0 h42 m-524 -44 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v68 m544 0 v-68 m-544 68 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m52 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m80 0 h10 m0 0 h2 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m64 0 h10 m0 0 h18 m20 -88 h234 m23 -88 h-3"></path>
-         <polygon points="657 61 665 57 665 65"></polygon>
-         <polygon points="657 61 649 57 649 65"></polygon>
+         <rect x="375" y="245" width="80" height="32" rx="10"></rect>
+         <rect x="373" y="243" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="383" y="263">DEFAULT</text>
+         <rect x="375" y="289" width="64" height="32" rx="10"></rect>
+         <rect x="373" y="287" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="383" y="307">LOCAL</text>
+         <rect x="207" y="333" width="66" height="32" rx="10"></rect>
+         <rect x="205" y="331" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="351">NAMES</text>
+         <a xlink:href="sql-grammar.html#var_value" xlink:title="var_value">
+            <rect x="313" y="333" width="82" height="32"></rect>
+            <rect x="311" y="331" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="321" y="351">var_value</text>
+         </a>
+         <rect x="313" y="377" width="80" height="32" rx="10"></rect>
+         <rect x="311" y="375" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="395">DEFAULT</text>
+         <rect x="45" y="421" width="82" height="32" rx="10"></rect>
+         <rect x="43" y="419" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="439">SESSION</text>
+         <rect x="147" y="421" width="146" height="32" rx="10"></rect>
+         <rect x="145" y="419" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="439">CHARACTERISTICS</text>
+         <rect x="313" y="421" width="38" height="32" rx="10"></rect>
+         <rect x="311" y="419" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="439">AS</text>
+         <rect x="371" y="421" width="118" height="32" rx="10"></rect>
+         <rect x="369" y="419" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="379" y="439">TRANSACTION</text>
+         <a xlink:href="sql-grammar.html#transaction_iso_level" xlink:title="transaction_iso_level">
+            <rect x="509" y="421" width="154" height="32"></rect>
+            <rect x="507" y="419" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="517" y="439">transaction_iso_level</text>
+         </a>
+         <path class="line" d="m19 17 h2 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-96 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m40 -32 h10 m82 0 h10 m20 0 h10 m38 0 h10 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v24 m78 0 v-24 m-78 24 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m30 0 h10 m0 0 h8 m60 -44 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m-142 44 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m80 0 h10 m0 0 h42 m-382 -44 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v68 m402 0 v-68 m-402 68 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m52 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m80 0 h10 m0 0 h2 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m64 0 h10 m0 0 h18 m20 -88 h92 m-392 -10 v20 m402 0 v-20 m-402 20 v112 m402 0 v-112 m-402 112 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m66 0 h10 m20 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m80 0 h10 m0 0 h2 m20 -44 h154 m20 -220 h74 m-658 0 h20 m638 0 h20 m-678 0 q10 0 10 10 m658 0 q0 -10 10 -10 m-668 10 v288 m658 0 v-288 m-658 288 q0 10 10 10 m638 0 q10 0 10 -10 m-648 10 h10 m82 0 h10 m0 0 h10 m146 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m154 0 h10 m23 -308 h-3"></path>
+         <polygon points="701 127 709 123 709 131"></polygon>
+         <polygon points="701 127 693 123 693 131"></polygon>
       </svg></div>

--- a/v1.1/diagnostics-reporting.md
+++ b/v1.1/diagnostics-reporting.md
@@ -204,7 +204,7 @@ This JSON example shows an excerpt of what query statistics look like when sent 
 
 ### At Cluster Initialization
 
-To make sure that absolutely no diagnostic details are shared, you can set the environment variable `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true` before starting the first node of the cluster. Note that this works only when set before starting the first node of the cluster. Once the cluster is running, you need to use the `SET` method described below.
+To make sure that absolutely no diagnostic details are shared, you can set the environment variable `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true` before starting the first node of the cluster. Note that this works only when set before starting the first node of the cluster. Once the cluster is running, you need to use the `SET CLUSTER SETTING` method described below.
 
 ### After Cluster Initialization
 

--- a/v1.1/set-vars.md
+++ b/v1.1/set-vars.md
@@ -37,7 +37,7 @@ The variable name is case insensitive. The value can be a list of one or more it
 | `application_name`              | The current application name for statistics collection. | Empty string.                                                                                                                                                                                                         | Yes |
 | `database`                      | The default database for the current session. | Database in connection string, or empty if not specified.                                                                                                                                                                       | Yes |
 | `search_path`                   | A list of databases or namespaces that will be searched to resolve unqualified table or function names. For more details, see [Name Resolution](sql-name-resolution.html). | "`{pg_catalog}`" (for ORM compatibility).                                                          | Yes |
-| `time zone`                     | The default time zone for the current session. See [`SET TIME ZONE` notes](#set-time-zone) below. | `UTC`                                                                                                                                                                       | Yes |
+| `time zone`                     | The default time zone for the current session.<br><br>This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`, `LOCAL`, or `0` sets the session time zone to `UTC`. | `UTC`                                                                                                                                                                       | Yes |
 | `default_transaction_isolation` | The default transaction isolation level for the current session. See [Transaction parameters](transactions.html#transaction-parameters) and [`SET TRANSACTION`](set-transaction.html) for more details. | Settings in connection string, or "`SERIALIZABLE`" if not specified.  | Yes |
 | `client_encoding`               | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`UTF8`". | N/A                                                                                                                                                                           | No  |
 | `client_min_messages`           | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`on`". | N/A                                                                                                                                                                             | No  |
@@ -46,11 +46,12 @@ The variable name is case insensitive. The value can be a list of one or more it
 
 Special syntax cases:
 
-| Syntax | Equivalent to |
-|--------|---------------|
-| `SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL ...` | `SET default_transaction_isolation = ...` |
-| `SET TIME ZONE ...` | Special syntax because the variable name contains a space. See [`SET TIME ZONE`](#set-time-zone) below. |
-
+| Syntax | Equivalent to | Notes |
+|--------|---------------|-------|
+| `USE ...` | `SET database = ...` | This is provided as convenience for users with a MySQL/MSSQL background.
+| `SET NAMES ...` | `SET client_encoding = ...` | This is provided for compatibility with PostgreSQL clients.
+| `SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL ...` | `SET default_transaction_isolation = ...` | This is provided for compatibility with standard SQL.
+| `SET TIME ZONE ...` | `SET "time zone" = ...` | This is provided for compatibility with PostgreSQL clients.
 
 ## Examples
 
@@ -109,26 +110,10 @@ The following demonstrates how to assign a list of values:
 (1 row)
 ~~~
 
-## `SET TIME ZONE`
-
-The statement `SET TIME ZONE` can configure the default time zone for
-the current session. This is a special syntax form used to configure
-the `"time zone"` session parameter; the special syntax is necessary
-because `SET` cannot assign to parameter names containing spaces.
-
-### Parameters
-
-The time zone value indicates the time zone for the current session.
-
-This value can be a string representation of a local system-defined
-time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or
-negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`,
-`LOCAL`, or `0` sets the session time zone to `UTC`.
-
-### Example: Set the Default Time Zone via `SET TIME ZONE`
+### Set the default time zone via `SET TIME ZONE`
 
 ~~~ sql
-> SET TIME ZONE 'EST';
+> SET TIME ZONE 'EST'; -- same as SET "time zone" = 'EST'
 > SHOW TIME ZONE;
 ~~~
 ~~~ shell
@@ -140,7 +125,7 @@ negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`,
 (1 row)
 ~~~
 ~~~ sql
-> SET TIME ZONE DEFAULT;
+> SET TIME ZONE DEFAULT; -- same as SET "time zone" = DEFAULT
 > SHOW TIME ZONE;
 ~~~
 ~~~ shell


### PR DESCRIPTION
Both SHOW and SET are really single statements which act on the
session (and they are also handled using a single code path in
CockroachDB!), with the exception of SET TRANSACTION which acts on the
current transaction. This patch acknowledges the commonality and
merges the various documentation pages into two more general pages.

Extends #1107, off `release-1.1`.

Fixes #1502.
Fixes #1503.

Also covers the change implemented in cockroachdb/cockroach#16459.

