### PR TITLE
Fixing nav for architecture-related content

### DIFF
--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -1239,12 +1239,6 @@
         ]
       },
       {
-        "title": "CockroachDB Architecture",
-        "urls": [
-          "/${VERSION}/cockroachdb-architecture.html"
-        ]
-      },
-      {
         "title": "CockroachDB Features",
         "items": [
           {

--- a/_plugins/versions.rb
+++ b/_plugins/versions.rb
@@ -10,11 +10,13 @@
 # additional aliased versions. (At the time of writing, we named a `stable` and
 # `edge` version.) These are implemented as directory symlinks. For example, if
 # `stable: v1.0` is specified, a symlink `stable -> v1.0` will be written to the
-# build directory. If a page is renamed, set `key: original-file-name.md` in its
-# front matter so the version switcher can find its old versions. The `stable`
-# mapping is special and must exist, as `docs/FOO.html` will be automatically
-# redirected to `docs/stable/FOO.html` for every FOO.md in the stable directory.
-# Other name mappings are optional and can be added and removed at will.
+# build directory. The `stable` mapping is special and must exist, as
+# `docs/FOO.html` will be automatically redirected to `docs/stable/FOO.html` for
+# every FOO.md in the stable directory. Other name mappings are optional and can
+# be added and removed at will.
+#
+# If a page is renamed, set `key: original-file-name.html` in its front matter
+# so the version switcher can find its old versions.
 #
 # Each page has the following variables injected:
 #     `version` — the raw (non-logical) version of the page, like `v1.0`

--- a/_plugins/versions/generator.rb
+++ b/_plugins/versions/generator.rb
@@ -31,7 +31,7 @@ module JekyllVersions
         end
 
         @site.pages << JekyllRedirectFrom::RedirectPage.from_paths(
-          @site, vp.basename, vp.url) if vp.stable?
+          @site, vp.unversioned_path, vp.url) if vp.stable?
       end
 
       @config.versions.each do |name, version|

--- a/_plugins/versions/version.rb
+++ b/_plugins/versions/version.rb
@@ -7,7 +7,7 @@ module JekyllVersions
     attr_reader :version
 
     def self.from_path(config, path)
-      if v = path.split('/').find { |p| REGEX =~ p }
+      if (v = Pathname.new(path).each_filename.first) =~ REGEX
         Version.new(config, v)
       end
     end

--- a/_plugins/versions/versioned_page.rb
+++ b/_plugins/versions/versioned_page.rb
@@ -5,21 +5,20 @@ module JekyllVersions
     def initialize(config, page)
       @config = config
       @page = page
-      @key = page.data['key'] || basename
       @version = Version.from_path(config, page.url)
+      @key = page.data['key'] || unversioned_path
     end
 
-    def basename
-      # `page.basename` isn't sufficient, as the JekyllRedirectFrom plugin uses
+    def unversioned_path
+      # `page.path` isn't sufficient, as the JekyllRedirectFrom plugin uses
       # permalinks to hide the fact that every RedirectPage has a basename of
       # "redirect.html". Using `page.url` properly takes the permalink into
-      # account, but we need to unfold bare directories into the index.html
-      # within.
-      if page.url.end_with?('/')
-        'index.html'
-      else
-        File.basename(page.url)
-      end
+      # account, but we need to convert the URL back to a path by a) dropping
+      # the leading slash and maybe the version from the front of the URL, and
+      # b) tacking on `index.html` to bare directories.
+      url = page.url.split('/').drop(@version ? 2 : 1).join('/')
+      url << 'index.html' if url.end_with?('/')
+      url
     end
 
     def stable?

--- a/v1.0/cockroachdb-architecture.md
+++ b/v1.0/cockroachdb-architecture.md
@@ -5,4 +5,4 @@ toc: false
 feedback: false
 ---
 
-Coming soon. For now, see the [CockroachDB Design](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md) doc.
+You can find our architecture guide starting with the [CockroachDB 1.1 release](../v1.1/architecture/overview.html). While some details have changed between the two versions, most of the content remains applicable.

--- a/v1.1/architecture/overview.md
+++ b/v1.1/architecture/overview.md
@@ -2,6 +2,8 @@
 title: Architecture Overview
 summary: 
 toc: false
+key: cockroachdb-architecture.html
+redirect_from: index.html
 ---
 
 CockroachDB was designed to create the open-source database our developers would want to use: one that is both scalable and consistent. Developers often have questions about how we've achieved this, and this guide sets out to detail the inner-workings of the `cockroach` process as a means of explanation.

--- a/v1.1/cockroachdb-architecture.md
+++ b/v1.1/cockroachdb-architecture.md
@@ -1,8 +1,0 @@
----
-title: CockroachDB Architecture
-summary: Explore the architecture of CockroachDB.
-toc: false
-feedback: false
----
-
-Coming soon. For now, see the [CockroachDB Design](https://github.com/cockroachdb/cockroach/blob/master/docs/design.md) doc.


### PR DESCRIPTION
General nav cleanup given where the architecture docs landed.

- Until we decide to backport the v1.1 architecture docs to v1.0, leaving stub in place with link to 1.1. Hardcoding 1.1 link because it will always be the closest approximation.
- Adding redirects to `architecture/overview.html`––first attempt is experimental. @benesch, would love some help here to ensure I get this right.
- Removing vestigial `cockroachdb-architecture.html` page