### PR TITLE
Un-break links to the dev docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ redcarpet:
 
 versions:
   stable: v1.1
+  dev: v1.1
   # dev: v1.2
 
 release_info:


### PR DESCRIPTION
This can be switched back to pointing to v1.2 once we have a v1.2
release to point at.

Temporary band-aid on top of f3eb4a30ca59e0be2b56495627300405175df79b to fix the main repo's build, which expects the dev docs to be functional. Other URLs out there on the web may also refer to the dev docs. I'm not sure whether this will work, but teamcity should make it apparent soon.