### PR TITLE
Mark as new in 1.1

### DIFF
--- a/v1.1/cockroach-commands.md
+++ b/v1.1/cockroach-commands.md
@@ -15,13 +15,13 @@ You can run `cockroach help` in your shell to get similar guidance.
 Command | Usage
 --------|----
 [`start`](start-a-node.html) | Start a node.
-[`init`](initialize-a-cluster.html) | Initialize a cluster.
+[`init`](initialize-a-cluster.html) | <span class="version-tag">New in v1.1:</span> Initialize a cluster.
 [`cert`](create-security-certificates.html) | Create CA, node, and client certificates.
-[`quit`](stop-a-node.html) | <span class="version-tag">Changed in v1.1:</span> Temporarily stop a node or permanently remove a node.
+[`quit`](stop-a-node.html) | Temporarily stop a node or permanently remove a node.
 [`sql`](use-the-built-in-sql-client.html) | Use the built-in SQL client.
 [`user`](create-and-manage-users.html) | Get, set, list, and remove users.
 [`zone`](configure-replication-zones.html) | Configure the number and location of replicas for specific sets of data.
-[`node`](view-node-details.html) | <span class="version-tag">Changed in v1.1:</span> List node IDs, show their status, decommission nodes for removal, or recommission nodes.
+[`node`](view-node-details.html) | List node IDs, show their status, decommission nodes for removal, or recommission nodes.
 [`dump`](sql-dump.html) | Back up a table by outputting the SQL statements required to recreate the table and all its rows.
 [`debug zip`](debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`gen`](generate-cockroachdb-resources.html) | Generate manpages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.

--- a/v1.1/data-types.md
+++ b/v1.1/data-types.md
@@ -21,7 +21,8 @@ Type | Description | Example
 [`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'`
 [`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations. | `'a1b2c3' COLLATE en`
 [`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'`
-[`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec` 
+[`ARRAY`](array.html) | <span class="version-tag">New in v1.1:</span> A 1-dimensional, 1-indexed, homogenous array of any non-array data type. | `{"sky","road","car"}`
+[`UUID`](uuid.html) | <span class="version-tag">New in v1.1:</span> A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec`
 
 ## Data Type Conversions & Casts
 

--- a/v1.1/sql-dump.md
+++ b/v1.1/sql-dump.md
@@ -15,7 +15,7 @@ The `cockroach dump` [command](cockroach-commands.html) outputs the SQL statemen
 When `cockroach dump` is executed:
 
 - Table and view schemas and table data are dumped as they appeared at the time that the command is started. Any changes after the command starts will not be included in the dump.
-- Table and view schemas are dumped in the order in which they can successfully be recreated.
+- **New in v1.1:** Table and view schemas are dumped in the order in which they can successfully be recreated.
 - If the dump takes longer than the [`ttlseconds`](configure-replication-zones.html) replication setting for the table (24 hours by default), the dump may fail.
 - Reads, writes, and schema changes can happen while the dump is in progress, but will not affect the output of the dump.
 

--- a/v1.1/sql-statements.md
+++ b/v1.1/sql-statements.md
@@ -17,10 +17,11 @@ Statement | Usage
 [`CREATE TABLE AS`](create-table-as.html) | Create a new table in a database using the results from a `SELECT` statement.
 [`DELETE`](delete.html) | Delete specific rows from a table.
 [`EXPLAIN`](explain.html) | View debugging and analysis details for a `SELECT`, `INSERT`, `UPDATE`, or `DELETE` statement.
-[`IMPORT`](import.html) | Imports an entire table's data via CSV files.
+[`IMPORT`](import.html) | <span class="version-tag">New in v1.1:</span> Import an entire table's data via CSV files.
 [`INSERT`](insert.html) | Insert rows into a table.
 [`SELECT`](select.html) | Select rows from a table.
-[`TRUNCATE`](truncate.html) | Deletes all rows from specified tables.
+[`SHOW TRACE`](show-trace.html) | <span class="version-tag">New in v1.1:</span> Execute a statement and then return a trace of its actions through all of CockroachDB's software layers.
+[`TRUNCATE`](truncate.html) | Delete all rows from specified tables.
 [`UPDATE`](update.html) | Update rows in a table.
 [`UPSERT`](upsert.html) | Insert rows that do not violate uniqueness constraints; update rows that do.
 
@@ -75,7 +76,7 @@ Statement | Usage
 Statement | Usage
 ----------|------------
 [`CREATE USER`](create-user.html) | Create SQL users, which lets you control [privileges](privileges.html) on your databases and tables.
-[`DROP USER`](drop-user.html) | Remove SQL users.
+[`DROP USER`](drop-user.html) | <span class="version-tag">New in v1.1:</span> Remove SQL users.
 [`GRANT`](grant.html) | Grant privileges to users.
 [`REVOKE`](revoke.html) | Revoke privileges from users.
 [`SHOW GRANTS`](show-grants.html) | View privileges granted to users.
@@ -85,7 +86,7 @@ Statement | Usage
 
 Statement | Usage
 ----------|------------
-[`RESET`](reset-vars.html) | Reset a session variable to its default value.
+[`RESET`](reset-vars.html) | <span class="version-tag">New in v1.1:</span> Reset a session variable to its default value.
 [`SET`](set-vars.html) | Set a current session variable.
 [`SET TRANSACTION`](set-transaction.html) | Set the isolation level or priority for an individual [transaction](transactions.html).
 [`SHOW`](show-vars.html) | List the current session or transaction settings.
@@ -94,16 +95,32 @@ Statement | Usage
 
 Statement | Usage
 ----------|------------
-[`CANCEL QUERY`](cancel-query.html) | Cancel a running SQL query.
-[`RESET CLUSTER SETTING`](reset-cluster-setting.html) | Reset a cluster setting to its default value.
+[`RESET CLUSTER SETTING`](reset-cluster-setting.html) | <span class="version-tag">New in v1.1:</span> Reset a cluster setting to its default value.
 [`SET CLUSTER SETTING`](set-cluster-setting.html) | Set a cluster-wide setting.
 [`SHOW ALL CLUSTER SETTINGS`](show-cluster-setting.html) | List the current cluster-wide settings.
 [`SHOW SESSIONS`](show-sessions.html) | List details about currently active sessions.
-[`SHOW QUERIES`](show-queries.html) | List details about current active SQL queries.
+
+## Query Management Statements
+
+Statement | Usage
+----------|------------
+[`CANCEL QUERY`](cancel-query.html) | <span class="version-tag">New in v1.1:</span> Cancel a running SQL query.
+[`SHOW QUERIES`](show-queries.html) | <span class="version-tag">New in v1.1:</span> List details about current active SQL queries.
+
+## Job Management Statements
+
+Jobs in CockroachDB represent tasks that might not complete immediately, such as schema changes or enterprise backups or restores.
+
+Statement | Usage
+----------|------------
+[`CANCEL JOB`](pause-job.html) | <span class="version-tag">New in v1.1:</span> [*(Enterprise)*](https://www.cockroachlabs.com/product/cockroachdb-enterprise/) Cancel a `BACKUP` or `RESTORE` job.
+[`PAUSE JOB`](pause-job.html) | <span class="version-tag">New in v1.1:</span> [*(Enterprise)*](https://www.cockroachlabs.com/product/cockroachdb-enterprise/) Pause a `BACKUP` or `RESTORE` job.
+[`RESUME JOB`](resume-job.html) | <span class="version-tag">New in v1.1:</span> [*(Enterprise)*](https://www.cockroachlabs.com/product/cockroachdb-enterprise/) Resume paused `BACKUP` or `RESTORE` jobs.
+[`SHOW JOBS`](show-jobs.html) | <span class="version-tag">New in v1.1:</span> View information on jobs.
 
 ## Backup & Restore Statements (Enterprise)
 
-The following statements are availably only to [enterprise license](https://www.cockroachlabs.com/pricing/) users.
+The following statements are availably only to [enterprise](https://www.cockroachlabs.com/product/cockroachdb-enterprise/) users.
 
 {{site.data.alerts.callout_info}}For non-enterprise users, see <a href="back-up-data.html">Back up Data</a> and <a href="restore-data.html">Restore Data</a>.{{site.data.alerts.end}}
 
@@ -111,4 +128,4 @@ Statement | Usage
 ----------|------------
 [`BACKUP`](backup.html) | Create disaster recovery backups of databases and tables.
 [`RESTORE`](restore.html) | Restore databases and tables using your backups.
-[`SHOW BACKUP`](show-backup.html) | List the contents of a backup.
+[`SHOW BACKUP`](show-backup.html) | <span class="version-tag">New in v1.1:</span> List the contents of a backup.


### PR DESCRIPTION
Fixes #1968 

Add `New in v1.1` callout to cockroach command, sql statement, and data type overview pages so users can see newness at-a-glance. 

`Changed in v1.1` callouts are too numerous and so are only embedded directly with the features changed.
