### PR TITLE
Fix link to Replication Layer page

### DIFF
--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -1072,7 +1072,7 @@
           "/${VERSION}/create-a-file-server.html"
         ]
       },
-      {  
+      {
         "title": "Rotate Security Certificates",
         "urls": [
           "/${VERSION}/rotate-certificates.html"
@@ -1187,7 +1187,7 @@
       {
         "title": "Replication Layer",
         "urls": [
-          "/${VERSION}/architecture/transaction-layer.html"
+          "/${VERSION}/architecture/replication-layer.html"
         ]
       },
       {


### PR DESCRIPTION
It was incorrectly pointing to the Transaction Layer page.