### PR TITLE
Remove `cockroach version` step from install docs

### DIFF
--- a/v1.0/install-cockroachdb.html
+++ b/v1.0/install-cockroachdb.html
@@ -112,11 +112,6 @@ $(document).ready(function(){
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-binary-step4"><span class="gp" data-eventcategory="mac-binary-step4">$ </span>cockroach version</code></pre></div>
-    </li>
-    <li>
       <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-1 clearfix">
         <script>
@@ -155,11 +150,6 @@ $(document).ready(function(){
         <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
       </div>
       <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-homebrew-step2"><span class="gp" data-eventcategory="mac-homebrew-step2">$ </span>brew install cockroach</code></pre></div>
-    </li>
-    <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-homebrew-step3"><span class="gp" data-eventcategory="mac-homebrew-step3">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
       <p>Get future release notes emailed to you:</p>
@@ -246,11 +236,6 @@ $(document).ready(function(){
   <p>You can also execute the <code>cockroach</code> binary directly from its built location, <code>./src/github.com/cockroachdb/cockroach/cockroach</code>, but the rest of the documentation assumes you have the binary on your <code>PATH</code>.</p>
   </li>
   <li>
-    <p>Make sure the CockroachDB executable works:</p>
-
-    {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-source-step5"><span class="gp" data-eventcategory="mac-source-step5">$ </span>cockroach version</code></pre></div>
-  </li>
-  <li>
     <p>Get future release notes emailed to you:</p>
     <div class="hubspot-install-form install-form-3 clearfix">
       <script>
@@ -299,11 +284,6 @@ $(document).ready(function(){
     </div>
     <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step3"><span class="gp" data-eventcategory="mac-docker-step3">$ </span>docker pull cockroachdb/cockroach:{{page.release_info.version}}</code></pre>
     </div>
-  </li>
-  <li>
-    <p>Make sure the CockroachDB executable works:</p>
-
-    {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step4"><span class="gp" data-eventcategory="mac-docker-step4">$ </span>docker run --rm cockroachdb/cockroach:{{page.release_info.version}} version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>
@@ -361,11 +341,6 @@ $(document).ready(function(){
 
       {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin</code></pre></div>
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
-    </li>
-    <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="linux-binary-step3"><span class="gp" data-eventcategory="linux-binary-step3">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
       <p>Get future release notes emailed to you:</p>
@@ -453,11 +428,6 @@ $(document).ready(function(){
   <p>You can also execute the <code>cockroach</code> binary directly from its built location, <code>./src/github.com/cockroachdb/cockroach/cockroach</code>, but the rest of the documentation assumes you have the binary on your <code>PATH</code>.</p>
   </li>
   <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="linux-source-step5"><span class="gp" data-eventcategory="linux-source-step5">$ </span>cockroach version</code></pre></div>
-  </li>
-  <li>
       <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-6 clearfix">
         <script>
@@ -508,11 +478,6 @@ $(document).ready(function(){
     </div>
     <div class="highlight"><pre class="highlight"><code data-eventcategory="linux-docker-step3"><span class="gp" data-eventcategory="linux-docker-step3">$ </span>sudo docker pull cockroachdb/cockroach:{{page.release_info.version}}</code></pre>
     </div>
-  </li>
-  <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="linux-docker-step4"><span class="gp" data-eventcategory="linux-docker-step4">$ </span>sudo docker run --rm cockroachdb/cockroach:{{page.release_info.version}} version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>
@@ -619,11 +584,6 @@ $(document).ready(function(){
       <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
     </div>
     <div class="highlight"><pre class="highlight"><code data-eventcategory="win-docker-step3"><span class="nb" data-eventcategory="win-docker-step3">PS </span>C:\Users\username&gt; docker pull cockroachdb/cockroach:{{page.release_info.version}}</code></pre></div>
-  </li>
-  <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="win-docker-step4"><span class="nb" data-eventcategory="win-docker-step4">PS </span>C:\Users\username&gt; docker run --rm cockroachdb/cockroach:{{page.release_info.version}} version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>

--- a/v1.1/install-cockroachdb.html
+++ b/v1.1/install-cockroachdb.html
@@ -112,11 +112,6 @@ $(document).ready(function(){
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
     </li>
     <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-binary-step4"><span class="gp" data-eventcategory="mac-binary-step4">$ </span>cockroach version</code></pre></div>
-    </li>
-    <li>
       <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-1 clearfix">
         <script>
@@ -155,11 +150,6 @@ $(document).ready(function(){
         <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
       </div>
       <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-homebrew-step2"><span class="gp" data-eventcategory="mac-homebrew-step2">$ </span>brew install cockroach</code></pre></div>
-    </li>
-    <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-homebrew-step3"><span class="gp" data-eventcategory="mac-homebrew-step3">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
       <p>Get future release notes emailed to you:</p>
@@ -246,11 +236,6 @@ $(document).ready(function(){
   <p>You can also execute the <code>cockroach</code> binary directly from its built location, <code>./src/github.com/cockroachdb/cockroach/cockroach</code>, but the rest of the documentation assumes you have the binary on your <code>PATH</code>.</p>
   </li>
   <li>
-    <p>Make sure the CockroachDB executable works:</p>
-
-    {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-source-step5"><span class="gp" data-eventcategory="mac-source-step5">$ </span>cockroach version</code></pre></div>
-  </li>
-  <li>
     <p>Get future release notes emailed to you:</p>
     <div class="hubspot-install-form install-form-3 clearfix">
       <script>
@@ -299,11 +284,6 @@ $(document).ready(function(){
     </div>
     <div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step3"><span class="gp" data-eventcategory="mac-docker-step3">$ </span>docker pull cockroachdb/cockroach:{{page.release_info.version}}</code></pre>
     </div>
-  </li>
-  <li>
-    <p>Make sure the CockroachDB executable works:</p>
-
-    {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="mac-docker-step4"><span class="gp" data-eventcategory="mac-docker-step4">$ </span>docker run --rm cockroachdb/cockroach:{{page.release_info.version}} version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>
@@ -361,11 +341,6 @@ $(document).ready(function(){
 
       {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code><span class="gp noselect shellterminal"></span>cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin</code></pre></div>
       <p>If you get a permissions error, prefix the command with <code>sudo</code>.</p>
-    </li>
-    <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="linux-binary-step3"><span class="gp" data-eventcategory="linux-binary-step3">$ </span>cockroach version</code></pre></div>
     </li>
     <li>
       <p>Get future release notes emailed to you:</p>
@@ -453,11 +428,6 @@ $(document).ready(function(){
   <p>You can also execute the <code>cockroach</code> binary directly from its built location, <code>./src/github.com/cockroachdb/cockroach/cockroach</code>, but the rest of the documentation assumes you have the binary on your <code>PATH</code>.</p>
   </li>
   <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="linux-source-step5"><span class="gp" data-eventcategory="linux-source-step5">$ </span>cockroach version</code></pre></div>
-  </li>
-  <li>
       <p>Get future release notes emailed to you:</p>
       <div class="hubspot-install-form install-form-6 clearfix">
         <script>
@@ -508,11 +478,6 @@ $(document).ready(function(){
     </div>
     <div class="highlight"><pre class="highlight"><code data-eventcategory="linux-docker-step3"><span class="gp" data-eventcategory="linux-docker-step3">$ </span>sudo docker pull cockroachdb/cockroach:{{page.release_info.version}}</code></pre>
     </div>
-  </li>
-  <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="linux-docker-step4"><span class="gp" data-eventcategory="linux-docker-step4">$ </span>sudo docker run --rm cockroachdb/cockroach:{{page.release_info.version}} version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>
@@ -619,11 +584,6 @@ $(document).ready(function(){
       <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
     </div>
     <div class="highlight"><pre class="highlight"><code data-eventcategory="win-docker-step3"><span class="nb" data-eventcategory="win-docker-step3">PS </span>C:\Users\username&gt; docker pull cockroachdb/cockroach:{{page.release_info.version}}</code></pre></div>
-  </li>
-  <li>
-      <p>Make sure the CockroachDB executable works:</p>
-
-      {% include copy-clipboard.html %}<div class="highlight"><pre class="highlight"><code data-eventcategory="win-docker-step4"><span class="nb" data-eventcategory="win-docker-step4">PS </span>C:\Users\username&gt; docker run --rm cockroachdb/cockroach:{{page.release_info.version}} version</code></pre></div>
   </li>
   <li>
     <p>Get future release notes emailed to you:</p>


### PR DESCRIPTION
Fixes #1939 

Exception: Didn't remove from the Windows binary installation instructions because the step is unfortunately the only example of running a cockroach command in a Windows environment (powershell). 