### PR TITLE
Change go txn sample to use updated crdb.ExecuteTx signature

### DIFF
--- a/_includes/app/txn-sample.go
+++ b/_includes/app/txn-sample.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -39,7 +40,7 @@ func main() {
 	}
 
 	// Run a transfer in a transaction.
-	err = crdb.ExecuteTx(db, func(tx *sql.Tx) error {
+	err = crdb.ExecuteTx(context.Background(), db, nil, func(tx *sql.Tx) error {
 		return transferFunds(tx, 1 /* from acct# */, 2 /* to acct# */, 100 /* amount */)
 	})
 	if err == nil {


### PR DESCRIPTION
The cockroach-go `ExecuteTxn` signature was changed in a backward-incompatible way in https://github.com/cockroachdb/cockroach-go/pull/41, breaking the transaction example.

This change updates the sample transaction code to use the new signature.