### PR TITLE
add redirects for old show and set pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,17 @@ We show "Contribute" options in the top-right of every page by default. To remov
 
 We use the [JekyllRedirectFrom](https://github.com/jekyll/jekyll-redirect-from) plugin to ensure that multiple URLs resolve to a single page. This is most useful in cases where we change the filename or directory structure of a page.
 
-For example, if `v1.0.html` page were moved from the root level to `releases/v1.0.html`, you would add `redirect-from: v1.0.html` to the page's front-matter to ensure that `https://cockroachlabs.com/docs/v1.0.html` gets redirected to `https:/cockroachlabs.com/docs/releases/v1.0.html`.
+For example, if `v1.0.html` page were moved from the root level to `releases/v1.0.html`, you would add `redirect-from: /v1.0.html` to the page's front-matter to ensure that `https://cockroachlabs.com/docs/v1.0.html` gets redirected to `https:/cockroachlabs.com/docs/releases/v1.0.html`.
+
+If you rename or restructure a versioned page, use a relative link, not an absolute link. For example, if `show-transaction.md` and `show-time-zone.md` are merged into `show-vars.md` for v1.1, use the following `redirect_from` specification:
+
+```md
+redirect_from:
+- show-transaction.html
+- show-time-zone.html
+```
+
+This ensures that if `v1.1` is also the `stable` or `dev` version, the corresponding `stable` or `dev` redirects will be generated as well.
 
 #### A/B Testing
 

--- a/_plugins/redirect_from_relative.rb
+++ b/_plugins/redirect_from_relative.rb
@@ -1,0 +1,17 @@
+# Teach the JekyllRedirectFrom plugin to accept relative links in redirect_from
+# keys.
+
+module RedirectFromRelative
+  class Generator < Jekyll::Generator
+    # Ensure we run before JekyllRedirectFrom.
+    priority :highest
+
+    def generate(site)
+      site.pages.each do |page|
+        page.data['redirect_from'] = page.redirect_from.map do |r|
+          r.start_with?('/') ? r : File.join(File.dirname(page.path), r)
+        end
+      end
+    end
+  end
+end

--- a/_plugins/versions/generator.rb
+++ b/_plugins/versions/generator.rb
@@ -1,5 +1,9 @@
 module JekyllVersions
  class JekyllGenerator < Jekyll::Generator
+    # Ensure we run after JekyllRedirectFrom so we can apply version aliases
+    # (e.g. stable) to redirects.
+    priority :lowest
+
     def initialize(config)
       @config = Config.new(config)
     end
@@ -27,7 +31,7 @@ module JekyllVersions
         end
 
         @site.pages << JekyllRedirectFrom::RedirectPage.from_paths(
-          @site, page.basename + page.output_ext, vp.url) if vp.stable?
+          @site, vp.basename, vp.url) if vp.stable?
       end
 
       @config.versions.each do |name, version|

--- a/_plugins/versions/versioned_page.rb
+++ b/_plugins/versions/versioned_page.rb
@@ -5,8 +5,21 @@ module JekyllVersions
     def initialize(config, page)
       @config = config
       @page = page
-      @key = page.data['key'] || page.name
-      @version = Version.from_path(config, page.path)
+      @key = page.data['key'] || basename
+      @version = Version.from_path(config, page.url)
+    end
+
+    def basename
+      # `page.basename` isn't sufficient, as the JekyllRedirectFrom plugin uses
+      # permalinks to hide the fact that every RedirectPage has a basename of
+      # "redirect.html". Using `page.url` properly takes the permalink into
+      # account, but we need to unfold bare directories into the index.html
+      # within.
+      if page.url.end_with?('/')
+        'index.html'
+      else
+        File.basename(page.url)
+      end
     end
 
     def stable?

--- a/v1.0/set-vars.md
+++ b/v1.0/set-vars.md
@@ -2,6 +2,10 @@
 title: SET (session settings)
 summary: The SET statement modifies the current settings for the client session.
 toc: false
+redirect_from:
+- set-application-name.html
+- set-database.html
+- set-time-zone.html
 ---
 
 The `SET` [statement](sql-statements.html) can modify one of the

--- a/v1.0/show-vars.md
+++ b/v1.0/show-vars.md
@@ -2,6 +2,10 @@
 title: SHOW (session settings)
 summary: The SHOW statement displays the current settings for the client session.
 toc: false
+redirect_from:
+- show-all.html
+- show-transaction.html
+- show-time-zone.html
 ---
 
 The `SHOW` [statement](sql-statements.html) can display the value of either one or all of

--- a/v1.1/set-vars.md
+++ b/v1.1/set-vars.md
@@ -2,6 +2,10 @@
 title: SET (session settings)
 summary: The SET statement modifies the current settings for the client session.
 toc: false
+redirect_from:
+- set-application-name.html
+- set-database.html
+- set-time-zone.html
 ---
 
 The `SET` [statement](sql-statements.html) can modify one of the

--- a/v1.1/show-vars.md
+++ b/v1.1/show-vars.md
@@ -2,6 +2,10 @@
 title: SHOW (session settings)
 summary: The SHOW statement displays the current settings for the client session.
 toc: false
+redirect_from:
+- show-all.html
+- show-transaction.html
+- show-time-zone.html
 ---
 
 The `SHOW` [statement](sql-statements.html) can display the value of either one or all of


### PR DESCRIPTION
These pages were removed in #1107, but Google still knows about them.
Teach Jekyll about them too.