### PR TITLE
Add some late additions to 20170803 release notes

### DIFF
--- a/releases/v1.1-alpha.20170803.md
+++ b/releases/v1.1-alpha.20170803.md
@@ -35,6 +35,7 @@ Get future release notes emailed to you:
 
 - Table and column names in double quotes are now case-sensitive (same as in PostgreSQL). [#16884](https://github.com/cockroachdb/cockroach/pull/16884)
 - The `SHOW SESSION TRACE` statement is now [`SHOW TRACE FOR SESSION`](../v1.1/show-vars.html). The `SET/SHOW TRACE` statements are now `SET/SHOW TRACING`. [#17033](https://github.com/cockroachdb/cockroach/pull/17033)
+- It is no longer possible to drop columns in tables depended on by views. This is an overly-broad change to avoid schema changes that might break views; it will be narrowed in the future. [#17280](https://github.com/cockroachdb/cockroach/pull/17280)
 
 ### Build Changes
 
@@ -50,6 +51,8 @@ Get future release notes emailed to you:
 - Some new syntactic forms for table references with aliases are now supported. [#17031](https://github.com/cockroachdb/cockroach/pull/17031)
 - Strings within arrays are now formatted consistently with PostgreSQL. [#17069](https://github.com/cockroachdb/cockroach/pull/17069)
 - [Transactions](../v1.1/transactions.html) can now see their own changes to table schemas. [#16988](https://github.com/cockroachdb/cockroach/pull/16988)
+- `RETURNING` clauses now accept fully-qualified table names. [#17293](https://github.com/cockroachdb/cockroach/pull/17293)
+- Improved handling of null as a function argument. [#17264](https://github.com/cockroachdb/cockroach/pull/17264)
 
 ### Command-Line Interface Changes
 
@@ -61,6 +64,7 @@ Get future release notes emailed to you:
 - Fixed a race condition that could lead to serializability violations when requests race with a lease transfer. [#17109](https://github.com/cockroachdb/cockroach/pull/17109)
 - Fixed a potential raft election issue during range splits. [#17051](https://github.com/cockroachdb/cockroach/pull/17051)
 - Fixed a use-after-close for parallelized statements. [#17126](https://github.com/cockroachdb/cockroach/pull/17126)
+- Fixed some panics in `ORDER BY INDEX`. [#17314](https://github.com/cockroachdb/cockroach/pull/17314)
 
 ### Performance Improvements
 


### PR DESCRIPTION
Covers
https://github.com/cockroachdb/cockroach/compare/64be211fa...1e88c32588fd3d7cad826437c18b349fd70e4762

Only adding the highlights since the release is already done.