### PR TITLE
Fix copying of a few commands in 1.1 swarm docs

### DIFF
--- a/v1.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v1.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -119,7 +119,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
 1. On the instance running your manager node, create one swarm service for each CockroachDB node:
 
     {% include copy-clipboard.html %}
-    ~~~
+    ~~~ shell
     # Start the first service:
     $ sudo docker service create \
     --replicas 1 \
@@ -138,7 +138,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     ~~~
 
     {% include copy-clipboard.html %}
-    ~~~
+    ~~~ shell
     # Start the second service:
     $ sudo docker service create \
     --replicas 1 \
@@ -156,7 +156,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     ~~~
 
     {% include copy-clipboard.html %}
-    ~~~
+    ~~~ shell
     # Start the third service:
     $ sudo docker service create \
     --replicas 1 \

--- a/v1.1/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v1.1/orchestrate-cockroachdb-with-docker-swarm.md
@@ -314,7 +314,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
 1. On the instance running your manager node, create one swarm service for each CockroachDB node:
 
     {% include copy-clipboard.html %}
-    ~~~
+    ~~~ shell
     # Create the first service:
     $ sudo docker service create \
     --replicas 1 \
@@ -338,7 +338,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     ~~~
 
     {% include copy-clipboard.html %}
-    ~~~
+    ~~~ shell
     # Create the second service:
     $ sudo docker service create \
     --replicas 1 \
@@ -361,7 +361,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     ~~~
 
     {% include copy-clipboard.html %}
-    ~~~
+    ~~~ shell
     # Create the third service:
     $ sudo docker service create \
     --replicas 1 \


### PR DESCRIPTION
Using the copy-to-clipboard functionality was copying the dollar signs
along with everything else, breaking the ability to paste the commands
directly into my terminal. The 1.0 docs were already correct.

It's still a little awkward that this copies the comments along with the
command, but that doesn't break anything (most of the time, at least).