### PR TITLE
Fix default insert in learn-cockroachdb-sql.md

### DIFF
--- a/v1.0/learn-cockroachdb-sql.md
+++ b/v1.0/learn-cockroachdb-sql.md
@@ -198,7 +198,7 @@ To insert multiple rows into a table, use a comma-separated list of parentheses,
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts (id, balance) VALUES
+> INSERT INTO accounts (id) VALUES
     (5);
 ~~~
 

--- a/v1.1/learn-cockroachdb-sql.md
+++ b/v1.1/learn-cockroachdb-sql.md
@@ -198,7 +198,7 @@ To insert multiple rows into a table, use a comma-separated list of parentheses,
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts (id, balance) VALUES
+> INSERT INTO accounts (id) VALUES
     (5);
 ~~~
 

--- a/v1.2/learn-cockroachdb-sql.md
+++ b/v1.2/learn-cockroachdb-sql.md
@@ -198,7 +198,7 @@ To insert multiple rows into a table, use a comma-separated list of parentheses,
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO accounts (id, balance) VALUES
+> INSERT INTO accounts (id) VALUES
     (5);
 ~~~
 


### PR DESCRIPTION
Bug called out in Gitter:

> INSERT INTO accounts (id, balance) VALUES (5);
> Sql should be INSERT INTO accounts (id) VALUES (5);;
