### PR TITLE
Spelling fix in 1.1 data replication tutorial

### DIFF
--- a/v1.1/demo-data-replication.md
+++ b/v1.1/demo-data-replication.md
@@ -191,7 +191,7 @@ $ cockroach start --insecure \
 --join=localhost:26257
 ~~~
 
-In a new termional, add node 5:
+In a new terminal, add node 5:
 
 {% include copy-clipboard.html %}
 ~~~ shell


### PR DESCRIPTION
Follow-up to https://github.com/cockroachdb/docs/pull/1658.