### PR TITLE
Added content for FETCH FIRST and FETCH NEXT

### DIFF
--- a/v1.1/select.md
+++ b/v1.1/select.md
@@ -36,7 +36,7 @@ The user must have the `SELECT` [privilege](privileges.html) on the table.
 | `EXCEPT` | Only retrieve rows that are in the preceding `SELECT` statement but not in the following `SELECT` statement.  Returns distinct values.|
 | `ALL` | Include duplicate rows in the returned values of `UNION`, `INTERSECT`, or `EXCEPT`. |
 | `ORDER BY sortby_list` | Sort retrieved rows in the order of comma-separated column names you include in `sortby_list`. You can optionally specify `ASC` or `DESC` order for each column.<br><br>When <code>ORDER BY</code> is not included in a query, rows are not sorted by any consistent criteria. Instead, CockroachDB returns them as the coordinating node receives them.|
-| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br><span class="version-tag">New in v1.1:</span> CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched. `FETCH NEXT` is often used in conjunction with `OFFSET`.|
+| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br><span class="version-tag">New in v1.1:</span> CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched.|
 | `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` to "paginate" through retrieved rows.|
 
 ## Examples

--- a/v1.1/select.md
+++ b/v1.1/select.md
@@ -36,8 +36,8 @@ The user must have the `SELECT` [privilege](privileges.html) on the table.
 | `EXCEPT` | Only retrieve rows that are in the preceding `SELECT` statement but not in the following `SELECT` statement.  Returns distinct values.|
 | `ALL` | Include duplicate rows in the returned values of `UNION`, `INTERSECT`, or `EXCEPT`. |
 | `ORDER BY sortby_list` | Sort retrieved rows in the order of comma-separated column names you include in `sortby_list`. You can optionally specify `ASC` or `DESC` order for each column.<br><br>When <code>ORDER BY</code> is not included in a query, rows are not sorted by any consistent criteria. Instead, CockroachDB returns them as the coordinating node receives them.|
-| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. |
-| `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` to "paginate" through retrieved rows. |
+| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br><span class="version-tag">New in v1.1:</span> CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched. `FETCH NEXT` is often used in conjunction with `OFFSET`. |
+| `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` or `FETCH NEXT` to "paginate" through retrieved rows.|
 
 ## Examples
 
@@ -528,6 +528,25 @@ LIMIT 5;
 +----+------------------+
 ~~~
 
+Alternatively, you can use `FETCH FIRST`.
+
+~~~ sql
+> SELECT id, name 
+FROM accounts 
+FETCH FIRST 5 ROWS ONLY; 
+~~~
+~~~
++----+------------------+
+| id |       name       |
++----+------------------+
+|  1 | Bjorn Fairclough |
+|  2 | Bjorn Fairclough |
+|  3 | Arturo Nevin     |
+|  4 | Arturo Nevin     |
+|  5 | Naseem Joossens  |
++----+------------------+
+~~~
+
 #### Paginate Through Limited Results
 
 If you want to limit the number of results, but go beyond the initial set, use `OFFSET` to proceed to the next set of results. This is often used to paginate through large tables where not all of the values need to be immediately retrieved.
@@ -536,6 +555,26 @@ If you want to limit the number of results, but go beyond the initial set, use `
 > SELECT id, name
 FROM accounts
 LIMIT 5
+OFFSET 5;
+~~~
+~~~
++----+------------------+
+| id |       name       |
++----+------------------+
+|  6 | Juno Studwick    |
+|  7 | Juno Studwick    |
+|  8 | Eutychia Roberts |
+|  9 | Ricarda Moriarty |
+| 10 | Henrik Brankovic |
++----+------------------+
+~~~
+
+Alternatively, you can use `FETCH NEXT`.
+
+~~~ sql
+SELECT id, name 
+FROM accounts 
+FETCH NEXT 5 ROWS ONLY
 OFFSET 5;
 ~~~
 ~~~

--- a/v1.1/select.md
+++ b/v1.1/select.md
@@ -36,8 +36,8 @@ The user must have the `SELECT` [privilege](privileges.html) on the table.
 | `EXCEPT` | Only retrieve rows that are in the preceding `SELECT` statement but not in the following `SELECT` statement.  Returns distinct values.|
 | `ALL` | Include duplicate rows in the returned values of `UNION`, `INTERSECT`, or `EXCEPT`. |
 | `ORDER BY sortby_list` | Sort retrieved rows in the order of comma-separated column names you include in `sortby_list`. You can optionally specify `ASC` or `DESC` order for each column.<br><br>When <code>ORDER BY</code> is not included in a query, rows are not sorted by any consistent criteria. Instead, CockroachDB returns them as the coordinating node receives them.|
-| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br><span class="version-tag">New in v1.1:</span> CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched. `FETCH NEXT` is often used in conjunction with `OFFSET`. |
-| `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` or `FETCH NEXT` to "paginate" through retrieved rows.|
+| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br><span class="version-tag">New in v1.1:</span> CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched. `FETCH NEXT` is often used in conjunction with `OFFSET`.|
+| `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` to "paginate" through retrieved rows.|
 
 ## Examples
 
@@ -528,25 +528,6 @@ LIMIT 5;
 +----+------------------+
 ~~~
 
-Alternatively, you can use `FETCH FIRST`.
-
-~~~ sql
-> SELECT id, name 
-FROM accounts 
-FETCH FIRST 5 ROWS ONLY; 
-~~~
-~~~
-+----+------------------+
-| id |       name       |
-+----+------------------+
-|  1 | Bjorn Fairclough |
-|  2 | Bjorn Fairclough |
-|  3 | Arturo Nevin     |
-|  4 | Arturo Nevin     |
-|  5 | Naseem Joossens  |
-+----+------------------+
-~~~
-
 #### Paginate Through Limited Results
 
 If you want to limit the number of results, but go beyond the initial set, use `OFFSET` to proceed to the next set of results. This is often used to paginate through large tables where not all of the values need to be immediately retrieved.
@@ -555,26 +536,6 @@ If you want to limit the number of results, but go beyond the initial set, use `
 > SELECT id, name
 FROM accounts
 LIMIT 5
-OFFSET 5;
-~~~
-~~~
-+----+------------------+
-| id |       name       |
-+----+------------------+
-|  6 | Juno Studwick    |
-|  7 | Juno Studwick    |
-|  8 | Eutychia Roberts |
-|  9 | Ricarda Moriarty |
-| 10 | Henrik Brankovic |
-+----+------------------+
-~~~
-
-Alternatively, you can use `FETCH NEXT`.
-
-~~~ sql
-SELECT id, name 
-FROM accounts 
-FETCH NEXT 5 ROWS ONLY
 OFFSET 5;
 ~~~
 ~~~

--- a/v1.2/select.md
+++ b/v1.2/select.md
@@ -36,7 +36,7 @@ The user must have the `SELECT` [privilege](privileges.html) on the table.
 | `EXCEPT` | Only retrieve rows that are in the preceding `SELECT` statement but not in the following `SELECT` statement.  Returns distinct values.|
 | `ALL` | Include duplicate rows in the returned values of `UNION`, `INTERSECT`, or `EXCEPT`. |
 | `ORDER BY sortby_list` | Sort retrieved rows in the order of comma-separated column names you include in `sortby_list`. You can optionally specify `ASC` or `DESC` order for each column.<br><br>When <code>ORDER BY</code> is not included in a query, rows are not sorted by any consistent criteria. Instead, CockroachDB returns them as the coordinating node receives them.|
-| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br>CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched. `FETCH NEXT` is often used in conjunction with `OFFSET`.|
+| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br>CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched.|
 | `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` to "paginate" through retrieved rows.|
 ## Examples
 

--- a/v1.2/select.md
+++ b/v1.2/select.md
@@ -36,9 +36,8 @@ The user must have the `SELECT` [privilege](privileges.html) on the table.
 | `EXCEPT` | Only retrieve rows that are in the preceding `SELECT` statement but not in the following `SELECT` statement.  Returns distinct values.|
 | `ALL` | Include duplicate rows in the returned values of `UNION`, `INTERSECT`, or `EXCEPT`. |
 | `ORDER BY sortby_list` | Sort retrieved rows in the order of comma-separated column names you include in `sortby_list`. You can optionally specify `ASC` or `DESC` order for each column.<br><br>When <code>ORDER BY</code> is not included in a query, rows are not sorted by any consistent criteria. Instead, CockroachDB returns them as the coordinating node receives them.|
-| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. |
-| `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` to "paginate" through retrieved rows. |
-
+| `LIMIT limit_val` | Only retrieve `limit_val` number of rows. <br><br>CockroachDB also supports `FETCH FIRST limit_val ROWS ONLY` and `FETCH NEXT limit_val ROWS ONLY` as aliases for `LIMIT`. If `limit_val` is omitted, then one row is fetched. `FETCH NEXT` is often used in conjunction with `OFFSET`.|
+| `OFFSET offset_val` | Do not include the first `offset_value` number of rows.<br/><br/>`OFFSET` is often used in conjunction with `LIMIT` to "paginate" through retrieved rows.|
 ## Examples
 
 ### Choose Columns


### PR DESCRIPTION
Closes #1497 

As discussed, added information about FETCH FIRST and FETCH NEXT in same row as LIMIT, so as not to call attention, yet inform that we do support the parameters now. Also added examples.