### PR TITLE
Use --host to connect sql client

### DIFF
--- a/manual-deployment.md
+++ b/manual-deployment.md
@@ -201,7 +201,8 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node1 address>
 	~~~
 
 	~~~ sql
@@ -215,6 +216,7 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
+	--host=<node's IP address>
 	~~~
 
 5. View the cluster's databases, which will include `securenodetest`:


### PR DESCRIPTION
Add --host when connecting to prevent the following when following the doc.

$ cockroach sql \
> --certs-dir=certs
Error: unable to connect or connection lost.

Please check the address and credentials such as certificates (if attempting to
communicate with a secure cluster).

dial tcp 127.0.0.1:26257: getsockopt: connection refused
Failed running "sql"

The change below with host works shown

$ cockroach sql --certs-dir=certs --host=10.0.3.98
# Welcome to the cockroach SQL interface.
# All statements must be terminated by a semicolon.
# To exit: CTRL + D.
root@10.0.3.98:26257/>