### PR TITLE
typos in the first note "data.alerts.callout"

### DIFF
--- a/v1.1/architecture/overview.md
+++ b/v1.1/architecture/overview.md
@@ -18,7 +18,7 @@ This guide is broken out into pages detailing each layer of CockroachDB. It's re
 
 If you're looking for a high-level understanding of CockroachDB, you can simply read the **Overview** section of each layer. For more technical detail––for example, if you're interested in [contributing to the project](../contribute-to-cockroachdb.html)––you should read the **Components** sections as well.
 
-{{site.data.alerts.callout_info}}This guide detail how CockroachDB is built, but do not explain how <em>you</em> should architect an application using CockroachDB. For help with your own application's architecture using CockroachDB, check out our <a href="https://cockroachlabs.com/docs/stable">user documentation</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}This guide details how CockroachDB is built, but does not explain how <em>you</em> should architect an application using CockroachDB. For help with your own application's architecture using CockroachDB, check out our <a href="https://cockroachlabs.com/docs/stable">user documentation</a>.{{site.data.alerts.end}}
 
 ## Goals of CockroachDB
 

--- a/v1.2/architecture/overview.md
+++ b/v1.2/architecture/overview.md
@@ -18,7 +18,7 @@ This guide is broken out into pages detailing each layer of CockroachDB. It's re
 
 If you're looking for a high-level understanding of CockroachDB, you can simply read the **Overview** section of each layer. For more technical detail––for example, if you're interested in [contributing to the project](../contribute-to-cockroachdb.html)––you should read the **Components** sections as well.
 
-{{site.data.alerts.callout_info}}This guide detail how CockroachDB is built, but do not explain how <em>you</em> should architect an application using CockroachDB. For help with your own application's architecture using CockroachDB, check out our <a href="https://cockroachlabs.com/docs/stable">user documentation</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}This guide details how CockroachDB is built, but does not explain how <em>you</em> should architect an application using CockroachDB. For help with your own application's architecture using CockroachDB, check out our <a href="https://cockroachlabs.com/docs/stable">user documentation</a>.{{site.data.alerts.end}}
 
 ## Goals of CockroachDB
 


### PR DESCRIPTION
- add "s" on "detail" -- "This guide details how..."
- change "do" to "does" -- "but does not explain..."