### PR TITLE
More detailed docs on clock sync

### DIFF
--- a/_includes/faq/clock-synchronization.html
+++ b/_includes/faq/clock-synchronization.html
@@ -1,5 +1,15 @@
-CockroachDB needs moderately accurate time to preserve data consistency, so it's important to run [NTP](http://www.ntp.org/) or other clock synchronization software on each node.
-
-By default, CockroachDB's maximum allowed clock offset is 500ms. When a node detects that its clock offset, relative to other nodes, is half or more of the maximum allowed, it spontaneously shuts down. This is well in advance of the maximum offset (500ms by default), beyond which [serializable consistency](https://en.wikipedia.org/wiki/Serializability) is not guaranteed and stale reads and write skews could occur. With NTP or other clock synchronization software running on each node, there's very little risk of ever exceeding the maximum offset and encountering such anomalies, and even on well-functioning hardware not running synchronization software, slow clock drift is most common, which CockroachDB handles safely.
+CockroachDB requires moderate levels of clock synchronization to preserve data consistency. For this reason, when a node detects that its clock is out of synch with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default), it spontaneously shuts down. This avoids the risk of violating [serializable consistency](https://en.wikipedia.org/wiki/Serializability) and causing stale reads and write skews, but it's important to prevent clocks from drifting too far in the first place by running [NTP](http://www.ntp.org/) or other clock synchronization software on each node.
 
 The one rare case to note is when a node's clock suddenly jumps beyond the maximum offset before the node detects it. Although extremely unlikely, this could occur, for example, when running CockroachDB inside a VM and the VM hypervisor decides to migrate the VM to different hardware with a different time. In this case, there can be a small window of time between when the node's clock becomes unsynchronized and when the node spontaneously shuts down. During this window, it would be possible for a client to read stale data and write data derived from stale reads.
+
+For guidance on synchronizing clocks, see the tutorial for your deployment environment:
+
+Environment | Recommended Approach
+------------|---------------------
+[Manual](manual-deployment.html#step-1-synchronize-clocks) | Use NTP with Google's external NTP service.
+[AWS](deploy-cockroachdb-on-aws.html#step-3-synchronize-clocks) | Use the Amazon Time Sync Service.
+[Azure](deploy-cockroachdb-on-microsoft-azure.html#step-3-synchronize-clocks) | Disable Hyper-V time synchronization and use NTP with Google's external NTP service.
+[Digital Ocean](deploy-cockroachdb-on-digital-ocean.html#step-2-sychronize-clocks) | Use NTP with Google's external NTP service.
+[GCE](deploy-cockroachdb-on-google-cloud-platform.html#step-3-synchronize-clocks) | Use NTP with Google's internal NTP service.
+
+{{site.data.alerts.callout_info}}In most cases, we recommend Google's external NTP service because they handle <a href="https://developers.google.com/time/smear">"smearing" the leap second</a>. If you use a different NTP service that doesn't smear the leap second, you must configure client-side smearing manually and do so in the same way on each machine.{{site.data.alerts.end}}

--- a/_includes/prod_deployment/synchronize-clocks.md
+++ b/_includes/prod_deployment/synchronize-clocks.md
@@ -1,0 +1,173 @@
+CockroachDB requires moderate levels of [clock synchronization](recommended-production-settings.html#clock-synchronization) to preserve data consistency. For this reason, when a node detects that its clock is out of synch with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default), it spontaneously shuts down. This avoids the risk of consistency anomalies, but it's best to prevent clocks from drifting too far in the first place by running clock synchronization software on each node.
+
+{% if page.title contains "Digital Ocean" or page.title contains "Manual" %}
+
+[`ntpd`](http://doc.ntp.org/) should keep offsets in the single-digit milliseconds, so that software is featured here, but other methods of clock synchronization are suitable as well.
+
+1. SSH to the first machine.
+
+2. Disable `timesyncd`, which tends to be active by default on some Linux distributions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo timedatectl set-ntp no
+    ~~~
+
+    Verify that `timesyncd` is off:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ timedatectl
+    ~~~
+
+    Look for `Network time on: no` or `NTP enabled: no` in the output.
+
+3. Install the `ntp` package:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo apt-get install ntp
+    ~~~
+
+4. Stop the NTP daemon:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo service ntp stop
+    ~~~
+
+5. Synch the machine's clock with Google's NTP service:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo ntpd -b time.google.com
+    ~~~
+
+    To make this change permanent, in the `/etc/ntp.conf` file, remove or comment out any lines starting with `server` or `pool` and add the following lines:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    server time1.google.com iburst
+    server time2.google.com iburst
+    server time3.google.com iburst
+    server time4.google.com iburst
+    ~~~
+
+    Restart the NTP daemon:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo service ntp start
+    ~~~
+
+    {{site.data.alerts.callout_info}}We recommend Google's external NTP service because they handle <a href="https://developers.google.com/time/smear">"smearing" the leap second</a>. If you use a different NTP service that doesn't smear the leap second, you must configure client-side smearing manually and do so in the same way on each machine.{{site.data.alerts.end}}
+
+6. Verify that the machine is using a Google NTP server:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo ntpq -p
+    ~~~
+
+    The active NTP server will be marked with an asterisk.
+
+7. Repeat these steps for each machine where a CockroachDB node will run.
+
+{% elsif page.title contains "Google" %}
+
+Compute Engine instances are preconfigured to use [NTP](http://www.ntp.org/), which should keep offsets in the single-digit milliseconds. However, Google can’t predict how external NTP services, such as `pool.ntp.org`, will handle the leap second. Therefore, you should:
+
+- [Configure each GCE instances to use Google's internal NTP service](https://cloud.google.com/compute/docs/instances/managing-instances#configure_ntp_for_your_instances).
+- If you plan to run a hybrid cluster across GCE and other cloud providers or environments, [configure the non-GCE machines to use Google's external NTP service](deploy-cockroachdb-on-digital-ocean.html#step-2-sychronize-clocks).
+
+{% elsif page.title contains "AWS" %}
+
+Amazon provides the [Amazon Time Sync Service](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html), which uses a fleet of satellite-connected and atomic reference clocks in each AWS Region to deliver accurate current time readings. The service also smears the leap second.
+
+- If you plan to run your entire cluster on AWS, [configure each AWS instance to use the internal Amazon Time Sync Service](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html#configure-amazon-time-service).
+- However, if you plan to run a hybrid cluster across AWS and other cloud providers or environments, [configure all machines to use Google's external NTP service](deploy-cockroachdb-on-digital-ocean.html#step-2-sychronize-clocks), which is comparably accurate and also handles <a href="https://developers.google.com/time/smear">"smearing" the leap second</a>.
+
+{% elsif page.title contains "Azure" %}
+
+[`ntpd`](http://doc.ntp.org/) should keep offsets in the single-digit milliseconds, so that software is featured here. However, to run `ntpd` properly on Azure VMs, it's necessary to first unbind the Time Synchronization device used by the Hyper-V technology running Azure VMs; this device aims to synchronize time between the VM and its host operating system but has been known to cause problems.
+
+1. SSH to the first machine.
+
+2. Find the the ID of the Hyper-V Time Synchronization device:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ curl -O https://raw.githubusercontent.com/torvalds/linux/master/tools/hv/lsvmbus
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ python lsvmbus -vv | grep -w "Time Synchronization" -A 3
+    ~~~
+
+    ~~~
+    VMBUS ID 12: Class_ID = {9527e630-d0ae-497b-adce-e80ab0175caf} - [Time Synchronization]
+        Device_ID = {2dd1ce17-079e-403c-b352-a1921ee207ee}
+        Sysfs path: /sys/bus/vmbus/devices/2dd1ce17-079e-403c-b352-a1921ee207ee
+        Rel_ID=12, target_cpu=0
+    ~~~
+
+3. Unbind the device, using the `Device_ID` from the previous command's output:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ echo <DEVICE_ID> | sudo tee /sys/bus/vmbus/drivers/hv_util/unbind
+    ~~~
+
+4. Install the `ntp` package:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo apt-get install ntp
+    ~~~
+
+5. Stop the NTP daemon:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo service ntp stop
+    ~~~
+
+6. Synch the machine's clock with Google's NTP service:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo ntpd -b time.google.com
+    ~~~
+
+    To make this change permanent, in the `/etc/ntp.conf` file, remove or comment out any lines starting with `server` or `pool` and add the following lines:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    server time1.google.com iburst
+    server time2.google.com iburst
+    server time3.google.com iburst
+    server time4.google.com iburst
+    ~~~
+
+    Restart the NTP daemon:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo service ntp start
+    ~~~
+
+    {{site.data.alerts.callout_info}}We recommend Google's NTP service because they handle <a href="https://developers.google.com/time/smear">"smearing" the leap second</a>. If you use a different NTP service that doesn't smear the leap second, be sure to configure client-side smearing in the same way on each machine.{{site.data.alerts.end}}
+
+7. Verify that the machine is using a Google NTP server:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo ntpq -p
+    ~~~
+
+    The active NTP server will be marked with an asterisk.
+
+8. Repeat these steps for each machine where a CockroachDB node will run.
+
+{% endif %}

--- a/v1.0/operational-faqs.md
+++ b/v1.0/operational-faqs.md
@@ -45,7 +45,11 @@ Collecting information about CockroachDB's real world usage helps us prioritize 
 
 ## What happens when node clocks are not properly synchronized?
 
-{% include faq/clock-synchronization.html %}
+CockroachDB needs moderately accurate time to preserve data consistency, so it's important to run [NTP](http://www.ntp.org/) or other clock synchronization software on each node.
+
+By default, CockroachDB's maximum allowed clock offset is 500ms. When a node detects that its clock offset, relative to other nodes, is half or more of the maximum allowed, it spontaneously shuts down. This is well in advance of the maximum offset (500ms by default), beyond which [serializable consistency](https://en.wikipedia.org/wiki/Serializability) is not guaranteed and stale reads and write skews could occur. With NTP or other clock synchronization software running on each node, there's very little risk of ever exceeding the maximum offset and encountering such anomalies, and even on well-functioning hardware not running synchronization software, slow clock drift is most common, which CockroachDB handles safely.
+
+The one rare case to note is when a node's clock suddenly jumps beyond the maximum offset before the node detects it. Although extremely unlikely, this could occur, for example, when running CockroachDB inside a VM and the VM hypervisor decides to migrate the VM to different hardware with a different time. In this case, there can be a small window of time between when the node's clock becomes unsynchronized and when the node spontaneously shuts down. During this window, it would be possible for a client to read stale data and write data derived from stale reads.
 
 ## See Also
 

--- a/v1.0/recommended-production-settings.md
+++ b/v1.0/recommended-production-settings.md
@@ -44,7 +44,11 @@ For details about controlling the number and location of replicas, see [Configur
 
 ## Clock Synchronization
 
-{% include faq/clock-synchronization.html %}
+CockroachDB needs moderately accurate time to preserve data consistency, so it's important to run [NTP](http://www.ntp.org/) or other clock synchronization software on each node.
+
+By default, CockroachDB's maximum allowed clock offset is 500ms. When a node detects that its clock offset, relative to other nodes, is half or more of the maximum allowed, it spontaneously shuts down. This is well in advance of the maximum offset (500ms by default), beyond which [serializable consistency](https://en.wikipedia.org/wiki/Serializability) is not guaranteed and stale reads and write skews could occur. With NTP or other clock synchronization software running on each node, there's very little risk of ever exceeding the maximum offset and encountering such anomalies, and even on well-functioning hardware not running synchronization software, slow clock drift is most common, which CockroachDB handles safely.
+
+The one rare case to note is when a node's clock suddenly jumps beyond the maximum offset before the node detects it. Although extremely unlikely, this could occur, for example, when running CockroachDB inside a VM and the VM hypervisor decides to migrate the VM to different hardware with a different time. In this case, there can be a small window of time between when the node's clock becomes unsynchronized and when the node spontaneously shuts down. During this window, it would be possible for a client to read stale data and write data derived from stale reads.
 
 ## Cache Size
 

--- a/v1.1/common-errors.md
+++ b/v1.1/common-errors.md
@@ -137,9 +137,17 @@ When running a multi-node CockroachDB cluster, if you see an error like the one 
 
 ## clock synchronization error: this node is more than 500ms away from at least half of the known nodes
 
-This message indicates that a node has spontaneously shut down because it detected that its clock is out of sync with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default). CockroachDB requires moderate levels of [clock synchronization](recommended-production-settings.html#clock-synchronization) to preserve data consistency, so the node shutting down in this way avoids the risk of consistency anomalies.
+This error indicates that a node has spontaneously shut down because it detected that its clock is out of synch with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default). CockroachDB requires moderate levels of [clock synchronization](recommended-production-settings.html#clock-synchronization) to preserve data consistency, so the node shutting down in this way avoids the risk of consistency anomalies.
 
-To prevent this from happening, you should run [NTP](http://www.ntp.org/) or other clock synchronization software on each node.
+To prevent this from happening, you should run clock synchronization software on each node. For guidance on synchronizing clocks, see the tutorial for your deployment environment:
+
+Environment | Recommended Approach
+------------|---------------------
+[Manual](manual-deployment.html#step-1-synchronize-clocks) | Use NTP with Google's external NTP service.
+[AWS](deploy-cockroachdb-on-aws.html#step-3-synchronize-clocks) | Use the Amazon Time Sync Service.
+[Azure](deploy-cockroachdb-on-microsoft-azure.html#step-3-synchronize-clocks) | Disable Hyper-V time synchronization and use NTP with Google's external NTP service.
+[Digital Ocean](deploy-cockroachdb-on-digital-ocean.html#step-2-sychronize-clocks) | Use NTP with Google's external NTP service.
+[GCE](deploy-cockroachdb-on-google-cloud-platform.html#step-3-synchronize-clocks) | Use NTP with Google's internal NTP service.
 
 ## context deadline exceeded
 

--- a/v1.1/deploy-cockroachdb-on-aws-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-aws-insecure.md
@@ -70,7 +70,11 @@ You can create these rules using [Security Groups' Inbound Rules](http://docs.aw
 - Running at least 3 CockroachDB nodes to ensure survivability.
 - Selecting the same continent for all of your instances for best performance.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -87,23 +91,23 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of AWS's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -111,11 +115,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the AWS load balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-aws.md
+++ b/v1.1/deploy-cockroachdb-on-aws.md
@@ -70,7 +70,11 @@ You can create these rules using [Security Groups' Inbound Rules](http://docs.aw
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your instances for best performance.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -87,35 +91,35 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of AWS's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test your cluster
+## Step 8. Test your cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -34,7 +34,11 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your Droplets for best performance.
 
-## Step 2. Set up load balancing
+## Step 2. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 3. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -51,7 +55,7 @@ Digital Ocean offers fully-managed load balancers to distribute traffic between 
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Digital Ocean's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 3. Configure your network
+## Step 4. Configure your network
 
 Set up a firewall for each of your Droplets, allowing TCP communication on the following two ports:
 
@@ -66,23 +70,23 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 - CoreOS can use [`iptables`](https://www.digitalocean.com/community/tutorials/how-to-secure-your-coreos-cluster-with-tls-ssl-and-firewall-rules).
 - CentOS can use [`firewalld`](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7).
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -90,11 +94,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Digital Ocean Load Balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.1/deploy-cockroachdb-on-digital-ocean.md
@@ -34,7 +34,11 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your Droplets for best performance.
 
-## Step 2. Set up load balancing
+## Step 2. Sychronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 3. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -51,7 +55,7 @@ Digital Ocean offers fully-managed load balancers to distribute traffic between 
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Digital Ocean's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 3. Configure your network
+## Step 4. Configure your network
 
 Set up a firewall for each of your Droplets, allowing TCP communication on the following two ports:
 
@@ -66,35 +70,35 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 - CoreOS can use [`iptables`](https://www.digitalocean.com/community/tutorials/how-to-secure-your-coreos-cluster-with-tls-ssl-and-firewall-rules).
 - CentOS can use [`firewalld`](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7).
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test the cluster
+## Step 8. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -50,7 +50,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application Data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 3](#step-3-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it can't be used across zones. You might also consider using the HAProxy load balancer (see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance).{{site.data.alerts.end}}
 
@@ -63,7 +63,11 @@ Applications will not connect directly to your CockroachDB nodes. Instead, they'
 
 If you used a tag for your firewall rules, when you create the instance, select **Management, disk, networking, SSH keys**. Then on the **Networking** tab, in the **Network tags** field, enter **cockroachdb**.
 
-## Step 3. Set up TCP Proxy Load Balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up TCP Proxy Load Balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -86,23 +90,23 @@ To use GCE's TCP Proxy Load Balancing service:
 4. [Create a firewall rule](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy#config-hc-firewall) to allow traffic from the load balancer and health checker to your instances. This is necessary because TCP Proxy Load Balancing is implemented at the edge of the Google Cloud.
     - Be sure to set **Source IP ranges** to `130.211.0.0/22` and `35.191.0.0/16` and set **Target tags** to `cockroachdb` (not to the value specified in the linked instructions).
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -110,11 +114,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the GCE load balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -50,7 +50,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application Data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 3](#step-3-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it can't be used across zones. You might also consider using the HAProxy load balancer (see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance).{{site.data.alerts.end}}
 
@@ -63,7 +63,11 @@ Applications will not connect directly to your CockroachDB nodes. Instead, they'
 
 If you used a tag for your firewall rules, when you create the instance, select **Management, disk, networking, SSH keys**. Then on the **Networking** tab, in the **Network tags** field, enter **cockroachdb**.
 
-## Step 3. Set up TCP Proxy Load Balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up TCP Proxy Load Balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -86,35 +90,35 @@ To use GCE's TCP Proxy Load Balancing service:
 4. [Create a firewall rule](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy#config-hc-firewall) to allow traffic from the load balancer and health checker to your instances. This is necessary because TCP Proxy Load Balancing is implemented at the edge of the Google Cloud.
     - Be sure to set **Source IP ranges** to `130.211.0.0/22` and `35.191.0.0/16` and set **Target tags** to `cockroachdb` (not to the value specified in the linked instructions).
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test the cluster
+## Step 8. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -75,7 +75,11 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 When creating the VMs, make sure to select the **Resource Group**, **Virtual Network**, and **Network Security Group** you created.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -93,23 +97,23 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Azure's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -117,11 +121,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Azure load balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -73,7 +73,11 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 When creating the VMs, make sure to select the **Resource Group**, **Virtual Network**, and **Network Security Group** you created.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -91,35 +95,35 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Azure's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test the cluster
+## Step 8. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v1.1/manual-deployment-insecure.md
+++ b/v1.1/manual-deployment-insecure.md
@@ -24,19 +24,23 @@ This tutorial shows you how to manually deploy an insecure multi-node CockroachD
 
 {% include prod_deployment/insecure-recommendations.md %}
 
-## Step 1. Start nodes
+## Step 1. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 2. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 2. Initialize the cluster
+## Step 3. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 3. Test the cluster
+## Step 4. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 4. Set up HAProxy load balancers
+## Step 5. Set up HAProxy load balancers
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -123,19 +127,19 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 7. Repeat these steps for each additional instance of HAProxy you want to run.
 
-## Step 5. Test load balancing
+## Step 6. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 6. Use the cluster
+## Step 7. Use the cluster
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 7. Monitor the cluster
+## Step 8. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 8. Scale the cluster
+## Step 9. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v1.1/manual-deployment.md
+++ b/v1.1/manual-deployment.md
@@ -24,23 +24,27 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 {% include prod_deployment/secure-recommendations.md %}
 
-## Step 1. Generate certificates
+## Step 1. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 2. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 2. Start nodes
+## Step 3. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 3. Initialize the cluster
+## Step 4. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 4. Test the cluster
+## Step 5. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 5. Set up HAProxy load balancers
+## Step 6. Set up HAProxy load balancers
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -118,19 +122,19 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 6. Repeat these steps for each additional instance of HAProxy you want to run.
 
-## Step 6. Test load balancing
+## Step 7. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 7. Use the cluster
+## Step 8. Use the cluster
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 8. Monitor the cluster
+## Step 9. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 9. Scale the cluster
+## Step 10. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v2.0/common-errors.md
+++ b/v2.0/common-errors.md
@@ -137,9 +137,17 @@ When running a multi-node CockroachDB cluster, if you see an error like the one 
 
 ## clock synchronization error: this node is more than 500ms away from at least half of the known nodes
 
-This message indicates that a node has spontaneously shut down because it detected that its clock is out of sync with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default). CockroachDB requires moderate levels of [clock synchronization](recommended-production-settings.html#clock-synchronization) to preserve data consistency, so the node shutting down in this way avoids the risk of consistency anomalies.
+This error indicates that a node has spontaneously shut down because it detected that its clock is out of synch with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default). CockroachDB requires moderate levels of [clock synchronization](recommended-production-settings.html#clock-synchronization) to preserve data consistency, so the node shutting down in this way avoids the risk of consistency anomalies.
 
-To prevent this from happening, you should run [NTP](http://www.ntp.org/) or other clock synchronization software on each node.
+To prevent this from happening, you should run clock synchronization software on each node. For guidance on synchronizing clocks, see the tutorial for your deployment environment:
+
+Environment | Recommended Approach
+------------|---------------------
+[Manual](manual-deployment.html#step-1-synchronize-clocks) | Use NTP with Google's external NTP service.
+[AWS](deploy-cockroachdb-on-aws.html#step-3-synchronize-clocks) | Use the Amazon Time Sync Service.
+[Azure](deploy-cockroachdb-on-microsoft-azure.html#step-3-synchronize-clocks) | Disable Hyper-V time synchronization and use NTP with Google's external NTP service.
+[Digital Ocean](deploy-cockroachdb-on-digital-ocean.html#step-2-sychronize-clocks) | Use NTP with Google's external NTP service.
+[GCE](deploy-cockroachdb-on-google-cloud-platform.html#step-3-synchronize-clocks) | Use NTP with Google's internal NTP service.
 
 ## context deadline exceeded
 

--- a/v2.0/deploy-cockroachdb-on-aws-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-aws-insecure.md
@@ -70,7 +70,11 @@ You can create these rules using [Security Groups' Inbound Rules](http://docs.aw
 - Running at least 3 CockroachDB nodes to ensure survivability.
 - Selecting the same continent for all of your instances for best performance.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -87,23 +91,23 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of AWS's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -111,11 +115,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the AWS load balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-aws.md
+++ b/v2.0/deploy-cockroachdb-on-aws.md
@@ -70,7 +70,11 @@ You can create these rules using [Security Groups' Inbound Rules](http://docs.aw
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your instances for best performance.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -87,35 +91,35 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of AWS's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test your cluster
+## Step 8. Test your cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -34,7 +34,11 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your Droplets for best performance.
 
-## Step 2. Set up load balancing
+## Step 2. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 3. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -51,7 +55,7 @@ Digital Ocean offers fully-managed load balancers to distribute traffic between 
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Digital Ocean's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 3. Configure your network
+## Step 4. Configure your network
 
 Set up a firewall for each of your Droplets, allowing TCP communication on the following two ports:
 
@@ -66,23 +70,23 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 - CoreOS can use [`iptables`](https://www.digitalocean.com/community/tutorials/how-to-secure-your-coreos-cluster-with-tls-ssl-and-firewall-rules).
 - CentOS can use [`firewalld`](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7).
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -90,11 +94,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Digital Ocean Load Balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-digital-ocean.md
+++ b/v2.0/deploy-cockroachdb-on-digital-ocean.md
@@ -34,7 +34,11 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 - Running at least 3 nodes to ensure survivability.
 - Selecting the same continent for all of your Droplets for best performance.
 
-## Step 2. Set up load balancing
+## Step 2. Sychronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 3. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -51,7 +55,7 @@ Digital Ocean offers fully-managed load balancers to distribute traffic between 
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Digital Ocean's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 3. Configure your network
+## Step 4. Configure your network
 
 Set up a firewall for each of your Droplets, allowing TCP communication on the following two ports:
 
@@ -66,35 +70,35 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 - CoreOS can use [`iptables`](https://www.digitalocean.com/community/tutorials/how-to-secure-your-coreos-cluster-with-tls-ssl-and-firewall-rules).
 - CentOS can use [`firewalld`](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7).
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test the cluster
+## Step 8. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -50,7 +50,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application Data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 3](#step-3-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it can't be used across zones. You might also consider using the HAProxy load balancer (see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance).{{site.data.alerts.end}}
 
@@ -63,7 +63,11 @@ Applications will not connect directly to your CockroachDB nodes. Instead, they'
 
 If you used a tag for your firewall rules, when you create the instance, select **Management, disk, networking, SSH keys**. Then on the **Networking** tab, in the **Network tags** field, enter **cockroachdb**.
 
-## Step 3. Set up TCP Proxy Load Balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up TCP Proxy Load Balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -86,23 +90,23 @@ To use GCE's TCP Proxy Load Balancing service:
 4. [Create a firewall rule](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy#config-hc-firewall) to allow traffic from the load balancer and health checker to your instances. This is necessary because TCP Proxy Load Balancing is implemented at the edge of the Google Cloud.
     - Be sure to set **Source IP ranges** to `130.211.0.0/22` and `35.191.0.0/16` and set **Target tags** to `cockroachdb` (not to the value specified in the linked instructions).
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -110,11 +114,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the GCE load balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v2.0/deploy-cockroachdb-on-google-cloud-platform.md
@@ -50,7 +50,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application Data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 3](#step-3-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it can't be used across zones. You might also consider using the HAProxy load balancer (see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance).{{site.data.alerts.end}}
 
@@ -63,7 +63,11 @@ Applications will not connect directly to your CockroachDB nodes. Instead, they'
 
 If you used a tag for your firewall rules, when you create the instance, select **Management, disk, networking, SSH keys**. Then on the **Networking** tab, in the **Network tags** field, enter **cockroachdb**.
 
-## Step 3. Set up TCP Proxy Load Balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up TCP Proxy Load Balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -86,35 +90,35 @@ To use GCE's TCP Proxy Load Balancing service:
 4. [Create a firewall rule](https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy#config-hc-firewall) to allow traffic from the load balancer and health checker to your instances. This is necessary because TCP Proxy Load Balancing is implemented at the edge of the Google Cloud.
     - Be sure to set **Source IP ranges** to `130.211.0.0/22` and `35.191.0.0/16` and set **Target tags** to `cockroachdb` (not to the value specified in the linked instructions).
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test the cluster
+## Step 8. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -75,7 +75,11 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 When creating the VMs, make sure to select the **Resource Group**, **Virtual Network**, and **Network Security Group** you created.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -93,23 +97,23 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Azure's managed load balancing, see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Start nodes
+## Step 5. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 5. Initialize the cluster
+## Step 6. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 6. Test the cluster
+## Step 7. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 7. Test load balancing
+## Step 8. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 8. Use the cluster
+## Step 9. Use the cluster
 
 Now that your deployment is working, you can:
 
@@ -117,11 +121,11 @@ Now that your deployment is working, you can:
 2. [Create users](create-and-manage-users.html) and [grant them privileges](grant.html).
 3. [Connect your application](install-client-drivers.html). Be sure to connect your application to the Azure load balancer, not to a CockroachDB node.
 
-## Step 9. Monitor the cluster
+## Step 10. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 10. Scale the cluster
+## Step 11. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v2.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v2.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -73,7 +73,11 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 When creating the VMs, make sure to select the **Resource Group**, **Virtual Network**, and **Network Security Group** you created.
 
-## Step 3. Set up load balancing
+## Step 3. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -91,35 +95,35 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {{site.data.alerts.callout_info}}If you would prefer to use HAProxy instead of Azure's managed load balancing, see <a href="manual-deployment.html">Manual Deployment</a> for guidance.{{site.data.alerts.end}}
 
-## Step 4. Generate certificates
+## Step 5. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 5. Start nodes
+## Step 6. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 6. Initialize the cluster
+## Step 7. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 7. Test the cluster
+## Step 8. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 8. Test load balancing
+## Step 9. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 9. Use the database
+## Step 10. Use the database
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 10. Monitor the cluster
+## Step 11. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 11. Scale the cluster
+## Step 12. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 

--- a/v2.0/manual-deployment-insecure.md
+++ b/v2.0/manual-deployment-insecure.md
@@ -24,19 +24,23 @@ This tutorial shows you how to manually deploy an insecure multi-node CockroachD
 
 {% include prod_deployment/insecure-recommendations.md %}
 
-## Step 1. Start nodes
+## Step 1. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 2. Start nodes
 
 {% include prod_deployment/insecure-start-nodes.md %}
 
-## Step 2. Initialize the cluster
+## Step 3. Initialize the cluster
 
 {% include prod_deployment/insecure-initialize-cluster.md %}
 
-## Step 3. Test the cluster
+## Step 4. Test the cluster
 
 {% include prod_deployment/insecure-test-cluster.md %}
 
-## Step 4. Set up HAProxy load balancers
+## Step 5. Set up HAProxy load balancers
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -123,19 +127,19 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 7. Repeat these steps for each additional instance of HAProxy you want to run.
 
-## Step 5. Test load balancing
+## Step 6. Test load balancing
 
 {% include prod_deployment/insecure-test-load-balancing.md %}
 
-## Step 6. Use the cluster
+## Step 7. Use the cluster
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 7. Monitor the cluster
+## Step 8. Monitor the cluster
 
 {% include prod_deployment/insecure-monitor-cluster.md %}
 
-## Step 8. Scale the cluster
+## Step 9. Scale the cluster
 
 {% include prod_deployment/insecure-scale-cluster.md %}
 

--- a/v2.0/manual-deployment.md
+++ b/v2.0/manual-deployment.md
@@ -24,23 +24,27 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 {% include prod_deployment/secure-recommendations.md %}
 
-## Step 1. Generate certificates
+## Step 1. Synchronize clocks
+
+{% include prod_deployment/synchronize-clocks.md %}
+
+## Step 2. Generate certificates
 
 {% include prod_deployment/secure-generate-certificates.md %}
 
-## Step 2. Start nodes
+## Step 3. Start nodes
 
 {% include prod_deployment/secure-start-nodes.md %}
 
-## Step 3. Initialize the cluster
+## Step 4. Initialize the cluster
 
 {% include prod_deployment/secure-initialize-cluster.md %}
 
-## Step 4. Test the cluster
+## Step 5. Test the cluster
 
 {% include prod_deployment/secure-test-cluster.md %}
 
-## Step 5. Set up HAProxy load balancers
+## Step 6. Set up HAProxy load balancers
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use TCP load balancing:
 
@@ -118,19 +122,19 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 6. Repeat these steps for each additional instance of HAProxy you want to run.
 
-## Step 6. Test load balancing
+## Step 7. Test load balancing
 
 {% include prod_deployment/secure-test-load-balancing.md %}
 
-## Step 7. Use the cluster
+## Step 8. Use the cluster
 
 {% include prod_deployment/use-cluster.md %}
 
-## Step 8. Monitor the cluster
+## Step 9. Monitor the cluster
 
 {% include prod_deployment/secure-monitor-cluster.md %}
 
-## Step 9. Scale the cluster
+## Step 10. Scale the cluster
 
 {% include prod_deployment/secure-scale-cluster.md %}
 


### PR DESCRIPTION
Fixes #960
Fixes #1867
Fixes #2129
Fixes #1799 
Fixes #1690 

@bdarnell, @mberhault, I've added clock sync instructions for digital ocean, gce, aws, azure, and for manual deployment. However, I haven't yet touched on centOS or Redhat, both of which @robert-s-lee has suggested would be helpful. I'm hesitant to document those distros until we've done more testing on them. Please let me know what you think.