### PR TITLE
Update known limitation about TRUNCATE and DELETE

### DIFF
--- a/v1.0/known-limitations.md
+++ b/v1.0/known-limitations.md
@@ -18,6 +18,8 @@ As a workaround, when you need to remove all rows from a large table:
 2. Use [`DROP TABLE`](drop-table.html) to remove the table.
 3. Use [`CREATE TABLE`](create-table.html) with the output from step 1 to recreate the table.
 
+{{site.data.alerts.callout_info}}Resolved as of v1.1. See <a href="https://github.com/cockroachdb/cockroach/pull/17016">#17016</a>.{{site.data.alerts.end}}
+
 ## Schema changes within transactions
 
 Within a single [transaction](transactions.html):

--- a/v1.1/known-limitations.md
+++ b/v1.1/known-limitations.md
@@ -4,19 +4,9 @@ summary:
 toc: false
 ---
 
-This page describes limitations we've identified in the [CockroachDB 1.0](../releases/v1.0.html) release and plan to investigate and possibly resolve in future releases.
+This page describes limitations we've identified in the CockroachDB 1.1 release and plan to investigate and possibly resolve in future releases.
 
 <div id="toc"></div>
-
-## Removing all rows from large tables
-
-When removing all rows from a table via a [`TRUNCATE`](truncate.html) statement or a [`DELETE`](delete.html#delete-all-rows) statement without a `WHERE` clause, CockroachDB batches the entire operation as a single [transaction](transactions.html). For large tables, this can cause the nodes containing the table data to either crash or exhibit poor performance due to elevated memory and CPU usage.
-
-As a workaround, when you need to remove all rows from a large table:
-
-1. Use [`SHOW CREATE TABLE`](show-create-table.html) to get the table schema.
-2. Use [`DROP TABLE`](drop-table.html) to remove the table.
-3. Use [`CREATE TABLE`](create-table.html) with the output from step 1 to recreate the table.
 
 ## Schema changes within transactions
 
@@ -116,61 +106,6 @@ Many string operations are not properly overloaded for [collated strings](collat
 pq: unsupported binary operator: <collatedstring{en}> || <collatedstring{en}>
 ~~~
 
-## Quoting collation locales containing uppercase letters
-
-Quoting a [collation](collate.html) locale containing uppercase letters results in an error, for example:
-
-~~~ sql
-> CREATE TABLE a (b STRING COLLATE "DE");
-~~~
-
-~~~
-invalid syntax: statement ignored: invalid locale "DE": language: tag is not well-formed at or near ")"
-CREATE TABLE a (b STRING COLLATE "DE");
-                                     ^
-~~~
-
-As a workaround, make the locale lowercase or remove the quotes, for example:
-
-~~~ sql
-> CREATE TABLE a (b STRING COLLATE "de");
-
-> CREATE TABLE b (c STRING COLLATE DE);
-~~~
-
-{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.0.1.html">version 1.0.1</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/15917">#15917</a>.{{site.data.alerts.end}}
-
-## Creating views with array types
-
-Because arrays are not supported, attempting to [create a view](create-view.html) with an array in the `SELECT` query crashes the node that receives the request.
-
-{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.0.1.html">version 1.0.1</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/15913">#15913</a>.{{site.data.alerts.end}}
-
-## Dropping a database containing views
-
-When a [view](views.html) queries multiple tables or a single table multiple times (e.g., via [`UNION`](select.html#combine-multiple-selects-union-intersect-except)), dropping the
-database containing the tables fails silently.
-
-{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.0.1.html">version 1.0.1</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/15983">#15983</a>.{{site.data.alerts.end}}
-
-## Qualifying a column that comes from a view
-
-It is not possible to fully qualify a column that comes from a view because the view gets replaced by an anonymous subquery, for example:
-
-~~~ sql
-> CREATE TABLE test (a INT, b INT);
-
-> CREATE VIEW Caps AS SELECT a, b FROM test;
-
-> SELECT sum(Caps.a) FROM Caps GROUP BY b;
-~~~
-
-~~~
-pq: source name "caps" not found in FROM clause
-~~~
-
-{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.0.1.html">version 1.0.1</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/15984">#15984</a>.{{site.data.alerts.end}}
-
 ## Write and update limits for a single transaction
 
 A single transaction can contain at most 100,000 write operations (e.g., changes to individual columns) and at most 64MiB of combined updates. When a transaction exceeds these limits, it gets aborted. `INSERT INTO .... SELECT FROM ...` queries commonly encounter these limits.
@@ -228,18 +163,6 @@ As a workaround, list the columns explicitly, for example:
 +----------------------------+
 (1 row)
 ~~~
-
-## Running on Windows as a non-admin user
-
-By default, CockroachDB periodically rotates the file it writes logs to, as well as a symlink pointing to the file it's currently using. However, on Windows, non-admin users cannot create symlinks, which prevents CockroachDB from starting because it cannot create logs.
-
-To resolve this issue, non-admin users must log to `stdout` (instead of files) by passing `--log-dir=` (with the empty value) to the `cockroach start` command, e.g.:
-
-~~~ shell
-$ cockroach.exe start --log-dir= --insecure
-~~~
-
-{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.0.1.html">version 1.0.1</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/15916">#15916</a>.{{site.data.alerts.end}}
 
 ## Query planning for `OR` expressions
 


### PR DESCRIPTION
- On 1.0 Known Limitation page, mark the limitation as resolve as of 1.1.
- Add a 1.1 Known Limitations page.
- Remove this and other resolved limitations from 1.1 page.

Fixes #1553