### PR TITLE
Add stubs for Window Functions documentation

### DIFF
--- a/_includes/sidebar-data-v1.0.json
+++ b/_includes/sidebar-data-v1.0.json
@@ -510,6 +510,12 @@
             ]
           },
           {
+            "title": "<code>NULL</code> Handling",
+            "urls": [
+              "/${VERSION}/null-handling.html"
+            ]
+          },
+          {
             "title": "Full SQL Grammar",
             "urls": [
               "/${VERSION}/sql-grammar.html"
@@ -560,41 +566,6 @@
             "title": "Unique",
             "urls": [
               "/${VERSION}/unique.html"
-            ]
-          }
-        ]
-      },
-      {
-        "title": "Data Definition",
-        "items": [
-          {
-            "title": "Indexes",
-            "urls": [
-              "/${VERSION}/indexes.html"
-            ]
-          },
-          {
-            "title": "Views",
-            "urls": [
-              "/${VERSION}/views.html"
-            ]
-          },
-          {
-            "title": "Column Families",
-            "urls": [
-              "/${VERSION}/column-families.html"
-            ]
-          },
-          {
-            "title": "Interleaved Tables",
-            "urls": [
-              "/${VERSION}/interleave-in-parent.html"
-            ]
-          },
-          {
-            "title": "<code>NULL</code> Handling",
-            "urls": [
-              "/${VERSION}/null-handling.html"
             ]
           }
         ]
@@ -692,6 +663,41 @@
         "title": "Transactions",
         "urls": [
           "/${VERSION}/transactions.html"
+        ]
+      },
+      {
+        "title": "Views",
+        "urls": [
+          "/${VERSION}/views.html"
+        ]
+      },
+      {
+        "title": "Window Functions",
+        "urls": [
+          "/${VERSION}/window-functions.html"
+        ]
+      },
+      {
+        "title": "Performance Optimization",
+        "items": [
+          {
+            "title": "Indexes",
+            "urls": [
+              "/${VERSION}/indexes.html"
+            ]
+          },
+          {
+            "title": "Column Families",
+            "urls": [
+              "/${VERSION}/column-families.html"
+            ]
+          },
+          {
+            "title": "Interleaved Tables",
+            "urls": [
+              "/${VERSION}/interleave-in-parent.html"
+            ]
+          }
         ]
       },
       {

--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -525,6 +525,12 @@
         ]
       },
       {
+        "title": "Functions and Operators",
+        "urls": [
+          "/${VERSION}/functions-and-operators.html"
+        ]
+      },
+      {
         "title": "SQL Syntax",
         "items": [
           {
@@ -714,12 +720,6 @@
         ]
       },
       {
-        "title": "Functions and Operators",
-        "urls": [
-          "/${VERSION}/functions-and-operators.html"
-        ]
-      },
-      {
         "title": "Transactions",
         "urls": [
           "/${VERSION}/transactions.html"
@@ -729,6 +729,12 @@
         "title": "Views",
         "urls": [
         "/${VERSION}/views.html"
+        ]
+      },
+      {
+        "title": "Window Functions",
+        "urls": [
+          "/${VERSION}/window-functions.html"
         ]
       },
       {

--- a/v1.0/sql-feature-support.md
+++ b/v1.0/sql-feature-support.md
@@ -161,7 +161,7 @@ table tr td:nth-child(2) {
 | Interleaved tables | ✓ | CockroachDB Extension | [Interleaved Tables documentation](interleave-in-parent.html) |
 | Information Schema | ✓ | Standard | [Information Schema documentation](information-schema.html)
 | Views | ✓ | Standard | [Views documentation](views.html) |
-| Window functions | Partial | Standard | Perform calculations related on a selected row. |
+| Window functions | ✓ | Standard | [Window Functions documentation](window-functions.html) |
 | Common Table Expressions | Planned | Common Extension | Similar to Views, though they are not stored. |
 | Stored Procedures | Planned | Common Extension | Execute a procedure explicitly. |
 | Cursors | ✗ | Standard | Traverse a table's rows. |

--- a/v1.0/window-functions.md
+++ b/v1.0/window-functions.md
@@ -1,0 +1,9 @@
+---
+title: WINDOW FUNCTIONS
+summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
+toc: false
+---
+
+CockroachDB supports the application of an aggregate or window function over the subset ("window") of the rows selected by a query.
+
+Docs on this feature are coming soon. In the meantime, see the [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/static/tutorial-window.html) for an introduction to this topic.

--- a/v1.1/sql-feature-support.md
+++ b/v1.1/sql-feature-support.md
@@ -163,7 +163,7 @@ table tr td:nth-child(2) {
 | Parallel Statement Execution | ✓ | CockroachDB Extension | [Parallel Statement Execution documentation](parallel-statement-execution.html) |
 | Information Schema | ✓ | Standard | [Information Schema documentation](information-schema.html)
 | Views | ✓ | Standard | [Views documentation](views.html) |
-| Window functions | Partial | Standard | Perform calculations related on a selected row. |
+| Window functions | ✓ | Standard | [Window Functions documentation](window-functions.html) |
 | Common Table Expressions | Planned | Common Extension | Similar to Views, though they are not stored. |
 | Stored Procedures | Planned | Common Extension | Execute a procedure explicitly. |
 | Cursors | ✗ | Standard | Traverse a table's rows. |

--- a/v1.1/window-functions.md
+++ b/v1.1/window-functions.md
@@ -1,0 +1,9 @@
+---
+title: WINDOW FUNCTIONS
+summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
+toc: false
+---
+
+CockroachDB supports the application of an aggregate or window function over the subset ("window") of the rows selected by a query.
+
+Docs on this feature are coming soon. In the meantime, see the [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/static/tutorial-window.html) for an introduction to this topic.


### PR DESCRIPTION
- Add 1.0 and 1.1 stub pages
- Add to 1.0 and 1.1 sidenavs
- Update 1.0 and 1.1 sql feature support pages

Although docs are incomplete, these changes will help make users at least aware that CockroachDB supports window functions.