### PR TITLE
Fix 1.1 upgrade doc

### DIFF
--- a/v1.0/upgrade-cockroach-version.md
+++ b/v1.0/upgrade-cockroach-version.md
@@ -38,47 +38,7 @@ For each node in your cluster, complete the following steps.
 
 1. Connect to the node.
 
-2. Download and install the CockroachDB binary you want to use:
-    - **Mac**:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Optional: Place cockroach in your $PATH
-        $ cp -i cockroach-{{page.release_info.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
-    - **Linux**:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Optional: Place cockroach in your $PATH
-        $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
-
-3. Stop the `cockroach` process.
+2. Stop the `cockroach` process.
 
     Without a process manager, use this command:
 
@@ -95,6 +55,34 @@ For each node in your cluster, complete the following steps.
     ~~~
 
     Alternately, you can check the node's logs for the message `server drained and shutdown completed`.
+
+3. Download and install the CockroachDB binary you want to use:
+    - **Mac**:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Get the CockroachDB tarball:
+        $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+        ~~~
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Extract the binary:
+        $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+        ~~~
+    - **Linux**:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Get the CockroachDB tarball:
+        $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
+        ~~~
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Extract the binary:
+        $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
+        ~~~
 
 4. If you use `cockroach` in your `$PATH`, rename the outdated `cockroach` binary, and then move the new one into its place:
     - **Mac**:
@@ -120,8 +108,6 @@ For each node in your cluster, complete the following steps.
         $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
         ~~~
 
-    If you leave versioned binaries on your servers, you don't need to do anything.
-
 5. If you're running with a process manager, have the node rejoin the cluster by starting it.
 
     Without a process manager, use this command:
@@ -140,6 +126,8 @@ For each node in your cluster, complete the following steps.
     ~~~ shell
     $ rm /usr/local/bin/cockroach_old
     ~~~
+
+    If you leave versioned binaries on your servers, you don't need to do anything.
 
 8. Wait at least one minute after the node has rejoined the cluster, and then repeat these steps for the next node.
 

--- a/v1.0/upgrade-cockroach-version.md
+++ b/v1.0/upgrade-cockroach-version.md
@@ -19,9 +19,10 @@ Before starting the upgrade, complete the following steps.
 
 2. Verify the cluster's overall health by running the [`cockroach node status`](view-node-details.html) command against any node in the cluster.
 
-    In the response, if any nodes that should be live are not listed, identify why the nodes are offline and restart them before begining your upgrade.
-
-    Also make sure `ranges_unavailable` and `ranges_underreplicated` show `0` for all nodes. If there are unavailable or underreplicated ranges in your cluster, performing a rolling upgrade increases the risk that ranges will lose a majority of their replicas and cause cluster unavailability. Therefore, it's important to identify and resolve the cause of range unavailability and underreplication before beginning your upgrade.Run the [`cockroach node status`](view-node-details.html) command with the `--decommission` flag against any node in the cluster.
+    In the response:
+    - If any nodes that should be live are not listed, identify why the nodes are offline and restart them before begining your upgrade.
+    - Make sure the `build` field shows the same version of CockroachDB for all nodes. If any nodes are behind, upgrade them to the cluster's current version first, and then start this process over.
+    - Make sure `ranges_unavailable` and `ranges_underreplicated` show `0` for all nodes. If there are unavailable or underreplicated ranges in your cluster, performing a rolling upgrade increases the risk that ranges will lose a majority of their replicas and cause cluster unavailability. Therefore, it's important to identify and resolve the cause of range unavailability and underreplication before beginning your upgrade.
 
 3. Capture the cluster's current state by running the [`cockroach debug zip`](debug-zip.html) command against any node in the cluster. If the upgrade does not go according to plan, the captured details will help you and Cockroach Labs troubleshoot issues.
 

--- a/v1.0/upgrade-cockroach-version.md
+++ b/v1.0/upgrade-cockroach-version.md
@@ -57,56 +57,72 @@ For each node in your cluster, complete the following steps.
     Alternately, you can check the node's logs for the message `server drained and shutdown completed`.
 
 3. Download and install the CockroachDB binary you want to use:
-    - **Mac**:
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
+    <div class="filters clearfix">
+      <button style="width: 15%" class="filter-button" data-scope="mac">Mac</button>
+      <button style="width: 15%" class="filter-button" data-scope="linux">Linux</button>
+    </div>
+    <p></p>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
-    - **Linux**:
+    <div class="filter-content" markdown="1" data-scope="mac">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Get the CockroachDB tarball:
+    $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+    ~~~
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Extract the binary:
+    $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+    ~~~
+    </div>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
+    <div class="filter-content" markdown="1" data-scope="linux">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Get the CockroachDB tarball:
+    $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Extract the binary:
+    $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
+    ~~~
+    </div>
 
 4. If you use `cockroach` in your `$PATH`, rename the outdated `cockroach` binary, and then move the new one into its place:
-    - **Mac**:
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ i="$(which cockroach)"; mv "$i" "$i"_old
-        ~~~
+    <div class="filters clearfix">
+      <button style="width: 15%" class="filter-button" data-scope="mac">Mac</button>
+      <button style="width: 15%" class="filter-button" data-scope="linux">Linux</button>
+    </div>
+    <p></p>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ cp -i cockroach-{{page.release_info.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
-    - **Linux**:
+    <div class="filter-content" markdown="1" data-scope="mac">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ i="$(which cockroach)"; mv "$i" "$i"_old
+    ~~~
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ i="$(which cockroach)"; mv "$i" "$i"_old
-        ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{page.release_info.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
+    ~~~
+    </div>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
+    <div class="filter-content" markdown="1" data-scope="linux">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ i="$(which cockroach)"; mv "$i" "$i"_old
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
+    ~~~
+    </div>
 
 5. If you're running with a process manager, have the node rejoin the cluster by starting it.
 

--- a/v1.0/upgrade-cockroach-version.md
+++ b/v1.0/upgrade-cockroach-version.md
@@ -7,7 +7,7 @@ toc_not_nested: true
 
 Because of CockroachDB's multi-active availability design, you can perform a "rolling upgrade" of CockroachDB on your cluster. This means you can upgrade individual nodes in your cluster one at a time without any downtime for your cluster.
 
-This page shows you how to upgrade a cluster from v1.0 to a patch release in the 1.0.x series. To upgrade from v1.0.x to v1.1, see [the 1.1 version of this page](../v1.1/upgrade-cockroach-version.html).
+{{site.data.alerts.callout_info}}This page shows you how to upgrade from v1.0 to a patch release in the 1.0.x series. To upgrade from v1.0.x to v1.1, see <a href="https://www.cockroachlabs.com/docs/v1.1/upgrade-cockroach-version.html">the 1.1 version of this page</a>.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/v1.1/upgrade-cockroach-version.md
+++ b/v1.1/upgrade-cockroach-version.md
@@ -7,7 +7,7 @@ toc_not_nested: true
 
 Because of CockroachDB's multi-active availability design, you can perform a "rolling upgrade" of CockroachDB on your cluster. This means you can upgrade individual nodes in your cluster one at a time without any downtime for your cluster.
 
-This page shows you how to upgrade a cluster from v1.0.x to v1.1, or from v1.1 to a patch release in the 1.1.x series. To upgrade within the 1.0.x series, see [the 1.0 version of this page](../v1.0/upgrade-cockroach-version.html).
+{{site.data.alerts.callout_info}}This page shows you how to upgrade from v1.0.x to v1.1, or from v1.1 to a patch release in the 1.1.x series. To upgrade within the 1.0.x series, see <a href="https://www.cockroachlabs.com/docs/v1.0/upgrade-cockroach-version.html">the 1.0 version of this page</a>.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/v1.1/upgrade-cockroach-version.md
+++ b/v1.1/upgrade-cockroach-version.md
@@ -58,56 +58,72 @@ For each node in your cluster, complete the following steps.
     Alternately, you can check the node's logs for the message `server drained and shutdown completed`.
 
 3. Download and install the CockroachDB binary you want to use:
-    - **Mac**:
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
+    <div class="filters clearfix">
+      <button style="width: 15%" class="filter-button" data-scope="mac">Mac</button>
+      <button style="width: 15%" class="filter-button" data-scope="linux">Linux</button>
+    </div>
+    <p></p>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
-    - **Linux**:
+    <div class="filter-content" markdown="1" data-scope="mac">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Get the CockroachDB tarball:
+    $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+    ~~~
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Extract the binary:
+    $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+    ~~~
+    </div>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
+    <div class="filter-content" markdown="1" data-scope="linux">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Get the CockroachDB tarball:
+    $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    # Extract the binary:
+    $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
+    ~~~
+    </div>
 
 4. If you use `cockroach` in your `$PATH`, rename the outdated `cockroach` binary, and then move the new one into its place:
-    - **Mac**:
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ i="$(which cockroach)"; mv "$i" "$i"_old
-        ~~~
+    <div class="filters clearfix">
+      <button style="width: 15%" class="filter-button" data-scope="mac">Mac</button>
+      <button style="width: 15%" class="filter-button" data-scope="linux">Linux</button>
+    </div>
+    <p></p>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ cp -i cockroach-{{page.release_info.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
-    - **Linux**:
+    <div class="filter-content" markdown="1" data-scope="mac">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ i="$(which cockroach)"; mv "$i" "$i"_old
+    ~~~
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ i="$(which cockroach)"; mv "$i" "$i"_old
-        ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{page.release_info.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
+    ~~~
+    </div>
 
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
+    <div class="filter-content" markdown="1" data-scope="linux">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ i="$(which cockroach)"; mv "$i" "$i"_old
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
+    ~~~
+    </div>
 
 5. If you're running with a process manager, have the node rejoin the cluster by starting it.
 

--- a/v1.1/upgrade-cockroach-version.md
+++ b/v1.1/upgrade-cockroach-version.md
@@ -39,47 +39,7 @@ For each node in your cluster, complete the following steps.
 
 1. Connect to the node.
 
-2. Download and install the CockroachDB binary you want to use:
-    - **Mac**:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Optional: Place cockroach in your $PATH
-        $ cp -i cockroach-{{page.release_info.version}}.darwin-10.9-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
-    - **Linux**:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Get the CockroachDB tarball:
-        $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Extract the binary:
-        $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
-        ~~~
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        # Optional: Place cockroach in your $PATH
-        $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
-        ~~~
-
-3. Stop the `cockroach` process.
+2. Stop the `cockroach` process.
 
     Without a process manager, use this command:
 
@@ -96,6 +56,34 @@ For each node in your cluster, complete the following steps.
     ~~~
 
     Alternately, you can check the node's logs for the message `server drained and shutdown completed`.
+
+3. Download and install the CockroachDB binary you want to use:
+    - **Mac**:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Get the CockroachDB tarball:
+        $ curl -O https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+        ~~~
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Extract the binary:
+        $ tar xfz cockroach-{{page.release_info.version}}.darwin-10.9-amd64.tgz
+        ~~~
+    - **Linux**:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Get the CockroachDB tarball:
+        $ wget https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz
+        ~~~
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        # Extract the binary:
+        $ tar xfz cockroach-{{page.release_info.version}}.linux-amd64.tgz
+        ~~~
 
 4. If you use `cockroach` in your `$PATH`, rename the outdated `cockroach` binary, and then move the new one into its place:
     - **Mac**:
@@ -121,8 +109,6 @@ For each node in your cluster, complete the following steps.
         $ cp -i cockroach-{{page.release_info.version}}.linux-amd64/cockroach /usr/local/bin/cockroach
         ~~~
 
-    If you leave versioned binaries on your servers, you don't need to do anything.
-
 5. If you're running with a process manager, have the node rejoin the cluster by starting it.
 
     Without a process manager, use this command:
@@ -141,6 +127,8 @@ For each node in your cluster, complete the following steps.
     ~~~ shell
     $ rm /usr/local/bin/cockroach_old
     ~~~
+
+    If you leave versioned binaries on your servers, you don't need to do anything.
 
 8. Wait at least one minute after the node has rejoined the cluster, and then repeat these steps for the next node.
 

--- a/v1.1/upgrade-cockroach-version.md
+++ b/v1.1/upgrade-cockroach-version.md
@@ -17,19 +17,17 @@ Before starting the upgrade, complete the following steps.
 
 1. Make sure your cluster is behind a load balancer, or your clients are configured to talk to multiple nodes. If your application communicates with a single node, stopping that node to upgrade its CockroachDB binary will cause your application to fail.
 
-2. Verify that all nodes are live by running the [`cockroach node status`](view-node-details.html) command with the `--decommission` flag against any node in the cluster.
+2. Verify the cluster's overall health by running the [`cockroach node status`](view-node-details.html) command against any node in the cluster.
 
-    In the response, if `is_live` is `false` for any nodes that should be live, identify why the nodes are offline and restart them before begining your upgrade.
+    In the response:
+    - If any nodes that should be live are not listed, identify why the nodes are offline and restart them before begining your upgrade.
+    - Make sure the `build` field shows the same version of CockroachDB for all nodes. If any nodes are behind, upgrade them to the cluster's current version first, and then start this process over.
+    - Make sure `ranges_unavailable` and `ranges_underreplicated` show `0` for all nodes. If there are unavailable or underreplicated ranges in your cluster, performing a rolling upgrade increases the risk that ranges will lose a majority of their replicas and cause cluster unavailability. Therefore, it's important to identify and resolve the cause of range unavailability and underreplication before beginning your upgrade.
+        {{site.data.alerts.callout_info}}When upgrading within the v1.1.x series, pass the <code>--ranges</code> or <code>--all</code> flag to include these range details in the response.{{site.data.alerts.end}}
 
-3. Verify the cluster's overall health and version by running the [`cockroach node status`](view-node-details.html) command with the `--ranges` flag against any node in the cluster.
+3. Capture the cluster's current state by running the [`cockroach debug zip`](debug-zip.html) command against any node in the cluster. If the upgrade does not go according to plan, the captured details will help you and Cockroach Labs troubleshoot issues.
 
-    In the response, make sure `ranges_unavailable` and `ranges_underreplicated` show `0` for all nodes. If there are unavailable or underreplicated ranges in your cluster, performing a rolling upgrade increases the risk that ranges will lose a majority of their replicas and cause cluster unavailability. Therefore, it's important to identify and resolve the cause of range unavailability and underreplication before beginning your upgrade.
-
-    Also, make sure the `build` field shows the same version of CockroachDB for all nodes. If any nodes are behind, upgrade them to the cluster's current version first, and then start this process over.
-
-4. Capture the cluster's current state by running the [`cockroach debug zip`](debug-zip.html) command against any node in the cluster. If the upgrade does not go according to plan, the captured details will help you and Cockroach Labs troubleshoot issues.
-
-5. [Back up the cluster](back-up-data.html). If the upgrade does not go according to plan, you can use the data to restore your cluster to its previous state.
+4. [Back up the cluster](back-up-data.html). If the upgrade does not go according to plan, you can use the data to restore your cluster to its previous state.
 
 ## Step 2. Perform the rolling upgrade
 


### PR DESCRIPTION
Fixes #1964 

- Use callout at top to make the upgrade path clearer.
- Fix prepare step: Encouraging users to check that all nodes are on the same version before upgrading. Also add note about using `--ranges` flag when upgrading within 1.1 series.
- Fix the node upgrade sequence: Previously, we were telling users to download the new binary
and move it onto the path before stoping and renaming the old binary. Now, we tell users to stop the process, download the new binary, and then rename the old binary and move the new binary onto the `PATH`.
- Improve usability: Use max/linux toggles.