### PR TITLE
preserve dots when copying to clipboard

### DIFF
--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -250,7 +250,7 @@ $(function() {
     },
     text: function(trigger) {
       var text = $(trigger).next().find('code').text();
-      text = text.replace(/\\\n(?=.)|(^[\r\n]+|\.|[\r\n]+$)/g, '');
+      text = text.replace(/\\\n(?=.)|(^[\r\n]+|[\r\n]+$)/g, '');
       return text;
     }
   });


### PR DESCRIPTION
Looks like the copy-to-clipboard sanitizing regex was sourced from a StackOverflow question titled "Regex for removing leading and trailing carriage returns and line feeds from a sentence" (https://stackoverflow.com/a/2550845/1122351), but the question text sneakily also asked for the solution to combine this with "removing periods from within the string."

We want to keep these dots when copying to the clipboard, so remove the part of the regex that strips these dots.