### PR TITLE
./cockroach no longer needed with docker

### DIFF
--- a/v1.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v1.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -205,7 +205,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ sudo docker run -it --rm --network=cockroachdb cockroachdb/cockroach:{{page.release_info.version}} ./cockroach init --host=cockroachdb-1 --insecure
+    $ sudo docker run -it --rm --network=cockroachdb cockroachdb/cockroach:{{page.release_info.version}} init --host=cockroachdb-1 --insecure
     ~~~
 
 
@@ -215,7 +215,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ sudo docker run -it --rm --network=cockroachdb cockroachdb/cockroach:{{page.release_info.version}} ./cockroach sql --host=cockroachdb-1 --insecure
+    $ sudo docker run -it --rm --network=cockroachdb cockroachdb/cockroach:{{page.release_info.version}} sql --host=cockroachdb-1 --insecure
     ~~~
 
 2. Create an `insecurenodetest` database:


### PR DESCRIPTION
Only insecure docker swarm doc is affected.