### PR TITLE
Clarify that truncate is equivalent to dropping and recreating a table

### DIFF
--- a/v1.0/known-limitations.md
+++ b/v1.0/known-limitations.md
@@ -25,7 +25,7 @@ As a workaround, when you need to remove all rows from a large table:
 Within a single [transaction](transactions.html):
 
 - DDL statements cannot follow DML statements. As a workaround, arrange DML statements before DDL statements, or split the statements into separate transactions.
-- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
+- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table. This also applies to running [`TRUNCATE`](truncate.html) on such a table because `TRUNCATE` implicitly drops and recreates the table.
 - A table cannot be dropped and then recreated with the same name. This is not possible within a single transaction because `DROP TABLE` does not immediately drop the name of the table. As a workaround, split the [`DROP TABLE`](drop-table.html) and [`CREATE TABLE`](create-table.html) statements into separate transactions.
 
 ## Schema changes between executions of prepared statements

--- a/v1.0/truncate.md
+++ b/v1.0/truncate.md
@@ -6,6 +6,8 @@ toc: false
 
 The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
 
+{{site.data.alerts.callout_info}}The <code>TRUNCATE</code> removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a <a href="delete.html#delete-all-rows"><code>DELETE</code> statement without a <code>WHERE</code> clause<a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis

--- a/v1.1/known-limitations.md
+++ b/v1.1/known-limitations.md
@@ -39,7 +39,7 @@ If you have started or [upgraded](upgrade-cockroach-version.html#finalize-the-up
 Within a single [transaction](transactions.html):
 
 - DDL statements cannot follow DML statements. As a workaround, arrange DML statements before DDL statements, or split the statements into separate transactions.
-- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
+- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table. This also applies to running [`TRUNCATE`](truncate.html) on such a table because `TRUNCATE` implicitly drops and recreates the table.
 - A table cannot be dropped and then recreated with the same name. This is not possible within a single transaction because `DROP TABLE` does not immediately drop the name of the table. As a workaround, split the [`DROP TABLE`](drop-table.html) and [`CREATE TABLE`](create-table.html) statements into separate transactions.
 
 ### Schema changes between executions of prepared statements

--- a/v1.1/known-limitations.md
+++ b/v1.1/known-limitations.md
@@ -20,6 +20,8 @@ As a workaround, any time you create, drop, or truncate a table, perform another
 
 ### Maximum cluster size
 
+{{site.data.alerts.callout_info}}Resolved as of <a href="../releases/v1.2-alpha.20171026.html">v1.2-alpha.20171026</a>. See <a href="https://github.com/cockroachdb/cockroach/pull/18970">#17016</a>.{{site.data.alerts.end}}
+
 The locations of all ranges in a cluster are stored in a two-level index at the beginning of the key-space, known as [meta ranges](architecture/distribution-layer.html#meta-ranges), where the first level (`meta1`) addresses the second, and the second level (`meta2`) addresses data in the cluster. A limitation in v1.1 prevents `meta2` from being split; thus, the max size of a single range, 64MiB by default, limits the overall size of a cluster to 64TB. Clusters beyond this size will experience problems.
 
 ### Available capacity metric in the Admin UI

--- a/v1.1/truncate.md
+++ b/v1.1/truncate.md
@@ -6,6 +6,8 @@ toc: false
 
 The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
 
+{{site.data.alerts.callout_info}}The <code>TRUNCATE</code> removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a <a href="delete.html#delete-all-rows"><code>DELETE</code> statement without a <code>WHERE</code> clause<a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis

--- a/v1.2/known-limitations.md
+++ b/v1.2/known-limitations.md
@@ -18,10 +18,6 @@ It is not possible to perform an [enterprise `RESTORE`](restore.html) from a ful
 
 As a workaround, any time you create, drop, or truncate a table, perform another full `BACKUP` of your cluster.
 
-### Maximum cluster size
-
-The locations of all ranges in a cluster are stored in a two-level index at the beginning of the key-space, known as [meta ranges](architecture/distribution-layer.html#meta-ranges), where the first level (`meta1`) addresses the second, and the second level (`meta2`) addresses data in the cluster. A limitation in v1.1 prevents `meta2` from being split; thus, the max size of a single range, 64MiB by default, limits the overall size of a cluster to 64TB. Clusters beyond this size will experience problems.
-
 ### Available capacity metric in the Admin UI
 
 If you are running multiple nodes on a single machine (not recommended) and didnt' specified the maximum allocated storage capacity for each node using the [`--store`](start-a-node.html#store) flag, the available capacity shown in the [**Capacity**](admin-ui-storage-dashboard.html#capacity) graph in the Admin UI is incorrect. This is because when multiple nodes are running on a single machine, the machine's hard disk is treated as an available store for each node, while in reality, only one hard disk is available for all nodes. The total available capacity is then calculated as the hard disk size multiplied by the number of nodes on the machine.

--- a/v1.2/known-limitations.md
+++ b/v1.2/known-limitations.md
@@ -29,7 +29,7 @@ If you are running multiple nodes on a single machine (not recommended) and didn
 Within a single [transaction](transactions.html):
 
 - DDL statements cannot follow DML statements. As a workaround, arrange DML statements before DDL statements, or split the statements into separate transactions.
-- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
+- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table. This also applies to running [`TRUNCATE`](truncate.html) on such a table because `TRUNCATE` implicitly drops and recreates the table.
 - A table cannot be dropped and then recreated with the same name. This is not possible within a single transaction because `DROP TABLE` does not immediately drop the name of the table. As a workaround, split the [`DROP TABLE`](drop-table.html) and [`CREATE TABLE`](create-table.html) statements into separate transactions.
 
 ### Schema changes between executions of prepared statements

--- a/v1.2/truncate.md
+++ b/v1.2/truncate.md
@@ -6,6 +6,8 @@ toc: false
 
 The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
 
+{{site.data.alerts.callout_info}}The <code>TRUNCATE</code> removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a <a href="delete.html#delete-all-rows"><code>DELETE</code> statement without a <code>WHERE</code> clause<a>.{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Synopsis


### PR DESCRIPTION
Fixes #2065 
Fixes #2229 