### PR TITLE
Fixe ALTER TABLE page

### DIFF
--- a/_includes/custom/schema-change-view-job.md
+++ b/_includes/custom/schema-change-view-job.md
@@ -1,3 +1,1 @@
 Whenever you initiate a schema change, CockroachDB registers it as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
-
-{{site.data.alerts.callout_info}}Viewing jobs requires CockroachDB v1.1 or greater.{{site.data.alerts.end}}

--- a/v1.1/alter-table.md
+++ b/v1.1/alter-table.md
@@ -8,7 +8,7 @@ The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a 
 
 {{site.data.alerts.callout_info}}To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see <a href="https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/">Online Schema Changes in CockroachDB</a>.{{site.data.alerts.end}}
 
-<div id="toc"></div>div>
+<div id="toc"></div>
 
 ## Subcommands
 


### PR DESCRIPTION
- Remove extra tag to get page to render.
- Also remove callout from schema-change-view-job include, now that the header already calls out new in 1.1.