### PR TITLE
releases: Correct reference to timestamp cache

### DIFF
--- a/releases/v1.2-alpha.20171211.md
+++ b/releases/v1.2-alpha.20171211.md
@@ -77,7 +77,7 @@ Get future release notes emailed to you:
 - Smoothed out disk usage under very write heavy workloads by syncing to disk more frequently. [#20352](https://github.com/cockroachdb/cockroach/pull/20352)
 - Improved garbage collection of very large [transactions](../v1.2/transactions.html) and large volumes of abandoned write intents. [#20396](https://github.com/cockroachdb/cockroach/pull/20396)
 - Improved table scans and seeks on interleaved parent tables by skipping interleaved children rows at the end of a scan. [#20235](https://github.com/cockroachdb/cockroach/pull/20235)
-- Replaced the interval tree structure in `CommandQueue` with arena-backed concurrent skiplist. This reduces global locking and garbage collection pressure, improving average and tail latencies. [#20300](https://github.com/cockroachdb/cockroach/pull/20300)
+- Replaced the interval tree structure in `TimestampCache` with arena-backed concurrent skiplist. This reduces global locking and garbage collection pressure, improving average and tail latencies. [#20300](https://github.com/cockroachdb/cockroach/pull/20300)
 
 ### Doc Updates
 


### PR DESCRIPTION
cc @nvanbenschoten 