### PR TITLE
example apps: Update Rust example for Rust 1.19

### DIFF
--- a/_includes/app/basic-sample.rs
+++ b/_includes/app/basic-sample.rs
@@ -7,8 +7,10 @@ fn main() {
         .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute("INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)", &[])
-        .unwrap();
+    conn.execute(
+        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+        &[],
+    ).unwrap();
 
     // Print out the balances.
     println!("Initial balances:");

--- a/_includes/app/txn-sample.rs
+++ b/_includes/app/txn-sample.rs
@@ -8,34 +8,36 @@ use postgres::error::{Error, SqlState};
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
 fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
-    where F: FnMut(&Transaction) -> Result<T> 
+where
+    F: FnMut(&Transaction) -> Result<T>,
 {
-    let txn = try!(conn.transaction());
-    let res: Result<T>;
+    let txn = conn.transaction()?;
     loop {
-        let sp = try!(txn.savepoint("cockroach_restart"));
+        let sp = txn.savepoint("cockroach_restart")?;
         match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(Error::Db(ref e)) if e.code == SqlState::SerializationFailure => continue,
-            r => res = r,
+            Err(Error::Db(ref e)) if e.code == SqlState::SerializationFailure => {}
+            r => break r,
         }
-        break
-    }
-    res.and_then(|t| txn.commit().map(|_| t))
+    }.and_then(|t| txn.commit().map(|_| t))
 }
 
 fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
     // Read the balance.
-    let from_balance: i64 = try!(txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from]))
+    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0)
         .get(0);
-        
+
     assert!(from_balance >= amount);
 
     // Perform the transfer.
-    try!(txn.execute("UPDATE accounts SET balance = balance - $1 WHERE id = $2",
-                     &[&amount, &from]));
-    try!(txn.execute("UPDATE accounts SET balance = balance + $1 WHERE id = $2",
-                     &[&amount, &to]));
+    txn.execute(
+        "UPDATE accounts SET balance = balance - $1 WHERE id = $2",
+        &[&amount, &from],
+    )?;
+    txn.execute(
+        "UPDATE accounts SET balance = balance + $1 WHERE id = $2",
+        &[&amount, &to],
+    )?;
     Ok(())
 }
 
@@ -44,9 +46,8 @@ fn main() {
         .unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100))
-        .unwrap();
-    
+    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+
     // Check account balances after the transaction.
     for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
         let id: i64 = row.get(0);


### PR DESCRIPTION
This includes a few changes:
- Use the `?` operator in place of the `try!` macro. This new operator
  stabilized a few versions ago and is now the [preferred](https://doc.rust-lang.org/std/macro.try.html) syntax.
- Use `loop break value` functionality, which stabilized in [Rust
  1.19](https://blog.rust-lang.org/2017/07/20/Rust-1.19.html).
- Reformat using `rustfmt`, which seems to have changed since it was last
  run on this code.