### PR TITLE
parse recent blog posts from RSS feed

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,3 +11,8 @@ task :htmlproofer do
       :ssl_verifyhost => 0}
   }).run
 end
+
+task :blog_posts do
+  require 'open-uri'
+  IO.copy_stream(open('https://www.cockroachlabs.com/blog/index.xml'), '_data/blog_posts.xml')
+end

--- a/_data/blog_posts.xml
+++ b/_data/blog_posts.xml
@@ -1,0 +1,512 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Cockroach Labs Blog</title>
+    <link>https://www.cockroachlabs.com/blog/index.xml</link>
+    <description>Recent content in Blog on Cockroach Labs</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language>
+    <lastBuildDate>Tue, 27 Jun 2017 00:00:00 +0000</lastBuildDate>
+    <atom:link href="https://www.cockroachlabs.com/blog/index.xml" rel="self" type="application/rss+xml" />
+    
+    <item>
+      <title>The Limits of the CAP Theorem</title>
+      <link>https://www.cockroachlabs.com/blog/limits-of-the-cap-theorem/</link>
+      <pubDate>Tue, 27 Jun 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Ben Darnell</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/limits-of-the-cap-theorem/</guid>
+      <description>The CAP theorem is a fundamental part of the theory of distributed systems. It states that in the presence of partitions (i.e. network failures), a system cannot be both consistent and available, and must choose one of the two.
+CockroachDB chooses consistency, and is therefore a CP system in the terminology of the CAP theorem (as opposed to an AP system, which favors availability over consistency). Both consistency and availability are crucial to any business, and you might wonder how you are expected to choose between such important goals.</description>
+    </item>
+    
+    <item>
+      <title>CockroachDB 💖 ActiveRecord (and Ruby on Rails!)</title>
+      <link>https://www.cockroachlabs.com/blog/cockroachdb-hearts-activerecord-ruby-on-rails/</link>
+      <pubDate>Thu, 15 Jun 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Jordan Lewis</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cockroachdb-hearts-activerecord-ruby-on-rails/</guid>
+      <description>This post is the second in our series on providing support for popular ORM libraries.
+In our first blog post on ORM support, Cuong Do detailed how we provided support for Hibernate, a full-featured Java ORM, in CockroachDB. He also discussed our general motivation for providing support for popular ORMs in CockroachDB: to make it as easy as possible for developers to build applications with CockroachDB using a variety of languages and frameworks.</description>
+    </item>
+    
+    <item>
+      <title>Local and distributed query processing in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/local-and-distributed-processing-in-cockroachdb/</link>
+      <pubDate>Thu, 08 Jun 2017 19:31:36 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/local-and-distributed-processing-in-cockroachdb/</guid>
+      <description>When a CockroachDB node receives a SQL query, this is approximately what happens:
+ The pgwire module handles the communication with the client application, and receives the query from the client. The SQL text is analyzed and transformed into an Abstract Syntax Tree (AST). This is then further analyzed and transformed into a logical query plan which is a tree of relational operators like filter, render (project), join. Incidentally, the logical plan tree is the data reported by the EXPLAIN statement.</description>
+    </item>
+    
+    <item>
+      <title>The Path from Beta to 1.0</title>
+      <link>https://www.cockroachlabs.com/blog/coming-soon-what-to-expect-in-cockroachdb-1-0/</link>
+      <pubDate>Thu, 01 Jun 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Diana Hsieh</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/coming-soon-what-to-expect-in-cockroachdb-1-0/</guid>
+      <description>A version of this blog post was originally published on May 1, 2017 and has been modified to provide the newest information available.
+With the recent 1.0 release, CockroachDB is now a production-ready database. 1.0 showcases the core capabilities of CockroachDB, while also offering users improved performance and stability with a cloud-native architecture that flexibly supports all manner of cloud deployments. It encompasses the core features that allow our users to run CockroachDB successfully in production.</description>
+    </item>
+    
+    <item>
+      <title>🎙[podcast] Unscripted Founders Q&amp;A on CockroachDB 1.0</title>
+      <link>https://www.cockroachlabs.com/blog/podcast-unscripted-founders-1dot0/</link>
+      <pubDate>Thu, 11 May 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Ben Darnell</dc:creator><dc:creator>Spencer Kimball</dc:creator><dc:creator>Peter Mattis</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/podcast-unscripted-founders-1dot0/</guid>
+      <description>LISTEN ON: | SoundCloud |
+Join the Cockroach Labs founders for an unscripted conversation about the dirty details building 1.0 and in achieving consensus across three co-founders. What do they wish they could have made it into the 1.0 release? What are they most excited about in this production-ready release? And what happens when they disagree with each other?
+FULL TRANSCRIPT:
+Peter: Hi, I’m Peter Mattis and welcome to our first-ever Cockroach Labs podcast.</description>
+    </item>
+    
+    <item>
+      <title>CockroachDB 1.0 is Production-Ready</title>
+      <link>https://www.cockroachlabs.com/blog/cockroachdb-1-0-release/</link>
+      <pubDate>Wed, 10 May 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cockroachdb-1-0-release/</guid>
+      <description>Today, we are pleased to announce the release of CockroachDB 1.0, the first open source, cloud-native SQL database. We’re also announcing a series B fundraise from investors who share our vision. The launch of 1.0 marks our graduation from beta to a production-ready database, designed to power business at any scale from the startup to the enterprise.
+A brief introduction is in order. While databases aren’t generally considered the most thrilling subject in technology news, ignoring them would be a mistake.</description>
+    </item>
+    
+    <item>
+      <title>Implementing Unicode Collation in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/unicode-collation-in-cockroachdb.md/</link>
+      <pubDate>Thu, 13 Apr 2017 00:00:00 +0000</pubDate>
+      <dc:creator>David Eisenstat</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/unicode-collation-in-cockroachdb.md/</guid>
+      <description>CockroachDB recently gained support for Unicode collation, a standard for ordering strings in the different ways that our users around the world expect. This post describes the motivation for Unicode collation as well as the implementation challenges in providing collated strings as a first-class type.
+Collated strings are documented here. Note that CockroachDB doesn’t support every use of collation that PostgreSQL does, due in part to implementation deficiencies that we plan to address and in part because we believe that the bugs and performance problems caused by implicit type conversions outweigh their convenience.</description>
+    </item>
+    
+    <item>
+      <title>Building Support for Java ORM Hibernate in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/building-support-for-java-orm-hibernate-in-cockroachdb/</link>
+      <pubDate>Fri, 07 Apr 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Cuong Do</dc:creator><dc:creator>Jordan Lewis</dc:creator><dc:creator>Nathan VanBenschoten</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/building-support-for-java-orm-hibernate-in-cockroachdb/</guid>
+      <description>We’re working hard to make CockroachDB scalable and robust, yet simple to use. One way we’ve approached this is by adding support for existing object-relational mappers (ORMs), which make it fast and easy to develop applications that interact with CockroachDB. To determine which ORMs to support first, we asked users of our forum, conducted developer surveys, and performed other research. Hibernate came up most often, likely because of Java’s large developer community and Hibernate’s popularity within that.</description>
+    </item>
+    
+    <item>
+      <title>Announcing the First CockroachDB User Groups in NYC and SF</title>
+      <link>https://www.cockroachlabs.com/blog/announcing-the-first-cockroachdb-user-groups-in-nyc-and-sf/</link>
+      <pubDate>Mon, 27 Mar 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Swati Kumar</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/announcing-the-first-cockroachdb-user-groups-in-nyc-and-sf/</guid>
+      <description>Calling all database and infrastructure experts: get ready to nerd out with the best CockroachDB devs in your city! A year after our Beta release and a shortly before CockroachDB 1.0 becomes available for download, we are excited to announce the newly minted CockroachDB User Groups. We are kicking off our user groups April 4th and 5th, with inaugural events in New York City and San Francisco respectively.
+Spencer Kimball, Co-Founder and CEO at Cockroach Labs, will discuss the inspiration and technology behind CockroachDB.</description>
+    </item>
+    
+    <item>
+      <title>apd: An Arbitrary-Precision Decimal Package for Go</title>
+      <link>https://www.cockroachlabs.com/blog/apd-arbitrary-precision-decimal-package/</link>
+      <pubDate>Wed, 15 Mar 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Matt Jibson</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/apd-arbitrary-precision-decimal-package/</guid>
+      <description>With the release of CockroachDB beta-20170223, we’d like to announce a new arbitrary-precision decimal package for Go: apd. This package replaces the underlying implementation of the DECIMAL type in CockroachDB and is available for anyone to fork and use. Here we will describe why we made apd, some of its features, and how it improved CockroachDB.
+Background on Decimals The two standard numeric types in computing are integers and floats, which handle the two main problems in number representation: the need for exact integral numbers within a fixed, relatively small range (ints) and the need for numbers, within an arbitrarily large range, that can be approximate (floats).</description>
+    </item>
+    
+    <item>
+      <title>Research, Reuse, Recycle</title>
+      <link>https://www.cockroachlabs.com/blog/research-reuse-recycle/</link>
+      <pubDate>Tue, 07 Mar 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Kuan Luo</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/research-reuse-recycle/</guid>
+      <description>table { border-collapse: collapse; width: 100%; } th { font-family: &#39;AvenirLTStd-Heavy&#39;, serif !important; font-size: 18px !important; font-weight: normal !important; } td, th { border: 1px solid #dddddd !important; text-align: left !important; padding: 8px !important; background-color: #ffffff !important; }  I recently came across an old piece on The Atlantic on design research. Author and educator Jon Freach wrote, “Design can exist without ‘the research.’ But if we don&amp;rsquo;t study the world, we don&amp;rsquo;t always know how or what to create.</description>
+    </item>
+    
+    <item>
+      <title>CockroachDB Beta Passes Jepsen Testing</title>
+      <link>https://www.cockroachlabs.com/blog/cockroachdb-beta-passes-jepsen-testing/</link>
+      <pubDate>Thu, 23 Feb 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Ben Darnell</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cockroachdb-beta-passes-jepsen-testing/</guid>
+      <description>Almost a year ago, we wrote about our use of Jepsen in testing CockroachDB. As we prepare for CockroachDB 1.0, we wanted to get independent verification of our findings, so last fall we hired Kyle Kingsbury, the author of Jepsen, to review our tests and add more of his own. Last week, Kyle published his results.
+Kyle’s testing found two new bugs: one in CockroachDB’s timestamp cache which could allow inconsistencies whenever two transactions are assigned the same timestamp, and one in which certain transactions could be applied twice due to internal retries.</description>
+    </item>
+    
+    <item>
+      <title>On the Way to Better SQL Joins in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/</link>
+      <pubDate>Thu, 09 Feb 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/</guid>
+      <description>Six months ago, we reported our first implementation of SQL joins in CockroachDB. At that point in development, we merely provided a functional proof of concept that was severely limited performance-wise.
+This is changing, gradually.
+We are preparing to launch CockroachDB 1.0 later this spring, and SQL joins in CockroachDB 1.0 will be usable, if underpowered.
+img{display:block;margin-left:auto;margin-right:auto;}b a{font-weight:bold!important;} The story in the infographic above is that we are working to make SQL joins perform better than the naive code we presented in July 2016.</description>
+    </item>
+    
+    <item>
+      <title>Journey to Design for Enterprise</title>
+      <link>https://www.cockroachlabs.com/blog/journey-to-design-for-enterprise/</link>
+      <pubDate>Thu, 02 Feb 2017 00:00:00 +0000</pubDate>
+      <dc:creator>Kuan Luo</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/journey-to-design-for-enterprise/</guid>
+      <description>One would think that designing for creative consumers through a massively popular brand would be a dream come true for any young designer. After all, what more could you want than a great company, compelling product, and an engaged team?
+A bigger challenge, it turns out.
+Design for Enterprise Technology I started my design career working on printed materials and corporate identities at a Brooklyn studio. Even then, I was attracted to the endless possibilities of the digital interface and changed course to immerse myself in web and mobile design at the Washington Post.</description>
+    </item>
+    
+    <item>
+      <title>How We’re Fighting Unconscious Bias</title>
+      <link>https://www.cockroachlabs.com/blog/fighting-unconscious-bias-cockroach-labs/</link>
+      <pubDate>Thu, 26 Jan 2017 18:07:54 +0000</pubDate>
+      <dc:creator>Lindsay Grenawalt</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/fighting-unconscious-bias-cockroach-labs/</guid>
+      <description>Before meeting a candidate, your brain has already started playing some unconscious games. You get excited if you see a candidate who went to the same school as you. You get irritated if you see a company you don&amp;rsquo;t like. You have already started making assumptions simply based by what is on paper, showing the power unconscious bias can have in the hiring process.
+ Unconscious biases are social stereotypes about certain groups of people that individuals form outside their own conscious awareness.</description>
+    </item>
+    
+    <item>
+      <title>How We&#39;re Building a Business to Last</title>
+      <link>https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/</link>
+      <pubDate>Thu, 19 Jan 2017 18:28:23 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/</guid>
+      <description>CockroachDB was inspired by frustration with the available open source databases and cloud DBaaS offerings. It was never conceived of as anything but open source software.
+In late 2014, with encouraging interest from the GitHub community and concomitant inquiries from some forward-looking venture capitalists, it was decision time: should we start a company to accelerate CockroachDB development? On the one hand, hiring a team of exceptional people would lead more quickly to a viable product.</description>
+    </item>
+    
+    <item>
+      <title>Enriching Log Messages Using Go Contexts</title>
+      <link>https://www.cockroachlabs.com/blog/enriching-log-messages-using-go-contexts/</link>
+      <pubDate>Thu, 15 Dec 2016 16:13:57 +0000</pubDate>
+      <dc:creator>Radu Berinde</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/enriching-log-messages-using-go-contexts/</guid>
+      <description>Building a complex system requires writing and debugging many tests. Developer tests that can be run without any infrastructure or configuration are crucial for allowing fast-paced development while avoiding regressions. Even for a distributed system like CockroachDB, tests that run on a single anode (e.g. as part of go test) can cover many aspects of the system: one technique we use is that of creating a virtual test cluster with multiple CockroachDB nodes, all running within the same process.</description>
+    </item>
+    
+    <item>
+      <title>[community post] Flowable and CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/community-post-running-flowable-cockroachdb/</link>
+      <pubDate>Wed, 07 Dec 2016 15:00:23 +0000</pubDate>
+      <dc:creator>Community</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/community-post-running-flowable-cockroachdb/</guid>
+      <description>Software engineer and tech blogger Joram Barrez discusses Flowable and CockroachDB, and how to best use the two together. Check out his tutorial below:
+ CockroachDB is a project I’ve been keeping an eye on for a while. It’s a an open-source, Apache 2 licensed, database system(Github link). At it’s core its a key-value store that scales horizontally. But what makes it really interesting for us though, is that 1) it supports SQL by using the Postgres wire protocol and 2) has full ACID semantics and distributed transactions.</description>
+    </item>
+    
+    <item>
+      <title>Roaches on Open Water! CockroachDB on DigitalOcean</title>
+      <link>https://www.cockroachlabs.com/blog/roaches-on-open-water-cockroachdb-on-digitalocean/</link>
+      <pubDate>Wed, 30 Nov 2016 19:02:53 +0000</pubDate>
+      <dc:creator>Sean Loiselle</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/roaches-on-open-water-cockroachdb-on-digitalocean/</guid>
+      <description>If you’re a fan of DigitalOcean and its powerful but simple platform to deploy cloud-based infrastructure, you’ll appreciate CockroachDB: it’s similarly simple to deploy and provides your stack a lot of power and flexibility. And while CockroachDB can be deployed anywhere, it’s a natural fit within DigitalOcean’s no-fuss framework: both are for developers who like easy-to-reason-about technology that lets them get work done quickly.
+Check out our office mascot Carl, who looks adorable in a costume clearly inspired by DigitalOcean’s Sammy the Shark.</description>
+    </item>
+    
+    <item>
+      <title>CockroachDB Stability Post-Mortem: From 1 Node to 100 Nodes</title>
+      <link>https://www.cockroachlabs.com/blog/cockroachdb-stability-from-1-node-to-100-nodes/</link>
+      <pubDate>Tue, 15 Nov 2016 17:00:14 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cockroachdb-stability-from-1-node-to-100-nodes/</guid>
+      <description>In August, we published a blog post entitled “Why Can’t I Run a 100-Node CockroachDB Cluster?”. The post outlined difficulties we encountered stabilizing CockroachDB. CockroachDB stability (or the lack of) had become significant enough that we designated it a “code yellow” issue, a concept borrowed from Google that means a problem is so pressing that it merits promotion to a primary concern of the company. For us, the code yellow was more than warranted; a database program isn’t worth the bytes to store its binary if it lacks stability.</description>
+    </item>
+    
+    <item>
+      <title>Memory Usage in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/memory-usage-cockroachdb/</link>
+      <pubDate>Thu, 10 Nov 2016 14:57:31 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/memory-usage-cockroachdb/</guid>
+      <description>In this blog post, we provide some details on how CockroachDB uses system memory on each node, and what you can do to keep memory usage in CockroachDB under control.
+Overview To understand memory usage in CockroachDB, and specifically within a CockroachDB node, it is perhaps useful to imagine memory like a giant cake that is being split up in pieces and distributed to “eat” CockroachDB’s various components.
+There are three main cake eaters in CockroachDB; in approximately decreasing order of appetite:</description>
+    </item>
+    
+    <item>
+      <title>How to Survive a Hackathon as a Sponsor</title>
+      <link>https://www.cockroachlabs.com/blog/surviving-a-hackathon-as-a-sponsor/</link>
+      <pubDate>Tue, 01 Nov 2016 18:58:44 +0000</pubDate>
+      <dc:creator>Jessica Edwards</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/surviving-a-hackathon-as-a-sponsor/</guid>
+      <description>Surviving a hackathon as a sponsor without becoming a complete zombie is no joke. To start, you’ll have plenty of practical, technical concerns that have to be sorted (How do you get people to try your product? Will the hackers be familiar with your application’s language?). But once you’ve got the technical issues taken care of, you’ll likely have nearly as many questions about how to keep your team as sane and functional as possible––despite running on limited sleep, consuming excessive caffeine, and likely being completely out of their comfort zones.</description>
+    </item>
+    
+    <item>
+      <title>Testing Random, Valid SQL in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/testing-random-valid-sql-in-cockroachdb/</link>
+      <pubDate>Wed, 19 Oct 2016 16:00:27 +0000</pubDate>
+      <dc:creator>Matt Jibson</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/testing-random-valid-sql-in-cockroachdb/</guid>
+      <description>Some months ago I started work on a way to test random SQL statements with CockroachDB. This is important to expose unintended behavior in our server. For example, we want to prevent valid SQL statements from unexpectedly crashing a server or using all of its CPU or memory.
+We have already performed some small-scale fuzz testing, but fuzz testing often produces un-parseable input since it modifies bytes (although some fuzzers like AFL do attempt to produce clean input).</description>
+    </item>
+    
+    <item>
+      <title>Running CockroachDB on Kubernetes</title>
+      <link>https://www.cockroachlabs.com/blog/running-cockroachdb-on-kubernetes/</link>
+      <pubDate>Tue, 11 Oct 2016 15:05:19 +0000</pubDate>
+      <dc:creator>Alex Robinson</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/running-cockroachdb-on-kubernetes/</guid>
+      <description>[Instructions updated on January 4, 2017.]
+At Cockroach Labs, we’re working hard to make it easier to keep your data safe and available even in the face of catastrophic failures. However, if you’ve ever been responsible for deploying and operating services in production, you know that there’s more involved in achieving high reliability than just starting up a few processes and stepping away from the keyboard, even for highly survivable applications like CockroachDB.</description>
+    </item>
+    
+    <item>
+      <title>Implementing Column Families in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/sql-cockroachdb-column-families/</link>
+      <pubDate>Thu, 29 Sep 2016 15:00:46 +0000</pubDate>
+      <dc:creator>Daniel Harrison</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/sql-cockroachdb-column-families/</guid>
+      <description>CockroachDB is a scalable SQL database built on top of a transactional key value store. We don’t (yet) expose the kv layer but it’s general purpose enough that we’ve used it to implement SQL without any special trickery.
+The particulars of how we represent data in a SQL table as well as the table metadata are internally called the “format version”. Our first format version was deliberately simple, causing some performance inefficiencies.</description>
+    </item>
+    
+    <item>
+      <title>How to Run CockroachDB on a Raspberry Pi</title>
+      <link>https://www.cockroachlabs.com/blog/run-cockroachdb-on-a-raspberry-pi/</link>
+      <pubDate>Mon, 19 Sep 2016 20:46:37 +0000</pubDate>
+      <dc:creator>Nathan VanBenschoten</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/run-cockroachdb-on-a-raspberry-pi/</guid>
+      <description>Scaling effortlessly over multiple nodes is one of the defining properties of CockroachDB. By maintaining a strongly-consistent database state across a network of machines, the distributed system can provide reliability and availability, while transparently tolerating disk, machine, and even datacenter failures. But not everyone has access to a datacenter at their fingertips, so we recently began looking into what it would take to run CockroachDB on a Raspberry Pi, one of the go-to tools of the modern day computer tinkerer.</description>
+    </item>
+    
+    <item>
+      <title>Why Can’t I Run a 100-Node CockroachDB Cluster?</title>
+      <link>https://www.cockroachlabs.com/blog/cant-run-100-node-cockroachdb-cluster/</link>
+      <pubDate>Thu, 25 Aug 2016 18:46:39 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cant-run-100-node-cockroachdb-cluster/</guid>
+      <description>CockroachDB is designed to be a scalable, survivable, and strongly consistent SQL database. Building a distributed system with these capabilities is a big task. Beyond the required functionality, it must also be correct, performant, and stable, or it isn’t worth the bits used to copy the binary.
+From the start, our approach was to focus first on correctness, as it always proves the most difficult to retrofit, next on performance for single nodes, and then on stability and performance for multi-node clusters.</description>
+    </item>
+    
+    <item>
+      <title>Squashing a Schrödinbug With Strong Typing</title>
+      <link>https://www.cockroachlabs.com/blog/squashing-a-schroedinbug-with-strong-typing/</link>
+      <pubDate>Thu, 18 Aug 2016 14:01:52 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/squashing-a-schroedinbug-with-strong-typing/</guid>
+      <description>Until recently, CockroachDB’s SQL was suffering from a serious, long-standing bug &amp;#8211; a schrödinbug, in fact &amp;#8211; in its handling of table and column references. This blog post outlines how fuzz testing uncovered the error, how we discovered that our way of using Go was partly to blame, and how we addressed the issue using a form of strong typing.
+tl;dr:
+ Fuzz testing is good. Don’t use the same type for different things.</description>
+    </item>
+    
+    <item>
+      <title>Launching the CockroachDB Community Forum</title>
+      <link>https://www.cockroachlabs.com/blog/launching-cockroachdb-community-forum/</link>
+      <pubDate>Wed, 10 Aug 2016 15:07:43 +0000</pubDate>
+      <dc:creator>Jessica Edwards</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/launching-cockroachdb-community-forum/</guid>
+      <description>As CockroachDB has grown over the last 30+ months of development, avenues for communicating between users and developers have proliferated. We started with GitHub, then created a Google Group, then an info@ email, then another Google Group, a Gitter room, and on we went.
+And while getting in touch with our developers is easier than ever (I suppose we don’t have Snapchat yet&amp;#8230;), we hadn’t made a concerted effort to centralize our community’s brainpower – but that’s changing!</description>
+    </item>
+    
+    <item>
+      <title>Modesty in Simplicity: CockroachDB&#39;s JOIN</title>
+      <link>https://www.cockroachlabs.com/blog/cockroachdbs-first-join/</link>
+      <pubDate>Wed, 20 Jul 2016 15:54:11 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cockroachdbs-first-join/</guid>
+      <description>CockroachDB&amp;#8217;s JOIN: An Early Implementation When our VP of engineering, Peter Mattis, made the decision in 2015 to support SQL, little did he know that the team would get as far as shipping the first implementation of CockroachDB&amp;#8217;s JOIN exactly one year after that. A celebration is in order!
+The good news is that CockroachDB’s JOIN seems to work, as in, “it returns correct results.”
+However, we’d like to underline that this is just our first, unoptimimized implementation.</description>
+    </item>
+    
+    <item>
+      <title>Consensus, Made Thrive</title>
+      <link>https://www.cockroachlabs.com/blog/consensus-made-thrive/</link>
+      <pubDate>Thu, 14 Jul 2016 14:22:02 +0000</pubDate>
+      <dc:creator>Tobias Schottdorf</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/consensus-made-thrive/</guid>
+      <description>When you write data to CockroachDB (for example, if you insert a row into a table through the SQL client), we take care of replication for you. To do this, we use a consensus protocol &amp;#8211; an algorithm which makes sure that your data is safely stored on multiple machines, and that those machines agree on the current state even if some of them are temporarily disconnected.
+In this post, I will give an overview of common implementation concerns and how we address these concerns in CockroachDB.</description>
+    </item>
+    
+    <item>
+      <title>Critters in a Jar: Running CockroachDB in a FreeBSD Jail</title>
+      <link>https://www.cockroachlabs.com/blog/critters-in-a-jar-running-cockroachdb-in-a-freebsd-jail/</link>
+      <pubDate>Thu, 07 Jul 2016 19:31:36 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/critters-in-a-jar-running-cockroachdb-in-a-freebsd-jail/</guid>
+      <description>Note: this blog post was updated on June 2, 2017.
+Jails are FreeBSD’s native solution to contain and isolate server processes. They are an alternative to (and predate) Linux cgroups, Solaris zones, and other OS-level process isolation technologies (the technologies that underlie Docker, CoreOS and a few others) .
+This blog post will explain how to natively run CockroachDB in a FreeBSD jail. This is lighter weight and as secure as running Docker on FreeBSD.</description>
+    </item>
+    
+    <item>
+      <title>Time-Travel Queries: SELECT witty_subtitle FROM THE FUTURE</title>
+      <link>https://www.cockroachlabs.com/blog/time-travel-queries-select-witty_subtitle-the_future/</link>
+      <pubDate>Wed, 22 Jun 2016 14:09:25 +0000</pubDate>
+      <dc:creator>Matt Jibson</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/time-travel-queries-select-witty_subtitle-the_future/</guid>
+      <description>In our most recent beta, we added a new feature: time-travel queries. These are `SELECT` queries where you can specify a timestamp, and the data returned will be the data as it was at that time. This has various uses including backups, undo, and historical reporting. The SQL:2011 standard describes this feature, and a few SQL databases (Oracle, MSSQL) have implemented it, in addition to various non-SQL DBs (Datomic). I&amp;#8217;d like to introduce this feature: what it is, why we built it, and details about how it works for those interested in CockroachDB&amp;#8217;s lower layers.</description>
+    </item>
+    
+    <item>
+      <title>Outsmarting Go Dependencies in Testing Code</title>
+      <link>https://www.cockroachlabs.com/blog/outsmarting-go-dependencies-testing-code/</link>
+      <pubDate>Thu, 16 Jun 2016 14:05:09 +0000</pubDate>
+      <dc:creator>Andrei Matei</dc:creator><dc:creator>Radu Berinde</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/outsmarting-go-dependencies-testing-code/</guid>
+      <description>Reading time: 9 minutes
+Writing good tests is tricky when the system has a lot of moving parts. When using Go’s testing infrastructure, tests that involve multiple modules can cause dependency cycles which are not allowed by the compiler. In this post we will go over a technique we devised to break these dependency cycles.
+Background The CockroachDB Go code base is split up into various packages; some of the major ones are:</description>
+    </item>
+    
+    <item>
+      <title>Revisiting SQL typing in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/revisiting-sql-typing-in-cockroachdb/</link>
+      <pubDate>Thu, 09 Jun 2016 19:15:37 +0000</pubDate>
+      <dc:creator>Nathan VanBenschoten</dc:creator><dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/revisiting-sql-typing-in-cockroachdb/</guid>
+      <description>Adopting a SQL interface for CockroachDB had an unexpected consequence; it forced us to dabble in language design.
+Most developers working with SQL have heard rumors of a SQL standard, pages upon pages of norms and requirements for all SQL compliant dialects to respect. Based on its existence, it’s natural to draw the conclusion that SQL is fully specified and straightforward to implement. A developer need only carefully follow each step laid out in the standard until they arrive at a working database.</description>
+    </item>
+    
+    <item>
+      <title>Building an Application With CockroachDB and SQLAlchemy</title>
+      <link>https://www.cockroachlabs.com/blog/building-application-cockroachdb-sqlalchemy-2/</link>
+      <pubDate>Wed, 01 Jun 2016 14:05:02 +0000</pubDate>
+      <dc:creator>Ben Darnell</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/building-application-cockroachdb-sqlalchemy-2/</guid>
+      <description>One of the great things about CockroachDB&amp;#8217;s support for SQL is the wide variety of frameworks and tools for working with SQL data. Today, we&amp;#8217;ll demonstrate this by building a simple application in Python, using SQLAlchemy and Flask.
+Adapting SQLAlchemy to CockroachDB Every SQL database is a little bit different, so a library like SQLAlchemy requires some code (called a dialect) to adapt its interface to the database in use.</description>
+    </item>
+    
+    <item>
+      <title>[community post] Running CockroachDB on DC/OS</title>
+      <link>https://www.cockroachlabs.com/blog/community-post-making-cockroaches-fly-high/</link>
+      <pubDate>Thu, 26 May 2016 14:05:24 +0000</pubDate>
+      <dc:creator>Community</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/community-post-making-cockroaches-fly-high/</guid>
+      <description>This week, Mesosphere Developer and Cloud Advocate Michael Hausenblas made it his mission to run CockroachDB on DC/OS. He covers the experience of using CockroachDB&amp;#8217;s Docker image, ramping up a DC/OS cluster, and testing data ingestion and querying in a post on Medium. The TL;DR? &amp;#8220;It&amp;#8217;s awesome.&amp;#8221;
+You can read the full post here: Making Cockroaches Fly High.</description>
+    </item>
+    
+    <item>
+      <title>[community post] Handling NULL Values in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/community-post-handling-null-values-cockroachdb/</link>
+      <pubDate>Wed, 25 May 2016 16:34:28 +0000</pubDate>
+      <dc:creator>Community</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/community-post-handling-null-values-cockroachdb/</guid>
+      <description>CockroachDB contributor Paul Steffensen (aka uptimeDBA) has analyzed CockroachDB&amp;#8217;s handling of NULL values as compared to the SQL standard and other SQL implementations. He shares his analysis in his blog post &amp;#8220;I&amp;#8217;ve got nothing. NULL handing in CockroachDB.&amp;#8221; You can read the full post here.</description>
+    </item>
+    
+    <item>
+      <title>Trust, But Verify: How CockroachDB Checks Replication</title>
+      <link>https://www.cockroachlabs.com/blog/trust-but-verify-cockroachdb-checks-replication/</link>
+      <pubDate>Thu, 19 May 2016 15:35:50 +0000</pubDate>
+      <dc:creator>Vivek Menezes</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/trust-but-verify-cockroachdb-checks-replication/</guid>
+      <description>We built survivability into the DNA of CockroachDB. And while we had a lot of fun doing so, and are confident that we have built a solution on a firm foundation, we felt a nagging concern: Does CockroachDB really survive? When data is written to the database, will a failure really not end up in data loss? So to assuage those concerns, we adopted a Russian maxim: “Dovorey, no provorey – Trust, but Verify.</description>
+    </item>
+    
+    <item>
+      <title>A Tale of Two Ports</title>
+      <link>https://www.cockroachlabs.com/blog/a-tale-of-two-ports/</link>
+      <pubDate>Wed, 11 May 2016 14:10:15 +0000</pubDate>
+      <dc:creator>Tamir Duberstein</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/a-tale-of-two-ports/</guid>
+      <description>CockroachDB is pretty easy to deploy. We&amp;#8217;ve done our best to avoid the need for configuration files, mandatory environment variables, and copious command line flags, and it shows; we&amp;#8217;ve already had testimonials from folks who were able to deploy a 20-node cluster in just half a day. That&amp;#8217;s something to be proud of!
+However, there is still one wrinkle in the fabric, and that&amp;#8217;s our use of network ports. As of this writing, CockroachDB requires two ports, but why, and can we do better?</description>
+    </item>
+    
+    <item>
+      <title>Serializable, Lockless, Distributed: Isolation in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/serializable-lockless-distributed-isolation-cockroachdb/</link>
+      <pubDate>Wed, 04 May 2016 14:09:06 +0000</pubDate>
+      <dc:creator>Matt Tracy</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/serializable-lockless-distributed-isolation-cockroachdb/</guid>
+      <description>Several months ago, I discussed how CockroachDB’s distributed transactions are executed atomically. However, that discussion was incomplete; it ignored the concept of concurrency, where multiple transactions are active on the same data set at the same time. CockroachDB, like all database systems, tries to allow as much concurrency as possible in order to maximize access to the data set.
+Unfortunately, our atomicity guarantee is not sufficient to keep the database consistent in a world of concurrent transactions.</description>
+    </item>
+    
+    <item>
+      <title>From 5 to 500: Lessons Learned Hiring for Startups</title>
+      <link>https://www.cockroachlabs.com/blog/5-500-lessons-learned-hiring-for-startups/</link>
+      <pubDate>Wed, 27 Apr 2016 15:42:16 +0000</pubDate>
+      <dc:creator>Lindsay Grenawalt</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/5-500-lessons-learned-hiring-for-startups/</guid>
+      <description>Most founders agree that one of the greatest challenges that they face isn’t raising money or closing deals or finding partners. It’s finding people. In particular, finding great people who are interested and eager to take a chance on a startup. Turns out, hiring for startups is hard. 
+Early in my career, I was at Google and had a candidate who had offers from DE Shaw, Two Sigma, and Jane Street Capital.</description>
+    </item>
+    
+    <item>
+      <title>Index selection in CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/</link>
+      <pubDate>Thu, 21 Apr 2016 15:00:18 +0000</pubDate>
+      <dc:creator>Radu Berinde</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/</guid>
+      <description>In an earlier post we discussed how CockroachDB maps SQL table data and table indexes to key-value storage. In this post, we will go over some of the factors involved in choosing the best index to use for running a certain query.
+Introduction to indexes Tables are internally organized according to a certain column (or group of columns); this makes searching for rows according to values in that column or column group very efficient, even if the table contains a large number of rows.</description>
+    </item>
+    
+    <item>
+      <title>DIY Jepsen Testing CockroachDB</title>
+      <link>https://www.cockroachlabs.com/blog/diy-jepsen-testing-cockroachdb/</link>
+      <pubDate>Thu, 14 Apr 2016 14:55:58 +0000</pubDate>
+      <dc:creator>Raphael ‘kena’ Poss</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/diy-jepsen-testing-cockroachdb/</guid>
+      <description>img { display: block; margin-left: auto; margin-right: auto; } pre { white-space: pre-wrap; }  We at Cockroach Labs absolutely love Aphyr’s work. We are avid readers of the Jepsen series – which some know as a high quality review of the correctness and consistency claims of modern database systems, but which we really know as “Aphyr’s hunting tales about the highest profile bugs in our industry.” Most of us read each new blog entry with a mix of thrill, excitement, and curiosity about which new system will be eviscerated and which exotic error will be discovered next.</description>
+    </item>
+    
+    <item>
+      <title>CockroachDB Skitters into Beta</title>
+      <link>https://www.cockroachlabs.com/blog/cockroachdb-skitters-beta/</link>
+      <pubDate>Wed, 30 Mar 2016 14:45:53 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/cockroachdb-skitters-beta/</guid>
+      <description>We introduced Cockroach Labs last June with a simple yet ambitious mission: Make Data Easy.
+We’ve spent the intervening months moving CockroachDB from an alpha stage product to launching CockroachDB beta. In the process, the team has nearly tripled in size and development has accelerated to a blistering pace. We’ve supplemented our original investment led by Peter Fenton of Benchmark with an additional round of funding, led by Mike Volpi of Index Ventures.</description>
+    </item>
+    
+    <item>
+      <title>Creating a Digestible GitHub Digest</title>
+      <link>https://www.cockroachlabs.com/blog/creating-a-digestible-github-digest/</link>
+      <pubDate>Wed, 23 Mar 2016 13:00:30 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/creating-a-digestible-github-digest/</guid>
+      <description>If you&amp;#8217;ve ever &amp;#8220;watched&amp;#8221; a busy GitHub repository, your email inbox has discovered what it feels like to step in front of a firehose. If the project in question has active code reviewers, the problem is often worse by an order of magnitude. Every comment yields another email to all watchers. The CockroachDB repository’s weekly average is at 81 pull requests and 440 notification-generating comments.
+Most of us who once paid close attention to incoming changes have since lost the ability to do so; these days, monitoring the stream requires a superhuman effort.</description>
+    </item>
+    
+    <item>
+      <title>Efficient Documentation Using SQL Grammar Diagrams</title>
+      <link>https://www.cockroachlabs.com/blog/efficient-documentation-using-sql-grammar-diagrams/</link>
+      <pubDate>Wed, 16 Mar 2016 13:00:31 +0000</pubDate>
+      <dc:creator>Matt Jibson</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/efficient-documentation-using-sql-grammar-diagrams/</guid>
+      <description>As CockroachDB approaches beta, user documentation has become increasingly important, and one of the meatiest requirements is documentation of our SQL implementation. For inspiration, I researched how other databases have documented SQL. The most effective example I found was SQLite’s grammar diagrams.Figure 1: Example of the alter table statement in SQLite&amp;#8217;s grammar diagrams.
+These diagrams feature easy-to-understand railroad diagrams showing the possible options for a SQL statement. Compared to a text representation, these visual diagrams give users an intuitive way to explore the grammar and discover features.</description>
+    </item>
+    
+    <item>
+      <title>Adventures in Performance Debugging</title>
+      <link>https://www.cockroachlabs.com/blog/adventures-performance-debugging/</link>
+      <pubDate>Fri, 11 Mar 2016 14:00:27 +0000</pubDate>
+      <dc:creator>Peter Mattis</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/adventures-performance-debugging/</guid>
+      <description>As we’ve built CockroachDB, correctness has been our primary concern. But as we’ve drawn closer to our beta launch, we’ve had to start paying significantly more attention to performance. The design of CockroachDB always kept performance and scalability in mind, but when you start measuring performance, there are inevitably surprises. This is the story of the detection, investigation, and fix of just one performance bug.
+First, a little context about CockroachDB for those new to the project.</description>
+    </item>
+    
+    <item>
+      <title>Living Without Atomic Clocks</title>
+      <link>https://www.cockroachlabs.com/blog/living-without-atomic-clocks/</link>
+      <pubDate>Wed, 17 Feb 2016 15:01:25 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/living-without-atomic-clocks/</guid>
+      <description>It&amp;#8217;s a fact that the design of CockroachDB is based on Google&amp;#8217;s Spanner data storage system. One of the most surprising and inspired facets of Spanner is its use of atomic clocks and GPS clocks to give participating nodes really accurate wall time synchronization. The designers of Spanner call this &amp;#8216;TrueTime&amp;#8217;, and it provides a tight bound on clock offset between any two nodes in the system. TrueTime enables high levels of external consistency.</description>
+    </item>
+    
+    <item>
+      <title>What can we learn from our GitHub stars?</title>
+      <link>https://www.cockroachlabs.com/blog/what-can-we-learn-from-our-github-stars/</link>
+      <pubDate>Wed, 10 Feb 2016 15:22:37 +0000</pubDate>
+      <dc:creator>Spencer Kimball</dc:creator>
+      <guid>https://www.cockroachlabs.com/blog/what-can-we-learn-from-our-github-stars/</guid>
+      <description>It’s been almost two years since CockroachDB became a GitHub project. In that time, the project has racked up more than 6,000 GitHub stars, which is a simple way for GitHub users to bookmark repositories that interest them. Naturally, we’ve wondered how people find out about our project. Are there things we could do to accelerate awareness and interest?
+I decided to dedicate my Free Friday (our version of 20% time) to stargazers, a tool to query the CockroachDB repository for information about its GitHub stars and analyze the results.</description>
+    </item>
+    
+  </channel>
+</rss>

--- a/_plugins/rss_data.rb
+++ b/_plugins/rss_data.rb
@@ -1,0 +1,18 @@
+require 'rss'
+
+module RSSData
+  class Generator < Jekyll::Generator
+    def generate(site)
+      Dir[File.join(site.config['data_dir'], '*.xml')].each do |f|
+        site.data[File.basename(f, '.*')] = RSS::Parser.parse(File.read(f)).items.map do |item|
+          {
+            'title' => item.title,
+            'link' => item.link,
+            'pub_date' => item.pubDate,
+            'creator' => item.dc_creator
+          }
+        end
+      end
+    end
+  end
+end

--- a/v1.0/index.md
+++ b/v1.0/index.md
@@ -83,57 +83,21 @@ CockroachDB is an open source database for building global, scalable cloud servi
 
 ## [Recent Blog Posts](https://www.cockroachlabs.com/blog/)
 
+{% for post in site.data.blog_posts limit:5 %}
 <div class="row">
     <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/">
-        <div class="blog-post">
-            <div class="blog-title">On the Way to Better SQL Joins in CockroachDB</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Raphael Poss</span> on <span class="meta-emphasis">Feb 9, 2017</span></div>
+        <a href="{{ post.link }}">
+        <div class="blog-post {% if forloop.last %}last-entry{% endif %}">
+            <div class="blog-title">{{ post.title }}</div>
+            <div class="blog-meta">
+                Written by <span class="meta-emphasis">{{ post.creator }}</span>
+                on <span class="meta-emphasis">{{ post.pub_date | date:'%b %-d, %Y' }}</span>
+            </div>
         </div>
         </a>
     </div>
 </div>
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/journey-to-design-for-enterprise/">
-        <div class="blog-post">
-            <div class="blog-title">Journey to Design for Enterprise</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Kuan Luo</span> on <span class="meta-emphasis">Feb 2, 2017</span></div>
-        </div>
-        </a>
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/fighting-unconscious-bias-cockroach-labs/">
-        <div class="blog-post">
-            <div class="blog-title">How We're Fighting Unconscious Bias</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Lindsay Grenawalt</span> on <span class="meta-emphasis">Jan 26, 2017</span></div>
-        </div>
-        </a>
-    </div>
-</div>
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/">
-        <div class="blog-post">
-            <div class="blog-title">How We're Building a Business to Last</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Spencer Kimball</span> on <span class="meta-emphasis">Jan 19, 2017</span></div>
-        </div>
-        </a>
-    </div>
-</div>
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/enriching-log-messages-using-go-contexts/">
-        <div class="blog-post last-entry">
-            <div class="blog-title">Enriching Log Messages Using Go Contexts</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Radu Berinde</span> on <span class="meta-emphasis">Dec 15, 2016</span></div>
-        </div>
-        </a>
-    </div>
-</div>
+{% endfor %}
 <div class="row">
     <div class="col-xs-12">
         <div class="view-blog"><a href="https://www.cockroachlabs.com/blog">View All Posts</a></div>

--- a/v1.1/index.md
+++ b/v1.1/index.md
@@ -83,57 +83,21 @@ CockroachDB is an open source database for building global, scalable cloud servi
 
 ## [Recent Blog Posts](https://www.cockroachlabs.com/blog/)
 
+{% for post in site.data.blog_posts limit:5 %}
 <div class="row">
     <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/">
-        <div class="blog-post">
-            <div class="blog-title">On the Way to Better SQL Joins in CockroachDB</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Raphael Poss</span> on <span class="meta-emphasis">Feb 9, 2017</span></div>
+        <a href="{{ post.link }}">
+        <div class="blog-post {% if forloop.last %}last-entry{% endif %}">
+            <div class="blog-title">{{ post.title }}</div>
+            <div class="blog-meta">
+                Written by <span class="meta-emphasis">{{ post.creator }}</span>
+                on <span class="meta-emphasis">{{ post.pub_date | date:'%b %-d, %Y' }}</span>
+            </div>
         </div>
         </a>
     </div>
 </div>
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/journey-to-design-for-enterprise/">
-        <div class="blog-post">
-            <div class="blog-title">Journey to Design for Enterprise</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Kuan Luo</span> on <span class="meta-emphasis">Feb 2, 2017</span></div>
-        </div>
-        </a>
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/fighting-unconscious-bias-cockroach-labs/">
-        <div class="blog-post">
-            <div class="blog-title">How We're Fighting Unconscious Bias</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Lindsay Grenawalt</span> on <span class="meta-emphasis">Jan 26, 2017</span></div>
-        </div>
-        </a>
-    </div>
-</div>
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/how-were-building-a-business-to-last/">
-        <div class="blog-post">
-            <div class="blog-title">How We're Building a Business to Last</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Spencer Kimball</span> on <span class="meta-emphasis">Jan 19, 2017</span></div>
-        </div>
-        </a>
-    </div>
-</div>
-<div class="row">
-    <div class="col-xs-12">
-        <a href="https://www.cockroachlabs.com/blog/enriching-log-messages-using-go-contexts/">
-        <div class="blog-post last-entry">
-            <div class="blog-title">Enriching Log Messages Using Go Contexts</div>
-            <div class="blog-meta">Written by <span class="meta-emphasis">Radu Berinde</span> on <span class="meta-emphasis">Dec 15, 2016</span></div>
-        </div>
-        </a>
-    </div>
-</div>
+{% endfor %}
 <div class="row">
     <div class="col-xs-12">
         <div class="view-blog"><a href="https://www.cockroachlabs.com/blog">View All Posts</a></div>


### PR DESCRIPTION
This should make it easier to keep them up to date via a new shortcut,
`rake blog_posts`.

@jseldess thought this might make your life a little easier.