### PR TITLE
Update requirements for building v1.2 from source

### DIFF
--- a/v1.2/install-cockroachdb.html
+++ b/v1.2/install-cockroachdb.html
@@ -194,6 +194,14 @@ $(document).ready(function(){
         <td>Autoconf</td>
         <td>Version 2.68 or higher is required.</td>
       </tr>
+      <tr>
+        <td>NodeJS</td>
+        <td>Version 6.0 or higher is required.</td>
+      </tr>
+      <tr>
+        <td>Yarn</td>
+        <td>Version 1.0 or higher is required.</td>
+      </tr>
     </table>
     <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>
   </li>
@@ -380,6 +388,14 @@ $(document).ready(function(){
             part of a ncurses development package (e.g. <code>libtinfo-dev</code> on
             Debian/Ubuntu, but <code>ncurses-devel</code> on CentOS).
         </td>
+      </tr>
+      <tr>
+        <td>NodeJS</td>
+        <td>Version 6.x is required.</td>
+      </tr>
+      <tr>
+        <td>Yarn</td>
+        <td>Version 1.0 or higher is required.</td>
       </tr>
     </table>
     <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>

--- a/v1.2/install-cockroachdb.html
+++ b/v1.2/install-cockroachdb.html
@@ -180,7 +180,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>Go</td>
-        <td>Version 1.8.1 is required.</td>
+        <td>Version 1.9 is required.</td>
       </tr>
       <tr>
         <td>Bash</td>


### PR DESCRIPTION
Fixes #2150
Fixes #2166  

Note that the 1.2 build from source instructions are hidden for now, though. See https://github.com/cockroachdb/docs/issues/2155. #