### PR TITLE
Rework node cert workflow in cert and deployment docs

### DIFF
--- a/v1.0/create-security-certificates.md
+++ b/v1.0/create-security-certificates.md
@@ -96,11 +96,14 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 ### Create the CA certificate and key pair
 
-1. Create a safe directory for the CA key:
+1. Create two directories:
 
     ~~~ shell
+    $ mkdir certs
     $ mkdir my-safe-directory
     ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Generate the CA certificate and key:
 
@@ -113,12 +116,13 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     ~~~
 
     ~~~
-    -rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
+    total 8
+    -rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
     ~~~
 
 ### Create the certificate and key pairs for nodes
 
-1. Create the certificate and key for the first node:
+1. Generate the certificate and key for the first node:
 
     ~~~ shell
     $ cockroach cert create-node \
@@ -131,35 +135,74 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     ~~~
 
     ~~~
-    -rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
-    -rw-r--r--  1 maxroach  maxroach  1.2K Apr 19 09:36 node.crt
-    -rw-------  1 maxroach  maxroach  1.6K Apr 19 09:36 node.key
+    total 24
+    -rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
+    -rw-r--r--  1 maxroach  maxroach  1.2K Jul 10 14:16 node.crt
+    -rw-------  1 maxroach  maxroach  1.6K Jul 10 14:16 node.key
     ~~~
 
-2. Upload the files to the first node.
+2. Upload certificates to the first node:
 
-3. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node1 address> "mkdir certs"
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Upload the CA certificate and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node1 address>:~/certs
+    ~~~
+
+3. Delete the local copy of the first node's certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+4. Create the certificate and key for the second node:
 
     ~~~ shell
     $ cockroach cert create-node \
     node2.example.com \
     node2.another-example.com \
     --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key \
-    --overwrite
+    --ca-key=my-safe-directory/ca.key
 
     $ ls -l certs
     ~~~
 
     ~~~
-    -rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
-    -rw-r--r--  1 maxroach  maxroach  1.2K Apr 19 09:40 node.crt
-    -rw-------  1 maxroach  maxroach  1.6K Apr 19 09:40 node.key
+    total 24
+    -rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
+    -rw-r--r--  1 maxroach  maxroach  1.2K Jul 10 14:17 node.crt
+    -rw-------  1 maxroach  maxroach  1.6K Jul 10 14:17 node.key
     ~~~
 
-4. Upload the files to the second node.
+5. Upload certificates to the second node:
 
-5. Repeat for each additional node.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node2 address> "mkdir certs"
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Upload the CA certificate and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node2 address>:~/certs
+    ~~~
+
+6. Repeat steps 3 - 5 for each additional node.
 
 ### Create the certificate and key pair for a client
 
@@ -173,11 +216,12 @@ $ ls -l certs
 ~~~
 
 ~~~
--rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
--rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:39 client.maxroach.crt
--rw-------  1 maxroach  maxroach  1.6K Apr 19 09:39 client.maxroach.key
--rw-r--r--  1 maxroach  maxroach  1.2K Apr 19 09:36 node.crt
--rw-------  1 maxroach  maxroach  1.6K Apr 19 09:36 node.key
+total 40
+-rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
+-rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:13 client.maxroach.crt
+-rw-------  1 maxroach  maxroach  1.6K Jul 10 14:13 client.maxroach.key
+-rw-r--r--  1 maxroach  maxroach  1.2K Jul 10 14:17 node.crt
+-rw-------  1 maxroach  maxroach  1.6K Jul 10 14:17 node.key
 ~~~
 
 ### List certificates and keys
@@ -189,13 +233,14 @@ $ cockroach cert list \
 
 ~~~
 Certificate directory: certs
-+-----------------------+---------------------+---------------------+---------------+
-|         Usage         |  Certificate File   |      Key File       |     Notes     |
-+-----------------------+---------------------+---------------------+---------------+
-| Certificate Authority | ca.crt              |                     |               |
-| Node                  | node.crt            | node.key            |               |
-| Client                | client.maxroach.crt | client.maxroach.key | user=maxroach |
-+-----------------------+---------------------+---------------------+---------------+
++-----------------------+---------------------+---------------------+------------+--------------------------------------------------------+-------+
+|         Usage         |  Certificate File   |      Key File       |  Expires   |                         Notes                          | Error |
++-----------------------+---------------------+---------------------+------------+--------------------------------------------------------+-------+
+| Certificate Authority | ca.crt              |                     | 2027/07/18 | num certs: 1                                           |       |
+| Node                  | node.crt            | node.key            | 2022/07/14 | addresses: node2.example.com,node2.another-example.com |       |
+| Client                | client.maxroach.crt | client.maxroach.key | 2022/07/14 | user: maxroach                                         |       |
++-----------------------+---------------------+---------------------+------------+--------------------------------------------------------+-------+
+(3 rows)
 ~~~
 
 ## See Also

--- a/v1.0/create-security-certificates.md
+++ b/v1.0/create-security-certificates.md
@@ -98,8 +98,13 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
@@ -107,11 +112,15 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 2. Generate the CA certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ ls -l certs
     ~~~
 
@@ -124,13 +133,17 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 1. Generate the certificate and key for the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     node1.example.com \
     node1.another-example.com \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ ls -l certs
     ~~~
 
@@ -160,6 +173,7 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 3. Delete the local copy of the first node's certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -168,13 +182,17 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 4. Create the certificate and key for the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     node2.example.com \
     node2.another-example.com \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ ls -l certs
     ~~~
 
@@ -206,12 +224,16 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 ### Create the certificate and key pair for a client
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach cert create-client \
 maxroach \
 --certs-dir=certs \
 --ca-key=my-safe-directory/ca.key
+~~~
 
+{% include copy-clipboard.html %}
+~~~ shell
 $ ls -l certs
 ~~~
 
@@ -226,6 +248,7 @@ total 40
 
 ### List certificates and keys
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach cert list \
 --certs-dir=certs

--- a/v1.0/deploy-cockroachdb-on-aws.md
+++ b/v1.0/deploy-cockroachdb-on-aws.md
@@ -98,13 +98,15 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user (`client.root.crt` and `client.root.key`)
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
 - A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the AWS load balancer (`node.crt` and `node.key`)
+- A client key pair for the `root` user (`client.root.crt` and `client.root.key`).
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -115,24 +117,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
     - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
@@ -161,7 +153,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     - `<load balancer IP address>`
     - `<load balancer hostname>`
 
-5. Upload the certificates to the first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -171,11 +163,9 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node1 external IP address>:~/certs
@@ -207,7 +197,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -215,20 +205,29 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     $ ssh -i <path to AWS .pem> <username>@<node2 external IP address> "mkdir certs"
     ~~~
 
-
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node2 external IP address>:~/certs
     ~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 5. Start the first node
 
@@ -317,41 +316,33 @@ At this point, your cluster is live and operational but contains only a single n
 
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to your first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh -i <path to AWS .pem> <username>@<node2 external IP address>
-    ~~~
-
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the external IP address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node1 external IP address>
     ~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. In another terminal window, SSH to another node:
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh -i <path to AWS .pem> <username>@<node3 external IP address>
-    ~~~
-
-4. Launch the built-in SQL client:
+4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external IP address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node2 external IP address>
     ~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
@@ -380,11 +371,9 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 The AWS load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
+1. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -393,7 +382,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     --host=<load balancer IP address>
     ~~~
 
-3. View the cluster's databases:
+2. View the cluster's databases:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -415,7 +404,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
     As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
-4. Check which node you were redirected to:
+3. Check which node you were redirected to:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -431,7 +420,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     (1 row)
     ~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-aws.md
+++ b/v1.0/deploy-cockroachdb-on-aws.md
@@ -106,8 +106,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -115,6 +120,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
@@ -123,6 +129,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-client \
     root \
@@ -132,6 +139,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node1 internal IP address> \
@@ -145,20 +153,24 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
-  - `<node1 internal IP address>` which is the instance's **Internal IP**.
-  - `<node1 external IP address>` which is the instance's **External IP address**.
-  - `<node1 hostname>` which is the instance's hostname. You can find this by SSHing into a server and running `hostname`. For many AWS EC2 servers, this is `ip-` followed by the internal IP address delimited by dashes; e.g., `ip-172-31-18-168`.
-  - `<other common names for node1>` which include any domain names you point to the instance.
-  - `localhost` and `127.0.0.1`
-  - `<load balancer IP address>`
-  - `<load balancer hostname>`
+    - `<node1 internal IP address>` which is the instance's **Internal IP**.
+    - `<node1 external IP address>` which is the instance's **External IP address**.
+    - `<node1 hostname>` which is the instance's hostname. You can find this by SSHing into a server and running `hostname`. For many AWS EC2 servers, this is `ip-` followed by the internal IP address delimited by dashes; e.g., `ip-172-31-18-168`.
+    - `<other common names for node1>` which include any domain names you point to the instance.
+    - `localhost` and `127.0.0.1`
+    - `<load balancer IP address>`
+    - `<load balancer hostname>`
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh -i <path to AWS .pem> <username>@<node1 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
@@ -171,6 +183,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -179,6 +192,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node2 internal IP address> \
@@ -195,10 +209,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh -i <path to AWS .pem> <username>@<node2 external IP address> "mkdir certs"
+    ~~~
 
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
@@ -215,26 +234,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh -i <path to AWS .pem> <username>@<node1 external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background \
     --certs-dir=certs \
@@ -247,26 +275,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~
     $ ssh -i <path to AWS .pem> <username>@<additional node external IP address>
     ~~~
 
 2. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background  \
     --certs-dir=certs \
@@ -284,29 +321,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh -i <path to AWS .pem> <username>@<node2 external IP address>
     ~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
     ~~~
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh -i <path to AWS .pem> <username>@<node3 external IP address>
     ~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
@@ -314,9 +356,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -342,6 +386,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs \
@@ -350,9 +395,11 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 3. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -365,13 +412,16 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     +--------------------+
     (5 rows)
     ~~~
+
     As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
 4. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
     ~~~
+
     ~~~
     +---------+
     | node_id |

--- a/v1.0/deploy-cockroachdb-on-aws.md
+++ b/v1.0/deploy-cockroachdb-on-aws.md
@@ -104,12 +104,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
     ~~~ shell
     $ mkdir certs
     $ mkdir my-safe-directory
     ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -167,10 +169,18 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node1 external IP address>:~/certs
     ~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
 
     ~~~ shell
-    $ cockroach cert create-node --overwrite\
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
+
+    ~~~ shell
+    $ cockroach cert create-node \
     <node2 internal IP address> \
     <node2 external IP address> \
     <node2 hostname>  \
@@ -183,7 +193,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
     ~~~ shell
     # Create the certs directory:
@@ -199,7 +209,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node2 external IP address>:~/certs
     ~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 

--- a/v1.0/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.0/deploy-cockroachdb-on-digital-ocean.md
@@ -29,8 +29,8 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 - Set up your Droplets using [private networking](https://www.digitalocean.com/community/tutorials/how-to-set-up-and-use-digitalocean-private-networking).
 
 - Decide how you want to access your Admin UI:
-	- Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-	- Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+    - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
+    - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
 
 ## Step 1. Create Droplets
 
@@ -50,8 +50,8 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 Digital Ocean offers fully-managed load balancers to distribute traffic between Droplets.
 
 1. [Create a Digital Ocean Load Balancer](https://www.digitalocean.com/community/tutorials/an-introduction-to-digitalocean-load-balancers). Be sure to:
-	- Set forwarding rules to route TCP traffic from the load balancer's port **26257** to port **26257** on the node Droplets.
-	- Configure health checks to use HTTP port **8080** and path `/health`.
+    - Set forwarding rules to route TCP traffic from the load balancer's port **26257** to port **26257** on the node Droplets.
+    - Configure health checks to use HTTP port **8080** and path `/health`.
 2. Note the provisioned **IP Address** for the load balancer. You'll use this later to test load balancing and to connect your application to the cluster.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Digital Ocean's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
@@ -81,131 +81,140 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
-	~~~ shell
-	$ mkdir certs
-	$ mkdir my-safe-directory
-	~~~
+    ~~~ shell
+    $ mkdir certs
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
-	~~~ shell
-	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ cockroach cert create-ca \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
 3. Create a client key pair for the `root` user:
 
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
+    - `<node internal IP address>`, which is the node Droplet's **Private IP**.
+    - `<node external IP address>`, which is the node Droplet's **ipv4** address.
+    - `<node hostname>`, which is the node Droplet's **Name**.
+    - `<other common names for node>`, which include any domain names you point to the node Droplet.
+    - `localhost` and `127.0.0.1`
+    - `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
+    - `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
 
-	- `<node internal IP address>`, which is the node Droplet's **Private IP**.
-	- `<node external IP address>`, which is the node Droplet's **ipv4** address.
-	- `<node hostname>`, which is the node Droplet's **Name**.
-	- `<other common names for node>`, which include any domain names you point to the node Droplet.
-	- `localhost` and `127.0.0.1`
-	- `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
-	- `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
-
-	~~~ shell
-	$ cockroach cert create-node \
-	<node1 internal IP address> \
-	<node1 external IP address> \
-	<node1 hostname>  \
-	<other common names for node1> \
-	localhost \
-	127.0.0.1 \
-	<load balancer IP address> \
-	<load balancer hostname> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ cockroach cert create-node \
+    <node1 internal IP address> \
+    <node1 external IP address> \
+    <node1 hostname>  \
+    <other common names for node1> \
+    localhost \
+    127.0.0.1 \
+    <load balancer IP address> \
+    <load balancer hostname> \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
 5. Upload the certificates to the first node:
 
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node1 external IP address> "mkdir certs"
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node1 external IP address> "mkdir certs"
 
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node1 external IP address>:~/certs
-	~~~
+    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/client.root.crt \
+    certs/client.root.key \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node1 external IP address>:~/certs
+    ~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
 
-	~~~ shell
-	$ cockroach cert create-node --overwrite\
-	<node2 internal IP address> \
-	<node2 external IP address> \
-	<node2 hostname>  \
-	<other common names for node2> \
-	localhost \
-	127.0.0.1 \
-	<load balancer IP address> \
-	<load balancer hostname> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
 
-7. Upload the certificates to the second node:
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
 
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node2 external IP address> "mkdir certs"
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
 
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node2 external IP address>:~/certs
-	~~~
+    ~~~ shell
+    $ cockroach cert create-node \
+    <node2 internal IP address> \
+    <node2 external IP address> \
+    <node2 hostname>  \
+    <other common names for node2> \
+    localhost \
+    127.0.0.1 \
+    <load balancer IP address> \
+    <load balancer hostname> \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+8. Upload the certificates to the second node:
+
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node2 external IP address> "mkdir certs"
+
+    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/client.root.crt \
+    certs/client.root.key \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node2 external IP address>:~/certs
+    ~~~
+
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 
 1. SSH to your Droplet:
 
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
+    ~~~ shell
+    $ ssh <username>@<node1 external IP address>
+    ~~~
 
 2. Install the latest CockroachDB binary:
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~ shell
+    # Get the latest CockroachDB tarball.
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    # Extract the binary.
+    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
 
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
+    # Move the binary.
+    $ sudo mv cockroach /usr/local/bin
+    ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
-	~~~ shell
-	$ cockroach start --background \
-	--certs-dir=certs \
-	--advertise-host=<node1 internal IP address>
-	~~~
+    ~~~ shell
+    $ cockroach start --background \
+    --certs-dir=certs \
+    --advertise-host=<node1 internal IP address>
+    ~~~
 
 ## Step 6. Add nodes to the cluster
 
@@ -213,32 +222,32 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your Droplet:
 
-	~~~
-	$ ssh <username>@<additional node external IP address>
-	~~~
+    ~~~
+    $ ssh <username>@<additional node external IP address>
+    ~~~
 
 2. Install the latest CockroachDB binary:
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~ shell
+    # Get the latest CockroachDB tarball.
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    # Extract the binary.
+    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
 
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
+    # Move the binary.
+    $ sudo mv cockroach /usr/local/bin
+    ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
-	~~~ shell
-	$ cockroach start --background  \
-	--certs-dir=certs \
-	--advertise-host=<node internal IP address> \
-	--join=<node1 internal IP address>:26257
-	~~~
+    ~~~ shell
+    $ cockroach start --background  \
+    --certs-dir=certs \
+    --advertise-host=<node internal IP address> \
+    --join=<node1 internal IP address>:26257
+    ~~~
 
 4. Repeat these steps for each Droplet you want to use as a node.
 
@@ -250,52 +259,52 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
+    ~~~ shell
+    $ ssh <username>@<node1 external IP address>
+    ~~~
 
 2. Launch the built-in SQL client and create a database:
 
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs
-	~~~
+    ~~~ shell
+    $ cockroach sql \
+    --certs-dir=certs
+    ~~~
 
-	~~~ sql
-	> CREATE DATABASE securenodetest;
-	~~~
+    ~~~ sql
+    > CREATE DATABASE securenodetest;
+    ~~~
 
 3. In another terminal window, SSH to another node:
 
-	~~~ shell
-	$ ssh <username>@<node3 external IP address>
-	~~~
+    ~~~ shell
+    $ ssh <username>@<node3 external IP address>
+    ~~~
 
 4. Launch the built-in SQL client:
 
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs
-	~~~
+    ~~~ shell
+    $ cockroach sql \
+    --certs-dir=certs
+    ~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
 
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
+    ~~~ sql
+    > SHOW DATABASES;
+    ~~~
 
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
+    ~~~
+    +--------------------+
+    |      Database      |
+    +--------------------+
+    | crdb_internal      |
+    | information_schema |
+    | securenodetest     |
+    | pg_catalog         |
+    | system             |
+    +--------------------+
+    (5 rows)
+    ~~~
 
 6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
@@ -307,45 +316,45 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
 
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<load balancer IP address>
-	~~~
+    ~~~ shell
+    $ cockroach sql \
+    --certs-dir=certs \
+    --host=<load balancer IP address>
+    ~~~
 
 2. View the cluster's databases:
 
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
+    ~~~ sql
+    > SHOW DATABASES;
+    ~~~
+    ~~~
+    +--------------------+
+    |      Database      |
+    +--------------------+
+    | crdb_internal      |
+    | information_schema |
+    | securenodetest     |
+    | pg_catalog         |
+    | system             |
+    +--------------------+
+    (5 rows)
+    ~~~
 
-	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
+    As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
 3. Check which node you were redirected to:
 
-	~~~ sql
-	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
-	~~~
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
+    ~~~ sql
+    > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
+    ~~~
+    ~~~
+    +---------+
+    | node_id |
+    +---------+
+    |       3 |
+    +---------+
+    (1 row)
+    ~~~
 
 4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
@@ -359,7 +368,7 @@ On this page, verify that the cluster is running as expected:
 
 1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
 
-	Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--advertise-host` flag to the Droplet's internal IP address. This prevents the node from receiving replicas and working as part of the cluster.
+    Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--advertise-host` flag to the Droplet's internal IP address. This prevents the node from receiving replicas and working as part of the cluster.
 
 2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
 

--- a/v1.0/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.0/deploy-cockroachdb-on-digital-ocean.md
@@ -83,8 +83,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -92,6 +97,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
@@ -100,6 +106,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-client \
     root \
@@ -116,6 +123,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     - `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
     - `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node1 internal IP address> \
@@ -132,10 +140,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node1 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
@@ -147,6 +159,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -155,6 +168,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node2 internal IP address> \
@@ -171,10 +185,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node2 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
@@ -190,26 +208,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. SSH to your Droplet:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background \
     --certs-dir=certs \
@@ -222,26 +249,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your Droplet:
 
+    {% include copy-clipboard.html %}
     ~~~
     $ ssh <username>@<additional node external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background  \
     --certs-dir=certs \
@@ -259,29 +295,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
     ~~~
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node3 external IP address>
     ~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
@@ -289,6 +330,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
@@ -316,6 +358,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs \
@@ -324,9 +367,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 2. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -344,9 +389,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 3. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
     ~~~
+
     ~~~
     +---------+
     | node_id |

--- a/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
@@ -105,8 +105,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -114,6 +119,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
 	--certs-dir=certs \
@@ -122,6 +128,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-client \
 	root \
@@ -131,6 +138,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node1 internal IP address> \
@@ -154,10 +162,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node1 external IP address> "mkdir certs"
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -169,6 +181,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -177,6 +190,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node2 internal IP address> \
@@ -193,10 +207,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node2 external IP address> "mkdir certs"
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -212,26 +230,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ ssh <username>@<node1 external IP address>
 	~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Extract the binary.
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background \
 	--certs-dir=certs
@@ -243,26 +270,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
 	~~~
 	$ ssh <username>@<additional node external IP address>
 	~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Extract the binary.
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background  \
 	--certs-dir=certs \
@@ -279,29 +315,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ ssh <username>@<node1 external IP address>
 	~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
 	~~~
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ ssh <username>@<node3 external IP address>
 	~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
@@ -309,9 +350,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
+
 	~~~
 	+--------------------+
 	|      Database      |
@@ -335,6 +378,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
@@ -344,9 +388,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 2. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
+
 	~~~
 	+--------------------+
 	|      Database      |
@@ -364,9 +410,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 3. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
 	~~~
+
 	~~~
 	+---------+
 	| node_id |

--- a/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
@@ -103,12 +103,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
-	~~~ shell
-	$ mkdir certs
-	$ mkdir my-safe-directory
-	~~~
+    ~~~ shell
+    $ mkdir certs
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -165,10 +167,18 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node1 external IP address>:~/certs
 	~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
 
 	~~~ shell
-	$ cockroach cert create-node --overwrite\
+	$ cockroach cert create-node \
 	<node2 internal IP address> \
 	<node2 external IP address> \
 	<node2 hostname>  \
@@ -181,7 +191,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
 	~~~ shell
 	# Create the certs directory:
@@ -196,7 +206,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node2 external IP address>:~/certs
 	~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 

--- a/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
@@ -97,13 +97,15 @@ To use GCE's TCP Proxy Load Balancing service:
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the GCE load balancer
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
+- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the GCE load balancer.
+- A client key pair for the `root` user.
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -114,24 +116,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
     - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
 	--certs-dir=certs \
 	--ca-key=my-safe-directory/ca.key
 	~~~
@@ -160,7 +152,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	- `<load balancer IP address>`
 	- `<load balancer hostname>`
 
-5. Upload the certificates to the first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -170,10 +162,8 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node1 external IP address>:~/certs
@@ -205,7 +195,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -215,16 +205,26 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node2 external IP address>:~/certs
 	~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-client \
+	root \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 5. Start the first node
 
@@ -311,41 +311,33 @@ At this point, your cluster is live and operational but contains only a single n
 
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to your first node:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
-
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the external address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node1 external IP address>
 	~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. In another terminal window, SSH to another node:
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ ssh <username>@<node3 external IP address>
-	~~~
-
-4. Launch the built-in SQL client:
+4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node2 external IP address>
 	~~~
 
 5. View the cluster's databases, which will include `securenodetest`:

--- a/v1.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -108,8 +108,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -117,6 +122,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
@@ -125,6 +131,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-client \
     root \
@@ -134,6 +141,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node internal IP address> \
@@ -157,6 +165,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node1 external IP address> "mkdir certs"
@@ -172,6 +181,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -180,6 +190,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node2 internal IP address> \
@@ -196,10 +207,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node2 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
@@ -215,26 +230,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1.  SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start \
     --background \
@@ -248,26 +272,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1.  SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~
     $ ssh <username>@<additional node external IP address>
     ~~~
 
 2.  Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start \
     --background \
@@ -286,29 +319,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
     ~~~
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node3 external IP address>
     ~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
@@ -316,9 +354,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASE;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -344,6 +384,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 2.  Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs \
@@ -352,9 +393,11 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 3.  View the cluster's databases:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -372,9 +415,11 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 4.  Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
     ~~~
+
     ~~~
     +---------+
     | node_id |

--- a/v1.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -100,13 +100,15 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the Azure load balancer
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
+- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the Azure load balancer.
+- A client key pair for the `root` user.
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -117,24 +119,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
     - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
@@ -163,17 +155,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     - `<load balancer IP address>`
     - `<load balancer hostname>`
 
-5. Upload the certificates to the first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node1 external IP address> "mkdir certs"
 
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node1 external IP address>:~/certs
@@ -205,7 +195,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -215,16 +205,26 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node2 external IP address>:~/certs
     ~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 5. Start the first node
 
@@ -315,48 +315,40 @@ At this point, your cluster is live and operational but contains only a single n
 
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to your first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh <username>@<node1 external IP address>
-    ~~~
-
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, launch the built-in SQL client with the `--host` flag set to the external address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node1 external IP address>
     ~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. In another terminal window, SSH to another node:
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh <username>@<node3 external IP address>
-    ~~~
-
-4. Launch the built-in SQL client:
+4. Launch built-in SQL client with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node2 external IP address>
     ~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW DATABASE;
+    > SHOW DATABASES;
     ~~~
 
     ~~~
@@ -372,17 +364,15 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
     (5 rows)
     ~~~
 
-6.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Test load balancing
 
 The Azure load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1.  [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2.  Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
+1.  On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -391,7 +381,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     --host=<load balancer IP address>
     ~~~
 
-3.  View the cluster's databases:
+2.  View the cluster's databases:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -413,7 +403,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
     As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
-4.  Check which node you were redirected to:
+3.  Check which node you were redirected to:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -429,7 +419,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     (1 row)
     ~~~
 
-5.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -55,9 +55,9 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
         | Port range | **8080** |
         | Action | **Allow** |
     - **Application support:**
-    
+
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
-    
+
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
@@ -106,12 +106,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
     ~~~ shell
     $ mkdir certs
     $ mkdir my-safe-directory
     ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -168,7 +170,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node1 external IP address>:~/certs
     ~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
 
     ~~~ shell
     $ cockroach cert create-node \
@@ -184,7 +194,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
     ~~~ shell
     # Create the certs directory:
@@ -199,7 +209,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node2 external IP address>:~/certs
     ~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 

--- a/v1.0/manual-deployment.md
+++ b/v1.0/manual-deployment.md
@@ -31,13 +31,15 @@ For guidance on cluster topology, clock synchronization, and file descriptor lim
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
 - A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP addresses and common names for machines running HAProxy.
+- A client key pair for the `root` user.
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -48,24 +50,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
 	--certs-dir=certs \
 	--ca-key=my-safe-directory/ca.key
 	~~~
@@ -89,7 +81,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-5. Upload the certificates to first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -99,10 +91,8 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	{% include copy-clipboard.html %}
 	~~~ shell
-	# Upload the CA certificate, cclient (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node1 address>:~/certs
@@ -136,7 +126,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -146,16 +136,26 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	{% include copy-clipboard.html %}
 	~~~ shell
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node2 address>:~/certs
 	~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-client \
+	root \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 2. Start the first node
 
@@ -236,31 +236,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 ## Step 4. Test your cluster
 
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster. To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-1. SSH to your first node.
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, launch the built-in SQL client with the `--host` flag set to the address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node1 address>
 	~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. In other terminal window, SSH to another node.
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-4. Launch the built-in SQL client:
+4. Launch the built-in SQL client with the `--host` flag set to the address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node2 address>
 	~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
@@ -296,37 +300,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 [HAProxy](http://www.haproxy.org/) is one of the most popular open-source TCP load balancers, and CockroachDB includes a built-in command for generating a configuration file that is preset to work with your running cluster, so we feature that tool here.
 
-1. SSH to the machine where you want to run HAProxy.
-
-2. Install HAProxy:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ apt-get install haproxy
-	~~~
-
-3. Install CockroachDB from our latest binary:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-4. Run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command, specifying the address of any instance running a CockroachDB node and [security flags](create-security-certificates.html) pointing to the CA cert and the client cert and key:
+1. On your local machine, run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command with the `--host` flag set to the address of any node and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -368,6 +342,22 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 	{{site.data.alerts.callout_info}}For full details on these and other configuration settings, see the <a href="http://cbonte.github.io/haproxy-dconv/1.7/configuration.html">HAProxy Configuration Manual</a>.{{site.data.alerts.end}}
 
+2. Upload the `haproxy.cfg` file to the machine where you want to run HAProxy:
+
+	{% include copy-clipboard.html %}
+	~~~ shell
+	$ scp haproxy.cfg <username>@<haproxy address>:~/
+	~~~
+
+3. SSH to the machine where you want to run HAProxy.
+
+4. Install HAProxy:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ apt-get install haproxy
+	~~~
+
 5. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 
     {% include copy-clipboard.html %}
@@ -383,7 +373,7 @@ Now that HAProxy is running, it can serve as the client gateway to the cluster. 
 
 To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
+1. On your local machine, launch the built-in SQL client with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell

--- a/v1.0/manual-deployment.md
+++ b/v1.0/manual-deployment.md
@@ -37,12 +37,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
-	~~~ shell
-	$ mkdir certs
-	$ mkdir my-safe-directory
-	~~~
+    ~~~ shell
+    $ mkdir certs
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -60,7 +62,6 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--certs-dir=certs \
 	--ca-key=my-safe-directory/ca.key
 	~~~
-
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
@@ -86,7 +87,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	# Create the certs directory:
 	$ ssh <username>@<node1 address> "mkdir certs"
 
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate, cclient (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
 	certs/client.root.key \
@@ -95,10 +96,18 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node1 address>:~/certs
 	~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
 	~~~ shell
-	$ cockroach cert create-node --overwrite\
+	$ cockroach cert create-node \
 	<node2 internal IP address> \
 	<node2 external IP address> \
 	<node2 hostname>  \
@@ -113,7 +122,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
 	~~~ shell
 	# Create the certs directory:
@@ -128,7 +137,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node2 address>:~/certs
 	~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 2. Start the first node
 

--- a/v1.0/manual-deployment.md
+++ b/v1.0/manual-deployment.md
@@ -39,8 +39,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -48,6 +53,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
 	--certs-dir=certs \
@@ -56,6 +62,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-client \
 	root \
@@ -65,6 +72,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node1 internal IP address> \
@@ -83,10 +91,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to first node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node1 address> "mkdir certs"
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Upload the CA certificate, cclient (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -98,6 +110,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -106,6 +119,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node2 internal IP address> \
@@ -124,10 +138,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node2 address> "mkdir certs"
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -145,20 +163,28 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball:
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Extract the binary:
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new CockroachDB cluster with a single node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background \
 	--certs-dir=certs \
@@ -175,20 +201,28 @@ At this point, your cluster is live and operational but contains only a single n
 
 2. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball:
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Extract the binary:
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new node that joins the cluster using the first node's address:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background  \
 	--certs-dir=certs \
@@ -208,11 +242,13 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
 	~~~
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
@@ -221,6 +257,7 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
@@ -228,6 +265,7 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
@@ -262,26 +300,35 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 2. Install HAProxy:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ apt-get install haproxy
 	~~~
 
 3. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Extract the binary.
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 4. Run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command, specifying the address of any instance running a CockroachDB node and [security flags](create-security-certificates.html) pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach gen haproxy \
 	--certs-dir=certs \
@@ -323,6 +370,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 5. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ haproxy -f haproxy.cfg
 	~~~
@@ -337,6 +385,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs \
@@ -345,9 +394,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 2. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
+
 	~~~
 	+--------------------+
 	|      Database      |
@@ -365,9 +416,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 3. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
 	~~~
+
 	~~~
 	+---------+
 	| node_id |

--- a/v1.1/create-security-certificates.md
+++ b/v1.1/create-security-certificates.md
@@ -96,11 +96,14 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 ### Create the CA certificate and key pair
 
-1. Create a safe directory for the CA key:
+1. Create two directories:
 
     ~~~ shell
+    $ mkdir certs
     $ mkdir my-safe-directory
     ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Generate the CA certificate and key:
 
@@ -113,12 +116,13 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     ~~~
 
     ~~~
-    -rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
+    total 8
+    -rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
     ~~~
 
 ### Create the certificate and key pairs for nodes
 
-1. Create the certificate and key for the first node:
+1. Generate the certificate and key for the first node:
 
     ~~~ shell
     $ cockroach cert create-node \
@@ -131,35 +135,74 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     ~~~
 
     ~~~
-    -rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
-    -rw-r--r--  1 maxroach  maxroach  1.2K Apr 19 09:36 node.crt
-    -rw-------  1 maxroach  maxroach  1.6K Apr 19 09:36 node.key
+    total 24
+    -rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
+    -rw-r--r--  1 maxroach  maxroach  1.2K Jul 10 14:16 node.crt
+    -rw-------  1 maxroach  maxroach  1.6K Jul 10 14:16 node.key
     ~~~
 
-2. Upload the files to the first node.
+2. Upload certificates to the first node:
 
-3. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node1 address> "mkdir certs"
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Upload the CA certificate and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node1 address>:~/certs
+    ~~~
+
+3. Delete the local copy of the first node's certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+4. Create the certificate and key for the second node:
 
     ~~~ shell
     $ cockroach cert create-node \
     node2.example.com \
     node2.another-example.com \
     --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key \
-    --overwrite
+    --ca-key=my-safe-directory/ca.key
 
     $ ls -l certs
     ~~~
 
     ~~~
-    -rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
-    -rw-r--r--  1 maxroach  maxroach  1.2K Apr 19 09:40 node.crt
-    -rw-------  1 maxroach  maxroach  1.6K Apr 19 09:40 node.key
+    total 24
+    -rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
+    -rw-r--r--  1 maxroach  maxroach  1.2K Jul 10 14:17 node.crt
+    -rw-------  1 maxroach  maxroach  1.6K Jul 10 14:17 node.key
     ~~~
 
-4. Upload the files to the second node.
+5. Upload certificates to the second node:
 
-5. Repeat for each additional node.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node2 address> "mkdir certs"
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Upload the CA certificate and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node2 address>:~/certs
+    ~~~
+
+6. Repeat steps 3 - 5 for each additional node.
 
 ### Create the certificate and key pair for a client
 
@@ -173,11 +216,12 @@ $ ls -l certs
 ~~~
 
 ~~~
--rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:35 ca.crt
--rw-r--r--  1 maxroach  maxroach  1.1K Apr 19 09:39 client.maxroach.crt
--rw-------  1 maxroach  maxroach  1.6K Apr 19 09:39 client.maxroach.key
--rw-r--r--  1 maxroach  maxroach  1.2K Apr 19 09:36 node.crt
--rw-------  1 maxroach  maxroach  1.6K Apr 19 09:36 node.key
+total 40
+-rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:12 ca.crt
+-rw-r--r--  1 maxroach  maxroach  1.1K Jul 10 14:13 client.maxroach.crt
+-rw-------  1 maxroach  maxroach  1.6K Jul 10 14:13 client.maxroach.key
+-rw-r--r--  1 maxroach  maxroach  1.2K Jul 10 14:17 node.crt
+-rw-------  1 maxroach  maxroach  1.6K Jul 10 14:17 node.key
 ~~~
 
 ### List certificates and keys
@@ -189,13 +233,14 @@ $ cockroach cert list \
 
 ~~~
 Certificate directory: certs
-+-----------------------+---------------------+---------------------+---------------+
-|         Usage         |  Certificate File   |      Key File       |     Notes     |
-+-----------------------+---------------------+---------------------+---------------+
-| Certificate Authority | ca.crt              |                     |               |
-| Node                  | node.crt            | node.key            |               |
-| Client                | client.maxroach.crt | client.maxroach.key | user=maxroach |
-+-----------------------+---------------------+---------------------+---------------+
++-----------------------+---------------------+---------------------+------------+--------------------------------------------------------+-------+
+|         Usage         |  Certificate File   |      Key File       |  Expires   |                         Notes                          | Error |
++-----------------------+---------------------+---------------------+------------+--------------------------------------------------------+-------+
+| Certificate Authority | ca.crt              |                     | 2027/07/18 | num certs: 1                                           |       |
+| Node                  | node.crt            | node.key            | 2022/07/14 | addresses: node2.example.com,node2.another-example.com |       |
+| Client                | client.maxroach.crt | client.maxroach.key | 2022/07/14 | user: maxroach                                         |       |
++-----------------------+---------------------+---------------------+------------+--------------------------------------------------------+-------+
+(3 rows)
 ~~~
 
 ## See Also

--- a/v1.1/create-security-certificates.md
+++ b/v1.1/create-security-certificates.md
@@ -98,8 +98,13 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
@@ -107,11 +112,15 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 2. Generate the CA certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ ls -l certs
     ~~~
 
@@ -124,13 +133,17 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 1. Generate the certificate and key for the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     node1.example.com \
     node1.another-example.com \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ ls -l certs
     ~~~
 
@@ -160,6 +173,7 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 3. Delete the local copy of the first node's certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -168,13 +182,17 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 4. Create the certificate and key for the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     node2.example.com \
     node2.another-example.com \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ ls -l certs
     ~~~
 
@@ -206,12 +224,16 @@ If you need to troubleshoot this command's behavior, you can change its [logging
 
 ### Create the certificate and key pair for a client
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach cert create-client \
 maxroach \
 --certs-dir=certs \
 --ca-key=my-safe-directory/ca.key
+~~~
 
+{% include copy-clipboard.html %}
+~~~ shell
 $ ls -l certs
 ~~~
 
@@ -226,6 +248,7 @@ total 40
 
 ### List certificates and keys
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach cert list \
 --certs-dir=certs

--- a/v1.1/deploy-cockroachdb-on-aws.md
+++ b/v1.1/deploy-cockroachdb-on-aws.md
@@ -98,13 +98,15 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user (`client.root.crt` and `client.root.key`)
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
 - A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the AWS load balancer (`node.crt` and `node.key`)
+- A client key pair for the `root` user (`client.root.crt` and `client.root.key`).
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -115,24 +117,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
     - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
@@ -161,7 +153,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     - `<load balancer IP address>`
     - `<load balancer hostname>`
 
-5. Upload the certificates to the first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -171,11 +163,9 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node1 external IP address>:~/certs
@@ -207,7 +197,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -215,20 +205,29 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     $ ssh -i <path to AWS .pem> <username>@<node2 external IP address> "mkdir certs"
     ~~~
 
-
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node2 external IP address>:~/certs
     ~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 5. Start the first node
 
@@ -317,41 +316,33 @@ At this point, your cluster is live and operational but contains only a single n
 
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to your first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh -i <path to AWS .pem> <username>@<node2 external IP address>
-    ~~~
-
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the external IP address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node1 external IP address>
     ~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. In another terminal window, SSH to another node:
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh -i <path to AWS .pem> <username>@<node3 external IP address>
-    ~~~
-
-4. Launch the built-in SQL client:
+4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external IP address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node2 external IP address>
     ~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
@@ -380,11 +371,9 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 The AWS load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
+1. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -393,7 +382,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     --host=<load balancer IP address>
     ~~~
 
-3. View the cluster's databases:
+2. View the cluster's databases:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -415,7 +404,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
     As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
-4. Check which node you were redirected to:
+3. Check which node you were redirected to:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -431,7 +420,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     (1 row)
     ~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.1/deploy-cockroachdb-on-aws.md
+++ b/v1.1/deploy-cockroachdb-on-aws.md
@@ -106,8 +106,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -115,6 +120,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
@@ -123,6 +129,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-client \
     root \
@@ -132,6 +139,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node1 internal IP address> \
@@ -145,20 +153,24 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
-  - `<node1 internal IP address>` which is the instance's **Internal IP**.
-  - `<node1 external IP address>` which is the instance's **External IP address**.
-  - `<node1 hostname>` which is the instance's hostname. You can find this by SSHing into a server and running `hostname`. For many AWS EC2 servers, this is `ip-` followed by the internal IP address delimited by dashes; e.g., `ip-172-31-18-168`.
-  - `<other common names for node1>` which include any domain names you point to the instance.
-  - `localhost` and `127.0.0.1`
-  - `<load balancer IP address>`
-  - `<load balancer hostname>`
+    - `<node1 internal IP address>` which is the instance's **Internal IP**.
+    - `<node1 external IP address>` which is the instance's **External IP address**.
+    - `<node1 hostname>` which is the instance's hostname. You can find this by SSHing into a server and running `hostname`. For many AWS EC2 servers, this is `ip-` followed by the internal IP address delimited by dashes; e.g., `ip-172-31-18-168`.
+    - `<other common names for node1>` which include any domain names you point to the instance.
+    - `localhost` and `127.0.0.1`
+    - `<load balancer IP address>`
+    - `<load balancer hostname>`
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh -i <path to AWS .pem> <username>@<node1 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
@@ -171,6 +183,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -179,6 +192,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node2 internal IP address> \
@@ -195,10 +209,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh -i <path to AWS .pem> <username>@<node2 external IP address> "mkdir certs"
+    ~~~
 
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp -i <path to AWS .pem>\
     certs/ca.crt \
@@ -215,26 +234,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh -i <path to AWS .pem> <username>@<node1 external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background \
     --certs-dir=certs \
@@ -247,26 +275,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~
     $ ssh -i <path to AWS .pem> <username>@<additional node external IP address>
     ~~~
 
 2. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background  \
     --certs-dir=certs \
@@ -284,29 +321,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh -i <path to AWS .pem> <username>@<node2 external IP address>
     ~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
     ~~~
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh -i <path to AWS .pem> <username>@<node3 external IP address>
     ~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
@@ -314,9 +356,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -342,6 +386,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs \
@@ -350,9 +395,11 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 3. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -365,13 +412,16 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     +--------------------+
     (5 rows)
     ~~~
+
     As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
 4. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
     ~~~
+
     ~~~
     +---------+
     | node_id |

--- a/v1.1/deploy-cockroachdb-on-aws.md
+++ b/v1.1/deploy-cockroachdb-on-aws.md
@@ -104,12 +104,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
     ~~~ shell
     $ mkdir certs
     $ mkdir my-safe-directory
     ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -167,10 +169,18 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node1 external IP address>:~/certs
     ~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
 
     ~~~ shell
-    $ cockroach cert create-node --overwrite\
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
+
+    ~~~ shell
+    $ cockroach cert create-node \
     <node2 internal IP address> \
     <node2 external IP address> \
     <node2 hostname>  \
@@ -183,7 +193,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
     ~~~ shell
     # Create the certs directory:
@@ -199,7 +209,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node2 external IP address>:~/certs
     ~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 

--- a/v1.1/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.1/deploy-cockroachdb-on-digital-ocean.md
@@ -29,8 +29,8 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 - Set up your Droplets using [private networking](https://www.digitalocean.com/community/tutorials/how-to-set-up-and-use-digitalocean-private-networking).
 
 - Decide how you want to access your Admin UI:
-	- Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-	- Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+    - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
+    - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
 
 ## Step 1. Create Droplets
 
@@ -50,8 +50,8 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 Digital Ocean offers fully-managed load balancers to distribute traffic between Droplets.
 
 1. [Create a Digital Ocean Load Balancer](https://www.digitalocean.com/community/tutorials/an-introduction-to-digitalocean-load-balancers). Be sure to:
-	- Set forwarding rules to route TCP traffic from the load balancer's port **26257** to port **26257** on the node Droplets.
-	- Configure health checks to use HTTP port **8080** and path `/health`.
+    - Set forwarding rules to route TCP traffic from the load balancer's port **26257** to port **26257** on the node Droplets.
+    - Configure health checks to use HTTP port **8080** and path `/health`.
 2. Note the provisioned **IP Address** for the load balancer. You'll use this later to test load balancing and to connect your application to the cluster.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Digital Ocean's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
@@ -81,131 +81,140 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
-	~~~ shell
-	$ mkdir certs
-	$ mkdir my-safe-directory
-	~~~
+    ~~~ shell
+    $ mkdir certs
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
-	~~~ shell
-	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ cockroach cert create-ca \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
 3. Create a client key pair for the `root` user:
 
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
+    - `<node internal IP address>`, which is the node Droplet's **Private IP**.
+    - `<node external IP address>`, which is the node Droplet's **ipv4** address.
+    - `<node hostname>`, which is the node Droplet's **Name**.
+    - `<other common names for node>`, which include any domain names you point to the node Droplet.
+    - `localhost` and `127.0.0.1`
+    - `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
+    - `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
 
-	- `<node internal IP address>`, which is the node Droplet's **Private IP**.
-	- `<node external IP address>`, which is the node Droplet's **ipv4** address.
-	- `<node hostname>`, which is the node Droplet's **Name**.
-	- `<other common names for node>`, which include any domain names you point to the node Droplet.
-	- `localhost` and `127.0.0.1`
-	- `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
-	- `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
-
-	~~~ shell
-	$ cockroach cert create-node \
-	<node1 internal IP address> \
-	<node1 external IP address> \
-	<node1 hostname>  \
-	<other common names for node1> \
-	localhost \
-	127.0.0.1 \
-	<load balancer IP address> \
-	<load balancer hostname> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ cockroach cert create-node \
+    <node1 internal IP address> \
+    <node1 external IP address> \
+    <node1 hostname>  \
+    <other common names for node1> \
+    localhost \
+    127.0.0.1 \
+    <load balancer IP address> \
+    <load balancer hostname> \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
 5. Upload the certificates to the first node:
 
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node1 external IP address> "mkdir certs"
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node1 external IP address> "mkdir certs"
 
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node1 external IP address>:~/certs
-	~~~
+    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/client.root.crt \
+    certs/client.root.key \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node1 external IP address>:~/certs
+    ~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
 
-	~~~ shell
-	$ cockroach cert create-node --overwrite\
-	<node2 internal IP address> \
-	<node2 external IP address> \
-	<node2 hostname>  \
-	<other common names for node2> \
-	localhost \
-	127.0.0.1 \
-	<load balancer IP address> \
-	<load balancer hostname> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
 
-7. Upload the certificates to the second node:
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
 
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node2 external IP address> "mkdir certs"
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
 
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node2 external IP address>:~/certs
-	~~~
+    ~~~ shell
+    $ cockroach cert create-node \
+    <node2 internal IP address> \
+    <node2 external IP address> \
+    <node2 hostname>  \
+    <other common names for node2> \
+    localhost \
+    127.0.0.1 \
+    <load balancer IP address> \
+    <load balancer hostname> \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+8. Upload the certificates to the second node:
+
+    ~~~ shell
+    # Create the certs directory:
+    $ ssh <username>@<node2 external IP address> "mkdir certs"
+
+    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    $ scp certs/ca.crt \
+    certs/client.root.crt \
+    certs/client.root.key \
+    certs/node.crt \
+    certs/node.key \
+    <username>@<node2 external IP address>:~/certs
+    ~~~
+
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 
 1. SSH to your Droplet:
 
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
+    ~~~ shell
+    $ ssh <username>@<node1 external IP address>
+    ~~~
 
 2. Install the latest CockroachDB binary:
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~ shell
+    # Get the latest CockroachDB tarball.
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    # Extract the binary.
+    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
 
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
+    # Move the binary.
+    $ sudo mv cockroach /usr/local/bin
+    ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
-	~~~ shell
-	$ cockroach start --background \
-	--certs-dir=certs \
-	--advertise-host=<node1 internal IP address>
-	~~~
+    ~~~ shell
+    $ cockroach start --background \
+    --certs-dir=certs \
+    --advertise-host=<node1 internal IP address>
+    ~~~
 
 ## Step 6. Add nodes to the cluster
 
@@ -213,32 +222,32 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your Droplet:
 
-	~~~
-	$ ssh <username>@<additional node external IP address>
-	~~~
+    ~~~
+    $ ssh <username>@<additional node external IP address>
+    ~~~
 
 2. Install the latest CockroachDB binary:
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~ shell
+    # Get the latest CockroachDB tarball.
+    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    # Extract the binary.
+    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
+    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
 
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
+    # Move the binary.
+    $ sudo mv cockroach /usr/local/bin
+    ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
-	~~~ shell
-	$ cockroach start --background  \
-	--certs-dir=certs \
-	--advertise-host=<node internal IP address> \
-	--join=<node1 internal IP address>:26257
-	~~~
+    ~~~ shell
+    $ cockroach start --background  \
+    --certs-dir=certs \
+    --advertise-host=<node internal IP address> \
+    --join=<node1 internal IP address>:26257
+    ~~~
 
 4. Repeat these steps for each Droplet you want to use as a node.
 
@@ -250,52 +259,52 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
+    ~~~ shell
+    $ ssh <username>@<node1 external IP address>
+    ~~~
 
 2. Launch the built-in SQL client and create a database:
 
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs
-	~~~
+    ~~~ shell
+    $ cockroach sql \
+    --certs-dir=certs
+    ~~~
 
-	~~~ sql
-	> CREATE DATABASE securenodetest;
-	~~~
+    ~~~ sql
+    > CREATE DATABASE securenodetest;
+    ~~~
 
 3. In another terminal window, SSH to another node:
 
-	~~~ shell
-	$ ssh <username>@<node3 external IP address>
-	~~~
+    ~~~ shell
+    $ ssh <username>@<node3 external IP address>
+    ~~~
 
 4. Launch the built-in SQL client:
 
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs
-	~~~
+    ~~~ shell
+    $ cockroach sql \
+    --certs-dir=certs
+    ~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
 
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
+    ~~~ sql
+    > SHOW DATABASES;
+    ~~~
 
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
+    ~~~
+    +--------------------+
+    |      Database      |
+    +--------------------+
+    | crdb_internal      |
+    | information_schema |
+    | securenodetest     |
+    | pg_catalog         |
+    | system             |
+    +--------------------+
+    (5 rows)
+    ~~~
 
 6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
@@ -307,45 +316,45 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
 
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<load balancer IP address>
-	~~~
+    ~~~ shell
+    $ cockroach sql \
+    --certs-dir=certs \
+    --host=<load balancer IP address>
+    ~~~
 
 2. View the cluster's databases:
 
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
+    ~~~ sql
+    > SHOW DATABASES;
+    ~~~
+    ~~~
+    +--------------------+
+    |      Database      |
+    +--------------------+
+    | crdb_internal      |
+    | information_schema |
+    | securenodetest     |
+    | pg_catalog         |
+    | system             |
+    +--------------------+
+    (5 rows)
+    ~~~
 
-	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
+    As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
 3. Check which node you were redirected to:
 
-	~~~ sql
-	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
-	~~~
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
+    ~~~ sql
+    > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
+    ~~~
+    ~~~
+    +---------+
+    | node_id |
+    +---------+
+    |       3 |
+    +---------+
+    (1 row)
+    ~~~
 
 4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
@@ -359,7 +368,7 @@ On this page, verify that the cluster is running as expected:
 
 1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
 
-	Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--advertise-host` flag to the Droplet's internal IP address. This prevents the node from receiving replicas and working as part of the cluster.
+    Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--advertise-host` flag to the Droplet's internal IP address. This prevents the node from receiving replicas and working as part of the cluster.
 
 2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
 

--- a/v1.1/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.1/deploy-cockroachdb-on-digital-ocean.md
@@ -83,8 +83,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -92,6 +97,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
@@ -100,6 +106,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-client \
     root \
@@ -116,6 +123,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     - `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
     - `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node1 internal IP address> \
@@ -132,10 +140,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node1 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
@@ -147,6 +159,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -155,6 +168,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node2 internal IP address> \
@@ -171,10 +185,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node2 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
@@ -190,26 +208,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. SSH to your Droplet:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background \
     --certs-dir=certs \
@@ -222,26 +249,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your Droplet:
 
+    {% include copy-clipboard.html %}
     ~~~
     $ ssh <username>@<additional node external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start --background  \
     --certs-dir=certs \
@@ -259,29 +295,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
     ~~~
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node3 external IP address>
     ~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
@@ -289,6 +330,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
@@ -316,6 +358,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs \
@@ -324,9 +367,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 2. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -344,9 +389,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 3. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
     ~~~
+
     ~~~
     +---------+
     | node_id |

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -105,8 +105,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -114,6 +119,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
 	--certs-dir=certs \
@@ -122,6 +128,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-client \
 	root \
@@ -131,6 +138,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node1 internal IP address> \
@@ -154,10 +162,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node1 external IP address> "mkdir certs"
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -169,6 +181,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -177,6 +190,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node2 internal IP address> \
@@ -193,10 +207,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node2 external IP address> "mkdir certs"
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -212,26 +230,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ ssh <username>@<node1 external IP address>
 	~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Extract the binary.
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background \
 	--certs-dir=certs
@@ -243,26 +270,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1. SSH to your instance:
 
+    {% include copy-clipboard.html %}
 	~~~
 	$ ssh <username>@<additional node external IP address>
 	~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Extract the binary.
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background  \
 	--certs-dir=certs \
@@ -279,29 +315,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ ssh <username>@<node1 external IP address>
 	~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
 	~~~
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ ssh <username>@<node3 external IP address>
 	~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
@@ -309,9 +350,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
+
 	~~~
 	+--------------------+
 	|      Database      |
@@ -335,6 +378,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
@@ -344,9 +388,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 2. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
+
 	~~~
 	+--------------------+
 	|      Database      |
@@ -364,9 +410,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 3. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
 	~~~
+
 	~~~
 	+---------+
 	| node_id |

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -103,12 +103,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
-	~~~ shell
-	$ mkdir certs
-	$ mkdir my-safe-directory
-	~~~
+    ~~~ shell
+    $ mkdir certs
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -165,10 +167,18 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node1 external IP address>:~/certs
 	~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
 
 	~~~ shell
-	$ cockroach cert create-node --overwrite\
+	$ cockroach cert create-node \
 	<node2 internal IP address> \
 	<node2 external IP address> \
 	<node2 hostname>  \
@@ -181,7 +191,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
 	~~~ shell
 	# Create the certs directory:
@@ -196,7 +206,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node2 external IP address>:~/certs
 	~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -97,13 +97,15 @@ To use GCE's TCP Proxy Load Balancing service:
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the GCE load balancer
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
+- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the GCE load balancer.
+- A client key pair for the `root` user.
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -114,24 +116,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
     - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
 	--certs-dir=certs \
 	--ca-key=my-safe-directory/ca.key
 	~~~
@@ -160,7 +152,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	- `<load balancer IP address>`
 	- `<load balancer hostname>`
 
-5. Upload the certificates to the first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -170,10 +162,8 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node1 external IP address>:~/certs
@@ -205,7 +195,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -215,16 +205,26 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node2 external IP address>:~/certs
 	~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-client \
+	root \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 5. Start the first node
 
@@ -311,41 +311,33 @@ At this point, your cluster is live and operational but contains only a single n
 
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to your first node:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
-
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the external address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node1 external IP address>
 	~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. In another terminal window, SSH to another node:
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ ssh <username>@<node3 external IP address>
-	~~~
-
-4. Launch the built-in SQL client:
+4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node2 external IP address>
 	~~~
 
 5. View the cluster's databases, which will include `securenodetest`:

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -108,8 +108,13 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
@@ -117,6 +122,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
     --certs-dir=certs \
@@ -125,6 +131,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-client \
     root \
@@ -134,6 +141,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node internal IP address> \
@@ -157,6 +165,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to the first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node1 external IP address> "mkdir certs"
@@ -172,14 +181,16 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
 
-    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code>. As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-node \
     <node2 internal IP address> \
@@ -196,10 +207,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node2 external IP address> "mkdir certs"
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
@@ -215,26 +230,35 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1.  SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start \
     --background \
@@ -248,26 +272,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 1.  SSH to your instance:
 
+    {% include copy-clipboard.html %}
     ~~~
     $ ssh <username>@<additional node external IP address>
     ~~~
 
 2.  Install the latest CockroachDB binary:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     # Get the latest CockroachDB tarball.
     $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Extract the binary.
     $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
     --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
     # Move the binary.
     $ sudo mv cockroach /usr/local/bin
     ~~~
 
 3. Start a new node that joins the cluster using the first node's internal IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach start \
     --background \
@@ -286,29 +319,34 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 1. SSH to your first node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node1 external IP address>
     ~~~
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
     ~~~
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
 3. In another terminal window, SSH to another node:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ ssh <username>@<node3 external IP address>
     ~~~
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs
@@ -316,9 +354,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASE;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -344,6 +384,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 2.  Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
     --certs-dir=certs \
@@ -352,9 +393,11 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 3.  View the cluster's databases:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SHOW DATABASES;
     ~~~
+
     ~~~
     +--------------------+
     |      Database      |
@@ -372,9 +415,11 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 4.  Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
     ~~~
+
     ~~~
     +---------+
     | node_id |

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -100,13 +100,15 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the Azure load balancer
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
+- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the Azure load balancer.
+- A client key pair for the `root` user.
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -117,24 +119,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
     - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
     ~~~
@@ -163,17 +155,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     - `<load balancer IP address>`
     - `<load balancer hostname>`
 
-5. Upload the certificates to the first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     # Create the certs directory:
     $ ssh <username>@<node1 external IP address> "mkdir certs"
 
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node1 external IP address>:~/certs
@@ -205,7 +195,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -215,16 +205,26 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
-    certs/client.root.crt \
-    certs/client.root.key \
     certs/node.crt \
     certs/node.key \
     <username>@<node2 external IP address>:~/certs
     ~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 5. Start the first node
 
@@ -315,48 +315,40 @@ At this point, your cluster is live and operational but contains only a single n
 
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to your first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh <username>@<node1 external IP address>
-    ~~~
-
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, launch the built-in SQL client with the `--host` flag set to the external address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node1 external IP address>
     ~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. In another terminal window, SSH to another node:
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh <username>@<node3 external IP address>
-    ~~~
-
-4. Launch the built-in SQL client:
+4. Launch built-in SQL client with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach sql \
-    --certs-dir=certs
+    --certs-dir=certs \
+    --host=<node2 external IP address>
     ~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW DATABASE;
+    > SHOW DATABASES;
     ~~~
 
     ~~~
@@ -372,17 +364,15 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
     (5 rows)
     ~~~
 
-6.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Test load balancing
 
 The Azure load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1.  [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2.  Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
+1.  On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -391,7 +381,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     --host=<load balancer IP address>
     ~~~
 
-3.  View the cluster's databases:
+2.  View the cluster's databases:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -413,7 +403,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
     As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
-4.  Check which node you were redirected to:
+3.  Check which node you were redirected to:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -429,7 +419,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
     (1 row)
     ~~~
 
-5.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -55,9 +55,9 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
         | Port range | **8080** |
         | Action | **Allow** |
     - **Application support:**
-    
+
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
-    
+
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
@@ -106,12 +106,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
     ~~~ shell
     $ mkdir certs
     $ mkdir my-safe-directory
     ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -168,7 +170,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node1 external IP address>:~/certs
     ~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code>. As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
 
     ~~~ shell
     $ cockroach cert create-node \
@@ -184,7 +194,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     --ca-key=my-safe-directory/ca.key
     ~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
     ~~~ shell
     # Create the certs directory:
@@ -199,7 +209,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     <username>@<node2 external IP address>:~/certs
     ~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 5. Start the first node
 

--- a/v1.1/manual-deployment.md
+++ b/v1.1/manual-deployment.md
@@ -37,12 +37,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create a `certs` directory and a safe directory to keep your CA key:
+1. Create two directories:
 
-	~~~ shell
-	$ mkdir certs
-	$ mkdir my-safe-directory
-	~~~
+    ~~~ shell
+    $ mkdir certs
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
@@ -60,7 +62,6 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--certs-dir=certs \
 	--ca-key=my-safe-directory/ca.key
 	~~~
-
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
@@ -95,10 +96,18 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node1 address>:~/certs
 	~~~
 
-6. Create the certificate and key for the second node, using the `--overwrite` flag to replace the files created for the first node:
+6. Delete the local copy of the node certificate and key:
+
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
 	~~~ shell
-	$ cockroach cert create-node --overwrite\
+	$ cockroach cert create-node \
 	<node2 internal IP address> \
 	<node2 external IP address> \
 	<node2 hostname>  \
@@ -113,7 +122,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-7. Upload the certificates to the second node:
+8. Upload the certificates to the second node:
 
 	~~~ shell
 	# Create the certs directory:
@@ -128,7 +137,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	<username>@<node2 address>:~/certs
 	~~~
 
-8. Repeat steps 6 and 7 for each additional node.
+9. Repeat steps 6 - 8 for each additional node.
 
 ## Step 2. Start the first node
 

--- a/v1.1/manual-deployment.md
+++ b/v1.1/manual-deployment.md
@@ -39,15 +39,21 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 1. Create two directories:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
     $ mkdir my-safe-directory
     ~~~
     - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
 2. Create the CA key pair:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
 	--certs-dir=certs \
@@ -56,6 +62,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 3. Create a client key pair for the `root` user:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-client \
 	root \
@@ -65,6 +72,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node1 internal IP address> \
@@ -83,11 +91,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 5. Upload the certificates to first node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node1 address> "mkdir certs"
+	~~~
 
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	{% include copy-clipboard.html %}
+	~~~ shell
+	# Upload the CA certificate, cclient (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
 	certs/client.root.key \
@@ -98,6 +110,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 6. Delete the local copy of the node certificate and key:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ rm certs/node.crt certs/node.key
     ~~~
@@ -106,6 +119,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-node \
 	<node2 internal IP address> \
@@ -124,10 +138,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 8. Upload the certificates to the second node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Create the certs directory:
 	$ ssh <username>@<node2 address> "mkdir certs"
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
 	$ scp certs/ca.crt \
 	certs/client.root.crt \
@@ -145,20 +163,28 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 2. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball:
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Extract the binary:
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new CockroachDB cluster with a single node:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background \
 	--certs-dir=certs \
@@ -175,20 +201,28 @@ At this point, your cluster is live and operational but contains only a single n
 
 2. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball:
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Extract the binary:
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Move the binary:
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 3. Start a new node that joins the cluster using the first node's address:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach start --background  \
 	--certs-dir=certs \
@@ -208,11 +242,13 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 2. Launch the built-in SQL client and create a database:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
 	~~~
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
@@ -221,6 +257,7 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 4. Launch the built-in SQL client:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs
@@ -228,6 +265,7 @@ CockroachDB replicates and distributes data for you behind-the-scenes and uses a
 
 5. View the cluster's databases, which will include `securenodetest`:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
@@ -262,26 +300,35 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 2. Install HAProxy:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ apt-get install haproxy
 	~~~
 
 3. Install CockroachDB from our latest binary:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	# Get the latest CockroachDB tarball.
 	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Extract the binary.
 	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
 	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+	~~~
 
+	{% include copy-clipboard.html %}
+	~~~ shell
 	# Move the binary.
 	$ sudo mv cockroach /usr/local/bin
 	~~~
 
 4. Run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command, specifying the address of any instance running a CockroachDB node and [security flags](create-security-certificates.html) pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach gen haproxy \
 	--certs-dir=certs \
@@ -323,6 +370,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 5. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ haproxy -f haproxy.cfg
 	~~~
@@ -337,6 +385,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
 	--certs-dir=certs \
@@ -345,9 +394,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 2. View the cluster's databases:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SHOW DATABASES;
 	~~~
+
 	~~~
 	+--------------------+
 	|      Database      |
@@ -365,9 +416,11 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 
 3. Check which node you were redirected to:
 
+    {% include copy-clipboard.html %}
 	~~~ sql
 	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
 	~~~
+
 	~~~
 	+---------+
 	| node_id |

--- a/v1.1/manual-deployment.md
+++ b/v1.1/manual-deployment.md
@@ -31,13 +31,15 @@ For guidance on cluster topology, clock synchronization, and file descriptor lim
 
 Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`)
-- A client key pair for the `root` user
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
 - A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP addresses and common names for machines running HAProxy.
+- A client key pair for the `root` user.
 
 {{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
 
-1. Create two directories:
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -48,24 +50,14 @@ Locally, you'll need to [create the following certificates and keys](create-secu
     ~~~ shell
     $ mkdir my-safe-directory
     ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
 
-2. Create the CA key pair:
+3. Create the CA certificate and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-3. Create a client key pair for the `root` user:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
 	--certs-dir=certs \
 	--ca-key=my-safe-directory/ca.key
 	~~~
@@ -89,7 +81,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-5. Upload the certificates to first node:
+5. Upload certificates to the first node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -99,10 +91,8 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	{% include copy-clipboard.html %}
 	~~~ shell
-	# Upload the CA certificate, cclient (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node1 address>:~/certs
@@ -136,7 +126,7 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 	--ca-key=my-safe-directory/ca.key
 	~~~
 
-8. Upload the certificates to the second node:
+8. Upload certificates to the second node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -146,16 +136,26 @@ Locally, you'll need to [create the following certificates and keys](create-secu
 
 	{% include copy-clipboard.html %}
 	~~~ shell
-	# Upload the CA certificate, client (root) certificate and key, and node certificate and key:
+	# Upload the CA certificate and node certificate and key:
 	$ scp certs/ca.crt \
-	certs/client.root.crt \
-	certs/client.root.key \
 	certs/node.crt \
 	certs/node.key \
 	<username>@<node2 address>:~/certs
 	~~~
 
 9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-client \
+	root \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
 
 ## Step 2. Start the first node
 
@@ -236,31 +236,35 @@ At this point, your cluster is live and operational but contains only a single n
 
 ## Step 4. Test your cluster
 
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster. To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-1. SSH to your first node.
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-2. Launch the built-in SQL client and create a database:
+1. On your local machine, launch the built-in SQL client with the `--host` flag set to the address of node 1 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node1 address>
 	~~~
+
+2. Create a `securenodetest` database:
 
     {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. In other terminal window, SSH to another node.
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
 
-4. Launch the built-in SQL client:
+4. Launch the built-in SQL client with the `--host` flag set to the address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach sql \
-	--certs-dir=certs
+	--certs-dir=certs \
+	--host=<node2 address>
 	~~~
 
 5. View the cluster's databases, which will include `securenodetest`:
@@ -296,37 +300,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 [HAProxy](http://www.haproxy.org/) is one of the most popular open-source TCP load balancers, and CockroachDB includes a built-in command for generating a configuration file that is preset to work with your running cluster, so we feature that tool here.
 
-1. SSH to the machine where you want to run HAProxy.
-
-2. Install HAProxy:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ apt-get install haproxy
-	~~~
-
-3. Install CockroachDB from our latest binary:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-4. Run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command, specifying the address of any instance running a CockroachDB node and [security flags](create-security-certificates.html) pointing to the CA cert and the client cert and key:
+1. On your local machine, run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command with the `--host` flag set to the address of any node and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -368,6 +342,22 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 	{{site.data.alerts.callout_info}}For full details on these and other configuration settings, see the <a href="http://cbonte.github.io/haproxy-dconv/1.7/configuration.html">HAProxy Configuration Manual</a>.{{site.data.alerts.end}}
 
+2. Upload the `haproxy.cfg` file to the machine where you want to run HAProxy:
+
+	{% include copy-clipboard.html %}
+	~~~ shell
+	$ scp haproxy.cfg <username>@<haproxy address>:~/
+	~~~
+
+3. SSH to the machine where you want to run HAProxy.
+
+4. Install HAProxy:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ apt-get install haproxy
+	~~~
+
 5. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 
     {% include copy-clipboard.html %}
@@ -383,7 +373,7 @@ Now that HAProxy is running, it can serve as the client gateway to the cluster. 
 
 To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
+1. On your local machine, launch the built-in SQL client with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
 
     {% include copy-clipboard.html %}
 	~~~ shell


### PR DESCRIPTION
After generating and uploading certs to a node, remove
the node cert and key before generating those for the next
node. This is instead of using our custom `--overwrite` flag,
though I still mention the flag as an alternative.

Fixes #1678