### PR TITLE
Ensure font fall-backs for code samples

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -145,7 +145,7 @@ pre {
 
 pre, code {
   background-color: #F3F3F3;
-  font-family: 'Monaco';
+  font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
   font-size: 14px;
   line-height: 25px;
   color: #152849; }

--- a/css/customstyles.scss
+++ b/css/customstyles.scss
@@ -94,7 +94,7 @@ pre {
 
 pre, code {
   background-color: $cl_gray_light;
-  font-family: 'Monaco';
+  font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
   font-size: 14px;
   line-height: 25px;
   color: $cl_blue;


### PR DESCRIPTION
Hi @deronjohnson please check this PR out. This change is only for the docs, but the blog is affected as well. Can you ensure that the `pre` and `code` classes have fall-backs beyond Monaco please? Right now all our width-sensitive code samples are broken on non-OSX systems (Monaco is a proprietary Apple font)