### PR TITLE
Doc updates for cockroach init

### DIFF
--- a/_includes/app/common-steps.md
+++ b/_includes/app/common-steps.md
@@ -1,38 +1,13 @@
-## Step 2. Start a cluster
+## Step 2. Start a single-node cluster
 
 For the purpose of this tutorial, you need only one CockroachDB node running in insecure mode:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=hello-1 \
 --host=localhost
-~~~
-
-But as you might've seen in the [Start a Local Cluster](start-a-local-cluster.html) tutorial, it's incredibly easy to start and join addition nodes, if you want to simulate a real cluster.
-
-In a new terminal, start node 2:
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach start --insecure \
---store=hello-2 \
---host=localhost \
---port=26258 \
---http-port=8081 \
---join=localhost:26257
-~~~
-
-In a new terminal, start node 3:
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach start --insecure \
---store=hello-3 \
---host=localhost \
---port=26259 \
---http-port=8082 \
---join=localhost:26257
 ~~~
 
 ## Step 3. Create a user

--- a/_includes/prod_deployment/insecure-initialize-cluster.md
+++ b/_includes/prod_deployment/insecure-initialize-cluster.md
@@ -1,8 +1,12 @@
-To complete the node startup process and have them join together as a cluster, SSH to any node and run the [`cockroach init`](initialize-a-cluster.html) command:
+On your local machine, complete the node startup process and have them join together as a cluster:
 
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach init --insecure --host=<address of any node>
-~~~
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
 
-Each node then prints helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.
+2. Run the [`cockroach init`](initialize-a-cluster.html) command, with the `--host` flag set to the address of any node:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach init --insecure --host=<address of any node>
+    ~~~
+
+    Each node then prints helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.

--- a/_includes/prod_deployment/insecure-initialize-cluster.md
+++ b/_includes/prod_deployment/insecure-initialize-cluster.md
@@ -1,0 +1,8 @@
+To complete the node startup process and have them join together as a cluster, SSH to any node and run the [`cockroach init`](initialize-a-cluster.html) command:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach init --insecure --host=<address of any node>
+~~~
+
+Each node then prints helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.

--- a/_includes/prod_deployment/insecure-monitor-cluster.md
+++ b/_includes/prod_deployment/insecure-monitor-cluster.md
@@ -1,0 +1,9 @@
+View your cluster's Admin UI by going to `http://<address of any node>:8080`.
+
+In the UI, verify that the cluster is running as expected:
+
+1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
+
+2. Click the **Databases** tab on the left to verify that `insecurenodetest` is listed.
+
+{% include prometheus-callout.html %}

--- a/_includes/prod_deployment/insecure-recommendations.md
+++ b/_includes/prod_deployment/insecure-recommendations.md
@@ -1,0 +1,11 @@
+- If you plan to use CockroachDB in production, we recommend using a [secure cluster](manual-deployment.html) instead. Using an insecure cluster comes with risks:
+  - Your cluster is open to any client that can access any node's IP addresses.
+  - Any user, even `root`, can log in without providing a password.
+  - Any user, connecting as `root`, can read or write any data in your cluster.
+  - There is no network encryption or authentication, and thus no confidentiality.
+
+- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+
+- Decide how you want to access your Admin UI:
+  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
+  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.

--- a/_includes/prod_deployment/insecure-recommendations.md
+++ b/_includes/prod_deployment/insecure-recommendations.md
@@ -1,11 +1,15 @@
 - If you plan to use CockroachDB in production, we recommend using a [secure cluster](manual-deployment.html) instead. Using an insecure cluster comes with risks:
-  - Your cluster is open to any client that can access any node's IP addresses.
-  - Any user, even `root`, can log in without providing a password.
-  - Any user, connecting as `root`, can read or write any data in your cluster.
-  - There is no network encryption or authentication, and thus no confidentiality.
+    - Your cluster is open to any client that can access any node's IP addresses.
+    - Any user, even `root`, can log in without providing a password.
+    - Any user, connecting as `root`, can read or write any data in your cluster.
+    - There is no network encryption or authentication, and thus no confidentiality.
 
 - For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
 
 - Decide how you want to access your Admin UI:
-  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+
+    Access Level | Description
+    -------------|------------
+    Partially open | Set a firewall rule to allow only specific IP addresses to communicate on port `8080`.
+    Completely open | Set a firewall rule to allow all IP addresses to communicate on port `8080`.
+    Completely closed | Set a firewall rule to disallow all communication on port `8080`. In this case, a machine with SSH access to a node could use an SSH tunnel to access the Admin UI.

--- a/_includes/prod_deployment/insecure-requirements.md
+++ b/_includes/prod_deployment/insecure-requirements.md
@@ -1,5 +1,5 @@
-- You must have SSH access to each machine with `root` or `sudo` privileges. This is necessary for distributing and starting CockroachDB binaries.
+- You must have [SSH access]({{page.ssh-link}}) to each machine. This is necessary for distributing and starting CockroachDB binaries.
 
 - Your network configuration must allow TCP communication on the following ports:
-	- **26257** (`tcp:26257`) for intra-cluster and client-cluster communication
-	- **8080** (`tcp:8080`) to expose your Admin UI
+	- `26257` for intra-cluster and client-cluster communication
+	- `8080` to expose your Admin UI

--- a/_includes/prod_deployment/insecure-requirements.md
+++ b/_includes/prod_deployment/insecure-requirements.md
@@ -1,0 +1,5 @@
+- You must have SSH access to each machine with `root` or `sudo` privileges. This is necessary for distributing and starting CockroachDB binaries.
+
+- Your network configuration must allow TCP communication on the following ports:
+	- **26257** (`tcp:26257`) for intra-cluster and client-cluster communication
+	- **8080** (`tcp:8080`) to expose your Admin UI

--- a/_includes/prod_deployment/insecure-scale-cluster.md
+++ b/_includes/prod_deployment/insecure-scale-cluster.md
@@ -1,0 +1,32 @@
+For each additional node you want to add to the cluster, complete the following steps:
+
+1. SSH to the machine where you want the node to run.
+
+2. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
+    ~~~
+
+3. Copy the binary into the `PATH`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin
+    ~~~
+
+    If you get a permissions error, prefix the command with `sudo`.
+
+4. Run the [`cockroach start`](start-a-node.html) command just like you did for the initial nodes:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    $ cockroach start --insecure \
+    --host=<node4 address> \
+    --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
+    --cache=25% \
+    --max-sql-memory=25% \
+    --background
+    ~~~

--- a/_includes/prod_deployment/insecure-start-nodes.md
+++ b/_includes/prod_deployment/insecure-start-nodes.md
@@ -1,0 +1,48 @@
+For each initial node of your cluster, complete the following steps:
+
+{{site.data.alerts.callout_info}}After completing these steps, nodes will not yet be live. They will complete the startup process and join together to form a cluster as soon as the cluster is initialized in the next step.{{site.data.alerts.end}}
+
+1. SSH to the machine where you want the node to run.
+
+2. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
+    ~~~
+
+3. Copy the binary into the `PATH`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin
+    ~~~
+
+    If you get a permissions error, prefix the command with `sudo`.
+
+4. Run the [`cockroach start`](start-a-node.html) command:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    $ cockroach start --insecure \
+    --host=<node1 address> \
+    --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
+    --cache=25% \
+    --max-sql-memory=25% \
+    --background
+    ~~~
+
+    This command primes the node to start, using the following flags:
+
+    Flag | Description
+    -----|------------
+    `--insecure` | Indicates that the cluster is insecure, with no network encryption or authentication.
+    `--host` | Specifies the hostname or IP address to listen on for intra-cluster and client communication. If it is a hostname, it must be resolvable from all nodes, and if it is an IP address, it must be routable from all nodes.<br><br>If you want to listen on multiple interfaces, leave `--host` empty. If doing
+    `--join` | Identifies the address and port of 3-5 of the initial nodes of the cluster.
+    `--cache`<br>`--max-sql-memory` | Increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
+    `background` | Starts the node in the background so you gain control of the terminal to issue more commands.
+
+	For other flags not explicitly set, the command uses default values. For example, the node stores data in `--store=cockroach-data`, binds internal and client communication to `--port=26257`, and binds Admin UI HTTP requests to `--http-port=8080`. To set these options manually, see [Start a Node](start-a-node.html).
+
+5. Repeate these steps for each addition node that you want in your cluster.

--- a/_includes/prod_deployment/insecure-test-cluster.md
+++ b/_includes/prod_deployment/insecure-test-cluster.md
@@ -1,28 +1,28 @@
 CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. SSH to any node.
-
-2. Launch the built-in SQL client and create an `insecurenodetest` database:
+1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the address of any node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
-	$ cockroach sql --insecure --host=<address of this node>
+	$ cockroach sql --insecure --host=<address of any node>
 	~~~
+
+2. Create an `insecurenodetest` database:
 
     {% include copy-clipboard.html %}
 	~~~ sql
 	> CREATE DATABASE insecurenodetest;
 	~~~
 
-3. In another terminal window, SSH to another node.
+3. Use `\q` or `ctrl-d` to exit the SQL shell.
 
-4. Launch the built-in SQL client:
+4. Launch the built-in SQL client, with the `--host` flag set to the address of a different node:
 
     {% include copy-clipboard.html %}
 	~~~ shell
-	$ cockroach sql --insecure --host=<address of this node>
+	$ cockroach sql --insecure --host=<address of different node>
 	~~~
 
 5. View the cluster's databases, which will include `insecurenodetest`:
@@ -45,4 +45,4 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use `\q` or `ctrl-d` to exit the SQL shell.

--- a/_includes/prod_deployment/insecure-test-cluster.md
+++ b/_includes/prod_deployment/insecure-test-cluster.md
@@ -1,0 +1,48 @@
+CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
+
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+
+1. SSH to any node.
+
+2. Launch the built-in SQL client and create an `insecurenodetest` database:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach sql --insecure --host=<address of this node>
+	~~~
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> CREATE DATABASE insecurenodetest;
+	~~~
+
+3. In another terminal window, SSH to another node.
+
+4. Launch the built-in SQL client:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach sql --insecure --host=<address of this node>
+	~~~
+
+5. View the cluster's databases, which will include `insecurenodetest`:
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> SHOW DATABASES;
+	~~~
+
+	~~~
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| insecurenodetest   |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
+	~~~
+
+6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.

--- a/_includes/prod_deployment/insecure-test-load-balancing.md
+++ b/_includes/prod_deployment/insecure-test-load-balancing.md
@@ -1,10 +1,8 @@
 Now that a load balancer is running, it can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2. Launch the built-in SQL client, with the `--host` flag set to the address of the load balancer:
+1. Launch the built-in SQL client, with the `--host` flag set to the address of the load balancer:
 
     {% include copy-clipboard.html %}
 	~~~ shell
@@ -13,7 +11,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	--port=26257
 	~~~
 
-3. View the cluster's databases:
+2. View the cluster's databases:
 
     {% include copy-clipboard.html %}
 	~~~ sql
@@ -35,7 +33,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 
 	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
 
-4. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
+3. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -51,4 +49,4 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	(1 row)
 	~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use `\q` or `ctrl-d` to exit the SQL shell.

--- a/_includes/prod_deployment/insecure-test-load-balancing.md
+++ b/_includes/prod_deployment/insecure-test-load-balancing.md
@@ -1,0 +1,54 @@
+Now that a load balancer is running, it can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+
+To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
+
+2. Launch the built-in SQL client, with the `--host` flag set to the address of the load balancer:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach sql --insecure \
+	--host=<load balancer address> \
+	--port=26257
+	~~~
+
+3. View the cluster's databases:
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> SHOW DATABASES;
+	~~~
+
+	~~~
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| insecurenodetest   |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
+	~~~
+
+	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
+
+4. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SHOW node_id;
+    ~~~
+
+	~~~
+	+---------+
+	| node_id |
+	+---------+
+	|       3 |
+	+---------+
+	(1 row)
+	~~~
+
+5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.

--- a/_includes/prod_deployment/secure-generate-certificates.md
+++ b/_includes/prod_deployment/secure-generate-certificates.md
@@ -1,0 +1,125 @@
+Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
+
+- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
+- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP addresses and common names for machines running load balancers.
+- A client key pair for the `root` user.
+
+{{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
+
+1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+
+2. Create two directories:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ mkdir certs
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ mkdir my-safe-directory
+    ~~~
+    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
+    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
+
+3. Create the CA certificate and key:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-ca \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to the load balancer instances:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-node \
+	<node1 internal IP address> \
+	<node1 external IP address> \
+	<node1 hostname>  \
+	<other common names for node1> \
+	localhost \
+	127.0.0.1 \
+	<load balancer IP address> \
+	<load balancer hostname>  \
+	<other common names for load balancer instances> \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+5. Upload certificates to the first node:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	# Create the certs directory:
+	$ ssh <username>@<node1 address> "mkdir certs"
+	~~~
+
+	{% include copy-clipboard.html %}
+	~~~ shell
+	# Upload the CA certificate and node certificate and key:
+	$ scp certs/ca.crt \
+	certs/node.crt \
+	certs/node.key \
+	<username>@<node1 address>:~/certs
+	~~~
+
+6. Delete the local copy of the node certificate and key:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ rm certs/node.crt certs/node.key
+    ~~~
+
+    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
+
+7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to the load balancer instances:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-node \
+	<node2 internal IP address> \
+	<node2 external IP address> \
+	<node2 hostname>  \
+	<other common names for node1> \
+	localhost \
+	127.0.0.1 \
+	<load balancer IP address> \
+	<load balancer hostname>  \
+	<other common names for load balancer instances> \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+8. Upload certificates to the second node:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	# Create the certs directory:
+	$ ssh <username>@<node2 address> "mkdir certs"
+	~~~
+
+	{% include copy-clipboard.html %}
+	~~~ shell
+	# Upload the CA certificate and node certificate and key:
+	$ scp certs/ca.crt \
+	certs/node.crt \
+	certs/node.key \
+	<username>@<node2 address>:~/certs
+	~~~
+
+9. Repeat steps 6 - 8 for each additional node.
+
+10. Create a client certificate and key for the `root` user:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach cert create-client \
+	root \
+	--certs-dir=certs \
+	--ca-key=my-safe-directory/ca.key
+	~~~
+
+    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}

--- a/_includes/prod_deployment/secure-initialize-cluster.md
+++ b/_includes/prod_deployment/secure-initialize-cluster.md
@@ -1,0 +1,15 @@
+On your local machine, run the [`cockroach init`](initialize-a-cluster.html) command to complete the node startup process and have them join together as a cluster:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach init --certs-dir=certs --host=<address of any node>
+~~~
+
+This command requires the following flags:
+
+Flag | Description
+-----|------------
+`--certs-dir` | Specifies the directory where you placed the `ca.crt` file and the `client.root.crt` and `client.root.key` files for the `root` user.
+`--host` | Specifies the address of any node in the cluster.
+
+After running this command, each node prints helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.

--- a/_includes/prod_deployment/secure-monitor-cluster.md
+++ b/_includes/prod_deployment/secure-monitor-cluster.md
@@ -1,0 +1,9 @@
+View your cluster's Admin UI by going to `https://<address of any node>:8080`. Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.
+
+In the UI, verify that the cluster is running as expected:
+
+1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
+
+2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
+
+{% include prometheus-callout.html %}

--- a/_includes/prod_deployment/secure-recommendations.md
+++ b/_includes/prod_deployment/secure-recommendations.md
@@ -1,5 +1,9 @@
 - For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
 
 - Decide how you want to access your Admin UI:
-  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+
+    Access Level | Description
+    -------------|------------
+    Partially open | Set a firewall rule to allow only specific IP addresses to communicate on port `8080`.
+    Completely open | Set a firewall rule to allow all IP addresses to communicate on port `8080`.
+    Completely closed | Set a firewall rule to disallow all communication on port `8080`. In this case, a machine with SSH access to a node could use an SSH tunnel to access the Admin UI.

--- a/_includes/prod_deployment/secure-recommendations.md
+++ b/_includes/prod_deployment/secure-recommendations.md
@@ -1,0 +1,5 @@
+- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+
+- Decide how you want to access your Admin UI:
+  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
+  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.

--- a/_includes/prod_deployment/secure-requirements.md
+++ b/_includes/prod_deployment/secure-requirements.md
@@ -1,7 +1,7 @@
 - You must have [CockroachDB installed](install-cockroachdb.html) locally. This is necessary for generating and managing your deployment's certificates.
 
-- You must have [SSH access]({{page.ssh-link}}) to each machine with `root` or `sudo` privileges. This is necessary for distributing and starting CockroachDB binaries.
+- You must have [SSH access]({{page.ssh-link}}) to each machine. This is necessary for distributing and starting CockroachDB binaries.
 
 - Your network configuration must allow TCP communication on the following ports:
-	- **26257** (`tcp:26257`) for intra-cluster and client-cluster communication
-	- **8080** (`tcp:8080`) to expose your Admin UI
+	- `26257` for intra-cluster and client-cluster communication
+	- `8080` to expose your Admin UI

--- a/_includes/prod_deployment/secure-requirements.md
+++ b/_includes/prod_deployment/secure-requirements.md
@@ -1,0 +1,7 @@
+- You must have [CockroachDB installed](install-cockroachdb.html) locally. This is necessary for generating and managing your deployment's certificates.
+
+- You must have [SSH access]({{page.ssh-link}}) to each machine with `root` or `sudo` privileges. This is necessary for distributing and starting CockroachDB binaries.
+
+- Your network configuration must allow TCP communication on the following ports:
+	- **26257** (`tcp:26257`) for intra-cluster and client-cluster communication
+	- **8080** (`tcp:8080`) to expose your Admin UI

--- a/_includes/prod_deployment/secure-scale-cluster.md
+++ b/_includes/prod_deployment/secure-scale-cluster.md
@@ -1,0 +1,33 @@
+For each additional node you want to add to the cluster, complete the following steps:
+
+1. SSH to the machine where you want the node to run.
+
+2. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
+    ~~~
+
+3. Copy the binary into the `PATH`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin
+    ~~~
+
+    If you get a permissions error, prefix the command with `sudo`.
+
+4. Run the [`cockroach start`](start-a-node.html) command just like you did for the initial nodes:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    $ cockroach start \
+    --certs-dir=certs \
+    --host=<node4 address> \
+    --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
+    --cache=25% \
+    --max-sql-memory=25% \
+    --background
+    ~~~

--- a/_includes/prod_deployment/secure-start-nodes.md
+++ b/_includes/prod_deployment/secure-start-nodes.md
@@ -1,0 +1,49 @@
+For each initial node of your cluster, complete the following steps:
+
+{{site.data.alerts.callout_info}}After completing these steps, nodes will not yet be live. They will complete the startup process and join together to form a cluster as soon as the cluster is initialized in the next step.{{site.data.alerts.end}}
+
+1. SSH to the machine where you want the node to run.
+
+2. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
+    ~~~
+
+3. Copy the binary into the `PATH`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin
+    ~~~
+
+    If you get a permissions error, prefix the command with `sudo`.
+
+4. Run the [`cockroach start`](start-a-node.html) command:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    $ cockroach start \
+    --certs-dir=certs \
+    --host=<node1 address> \
+    --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
+    --cache=25% \
+    --max-sql-memory=25% \
+    --background
+    ~~~
+
+    This command primes the node to start, using the following flags:
+
+    Flag | Description
+    -----|------------
+    `--certs-dir` | Specifies the directory where you placed the `ca.crt` file and the `node.crt`, and `node.key` files for the node.
+    `--host` | Specifies the hostname or IP address to listen on for intra-cluster and client communication. If it is a hostname, it must be resolvable from all nodes, and if it is an IP address, it must be routable from all nodes.<br><br>If you want the node to listen on multiple interfaces, leave `--host` empty.<br><br>If you want the node to communicate with other nodes on an internal address (e.g., within a private network) while listening on all interfaces, leave `--host` empty and set the `--advertise-host` flag to the internal address.
+    `--join` | Identifies the address and port of 3-5 of the initial nodes of the cluster.
+    `--cache`<br>`--max-sql-memory` | Increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
+    `background` | Starts the node in the background so you gain control of the terminal to issue more commands.
+
+	For other flags not explicitly set, the command uses default values. For example, the node stores data in `--store=cockroach-data`, binds internal and client communication to `--port=26257`, and binds Admin UI HTTP requests to `--http-port=8080`. To set these options manually, see [Start a Node](start-a-node.html).
+
+5. Repeate these steps for each addition node that you want in your cluster.

--- a/_includes/prod_deployment/secure-test-cluster.md
+++ b/_includes/prod_deployment/secure-test-cluster.md
@@ -1,0 +1,55 @@
+CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
+
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+
+1. On your local machine, launch the built-in SQL client:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach sql --certs-dir=certs --host=<address of any node>
+	~~~
+
+    This command requires the following flags:
+
+    Flag | Description
+    -----|------------
+    `--certs-dir` | Specifies the directory where you placed the `ca.crt` file and the `client.root.crt` and `client.root.key` files for the `root` user.
+    `--host` | Specifies the address of any node in the cluster.
+
+2.  Create a `securenodetest` database:
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> CREATE DATABASE securenodetest;
+	~~~
+
+3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+
+4. Launch the built-in SQL client against a different node:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach sql --certs-dir=certs --host=<address of different node>
+	~~~
+
+5. View the cluster's databases, which will include `securenodetest`:
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> SHOW DATABASES;
+	~~~
+
+	~~~
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| securenodetest     |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
+	~~~
+
+6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.

--- a/_includes/prod_deployment/secure-test-cluster.md
+++ b/_includes/prod_deployment/secure-test-cluster.md
@@ -23,7 +23,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use `\q` or **CTRL + C** to exit the SQL shell.
 
 4. Launch the built-in SQL client against a different node:
 
@@ -52,4 +52,4 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use `\q` or **CTRL + C** to exit the SQL shell.

--- a/_includes/prod_deployment/secure-test-load-balancing.md
+++ b/_includes/prod_deployment/secure-test-load-balancing.md
@@ -1,0 +1,66 @@
+Now that a load balancer is running, it can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer server, which will then redirect the connection to a CockroachDB node.
+
+To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+
+1. On your local machine, launch the built-in SQL client:
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ cockroach sql \
+	--certs-dir=certs \
+	--host=<load balancer address>
+	~~~
+
+    This command requires the following flags:
+
+    Flag | Description
+    -----|------------
+    `--certs-dir` | Specifies the directory where you placed the `ca.crt` file and the `client.root.crt` and `client.root.key` files for the `root` user.
+    `--host` | Specifies the address of any node in the cluster.
+
+2. View the cluster's databases:
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> SHOW DATABASES;
+	~~~
+
+	~~~
+	+--------------------+
+	|      Database      |
+	+--------------------+
+	| crdb_internal      |
+	| information_schema |
+	| securenodetest     |
+	| pg_catalog         |
+	| system             |
+	+--------------------+
+	(5 rows)
+	~~~
+
+	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
+
+3. Check which node you were redirected to:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SHOW node_id;
+    ~~~
+
+	~~~
+	+---------+
+	| node_id |
+	+---------+
+	|       3 |
+	+---------+
+	(1 row)
+	~~~
+
+    The `node_id` [session variable](show-vars.html) used above is an alias for the following query, which you can use as well:
+
+    {% include copy-clipboard.html %}
+	~~~ sql
+	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
+	~~~
+
+4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.

--- a/_includes/prod_deployment/secure-test-load-balancing.md
+++ b/_includes/prod_deployment/secure-test-load-balancing.md
@@ -63,4 +63,4 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
 	~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use `\q` or `ctrl-d` to exit the SQL shell.

--- a/_includes/prod_deployment/use-cluster.md
+++ b/_includes/prod_deployment/use-cluster.md
@@ -1,0 +1,7 @@
+Now that your deployment is working, you can:
+
+1. [Implement your data model](sql-statements.html).
+2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
+3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the load balancer, not to a CockroachDB node.
+
+You may also want to adjusting the way the cluster replicates data. For example, by default, a multi-node cluster replicates all data 3 times; you can change this replication factor or create additional rules for replicating individual databases and tables differently. For more information, see [Configure Replication Zones](configure-replication-zones.html).

--- a/_includes/sidebar-data-v1.0.json
+++ b/_includes/sidebar-data-v1.0.json
@@ -135,7 +135,7 @@
             ]
           },
           {
-            "title": "Cross-Cloud Deployment & Migration",
+            "title": "Cross-Cloud Migration",
             "urls": [
               "/${VERSION}/demo-automatic-cloud-migration.html"
             ]

--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -877,6 +877,12 @@
         ]
       },
       {
+        "title": "Initialize a Cluster",
+        "urls": [
+          "/${VERSION}/initialize-a-cluster.html"
+        ]
+      },
+      {
         "title": "Create Security Certificates",
         "urls": [
           "/${VERSION}/create-security-certificates.html"

--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -135,7 +135,7 @@
             ]
           },
           {
-            "title": "Cross-Cloud Deployment & Migration",
+            "title": "Cross-Cloud Migration",
             "urls": [
               "/${VERSION}/demo-automatic-cloud-migration.html"
             ]

--- a/v1.1/cockroach-commands.md
+++ b/v1.1/cockroach-commands.md
@@ -15,6 +15,7 @@ You can run `cockroach help` in your shell to get similar guidance.
 Command | Usage
 --------|----
 [`start`](start-a-node.html) | Start a node.
+[`init`](initialize-a-cluster.html) | Initialize a cluster.
 [`cert`](create-security-certificates.html) | Create CA, node, and client certificates.
 [`quit`](stop-a-node.html) | <span class="version-tag">Changed in v1.1:</span> Temporarily stop a node or permanently remove a node.
 [`sql`](use-the-built-in-sql-client.html) | Use the built-in SQL client.

--- a/v1.1/demo-automatic-cloud-migration.md
+++ b/v1.1/demo-automatic-cloud-migration.md
@@ -1,5 +1,5 @@
 ---
-title: Cross-Cloud Deployment & Migration
+title: Cross-Cloud Migration
 summary: Use a local cluster to simulate migrating from one cloud platform to another.
 toc: false
 ---
@@ -31,42 +31,59 @@ In a new terminal, start node 1 on cloud 1:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --locality=cloud=1 \
 --store=cloud1node1 \
 --host=localhost \
---cache=100MB
+--cache=100MB \
+--join=localhost:26257,localhost:26258,localhost:26259
 ~~~~
 
 In a new terminal, start node 2 on cloud 1:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --locality=cloud=1 \
 --store=cloud1node2 \
 --host=localhost \
 --port=25258 \
 --http-port=8081 \
---join=localhost:26257 \
---cache=100MB
+--cache=100MB \
+--join=localhost:26257,localhost:26258,localhost:26259
 ~~~
 
 In a new terminal, start node 3 on cloud 1:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --locality=cloud=1 \
 --store=cloud1node3 \
 --host=localhost \
 --port=25259 \
 --http-port=8082 \
 --join=localhost:26257 \
---cache=100MB
+--cache=100MB \
+--join=localhost:26257,localhost:26258,localhost:26259
 ~~~
 
-## Step 3. Set up HAProxy load balancing
+## Step 3. Initialize the cluster
+
+In a new terminal, use the [`cockroach init`](initialize-a-cluster.html) command to perform a one-time initialization of the cluster:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach init \
+--insecure \
+--host=localhost \
+--port=26257
+~~~
+
+## Step 4. Set up HAProxy load balancing
 
 You're now running 3 nodes in a simulated cloud. Each of these nodes is an equally suitable SQL gateway to your cluster, but to ensure an even balancing of client requests across these nodes, you can use a TCP load balancer. Let's use the open-source [HAProxy](http://www.haproxy.org/) load balancer that you installed earlier.
 
@@ -74,7 +91,10 @@ In a new terminal, run the [`cockroach gen haproxy`](generate-cockroachdb-resour
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach gen haproxy --insecure --host=localhost --port=26257
+$ cockroach gen haproxy \
+--insecure \
+--host=localhost \
+--port=26257
 ~~~
 
 This command generates an `haproxy.cfg` file automatically configured to work with the 3 nodes of your running cluster. In the file, change `bind :26257` to `bind :26000`. This changes the port on which HAProxy accepts requests to a port that is not already in use by a node and that won't be used by the nodes you'll add later.
@@ -105,7 +125,7 @@ Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 $ haproxy -f haproxy.cfg
 ~~~
 
-## Step 4. Start a load generator
+## Step 5. Start a load generator
 
 Now that you have a load balancer running in front of your cluster, let's use the YCSB load generator that you installed earlier to simulate multiple client connections, each performing mixed read/write workloads.
 
@@ -118,7 +138,7 @@ $ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -rate-limit 1
 
 This command initiates 10 concurrent client workloads for 20 minutes, but limits each worker to 100 operations per second (since you're running everything on a single machine).
 
-## Step 5. Watch data balance across all 3 nodes
+## Step 6. Watch data balance across all 3 nodes
 
 Now open the Admin UI at `http://localhost:8080` and hover over the **SQL Queries** graph at the top. After a minute or so, you'll see that the load generator is executing approximately 95% reads and 5% writes across all nodes:
 
@@ -128,7 +148,7 @@ Scroll down a bit and hover over the **Replicas per Node** graph. Because Cockro
 
 <img src="{{ 'images/admin_ui_replicas_migration.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-## Step 6. Add 3 nodes on "cloud 2"
+## Step 7. Add 3 nodes on "cloud 2"
 
 At this point, you're running three nodes on cloud 1. But what if you'd like to start experimenting with resources provided by another cloud vendor? Let's try that by adding three more nodes to a new cloud platform. Again, the flag to note is [`--locality`](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes), which you're using to specify that these next 3 nodes are running on cloud 2.
 
@@ -136,45 +156,48 @@ In a new terminal, start node 4 on cloud 2:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --locality=cloud=2 \
 --store=cloud2node4 \
 --host=localhost \
 --port=26260 \
 --http-port=8083 \
---join=localhost:26257 \
---cache=100MB
+--cache=100MB \
+--join=localhost:26257,localhost:26258,localhost:26259
 ~~~
 
 In a new terminal, start node 5 on cloud 2:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --locality=cloud=2 \
 --store=cloud2node5 \
 --host=localhost \
 --port=25261 \
 --http-port=8084 \
---join=localhost:26257 \
---cache=100MB
+--cache=100MB \
+--join=localhost:26257,localhost:26258,localhost:26259
 ~~~
 
 In a new terminal, start node 6 on cloud 2:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --locality=cloud=2 \
 --store=cloud2node6 \
 --host=localhost \
 --port=25262 \
 --http-port=8085 \
---join=localhost:26257 \
---cache=100MB
+--cache=100MB \
+--join=localhost:26257,localhost:26258,localhost:26259
 ~~~
 
-## Step 7. Watch data balance across all 6 nodes
+## Step 8. Watch data balance across all 6 nodes
 
 Back in the Admin UI, hover over the **Replicas per Node** graph again. Because you used [`--locality`](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes) to specify that nodes are running on 2 clouds, you'll see an approximately even number of replicas on each node, indicating that CockroachDB has automatically rebalanced replicas across both simulated clouds:
 
@@ -182,7 +205,7 @@ Back in the Admin UI, hover over the **Replicas per Node** graph again. Because 
 
 Note that it takes a few minutes for the Admin UI to show accurate per-node replica counts on hover. This is why the new nodes in the screenshot above show 0 replicas. However, the graph lines are accurate, and you can click **View node list** in the **Summary** area for accurate per-node replica counts as well.
 
-## Step 8. Migrate all data to "cloud 2"
+## Step 9. Migrate all data to "cloud 2"
 
 So your cluster is replicating across two simulated clouds. But let's say that after experimentation, you're happy with cloud vendor 2, and you decide that you'd like to move everything there. Can you do that without interruption to your live client traffic? Yes, and it's as simple as running a single command to add a [hard constraint](configure-replication-zones.html#replication-constraints) that all replicas must be on nodes with `--locality=cloud=2`.
 
@@ -193,7 +216,7 @@ In a new terminal, edit the default replication zone:
 $ echo 'constraints: [+cloud=2]' | cockroach zone set .default --insecure --host=localhost -f -
 ~~~
 
-## Step 9. Verify the data migration
+## Step 10. Verify the data migration
 
 Back in the Admin UI, hover over the **Replicas per Node** graph again. Very soon, you'll see the replica count double on nodes 4, 5, and 6 and drop to 0 on nodes 1, 2, and 3:
 
@@ -201,7 +224,7 @@ Back in the Admin UI, hover over the **Replicas per Node** graph again. Very soo
 
 This indicates that all data has been migrated from cloud 1 to cloud 2. In a real cloud migration scenario, at this point you would update the load balancer to point to the nodes on cloud 2 and then stop the nodes on cloud 1. But for the purpose of this local simulation, there's no need to do that.
 
-## Step 10. Stop the cluster
+## Step 11. Stop the cluster
 
 Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL + C**. Then do the same for HAProxy and each CockroachDB node.
 

--- a/v1.1/demo-data-replication.md
+++ b/v1.1/demo-data-replication.md
@@ -16,7 +16,8 @@ Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=repdemo-node1 \
 --host=localhost
 ~~~
@@ -133,7 +134,8 @@ In a new terminal, add node 2:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=repdemo-node2 \
 --host=localhost \
 --port=26258 \
@@ -145,7 +147,8 @@ In a new terminal, add node 3:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=repdemo-node3 \
 --host=localhost \
 --port=26259 \
@@ -195,7 +198,8 @@ In a new terminal, add node 5:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --host=localhost \
 --store=repdemo-node5 \
 --port=26261 \

--- a/v1.1/deploy-cockroachdb-on-aws-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-aws-insecure.md
@@ -18,23 +18,13 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 ## Requirements
 
-You must have SSH access ([key pairs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)/[SSH login](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html)) to each machine with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/insecure-requirements.md %}
 
 ## Recommendations
 
-- If you plan to use CockroachDB in production, we recommend using a [secure cluster](deploy-cockroachdb-on-aws.html) instead. Using an insecure cluster comes with risks:
-  - Your cluster is open to any client that can access any node's IP addresses.
-  - Any user, even `root`, can log in without providing a password.
-  - Any user, connecting as `root`, can read or write any data in your cluster.
-  - There is no network encryption or authentication, and thus no confidentiality.
-
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+{% include prod_deployment/insecure-recommendations.md %}
 
 - All instances running CockroachDB should be members of the same Security Group.
-
-- Decide how you want to access your Admin UI:
-	- Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*
-	- Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes
 
 ## Step 1. Configure your network
 
@@ -96,206 +86,37 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of AWS's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Start the first node
+## Step 4. Start nodes
 
-1. SSH to your instance:
+{% include prod_deployment/insecure-start-nodes.md %}
 
-	~~~ shell
-	$ ssh -i <path to AWS .pem> <username>@<node1 external IP address>
-	~~~
+## Step 5. Initialize the cluster
 
-2. Install the latest CockroachDB binary:
+{% include prod_deployment/insecure-initialize-cluster.md %}
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+## Step 6. Test the cluster
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-	~~~
-	$ cockroach start --insecure \
-    --advertise-host=<node1 internal IP address> \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-	~~~
-
-	This commands starts an insecure node and identifies the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-	Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, listens for internal and client communication on port 26257, and listens for HTTP requests from the Admin UI on port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 5. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1. SSH to another instance:
-
-	~~~
-	$ ssh -i <path to AWS .pem> <username>@<additional node external IP address>
-	~~~
-
-2. Install CockroachDB from our latest binary:
-
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-	~~~
-	$ cockroach start --insecure \
-	--join=<node1 internal IP address>:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each instance you want to use as a node.
-
-## Step 6. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-1. SSH to your first node:
-
-	~~~ shell
-	$ ssh -i <path to AWS .pem> <username>@<node1 external IP address>
-	~~~
-
-2. Launch the built-in SQL client and create a database:
-
-	~~~ shell
-	$ cockroach sql --insecure
-	~~~
-	~~~ sql
-	> CREATE DATABASE insecurenodetest;
-	~~~
-
-3. In another terminal window, SSH to another node:
-
-	~~~ shell
-	$ ssh -i <path to AWS .pem> <username>@<node3 external IP address>
-	~~~
-
-4. Launch the built-in SQL client:
-
-	~~~ shell
-	$ cockroach sql --insecure
-	~~~
-
-5. View the cluster's databases, which will include `insecurenodetest`:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/insecure-test-cluster.md %}
 
 ## Step 7. Test load balancing
 
-The AWS load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/insecure-test-load-balancing.md %}
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
-
-	~~~ shell
-	$ cockroach sql --insecure \
-	--host=<load balancer IP address> \
-	--port=26257
-	~~~
-
-3. View the cluster's databases:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-4. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
-
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 8. Monitor the cluster
-
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-2. Click the **Databases** tab on the left to verify that `insecurenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 9. Use the database
+## Step 8. Use the cluster
 
 Now that your deployment is working, you can:
 
 1. [Implement your data model](sql-statements.html).
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the AWS load balancer, not to a CockroachDB node.
+
+## Step 9. Monitor the cluster
+
+{% include prod_deployment/insecure-monitor-cluster.md %}
+
+## Step 10. Scale the cluster
+
+{% include prod_deployment/insecure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/deploy-cockroachdb-on-aws-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-aws-insecure.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on AWS EC2 (Insecure)
 summary: Learn how to deploy CockroachDB on Amazon's AWS EC2 platform.
 toc: false
 toc_not_nested: true
+ssh-link: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 ---
 
 <div class="filters filters-big clearfix">

--- a/v1.1/deploy-cockroachdb-on-aws.md
+++ b/v1.1/deploy-cockroachdb-on-aws.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on AWS EC2
 summary: Learn how to deploy CockroachDB on Amazon's AWS EC2 platform.
 toc: false
 toc_not_nested: true
+ssh-link: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 ---
 
 <div class="filters filters-big clearfix">
@@ -18,19 +19,13 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 ## Requirements
 
-- Locally, you must have [CockroachDB installed](install-cockroachdb.html), which you'll use to generate and manage your deployment's certificates.
-
-- In AWS, you must have SSH access ([key pairs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html)/[SSH login](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html)) to each machine with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/secure-requirements.md %}
 
 ## Recommendations
 
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+{% include prod_deployment/secure-recommendations.md %}
 
 - All instances running CockroachDB should be members of the same Security Group.
-
-- Decide how you want to access your Admin UI:
-    - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*
-    - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes
 
 ## Step 1. Configure your network
 
@@ -94,365 +89,35 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 ## Step 4. Generate certificates
 
-Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
+{% include prod_deployment/secure-generate-certificates.md %}
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the AWS load balancer (`node.crt` and `node.key`)
-- A client key pair for the `root` user (`client.root.crt` and `client.root.key`).
+## Step 5. Start nodes
 
-{{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
+{% include prod_deployment/secure-start-nodes.md %}
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+## Step 6. Initialize the cluster
 
-2. Create two directories:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir certs
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir my-safe-directory
-    ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
-
-3. Create the CA certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-node \
-    <node1 internal IP address> \
-    <node1 external IP address> \
-    <node1 hostname>  \
-    <other common names for node1> \
-    localhost \
-    127.0.0.1 \
-    <load balancer IP address> \
-    <load balancer hostname> \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-    - `<node1 internal IP address>` which is the instance's **Internal IP**.
-    - `<node1 external IP address>` which is the instance's **External IP address**.
-    - `<node1 hostname>` which is the instance's hostname. You can find this by SSHing into a server and running `hostname`. For many AWS EC2 servers, this is `ip-` followed by the internal IP address delimited by dashes; e.g., `ip-172-31-18-168`.
-    - `<other common names for node1>` which include any domain names you point to the instance.
-    - `localhost` and `127.0.0.1`
-    - `<load balancer IP address>`
-    - `<load balancer hostname>`
-
-5. Upload certificates to the first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Create the certs directory:
-    $ ssh -i <path to AWS .pem> <username>@<node1 external IP address> "mkdir certs"
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Upload the CA certificate and node certificate and key:
-    $ scp -i <path to AWS .pem>\
-    certs/ca.crt \
-    certs/node.crt \
-    certs/node.key \
-    <username>@<node1 external IP address>:~/certs
-    ~~~
-
-6. Delete the local copy of the node certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ rm certs/node.crt certs/node.key
-    ~~~
-
-    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
-
-7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the AWS load balancer:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-node \
-    <node2 internal IP address> \
-    <node2 external IP address> \
-    <node2 hostname>  \
-    <other common names for node2> \
-    localhost \
-    127.0.0.1 \
-    <load balancer IP address> \
-    <load balancer hostname> \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-8. Upload certificates to the second node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Create the certs directory:
-    $ ssh -i <path to AWS .pem> <username>@<node2 external IP address> "mkdir certs"
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Upload the CA certificate and node certificate and key:
-    $ scp -i <path to AWS .pem>\
-    certs/ca.crt \
-    certs/node.crt \
-    certs/node.key \
-    <username>@<node2 external IP address>:~/certs
-    ~~~
-
-9. Repeat steps 6 - 8 for each additional node.
-
-10. Create a client certificate and key for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
-
-## Step 5. Start the first node
-
-1. SSH to your instance:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh -i <path to AWS .pem> <username>@<node1 external IP address>
-    ~~~
-
-2. Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Extract the binary.
-    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Move the binary.
-    $ sudo mv cockroach /usr/local/bin
-    ~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --advertise-host=<node1 internal IP address> \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    This command specifies the location of certificates and the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-    Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, binds internal and client communication to port 26257, and binds Admin UI HTTP requests to port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 6. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1. SSH to your instance:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ ssh -i <path to AWS .pem> <username>@<additional node external IP address>
-    ~~~
-
-2. Install CockroachDB from our latest binary:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Extract the binary.
-    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Move the binary.
-    $ sudo mv cockroach /usr/local/bin
-    ~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --advertise-host=<node2 internal IP address> \
-    --join=<node1 internal IP address>:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each instance you want to use as a node.
+{% include prod_deployment/secure-initialize-cluster.md %}
 
 ## Step 7. Test your cluster
 
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
-
-1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the external IP address of node 1 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<node1 external IP address>
-    ~~~
-
-2. Create a `securenodetest` database:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > CREATE DATABASE securenodetest;
-    ~~~
-
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external IP address of node 2 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<node2 external IP address>
-    ~~~
-
-5. View the cluster's databases, which will include `securenodetest`:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW DATABASES;
-    ~~~
-
-    ~~~
-    +--------------------+
-    |      Database      |
-    +--------------------+
-    | crdb_internal      |
-    | information_schema |
-    | securenodetest     |
-    | pg_catalog         |
-    | system             |
-    +--------------------+
-    (5 rows)
-    ~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/secure-test-cluster.md %}
 
 ## Step 8. Test load balancing
 
-The AWS load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/secure-test-load-balancing.md %}
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+## Step 9. Use the database
 
-1. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
+{% include prod_deployment/use-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<load balancer IP address>
-    ~~~
+## Step 10. Monitor the cluster
 
-2. View the cluster's databases:
+{% include prod_deployment/secure-monitor-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW DATABASES;
-    ~~~
+## Step 11. Scale the cluster
 
-    ~~~
-    +--------------------+
-    |      Database      |
-    +--------------------+
-    | crdb_internal      |
-    | information_schema |
-    | insecurenodetest   |
-    | pg_catalog         |
-    | system             |
-    +--------------------+
-    (5 rows)
-    ~~~
-
-    As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-3. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-    ~~~
-    +---------+
-    | node_id |
-    +---------+
-    |       3 |
-    +---------+
-    (1 row)
-    ~~~
-
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 9. Monitor the cluster
-
-View your cluster's Admin UI by going to `https://<any node's external IP address>:8080`.
-
-{{site.data.alerts.callout_info}}Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.{{site.data.alerts.end}}
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 10. Use the database
-
-Now that your deployment is working, you can:
-
-1. [Implement your data model](sql-statements.html).
-2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
-3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the AWS load balancer, not to a CockroachDB node.
+{% include prod_deployment/secure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on Digital Ocean (Insecure)
 summary: Learn how to deploy CockroachDB on Digital Ocean.
 toc: false
 toc_not_nested: true
+ssh-link: https://www.digitalocean.com/community/tutorials/how-to-connect-to-your-droplet-with-ssh
 ---
 
 <div class="filters filters-big clearfix">

--- a/v1.1/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.1/deploy-cockroachdb-on-digital-ocean.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on Digital Ocean
 summary: Learn how to deploy CockroachDB on Digital Ocean.
 toc: false
 toc_not_nested: true
+ssh-link: https://www.digitalocean.com/community/tutorials/how-to-connect-to-your-droplet-with-ssh
 ---
 
 <div class="filters filters-big clearfix">
@@ -18,23 +19,17 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 ## Requirements
 
-- Locally, you must have [CockroachDB installed](install-cockroachdb.html), which you’ll use to generate and manage your deployment’s certificates.
-
-- In Digitial Ocean, you must have [SSH access](https://www.digitalocean.com/community/tutorials/how-to-connect-to-your-droplet-with-ssh) to each Droplet with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/secure-requirements.md %}
 
 ## Recommendations
 
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+{% include prod_deployment/secure-recommendations.md %}
 
-- Set up your Droplets using [private networking](https://www.digitalocean.com/community/tutorials/how-to-set-up-and-use-digitalocean-private-networking).
-
-- Decide how you want to access your Admin UI:
-    - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-    - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+- If all of your CockroachDB nodes and clients will run on Droplets in a single region, consider using [private networking](https://www.digitalocean.com/community/tutorials/how-to-set-up-and-use-digitalocean-private-networking).
 
 ## Step 1. Create Droplets
 
-[Create Droplets with private networking](https://www.digitalocean.com/community/tutorials/how-to-set-up-and-use-digitalocean-private-networking) for each node you plan to have in your cluster. We [recommend](recommended-production-settings.html#cluster-topology):
+[Create Droplets](https://www.digitalocean.com/community/tutorials/how-to-create-your-first-digitalocean-droplet) for each node you plan to have in your cluster. We [recommend](recommended-production-settings.html#cluster-topology):
 
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your Droplets for best performance.
@@ -73,365 +68,35 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 
 ## Step 4. Generate certificates
 
-Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
+{% include prod_deployment/secure-generate-certificates.md %}
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the Digital Ocean Load Balancer.
-- A client key pair for the `root` user.
+## Step 5. Start nodes
 
-{{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
+{% include prod_deployment/secure-start-nodes.md %}
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+## Step 6. Initialize the cluster
 
-2. Create two directories:
+{% include prod_deployment/secure-initialize-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir certs
-    ~~~
+## Step 7. Test the cluster
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir my-safe-directory
-    ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
-
-3. Create the CA certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
-    - `<node internal IP address>`, which is the node Droplet's **Private IP**.
-    - `<node external IP address>`, which is the node Droplet's **ipv4** address.
-    - `<node hostname>`, which is the node Droplet's **Name**.
-    - `<other common names for node>`, which include any domain names you point to the node Droplet.
-    - `localhost` and `127.0.0.1`
-    - `<load balancer IP address>`, which is the Digital Ocean Load Balancer's provisioned **IP Address**.
-    - `<load balancer hostname>`, which is the Digital Ocean Load Balancer's **Name**.
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-node \
-    <node1 internal IP address> \
-    <node1 external IP address> \
-    <node1 hostname>  \
-    <other common names for node1> \
-    localhost \
-    127.0.0.1 \
-    <load balancer IP address> \
-    <load balancer hostname> \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-5. Upload certificates to the first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Create the certs directory:
-    $ ssh <username>@<node1 external IP address> "mkdir certs"
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Upload the CA certificate and node certificate and key:
-    $ scp certs/ca.crt \
-    certs/node.crt \
-    certs/node.key \
-    <username>@<node1 external IP address>:~/certs
-    ~~~
-
-6. Delete the local copy of the node certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ rm certs/node.crt certs/node.key
-    ~~~
-
-    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
-
-7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Digital Ocean Load Balancer:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-node \
-    <node2 internal IP address> \
-    <node2 external IP address> \
-    <node2 hostname>  \
-    <other common names for node2> \
-    localhost \
-    127.0.0.1 \
-    <load balancer IP address> \
-    <load balancer hostname> \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-8. Upload certificates to the second node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Create the certs directory:
-    $ ssh <username>@<node2 external IP address> "mkdir certs"
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Upload the CA certificate and node certificate and key:
-    $ scp certs/ca.crt \
-    certs/node.crt \
-    certs/node.key \
-    <username>@<node2 external IP address>:~/certs
-    ~~~
-
-9. Repeat steps 6 - 8 for each additional node.
-
-10. Create a client certificate and key for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
-
-## Step 5. Start the first node
-
-1. SSH to your Droplet:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh <username>@<node1 external IP address>
-    ~~~
-
-2. Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Extract the binary.
-    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Move the binary.
-    $ sudo mv cockroach /usr/local/bin
-    ~~~
-
-3. Start a new CockroachDB cluster with a single node, specifying the location of certificates and the address at which other nodes can reach it:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --advertise-host=<node1 internal IP address> \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    This command specifies the location of certificates and the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-    Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, binds internal and client communication to port 26257, and binds Admin UI HTTP requests to port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 6. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1. SSH to your Droplet:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ ssh <username>@<additional node external IP address>
-    ~~~
-
-2. Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Extract the binary.
-    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Move the binary.
-    $ sudo mv cockroach /usr/local/bin
-    ~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --advertise-host=<node2 internal IP address> \
-    --join=<node1 internal IP address>:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each Droplet you want to use as a node.
-
-## Step 7. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
-
-1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the address of node 1 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<node1 address>
-    ~~~
-
-2. Create a `securenodetest` database:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > CREATE DATABASE securenodetest;
-    ~~~
-
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-4. Connect the built-in SQL client to node 2, with the `--host` flag set to the address of node 2 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<node2 address>
-    ~~~
-
-5. View the cluster's databases, which will include `securenodetest`:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW DATABASES;
-    ~~~
-
-    ~~~
-    +--------------------+
-    |      Database      |
-    +--------------------+
-    | crdb_internal      |
-    | information_schema |
-    | securenodetest     |
-    | pg_catalog         |
-    | system             |
-    +--------------------+
-    (5 rows)
-    ~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/secure-test-cluster.md %}
 
 ## Step 8. Test load balancing
 
-The Digital Ocean Load Balancer created in [step 2](#step-2-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/secure-test-load-balancing.md %}
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+## Step 9. Use the database
 
-1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
+{% include prod_deployment/use-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<load balancer IP address>
-    ~~~
+## Step 10. Monitor the cluster
 
-2. View the cluster's databases:
+{% include prod_deployment/secure-monitor-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW DATABASES;
-    ~~~
+## Step 11. Scale the cluster
 
-    ~~~
-    +--------------------+
-    |      Database      |
-    +--------------------+
-    | crdb_internal      |
-    | information_schema |
-    | securenodetest     |
-    | pg_catalog         |
-    | system             |
-    +--------------------+
-    (5 rows)
-    ~~~
-
-    As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-3. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-    ~~~
-    +---------+
-    | node_id |
-    +---------+
-    |       3 |
-    +---------+
-    (1 row)
-    ~~~
-
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 9. Monitor the cluster
-
-View your cluster's Admin UI by going to `https://<any node's external IP address>:8080`.
-
-{{site.data.alerts.callout_info}}Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.{{site.data.alerts.end}}
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-    Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--advertise-host` flag to the Droplet's internal IP address. This prevents the node from receiving replicas and working as part of the cluster.
-
-2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 10. Use the database
-
-Now that your deployment is working, you can:
-
-1. [Implement your data model](sql-statements.html).
-2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
-3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Digital Ocean Load Balancer, not to a CockroachDB node.
+{% include prod_deployment/secure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -18,21 +18,11 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 ## Requirements
 
-You must have [SSH access](https://cloud.google.com/compute/docs/instances/connecting-to-instance) to each machine with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/insecure-requirements.md %}
 
 ## Recommendations
 
-- If you plan to use CockroachDB in production, we recommend using a [secure cluster](deploy-cockroachdb-on-google-cloud-platform.html) instead. Using an insecure cluster comes with risks:
-  - Your cluster is open to any client that can access any node's IP addresses.
-  - Any user, even `root`, can log in without providing a password.
-  - Any user, connecting as `root`, can read or write any data in your cluster.
-  - There is no network encryption or authentication, and thus no confidentiality.
-
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
-
-- Decide how you want to access your Admin UI:
-  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+{% include prod_deployment/insecure-recommendations.md %}
 
 ## Step 1. Configure your network
 
@@ -95,207 +85,37 @@ To use GCE's TCP Proxy Load Balancing service:
 4. [Create a firewall rule](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy#config-hc-firewall) to allow traffic from the load balancer and health checker to your instances. This is necessary because TCP Proxy Load Balancing is implemented at the edge of the Google Cloud.
     - Be sure to set **Source IP ranges** to `130.211.0.0/22` and `35.191.0.0/16` and set **Target tags** to `cockroachdb` (not to the value specified in the linked instructions).
 
-## Step 4. Start the first node
+## Step 4. Start nodes
 
-1. SSH to your instance:
+{% include prod_deployment/insecure-start-nodes.md %}
 
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
+## Step 5. Initialize the cluster
 
-2. Install the latest CockroachDB binary:
+{% include prod_deployment/insecure-initialize-cluster.md %}
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
+## Step 6. Test the cluster
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{page.release_info.version}}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{page.release_info.version}}.linux-amd64/cockroach
-
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-	~~~
-	$ cockroach start --insecure \
-	--host=<node1 internal address> \
-	--cache=25% \
-	--max-sql-memory=25% \
-	--background
-	~~~
-
-	This commands starts an insecure node and identifies the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-	Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, listens for internal and client communication on port 26257, and listens for HTTP requests from the Admin UI on port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 5. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1. SSH to your instance:
-
-	~~~
-	$ ssh <username>@<additional node external IP address>
-	~~~
-
-2. Install CockroachDB from our latest binary:
-
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
-
-	# Extract the binary.
-	$ tar -xf cockroach-{{page.release_info.version}}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{page.release_info.version}}.linux-amd64/cockroach
-
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-	~~~
-	$ cockroach start --insecure \
-	--host=<node2 internal address> \
-	--join=<node1 internal address>:26257 \
-	--cache=25% \
-	--max-sql-memory=25% \
-	--background
-	~~~
-
-	The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each instance you want to use as a node.
-
-## Step 6. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-1. SSH to your first node:
-
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
-
-2. Launch the built-in SQL client and create a database:
-
-	~~~ shell
-	$ cockroach sql --insecure
-	~~~
-	~~~ sql
-	> CREATE DATABASE insecurenodetest;
-	~~~
-
-3. In another terminal window, SSH to another node:
-
-	~~~ shell
-	$ ssh <username>@<node3 external IP address>
-	~~~
-
-4. Launch the built-in SQL client:
-
-	~~~ shell
-	$ cockroach sql --insecure
-	~~~
-
-5. View the cluster's databases, which will include `insecurenodetest`:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/insecure-test-cluster.md %}
 
 ## Step 7. Test load balancing
 
-The GCE load balancer created in [step 3](#step-3-set-up-tcp-proxy-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/insecure-test-load-balancing.md %}
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
-
-	~~~ shell
-	$ cockroach sql --insecure \
-	--host=<load balancer IP address> \
-	--port=<load balancer port>
-	~~~
-
-3. View the cluster's databases:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-4. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
-
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 8. Monitor the cluster
-
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-2. Click the **Databases** tab on the left to verify that `insecurenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 9. Use the database
+## Step 8. Use the cluster
 
 Now that your deployment is working, you can:
 
 1. [Implement your data model](sql-statements.html).
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the GCE load balancer, not to a CockroachDB node.
+
+## Step 9. Monitor the cluster
+
+{% include prod_deployment/insecure-monitor-cluster.md %}
+
+## Step 10. Scale the cluster
+
+{% include prod_deployment/insecure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on Google Cloud Platform GCE (Insecure)
 summary: Learn how to deploy CockroachDB on Google Cloud Platform's Compute Engine.
 toc: false
 toc_not_nested: true
+ssh-link: https://cloud.google.com/compute/docs/instances/connecting-to-instance
 ---
 
 <div class="filters filters-big clearfix">

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on Google Cloud Platform GCE
 summary: Learn how to deploy CockroachDB on Google Cloud Platform's Compute Engine.
 toc: false
 toc_not_nested: true
+ssh-link: https://cloud.google.com/compute/docs/instances/connecting-to-instance
 ---
 
 <div class="filters filters-big clearfix">
@@ -18,17 +19,11 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 ## Requirements
 
-- Locally, you must have [CockroachDB installed](install-cockroachdb.html), which you'll use to generate and manage your deployment's certificates.
-
-- In GCE, you must have [SSH access](https://cloud.google.com/compute/docs/instances/connecting-to-instance) to each machine with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/secure-requirements.md %}
 
 ## Recommendations
 
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
-
-- Decide how you want to access your Admin UI:
-  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+{% include prod_deployment/secure-recommendations.md %}
 
 ## Step 1. Configure your network
 
@@ -93,364 +88,35 @@ To use GCE's TCP Proxy Load Balancing service:
 
 ## Step 4. Generate certificates
 
-Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
+{% include prod_deployment/secure-generate-certificates.md %}
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the GCE load balancer.
-- A client key pair for the `root` user.
+## Step 5. Start nodes
 
-{{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
+{% include prod_deployment/secure-start-nodes.md %}
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+## Step 6. Initialize the cluster
 
-2. Create two directories:
+{% include prod_deployment/secure-initialize-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir certs
-    ~~~
+## Step 7. Test the cluster
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir my-safe-directory
-    ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
-
-3. Create the CA certificate and key:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-node \
-	<node1 internal IP address> \
-	<node1 external IP address> \
-	<node1 hostname>  \
-	<other common names for node1> \
-	localhost \
-	127.0.0.1 \
-	<load balancer IP address> \
-	<load balancer hostname> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-	- `<node1 internal IP address>` which is the instance's **Internal IP**.
-	- `<node1 external IP address>` which is the instance's **External IP address**.
-	- `<node1 hostname>` which is the instance's **Name**.
-	- `<other common names for node1>` which include any domain names you point to the instance.
-	- `localhost` and `127.0.0.1`
-	- `<load balancer IP address>`
-	- `<load balancer hostname>`
-
-5. Upload certificates to the first node:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node1 external IP address> "mkdir certs"
-	~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-	# Upload the CA certificate and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node1 external IP address>:~/certs
-	~~~
-
-6. Delete the local copy of the node certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ rm certs/node.crt certs/node.key
-    ~~~
-
-    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
-
-7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the GCE load balancer:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-node \
-	<node2 internal IP address> \
-	<node2 external IP address> \
-	<node2 hostname>  \
-	<other common names for node2> \
-	localhost \
-	127.0.0.1 \
-	<load balancer IP address> \
-	<load balancer hostname> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-8. Upload certificates to the second node:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node2 external IP address> "mkdir certs"
-	~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-	# Upload the CA certificate and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node2 external IP address>:~/certs
-	~~~
-
-9. Repeat steps 6 - 8 for each additional node.
-
-10. Create a client certificate and key for the `root` user:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
-
-## Step 5. Start the first node
-
-1. SSH to your instance:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
-
-2. Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-	~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-	~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-    {% include copy-clipboard.html %}
-	~~~
-	$ cockroach start \
-	--host=<node1 internal address> \
-	--certs-dir=certs \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    This command specifies the location of certificates and the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-    Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, binds internal and client communication to port 26257, and binds Admin UI HTTP requests to port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 6. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1. SSH to your instance:
-
-    {% include copy-clipboard.html %}
-	~~~
-	$ ssh <username>@<additional node external IP address>
-	~~~
-
-2. Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-	~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-	~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-    {% include copy-clipboard.html %}
-	~~~
-	$ cockroach start \
-	--certs-dir=certs \
-	--host=<node1 internal address> \
-	--join=<node1 internal IP address>:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-	~~~
-
-	The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each instance you want to use as a node.
-
-## Step 7. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
-
-1. On your local machine, connect the built-in SQL client to node 1, with the `--host` flag set to the external address of node 1 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<node1 external IP address>
-	~~~
-
-2. Create a `securenodetest` database:
-
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> CREATE DATABASE securenodetest;
-	~~~
-
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<node2 external IP address>
-	~~~
-
-5. View the cluster's databases, which will include `securenodetest`:
-
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/secure-test-cluster.md %}
 
 ## Step 8. Test load balancing
 
-The GCE load balancer created in [step 3](#step-3-set-up-tcp-proxy-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/secure-test-load-balancing.md %}
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+## Step 9. Use the database
 
-1. On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address and security flags pointing to the CA cert and the client cert and key:
+{% include prod_deployment/use-cluster.md %}
 
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs
-	--host=<load balancer IP address> \
-	--port=<load balancer port>
-	~~~
+## Step 10. Monitor the cluster
 
-2. View the cluster's databases:
+{% include prod_deployment/secure-monitor-cluster.md %}
 
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
+## Step 11. Scale the cluster
 
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-3. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
-
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 9. Monitor the cluster
-
-View your cluster's Admin UI by going to `https://<any node's external IP address>:8080`.
-
-{{site.data.alerts.callout_info}}Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.{{site.data.alerts.end}}
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 10. Use the database
-
-Now that your deployment is working, you can:
-
-1. [Implement your data model](sql-statements.html).
-2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
-3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the GCE load balancer, not to a CockroachDB node.
+{% include prod_deployment/secure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -18,21 +18,11 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 ## Requirements
 
-You must have [SSH access](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) to each machine with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/insecure-requirements.md %}
 
 ## Recommendations
 
-- If you plan to use CockroachDB in production, we recommend using a [secure cluster](deploy-cockroachdb-on-microsoft-azure.html) instead. Using an insecure cluster comes with risks:
-  - Your cluster is open to any client that can access any node's IP addresses.
-  - Any user, even `root`, can log in without providing a password.
-  - Any user, connecting as `root`, can read or write any data in your cluster.
-  - There is no network encryption or authentication, and thus no confidentiality.
-
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
-
-- Decide how you want to access your Admin UI:
-  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+{% include prod_deployment/insecure-requirements.md %}
 
 ## Step 1. Configure your network
 
@@ -102,210 +92,37 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Azure's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Start the first node
+## Step 4. Start nodes
 
-1. SSH to your VM:
+{% include prod_deployment/insecure-start-nodes.md %}
 
-	~~~ shell
-	$ ssh <username>@<node1 external IP address>
-	~~~
+## Step 5. Initialize the cluster
 
-2. Install the latest CockroachDB binary:
+{% include prod_deployment/insecure-initialize-cluster.md %}
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+## Step 6. Test the cluster
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-	~~~
-	$ cockroach start --insecure \
-	--advertise-host=<node1 internal IP address> \
-	--cache=25% \
-	--max-sql-memory=25% \
-	--background
-	~~~
-
-	This commands starts an insecure node and identifies the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-	Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, listens for internal and client communication on port 26257, and listens for HTTP requests from the Admin UI on port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-	{{site.data.alerts.callout_info}}You can find the VM's internal IP address listed in the Resource Group's Virtual Network.{{site.data.alerts.end}}
-
-## Step 5. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1. SSH to your VM:
-
-	~~~
-	$ ssh <username>@<additional node external IP address>
-	~~~
-
-2. Install CockroachDB from our latest binary:
-
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-	~~~
-	$ cockroach start --insecure \
-	--advertise-host=<node internal IP address> \
-	--join=<node1 internal IP address>:26257 \
-	--cache=25% \
-	--max-sql-memory=25% \
-	--background
-	~~~
-
-	The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each VM you want to use as a node.
-
-## Step 6. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-
-1. SSH to your first node:
-
-	~~~ shell
-	$ ssh <username>@<node2 external IP address>
-	~~~
-
-2. Launch the built-in SQL client and create a database:
-
-	~~~ shell
-	$ cockroach sql --insecure
-	~~~
-	~~~ sql
-	> CREATE DATABASE insecurenodetest;
-	~~~
-
-3. In another terminal window, SSH to another node:
-
-	~~~ shell
-	$ ssh <username>@<node3 external IP address>
-	~~~
-
-4. Launch the built-in SQL client:
-
-	~~~ shell
-	$ cockroach sql --insecure
-	~~~
-
-5. View the cluster's databases, which will include `insecurenodetest`:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/insecure-test-cluster.md %}
 
 ## Step 7. Test load balancing
 
-The Azure load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/insecure-test-load-balancing.md %}
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
-
-2. Launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
-
-	~~~ shell
-	$ cockroach sql --insecure \
-	--host=<load balancer IP address> \
-	--port=26257
-	~~~
-
-3. View the cluster's databases:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-	As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-4. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
-
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 8. Monitor the cluster
-
-View your cluster's Admin UI by going to `http://<any node's external IP address>:8080`.
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-2. Click the **Databases** tab on the left to verify that `insecurenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 9. Use the database
+## Step 8. Use the cluster
 
 Now that your deployment is working, you can:
 
 1. [Implement your data model](sql-statements.html).
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Azure load balancer, not to a CockroachDB node.
+
+## Step 9. Monitor the cluster
+
+{% include prod_deployment/insecure-monitor-cluster.md %}
+
+## Step 10. Scale the cluster
+
+{% include prod_deployment/insecure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on Microsoft Azure (Insecure)
 summary: Learn how to deploy CockroachDB on Microsoft Azure.
 toc: false
 toc_not_nested: true
+ssh-link: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys
 ---
 
 <div class="filters filters-big clearfix">
@@ -22,7 +23,7 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 ## Recommendations
 
-{% include prod_deployment/insecure-requirements.md %}
+{% include prod_deployment/insecure-recommendations.md %}
 
 ## Step 1. Configure your network
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -19,8 +19,6 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 ## Requirements
 
-## Requirements
-
 {% include prod_deployment/secure-requirements.md %}
 
 ## Recommendations

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -3,6 +3,7 @@ title: Deploy CockroachDB on Microsoft Azure
 summary: Learn how to deploy CockroachDB on Microsoft Azure.
 toc: false
 toc_not_nested: true
+ssh-link: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys
 ---
 
 <div class="filters filters-big clearfix">
@@ -18,17 +19,13 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 ## Requirements
 
-- Locally, you must have [CockroachDB installed](install-cockroachdb.html), which you'll use to generate and manage your deployment's certificates.
+## Requirements
 
-- In Azure, you must have [SSH access](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) to each machine with root or sudo privileges. This is necessary for distributing binaries and starting CockroachDB.
+{% include prod_deployment/secure-requirements.md %}
 
 ## Recommendations
 
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
-
-- Decide how you want to access your Admin UI:
-  - Only from specific IP addresses, which requires you to set firewall rules to allow communication on port `8080` *(documented on this page)*.
-  - Using an SSH tunnel, which requires you to use `--http-host=localhost` when starting your nodes.
+{% include prod_deployment/secure-recommendations.md %}
 
 ## Step 1. Configure your network
 
@@ -98,367 +95,35 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 ## Step 4. Generate certificates
 
-Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
+{% include prod_deployment/secure-generate-certificates.md %}
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP address provisioned for the Azure load balancer.
-- A client key pair for the `root` user.
+## Step 5. Start nodes
 
-{{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
+{% include prod_deployment/secure-start-nodes.md %}
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+## Step 6. Initialize the cluster
 
-2. Create two directories:
+{% include prod_deployment/secure-initialize-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir certs
-    ~~~
+## Step 7. Test the cluster
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir my-safe-directory
-    ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and  then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
-
-3. Create the CA certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-ca \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-node \
-    <node internal IP address> \
-    <node external IP address> \
-    <node hostname>  \
-    <other common names for node> \
-    localhost \
-    127.0.0.1 \
-    <load balancer IP address> \
-    <load balancer hostname> \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-    - `<node1 internal IP address>` which is the VM's **Private IP address** (available on the VM's **Network Interface**).
-    - `<node1 external IP address>` which is the VM's **Public IP address** (available on the VM's **Network Interface**).
-    - `<node1 hostname>` which is the VM's **Name**.
-    - `<other common names for node1>` which include any domain names you point to the instance.
-    - `localhost` and `127.0.0.1`
-    - `<load balancer IP address>`
-    - `<load balancer hostname>`
-
-5. Upload certificates to the first node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Create the certs directory:
-    $ ssh <username>@<node1 external IP address> "mkdir certs"
-
-    # Upload the CA certificate and node certificate and key:
-    $ scp certs/ca.crt \
-    certs/node.crt \
-    certs/node.key \
-    <username>@<node1 external IP address>:~/certs
-    ~~~
-
-6. Delete the local copy of the node certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ rm certs/node.crt certs/node.key
-    ~~~
-
-    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
-
-7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to addresses provisioned for the Azure load balancer:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-node \
-    <node2 internal IP address> \
-    <node2 external IP address> \
-    <node2 hostname>  \
-    <other common names for node2> \
-    localhost \
-    127.0.0.1 \
-    <load balancer IP address> \
-    <load balancer hostname> \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-8. Upload certificates to the second node:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Create the certs directory:
-    $ ssh <username>@<node2 external IP address> "mkdir certs"
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Upload the CA certificate and node certificate and key:
-    $ scp certs/ca.crt \
-    certs/node.crt \
-    certs/node.key \
-    <username>@<node2 external IP address>:~/certs
-    ~~~
-
-9. Repeat steps 6 - 8 for each additional node.
-
-10. Create a client certificate and key for the `root` user:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach cert create-client \
-    root \
-    --certs-dir=certs \
-    --ca-key=my-safe-directory/ca.key
-    ~~~
-
-    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
-
-## Step 5. Start the first node
-
-1.  SSH to your instance:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ ssh <username>@<node1 external IP address>
-    ~~~
-
-2. Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Get the latest CockroachDB tarball.
-    $ wget https://s3.amazonaws.com/binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Extract the binary.
-    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Move the binary.
-    $ sudo mv cockroach /usr/local/bin
-    ~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --advertise-host=<node1 internal IP address> \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    This command specifies the location of certificates and the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-    Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, binds internal and client communication to port 26257, and binds Admin UI HTTP requests to port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 6. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by setting up additional nodes that will join the cluster.
-
-1.  SSH to your instance:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ ssh <username>@<additional node external IP address>
-    ~~~
-
-2.  Install the latest CockroachDB binary:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Get the latest CockroachDB tarball.
-    $ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Extract the binary.
-    $ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-    --strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    # Move the binary.
-    $ sudo mv cockroach /usr/local/bin
-    ~~~
-
-3. Start a new node that joins the cluster using the first node's internal IP address:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --advertise-host=<node2 internal IP address> \
-    --join=<node1 internal IP address>:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4.  Repeat these steps for each instance you want to use as a node.
-
-## Step 7. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
-
-1. On your local machine, launch the built-in SQL client with the `--host` flag set to the external address of node 1 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<node1 external IP address>
-    ~~~
-
-2. Create a `securenodetest` database:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > CREATE DATABASE securenodetest;
-    ~~~
-
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-4. Launch built-in SQL client with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<node2 external IP address>
-    ~~~
-
-5. View the cluster's databases, which will include `securenodetest`:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW DATABASES;
-    ~~~
-
-    ~~~
-    +--------------------+
-    |      Database      |
-    +--------------------+
-    | crdb_internal      |
-    | information_schema |
-    | securenodetest     |
-    | pg_catalog         |
-    | system             |
-    +--------------------+
-    (5 rows)
-    ~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/secure-test-cluster.md %}
 
 ## Step 8. Test load balancing
 
-The Azure load balancer created in [step 3](#step-3-set-up-load-balancing) can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to the load balancer, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/secure-test-load-balancing.md %}
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+## Step 9. Use the database
 
-1.  On your local machine, launch the built-in SQL client, with the `--host` flag set to the load balancer's IP address:
+{% include prod_deployment/use-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql \
-    --certs-dir=certs \
-    --host=<load balancer IP address>
-    ~~~
+## Step 10. Monitor the cluster
 
-2.  View the cluster's databases:
+{% include prod_deployment/secure-monitor-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW DATABASES;
-    ~~~
+## Step 11. Scale the cluster
 
-    ~~~
-    +--------------------+
-    |      Database      |
-    +--------------------+
-    | crdb_internal      |
-    | information_schema |
-    | securenodetest     |
-    | pg_catalog         |
-    | system             |
-    +--------------------+
-    (5 rows)
-    ~~~
-
-    As you can see, the load balancer redirected the query to one of the CockroachDB nodes.
-
-3. Use the `node_id` [session variable](show-vars.html) to check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-    ~~~
-    +---------+
-    | node_id |
-    +---------+
-    |       3 |
-    +---------+
-    (1 row)
-    ~~~
-
-    The `node_id` [session variable](show-vars.html) used above is an alias for the following query, which you can use as well:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
-    ~~~
-
-4.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 9. Monitor the cluster
-
-View your cluster's Admin UI by going to `https://<any node's external IP address>:8080`.
-
-{{site.data.alerts.callout_info}}Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.{{site.data.alerts.end}}
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-2. Click the **Databases** tab on the left to verify that `securenodetest` is listed.
-
-{% include prometheus-callout.html %}
-
-## Step 10. Use the database
-
-Now that your deployment is working, you can:
-
-1. [Implement your data model](sql-statements.html).
-2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
-3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Azure load balancer, not to a CockroachDB node.
+{% include prod_deployment/secure-scale-cluster.md %}
 
 ## See Also
 

--- a/v1.1/initialize-a-cluster.md
+++ b/v1.1/initialize-a-cluster.md
@@ -1,0 +1,117 @@
+---
+title: Initialize a Cluster
+summary: Perform a one-time-only initialization of a CockroachDB cluster.
+toc: false
+---
+
+<span class="version-tag">New in v1.1:</span> This page explains the `cockroach init` [command](cockroach-commands.html), which you use to perform a one-time initialization of a new multi-node cluster. For a full walk-through of the cluster startup and initialization process, see [Manual Deployment](manual-deployment.html) or one of the [Cloud Deployment](cloud-deployment.html) tutorials.
+
+{{site.data.alerts.callout_info}}When <a href="start-a-node.html#start-a-single-node-cluster">starting a single-node cluster</a>, you don't need to use the <code>cockroach init</code> command. You can simply run the <code>cockroach start</code> command without the <code>--join</code> flag to start and initialize the single-node cluster.{{site.data.alerts.end}}
+
+<div id="toc"></div>
+
+## Synopsis
+
+~~~ shell
+# Perform a one-time initialization of a cluster:
+$ cockroach init <flags>
+
+# View help:
+$ cockroach init --help
+~~~
+
+## Flags
+
+The `cockroach init` command supports the following [general-use](#general) and [logging](#logging) flags.
+
+### General
+
+Flag | Description
+-----|-----------
+`--certs-dir` | The path to the [certificate directory](create-security-certificates.html). If the cluster is secure, this directory must contain a valid CA certificate and a client certificate and key for the `root` user. Client certificates for other users are not supported.<br><br>**Env Variable:** `COCKROACH_CERTS_DIR`<br>**Default:** `${HOME}/.cockroach-certs/`
+`--host` | The server host to connect to. This can be the address of any node. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:**`localhost`
+`--insecure` | Run in insecure mode. If this flag is not set, the `--certs-dir` flag must point to valid certificates.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
+`--port` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
+
+### Logging
+
+By default, the `init` command logs errors to `stderr`.
+
+If you need to troubleshoot this command's behavior, you can change its [logging behavior](debug-and-error-logs.html).
+
+## Examples
+
+These examples assume that nodes have already been started with [`cockroach start`](start-a-node.html) but are waiting to be initialized as a new cluster. For a more detailed walk-through, see [Manual Deployment](manual-deployment.html) or one of the [Cloud Deployment](cloud-deployment.html) tutorials.
+
+### Initialize a Cluster on a Node's Machine
+
+<div class="filters clearfix">
+  <button style="width: 15%" class="filter-button" data-scope="secure">Secure</button>
+  <button style="width: 15%" class="filter-button" data-scope="insecure">Insecure</button>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="secure">
+1. SSH to the machine where the node has been started.
+
+2. Make sure the `client.root.crt` and `client.root.key` files for the `root` user are on the machine.
+
+3. Run the `cockroach init` command with the `--certs-dir` flag set to the directory containing the `ca.crt` file and the files for the `root` user, and with the `--host` flag set to the address of the current node:
+
+    ~~~ shell
+    $ cockroach init --certs-dir=certs --host=<address of this node>
+    ~~~
+
+    At this point, all the nodes complete startup and print helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.
+</div>
+
+<div class="filter-content" markdown="1" data-scope="insecure">
+1. SSH to the machine where the node has been started.
+
+2. Run the `cockroach init` command with the `--host` flag set to the address of the current node:
+
+    ~~~ shell
+    $ cockroach init --insecure --host=<address of this node>
+    ~~~
+
+    At this point, all the nodes complete startup and print helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.
+</div>
+
+### Initialize a Cluster from Another Machine
+
+<div class="filters clearfix">
+  <button style="width: 15%" class="filter-button" data-scope="secure">Secure</button>
+  <button style="width: 15%" class="filter-button" data-scope="insecure">Insecure</button>
+</div>
+
+<div class="filter-content" markdown="1" data-scope="secure">
+1. [Install the `cockroach` binary](install-cockroachdb.html) on a machine separate from the node.
+
+2. Create a `certs` directory and copy the CA certificate and the client certificate and key for the `root` user into the directory.
+
+3. Run the `cockroach init` command with the `--certs-dir` flag set to the directory containing the `ca.crt` file and the files for the `root` user, and with the `--host` flag set to the address of any node:
+
+    ~~~ shell
+    $ cockroach init --certs-dir=certs --host=<address of any node>
+    ~~~
+
+    At this point, all the nodes complete startup and print helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.
+</div>
+
+<div class="filter-content" markdown="1" data-scope="insecure">
+1. [Install the `cockroach` binary](install-cockroachdb.html) on a machine separate from the node.
+
+2. Run the `cockroach init` command with the `--host` flag set to the address of any node:
+
+    ~~~ shell
+    $ cockroach init --insecure --host=<address of any node>
+    ~~~
+
+    At this point, all the nodes complete startup and print helpful details to the [standard output](start-a-node.html#standard-output), such as the CockroachDB version, the URL for the admin UI, and the SQL URL for clients.
+</div>
+
+## See Also
+
+- [Manual Deployment](manual-deployment.html)
+- [Cloud Deployment](cloud-deployment.html)
+- [`cockroach start`](start-a-node.html)
+- [Other Cockroach Commands](cockroach-commands.html)

--- a/v1.1/manual-deployment-insecure.md
+++ b/v1.1/manual-deployment-insecure.md
@@ -17,133 +17,23 @@ This tutorial shows you how to manually deploy an insecure multi-node CockroachD
 
 ## Requirements
 
-- You must have SSH access to each machine. This is necessary for distributing binaries.
-- Your network configuration must allow TCP communication on the following ports:
-	- **26257** (`tcp:26257`) for inter-node communication (i.e., working as a cluster) and for clients to connect to HAProxy
-	- **8080** (`tcp:8080`) to expose your Admin UI
+{% include prod_deployment/insecure-requirements.md %}
 
 ## Recommendations
 
-- If you plan to use CockroachDB in production, we recommend using a [secure cluster](manual-deployment.html) instead. Using an insecure cluster comes with risks:
-  - Your cluster is open to any client that can access any node's IP addresses.
-  - Any user, even `root`, can log in without providing a password.
-  - Any user, connecting as `root`, can read or write any data in your cluster.
-  - There is no network encryption or authentication, and thus no confidentiality.
+{% include prod_deployment/insecure-recommendations.md %}
 
-- For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+## Step 1. Start nodes
 
-## Step 1. Start the first node
+{% include prod_deployment/insecure-start-nodes.md %}
 
-1. SSH to your first machine.
+## Step 2. Initialize the cluster
 
-2. Install CockroachDB from our latest binary:
+{% include prod_deployment/insecure-initialize-cluster.md %}
 
-	~~~ shell
-	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+## Step 3. Test the cluster
 
-	# Extract the binary:
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-
-	# Move the binary:
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-	~~~
-	$ cockroach start --insecure \
-	--host=<node1 internal address> \
-	--cache=25% \
-	--max-sql-memory=25% \
-	--background
-	~~~
-
-	This commands starts an insecure node and identifies the address at which other nodes can reach it, in this case an internal address since you likely don't want applications outside your network reaching an insecure cluster. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-	Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, listens for internal and client communication on port 26257, and listens for HTTP requests from the Admin UI on port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 2. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by starting and joining additional nodes.
-
-1. SSH to another machine.
-
-2. Install CockroachDB from our latest binary:
-
-	~~~ shell
-	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-
-	# Extract the binary:
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-
-	# Move the binary:
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new node that joins the cluster using the first node's address:
-
-	~~~
-	$ cockroach start --insecure \
-	--host=<node2 internal address> \
-	--join=<node1 internal address>:26257 \
-	--cache=25% \
-	--max-sql-memory=25% \
-	--background
-	~~~
-
-	The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each node you want to add.
-
-## Step 3. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
-
-1. SSH to your first node.
-
-2. Launch the built-in SQL client and create a database:
-
-	~~~ shell
-	$ cockroach sql --insecure --host=<node1 internal address>
-	~~~
-
-	~~~ sql
-	> CREATE DATABASE insecurenodetest;
-	~~~
-
-3. In another terminal window, SSH to another node.
-
-4. Launch the built-in SQL client:
-
-	~~~ shell
-	$ cockroach sql --insecure --host=<node's internal address>
-	~~~
-
-5. View the cluster's databases, which will include `insecurenodetest`:
-
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/insecure-test-cluster.md %}
 
 ## Step 4. Set up HAProxy load balancers
 
@@ -160,29 +50,34 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 2. Install HAProxy:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ apt-get install haproxy
 	~~~
 
-3. Install CockroachDB from our latest binary:
+3. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, and extract the binary:
 
-	~~~ shell
-	# Get the latest CockroachDB tarball.
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
+    ~~~
 
-	# Extract the binary.
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
+4. Copy the binary into the `PATH`:
 
-	# Move the binary.
-	$ sudo mv cockroach /usr/local/bin
-	~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin
+    ~~~
 
-4. Run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command, specifying the address of any CockroachDB node:
+	If you get a permissions error, prefix the command with `sudo`.
 
+5. Run the [`cockroach gen haproxy`](generate-cockroachdb-resources.html) command, specifying the address of any CockroachDB node:
+
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ cockroach gen haproxy --insecure \
-	--host=<internal address of any node> \
+	--host=<address of any node> \
 	--port=26257 \
 	~~~
 
@@ -218,102 +113,30 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 	{{site.data.alerts.callout_info}}For full details on these and other configuration settings, see the <a href="http://cbonte.github.io/haproxy-dconv/1.7/configuration.html">HAProxy Configuration Manual</a>.{{site.data.alerts.end}}
 
-5. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
+6. Start HAProxy, with the `-f` flag pointing to the `haproxy.cfg` file:
 
+    {% include copy-clipboard.html %}
 	~~~ shell
 	$ haproxy -f haproxy.cfg
 	~~~
 
-6. Repeat these steps for each additional instance of HAProxy you want to run.
+7. Repeat these steps for each additional instance of HAProxy you want to run.
 
 ## Step 5. Test load balancing
 
-Now that HAProxy is running, it can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to a HAProxy server, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/insecure-test-load-balancing.md %}
 
-To test this, install CockroachDB locally and use the [built-in SQL client](use-the-built-in-sql-client.html) as follows:
+## Step 6. Use the cluster
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if it's not there already.
+{% include prod_deployment/use-cluster.md %}
 
-2. Launch the built-in SQL client, with the `--host` flag set to the address of one of the HAProxy servers:
+## Step 7. Monitor the cluster
 
-	~~~ shell
-	$ cockroach sql --insecure \
-	--host=<haproxy address> \
-	--port=26257
-	~~~
+{% include prod_deployment/insecure-monitor-cluster.md %}
 
-3. View the cluster's databases:
+## Step 8. Scale the cluster
 
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| insecurenodetest   |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-	As you can see, HAProxy redirected the query to one of the CockroachDB nodes.
-
-4. Check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
-
-    The `node_id` [session variable](show-vars.html) used above is an alias for the following query, which you can use as well:
-
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
-	~~~
-
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 6. Configure replication
-
-In CockroachDB, you use **replication zones** to control the number and location of replicas for specific sets of data. Initially, there is a single, default replication zone for the entire cluster. You can adjust this default zone as well as add zones for individual databases and tables as needed.
-
-For more information, see [Configure Replication Zones](configure-replication-zones.html).
-
-## Step 7. Use the cluster
-
-Now that your deployment is working, you can:
-
-1. [Implement your data model](sql-statements.html).
-2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
-3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the HAProxy server, not to a CockroachDB node.
-
-## Step 8. Monitor the cluster
-
-View your cluster's Admin UI by going to `http://<any node's address>:8080`.
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-    Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--host` flag. This prevents the node from receiving replicas and working as part of the cluster.
-
-2. Click the **Databases** tab on the left to verify that `insecurenodetest` is listed.
-
-{% include prometheus-callout.html %}
+{% include prod_deployment/insecure-scale-cluster.md %}
 
 ## See Also
 
@@ -321,4 +144,3 @@ On this page, verify that the cluster is running as expected:
 - [Orchestration](orchestration.html)
 - [Monitoring](monitor-cockroachdb-with-prometheus.html)
 - [Start a Local Cluster](start-a-local-cluster.html)
-- [Run CockroachDB in a VirtualBox VM](http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html) (community-supported)

--- a/v1.1/manual-deployment-insecure.md
+++ b/v1.1/manual-deployment-insecure.md
@@ -2,6 +2,7 @@
 title: Manual Deployment (Insecure)
 summary: Learn how to manually deploy an insecure, multi-node CockroachDB cluster on multiple machines.
 toc: false
+ssh-link: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2
 ---
 
 <div class="filters filters-big clearfix">

--- a/v1.1/manual-deployment.md
+++ b/v1.1/manual-deployment.md
@@ -2,6 +2,7 @@
 title: Manual Deployment
 summary: Learn how to manually deploy a secure, multi-node CockroachDB cluster on multiple machines.
 toc: false
+ssh-link: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2
 ---
 
 <div class="filters filters-big clearfix">
@@ -17,285 +18,27 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 ## Requirements
 
-- You must have [CockroachDB installed](install-cockroachdb.html) locally. This is necessary for generating and managing your deployment's certificates.
-- You must have SSH access to each machine. This is necessary for distributing binaries and certificates.
-- Your network configuration must allow TCP communication on the following ports:
-	- **26257** (`tcp:26257`) for inter-node communication (i.e., working as a cluster) and for clients to connect to HAProxy
-	- **8080** (`tcp:8080`) to expose your Admin UI
+{% include prod_deployment/secure-requirements.md %}
 
 ## Recommendations
 
-For guidance on cluster topology, clock synchronization, cache and SQL memory size, and file descriptor limits, see [Recommended Production Settings](recommended-production-settings.html).
+{% include prod_deployment/secure-recommendations.md %}
 
 ## Step 1. Generate certificates
 
-Locally, you'll need to [create the following certificates and keys](create-security-certificates.html):
+{% include prod_deployment/secure-generate-certificates.md %}
 
-- A certificate authority (CA) key pair (`ca.crt` and `ca.key`).
-- A node key pair for each node, issued to its IP addresses and any common names the machine uses, as well as to the IP addresses and common names for machines running HAProxy.
-- A client key pair for the `root` user.
+## Step 2. Start nodes
 
-{{site.data.alerts.callout_success}}Before beginning, it's useful to collect each of your machine's internal and external IP addresses, as well as any server names you want to issue certificates for.{{site.data.alerts.end}}
+{% include prod_deployment/secure-start-nodes.md %}
 
-1. [Install CockroachDB](install-cockroachdb.html) on your local machine, if you haven't already.
+## Step 3. Initialize the cluster
 
-2. Create two directories:
+{% include prod_deployment/secure-initialize-cluster.md %}
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir certs
-    ~~~
+## Step 4. Test the cluster
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ mkdir my-safe-directory
-    ~~~
-    - `certs`: You'll generate your CA certificate and all node and client certificates and keys in this directory and then upload some of the files to your nodes.
-    - `my-safe-directory`: You'll generate your CA key in this directory and then reference the key when generating node and client certificates. After that, you'll keep the key safe and secret; you will not upload it to your nodes.
-
-3. Create the CA certificate and key:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-ca \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-4. Create the certificate and key for the first node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-node \
-	<node1 internal IP address> \
-	<node1 external IP address> \
-	<node1 hostname>  \
-	<other common names for node1> \
-	localhost \
-	127.0.0.1 \
-	<haproxy internal IP addresses> \
-	<haproxy external IP addresses> \
-	<haproxy hostnames>  \
-	<other common names for haproxy instances> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-5. Upload certificates to the first node:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node1 address> "mkdir certs"
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Upload the CA certificate and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node1 address>:~/certs
-	~~~
-
-6. Delete the local copy of the node certificate and key:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ rm certs/node.crt certs/node.key
-    ~~~
-
-    {{site.data.alerts.callout_info}}This is necessary because the certificates and keys for additional nodes will also be named <code>node.crt</code> and <code>node.key</code> As an alternative to deleting these files, you can run the next <code>cockroach cert create-node</code> commands with the <code>--overwrite</code> flag.{{site.data.alerts.end}}
-
-7. Create the certificate and key for the second node, issued to all common names you might use to refer to the node as well as to the HAProxy instances:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-node \
-	<node2 internal IP address> \
-	<node2 external IP address> \
-	<node2 hostname>  \
-	<other common names for node1> \
-	localhost \
-	127.0.0.1 \
-	<haproxy internal IP addresses> \
-	<haproxy external IP addresses> \
-	<haproxy hostnames>  \
-	<other common names for haproxy instances> \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-8. Upload certificates to the second node:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Create the certs directory:
-	$ ssh <username>@<node2 address> "mkdir certs"
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Upload the CA certificate and node certificate and key:
-	$ scp certs/ca.crt \
-	certs/node.crt \
-	certs/node.key \
-	<username>@<node2 address>:~/certs
-	~~~
-
-9. Repeat steps 6 - 8 for each additional node.
-
-10. Create a client certificate and key for the `root` user:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach cert create-client \
-	root \
-	--certs-dir=certs \
-	--ca-key=my-safe-directory/ca.key
-	~~~
-
-    {{site.data.alerts.callout_success}}In later steps, you'll use the <code>root</code> user's certificate to run <a href="cockroach-commands.html"><code>cockroach</code></a> client commands from your local machine. If you might also want to run <code>cockroach</code> client commands directly on a node (e.g., for local debugging), you'll need to copy the <code>root</code> user's certificate and key to that node as well.{{site.data.alerts.end}}
-
-## Step 2. Start the first node
-
-1. SSH to your first machine.
-
-2. Install CockroachDB from our latest binary:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Extract the binary:
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Move the binary:
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new CockroachDB cluster with a single node:
-
-    {% include copy-clipboard.html %}
-    ~~~
-    $ cockroach start \
-    --certs-dir=certs \
-    --host=<node1 address> \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-    ~~~
-
-    This command specifies the location of certificates and the address at which other nodes can reach it. It also increases the node's cache and temporary SQL memory size to 25% of available system memory to improve read performance and increase capacity for in-memory SQL processing (see [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details).
-
-    Otherwise, it uses all available defaults. For example, the node stores data in the `cockroach-data` directory, binds internal and client communication to port 26257, and binds Admin UI HTTP requests to port 8080. To set these options manually, see [Start a Node](start-a-node.html).
-
-## Step 3. Add nodes to the cluster
-
-At this point, your cluster is live and operational but contains only a single node. Next, scale your cluster by starting and joining additional nodes.
-
-1. SSH to another machine.
-
-2. Install CockroachDB from our latest binary:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	# Get the latest CockroachDB tarball:
-	$ wget https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Extract the binary:
-	$ tar -xf cockroach-{{ page.release_info.version }}.linux-amd64.tgz  \
-	--strip=1 cockroach-{{ page.release_info.version }}.linux-amd64/cockroach
-	~~~
-
-	{% include copy-clipboard.html %}
-	~~~ shell
-	# Move the binary:
-	$ sudo mv cockroach /usr/local/bin
-	~~~
-
-3. Start a new node that joins the cluster using the first node's address:
-
-    {% include copy-clipboard.html %}
-	~~~
-	$ cockroach start \
-	--certs-dir=certs \
-	--host=<node2 address> \
-	--join=<node1 address>:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
-    --background
-	~~~
-
-	The only difference when adding a node is that you connect it to the cluster with the `--join` flag, which takes the address and port of the first node. Otherwise, it's fine to accept all defaults; since each node is on a unique machine, using identical ports won't cause conflicts.
-
-4. Repeat these steps for each node you want to add.
-
-## Step 4. Test your cluster
-
-CockroachDB replicates and distributes data for you behind-the-scenes and uses a [Gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to enable each node to locate data across the cluster.
-
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
-
-1. On your local machine, launch the built-in SQL client with the `--host` flag set to the address of node 1 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<node1 address>
-	~~~
-
-2. Create a `securenodetest` database:
-
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> CREATE DATABASE securenodetest;
-	~~~
-
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-4. Launch the built-in SQL client with the `--host` flag set to the address of node 2 and security flags pointing to the CA cert and the client cert and key:
-
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<node2 address>
-	~~~
-
-5. View the cluster's databases, which will include `securenodetest`:
-
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
-
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+{% include prod_deployment/secure-test-cluster.md %}
 
 ## Step 5. Set up HAProxy load balancers
 
@@ -377,93 +120,19 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 ## Step 6. Test load balancing
 
-Now that HAProxy is running, it can serve as the client gateway to the cluster. Instead of connecting directly to a CockroachDB node, clients can connect to a HAProxy server, which will then redirect the connection to a CockroachDB node.
+{% include prod_deployment/secure-test-load-balancing.md %}
 
-To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) locally as follows:
+## Step 7. Use the cluster
 
-1. On your local machine, launch the built-in SQL client with the `--host` flag set to the address of any HAProxy server and security flags pointing to the CA cert and the client cert and key:
+{% include prod_deployment/use-cluster.md %}
 
-    {% include copy-clipboard.html %}
-	~~~ shell
-	$ cockroach sql \
-	--certs-dir=certs \
-	--host=<haproxy address>
-	~~~
+## Step 8. Monitor the cluster
 
-2. View the cluster's databases:
+{% include prod_deployment/secure-monitor-cluster.md %}
 
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> SHOW DATABASES;
-	~~~
+## Step 9. Scale the cluster
 
-	~~~
-	+--------------------+
-	|      Database      |
-	+--------------------+
-	| crdb_internal      |
-	| information_schema |
-	| securenodetest     |
-	| pg_catalog         |
-	| system             |
-	+--------------------+
-	(5 rows)
-	~~~
-
-	As you can see, HAProxy redirected the query to one of the CockroachDB nodes.
-
-3. Check which node you were redirected to:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SHOW node_id;
-    ~~~
-
-	~~~
-	+---------+
-	| node_id |
-	+---------+
-	|       3 |
-	+---------+
-	(1 row)
-	~~~
-
-    The `node_id` [session variable](show-vars.html) used above is an alias for the following query, which you can use as well:
-
-    {% include copy-clipboard.html %}
-	~~~ sql
-	> SELECT node_id FROM crdb_internal.node_build_info LIMIT 1;
-	~~~
-
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
-
-## Step 7. Configure replication
-
-In CockroachDB, you use **replication zones** to control the number and location of replicas for specific sets of data. Initially, there is a single, default replication zone for the entire cluster. You can adjust this default zone as well as add zones for individual databases and tables as needed.
-
-For more information, see [Configure Replication Zones](configure-replication-zones.html).
-
-## Step 8. Use the cluster
-
-Now that your deployment is working, you can:
-
-1. [Implement your data model](sql-statements.html).
-2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
-3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the HAProxy server, not to a CockroachDB node.
-
-## Step 9. Monitor the cluster
-
-View your cluster's Admin UI by going to `https://<any node's address>:8080`.
-
-On this page, verify that the cluster is running as expected:
-
-1. Click **View nodes list** on the right to ensure that all of your nodes successfully joined the cluster.
-
-	Also check the **Replicas** column. If you have nodes with 0 replicas, it's possible you didn't properly set the `--host` flag. This prevents the node from receiving replicas and working as part of the cluster.
-
-2. Click the **Databases** tab on the left to verify that `insecurenodetest` is listed.
-
-{% include prometheus-callout.html %}
+{% include prod_deployment/secure-scale-cluster.md %}
 
 ## See Also
 
@@ -471,4 +140,3 @@ On this page, verify that the cluster is running as expected:
 - [Orchestration](orchestration.html)
 - [Monitoring](monitor-cockroachdb-with-prometheus.html)
 - [Start a Local Cluster](start-a-local-cluster.html)
-- [Run CockroachDB in a VirtualBox VM](http://uptimedba.github.io/cockroach-vb-single/cockroach-vb-single/home.html) (community-supported)

--- a/v1.1/start-a-local-cluster.md
+++ b/v1.1/start-a-local-cluster.md
@@ -62,7 +62,8 @@ In a new terminal, add the second node:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=node2 \
 --host=localhost \
 --port=26258 \
@@ -74,7 +75,8 @@ In a new terminal, add the third node:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=node3 \
 --host=localhost \
 --port=26259 \
@@ -232,7 +234,8 @@ Restart the first node from the parent directory of `cockroach-data/`:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --host=localhost
 ~~~
 
@@ -243,7 +246,8 @@ In a new terminal, restart the second node from the parent directory of `node2/`
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=node2 \
 --host=localhost \
 --port=26258 \
@@ -255,7 +259,8 @@ In a new terminal, restart the third node from the parent directory of `node3/`:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach start --insecure \
+$ cockroach start \
+--insecure \
 --store=node3 \
 --host=localhost \
 --port=26259 \

--- a/v1.1/start-a-node.md
+++ b/v1.1/start-a-node.md
@@ -17,7 +17,7 @@ This page explains the `cockroach start` [command](cockroach-commands.html), whi
 $ cockroach start <flags, excluding --join>
 
 # Start a multi-node cluster:
-$ cockroach start <flags, including --join>
+$ cockroach start <flags, including --join> &
 $ cockroach init <flags>
 
 # Add a node to a cluster:


### PR DESCRIPTION
- Document the `cockroach init` command
- Update 1.1 prod deployment docs 
  - Revise workflow to use `init` command
  - Use includes wherever possible 
- Update 1.1 `cockroach start` docs
- Use init command in 1.1 core feature demos
- Update formatting on 1.1 local deployment docs
- Make 1.1 build an app tutorials single-node only

Fixes #1288 
Fixes #1718 