### PR TITLE
draft: generate cockroach certs using openssl

### DIFF
--- a/openssl/ca.conf
+++ b/openssl/ca.conf
@@ -1,0 +1,38 @@
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+default_days = 3660
+database = index.txt
+serial = serial.txt 
+default_md = sha256 
+copy_extensions = copy
+
+# Used to generate the CA certificate.
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+x509_extensions = extensions
+
+[ distinguished_name ]
+organizationName = Cockroach
+commonName = Cockroach CA
+
+[ extensions ]
+keyUsage = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+basicConstraints = critical,CA:true,pathlen:1
+
+# Common policy for nodes and users.
+[ signing_policy ]
+organizationName = supplied
+commonName = supplied
+
+# Used to sign node certificates.
+[ signing_node_req ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth,clientAuth
+
+# Used to sign client certificates.
+[ signing_client_req ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth

--- a/openssl/client.conf
+++ b/openssl/client.conf
@@ -1,0 +1,7 @@
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+
+[ distinguished_name ]
+organizationName = Cockroach
+commonName = maxroach

--- a/openssl/create_certs.sh
+++ b/openssl/create_certs.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -e
+
+if ! which cockroach 2> /dev/null > /dev/null; then
+  echo "Please make sure cockroach is in your path"
+  exit 1
+fi
+
+if ! which openssl 2> /dev/null > /dev/null; then
+  echo "Please make sure openssl is installed and in your path"
+  exit 1
+fi
+
+CCERTS="cockroach_certs"
+OSCERTS="openssl_certs"
+rm -rf ${CCERTS}
+rm -rf ${OSCERTS}
+mkdir -p ${CCERTS}
+mkdir -p ${OSCERTS}
+
+# COCKROACH:
+# Create CA cert and key.
+cockroach cert create-ca --certs-dir=${CCERTS} --ca-key=${CCERTS}/ca.key
+# Create node cert and key.
+cockroach cert create-node --certs-dir=${CCERTS} --ca-key=${CCERTS}/ca.key localhost 127.0.0.1 myhost.mydomain.com
+# Create client cert and key.
+cockroach cert create-client --certs-dir=${CCERTS} --ca-key=${CCERTS}/ca.key maxroach
+
+# OPENSSL:
+# Key creation equivalent:
+# openssl genrsa -out ${OSCERTS}/ca.key 2048 2> /dev/null
+# chmod 400 ${OSCERTS}/ca.key
+
+# But we use the cockroach-generated keys to be able to compare certs.
+cp ${CCERTS}/ca.key ${OSCERTS}/ca.key
+cp ${CCERTS}/node.key ${OSCERTS}/node.key
+cp ${CCERTS}/client.maxroach.key ${OSCERTS}/client.maxroach.key
+
+# Create CA certificate.
+openssl req \
+  -new \
+  -x509 \
+  -config ca.conf \
+  -key ${CCERTS}/ca.key \
+  -out ${OSCERTS}/ca.crt \
+  -days 3660 \
+  -batch
+
+# Reset database and index files.
+rm -f index.txt serial.txt
+touch index.txt
+echo '01' > serial.txt
+
+# Create Node certificate signing request.
+# We reuse the cockroach node key.
+openssl req \
+  -new \
+  -config node.conf \
+  -key ${OSCERTS}/node.key \
+  -out ${OSCERTS}/node.csr \
+  -batch
+
+# Sign the CSR using the CA key.
+# We override the number of days.
+openssl ca \
+  -config ca.conf \
+  -keyfile ${OSCERTS}/ca.key \
+  -cert ${OSCERTS}/ca.crt \
+  -policy signing_policy \
+  -extensions signing_node_req \
+  -out ${OSCERTS}/node.crt \
+  -outdir ${OSCERTS}/ \
+  -in ${OSCERTS}/node.csr \
+  -days 1830 \
+  -batch
+
+# Create client certificate signing request.
+# We reuse the cockroach client key for maxroach.
+openssl req \
+  -new \
+  -config client.conf \
+  -key ${OSCERTS}/client.maxroach.key \
+  -out ${OSCERTS}/client.maxroach.csr \
+  -batch
+
+# Sign the CSR using the CA key.
+# We override the number of days.
+openssl ca \
+  -config ca.conf \
+  -keyfile ${OSCERTS}/ca.key \
+  -cert ${OSCERTS}/ca.crt \
+  -policy signing_policy \
+  -extensions signing_client_req \
+  -out ${OSCERTS}/client.maxroach.crt \
+  -outdir ${OSCERTS}/ \
+  -in ${OSCERTS}/client.maxroach.csr \
+  -days 1830 \
+  -batch
+
+
+# Turn certs into plain text.
+openssl x509 -noout -text -in ${CCERTS}/ca.crt > ${CCERTS}/ca.crt.text
+openssl x509 -noout -text -in ${CCERTS}/node.crt > ${CCERTS}/node.crt.text
+openssl x509 -noout -text -in ${CCERTS}/client.maxroach.crt > ${CCERTS}/client.maxroach.crt.text
+openssl x509 -noout -text -in ${OSCERTS}/ca.crt > ${OSCERTS}/ca.crt.text
+openssl x509 -noout -text -in ${OSCERTS}/node.crt > ${OSCERTS}/node.crt.text
+openssl x509 -noout -text -in ${OSCERTS}/client.maxroach.crt > ${OSCERTS}/client.maxroach.crt.text
+
+set +e
+# Show diff: only the serial, start date, and signature should differ.
+echo ""
+echo "########################################"
+echo "diff ${CCERTS}/ca.crt.text ${OSCERTS}/ca.crt.text"
+echo ""
+diff ${CCERTS}/ca.crt.text ${OSCERTS}/ca.crt.text
+
+echo ""
+echo "########################################"
+echo "diff ${CCERTS}/node.crt.text ${OSCERTS}/node.crt.text"
+echo ""
+diff ${CCERTS}/node.crt.text ${OSCERTS}/node.crt.text
+
+echo ""
+echo "########################################"
+echo "diff ${CCERTS}/client.maxroach.crt.text ${OSCERTS}/client.maxroach.crt.text"
+echo ""
+diff ${CCERTS}/client.maxroach.crt.text ${OSCERTS}/client.maxroach.crt.text

--- a/openssl/node.conf
+++ b/openssl/node.conf
@@ -1,0 +1,11 @@
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = Cockroach
+commonName = node
+
+[ extensions ]
+subjectAltName = DNS:localhost,DNS:myhost.mydomain.com,IP:127.0.0.1


### PR DESCRIPTION
This PR contains the commands and config files necessary to generate
nearly-identical certificates using `cockroach cert` and `openssl`.

This is needed for #119

We generate all certs using cockroach:
* CA cert/key
* node cert/key
* client cert/key for user `maxroach`

We then generate the same certificates using openssl, but we reuse the
cockroach keys to make diffs smaller:
1. generate CA certificate
1. generate node CSR (certificate signing request)
1. sign node CSR resulting in node certificate
1. generate client CSR
1. sign client CSR resulting in client certificate

There are various config files used for each step:
* ca.conf for 1) 3) and 5)
* node.conf for 2)
* client.conf for 4)