### PR TITLE
Update usage of pg package for node examples

### DIFF
--- a/_includes/app/basic-sample.js
+++ b/_includes/app/basic-sample.js
@@ -11,7 +11,10 @@ var config = {
   port: 26257
 };
 
-pg.connect(config, function (err, client, done) {
+// Create a pool.
+var pool = new pg.Pool(config);
+
+pool.connect(function (err, client, done) {
   // Closes communication with the database and exits.
   var finish = function () {
     done();

--- a/_includes/app/txn-sample.js
+++ b/_includes/app/txn-sample.js
@@ -105,7 +105,10 @@ function transferFunds(client, from, to, amount, next) {
   });
 }
 
-pg.connect(config, function (err, client, done) {
+// Create a pool.
+var pool = new pg.Pool(config);
+
+pool.connect(function (err, client, done) {
   // Closes communication with the database and exits.
   var finish = function () {
     done();


### PR DESCRIPTION
Running the samples as they exist now gives this warning:

(node:74958) DeprecationWarning: PG.connect is deprecated - please see the upgrade guide at https://node-postgres.com/guides/upgrading

That page explains that the pattern we're currently using for these
examples will be removed in the next major release of the pg package, so
we might as well update to the new way of using it now.