### PR TITLE
Add DELETE directive to nginx DAV docs

### DIFF
--- a/v1.1/create-a-file-server.md
+++ b/v1.1/create-a-file-server.md
@@ -52,7 +52,7 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
 
 1. Install `nginx` with the `webdav` module (often included in `-full` or similarly named packages in various distributions). 
 
-2. In the `nginx.conf` file, add a `dav_methods PUT` directive. For example:
+2. In the `nginx.conf` file, add a `dav_methods PUT DELETE` directive. For example:
 
     ~~~ nginx
     events {
@@ -62,7 +62,7 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
       server {
         listen 20150;
         location / {
-          dav_methods  PUT;
+          dav_methods  PUT DELETE;
           root /mnt/cockroach-exports;
           sendfile           on;
           sendfile_max_chunk 1m;

--- a/v1.2/create-a-file-server.md
+++ b/v1.2/create-a-file-server.md
@@ -52,7 +52,7 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
 
 1. Install `nginx` with the `webdav` module (often included in `-full` or similarly named packages in various distributions). 
 
-2. In the `nginx.conf` file, add a `dav_methods PUT` directive. For example:
+2. In the `nginx.conf` file, add a `dav_methods PUT DELETE` directive. For example:
 
     ~~~ nginx
     events {
@@ -62,7 +62,7 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
       server {
         listen 20150;
         location / {
-          dav_methods  PUT;
+          dav_methods  PUT DELETE;
           root /mnt/cockroach-exports;
           sendfile           on;
           sendfile_max_chunk 1m;


### PR DESCRIPTION
This allows deletion of BACKUP-CHECKPOINT.

Found this while testing with a real nginx server.