### PR TITLE
fix wrong directories

### DIFF
--- a/v1.0/build-a-go-app-with-cockroachdb.md
+++ b/v1.0/build-a-go-app-with-cockroachdb.md
@@ -74,12 +74,12 @@ With the default `SERIALIZABLE` isolation level, CockroachDB may require the [cl
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ mkdir -p $GOPATH/github.com/cockroachdb
+$ mkdir -p $GOPATH/src/github.com/cockroachdb
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cd $GOPATH/github.com/cockroachdb
+$ cd $GOPATH/src/github.com/cockroachdb
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v1.1/build-a-go-app-with-cockroachdb.md
+++ b/v1.1/build-a-go-app-with-cockroachdb.md
@@ -74,12 +74,12 @@ With the default `SERIALIZABLE` isolation level, CockroachDB may require the [cl
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ mkdir -p $GOPATH/github.com/cockroachdb
+$ mkdir -p $GOPATH/src/github.com/cockroachdb
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cd $GOPATH/github.com/cockroachdb
+$ cd $GOPATH/src/github.com/cockroachdb
 ~~~
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
src should be included in the source code directories of go projects.