### PR TITLE
Update Mesosphere docs to reflect support for newer cockroach versions

### DIFF
--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -928,6 +928,12 @@
               "/${VERSION}/orchestrate-cockroachdb-with-docker-swarm.html",
               "/${VERSION}/orchestrate-cockroachdb-with-docker-swarm-insecure.html"
             ]
+          },
+          {
+            "title": "Mesosphere DC/OS",
+            "urls": [
+              "/${VERSION}/orchestrate-cockroachdb-with-mesosphere-insecure.html"
+            ]
           }
         ]
       },

--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -952,6 +952,12 @@
               "/${VERSION}/orchestrate-cockroachdb-with-docker-swarm.html",
               "/${VERSION}/orchestrate-cockroachdb-with-docker-swarm-insecure.html"
             ]
+          },
+          {
+            "title": "Mesosphere DC/OS",
+            "urls": [
+              "/${VERSION}/orchestrate-cockroachdb-with-mesosphere-insecure.html"
+            ]
           }
         ]
       },

--- a/v1.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v1.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -117,7 +117,7 @@ When using AWS CloudFormation, the launch process generally takes 10 to 15 minut
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker run -it cockroachdb/cockroach:{{ page.release_info.version }}  sql --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
+    $ docker run -it {{ page.release_info.docker_image }}:{{ page.release_info.version }}  sql --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
     ~~~
 
     ~~~
@@ -205,7 +205,7 @@ $ dcos node ssh --master-proxy --leader
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ docker run -it cockroachdb/cockroach:{{ page.release_info.version }} node status --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
+$ docker run -it {{ page.release_info.docker_image }}:{{ page.release_info.version }} node status --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
 ~~~
 
 ~~~

--- a/v1.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v1.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -16,7 +16,6 @@ Before getting started, it's important to review some current requirements and l
 
 ### Requirements
 
-- At this time, only CockroachDB v1.0.x is supported. Support for subsequent versions of CockroachDB is coming soon.
 - Your cluster must have at least 3 private nodes.
 - If you are using Enterprise DC/OS, you may need to [provision a service account](https://docs.mesosphere.com/1.9/security/ent/service-auth/custom-service-auth/) before installing CockroachDB. Only someone with `superuser` permission can create the service account.
 
@@ -28,7 +27,12 @@ Before getting started, it's important to review some current requirements and l
 
 ### Limitations
 
+CockroachDB in DC/OS works the same as in other environments with the exception of the following limitations:
+
+- At this time, only CockroachDB v1.0.x is supported. Support for subsequent versions of CockroachDB is coming soon.
 - The `cockroachdb` DC/OS service has been tested only on DC/OS versions 1.9 and 1.10.
+- Running in secure mode is not supported at this time.
+- Running a multi-datacenter cluster is not supported at this time.
 - Removing a node is not supported at this time.
 - Neither volume type nor volume size requirements may be changed after initial deployment.
 - Rack placement and awareness are not supported at this time.

--- a/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -61,13 +61,13 @@ When using AWS CloudFormation, the launch process generally takes 10 to 15 minut
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ dcos package install cockroachdb --package-version=1.0.0-1.0.2
+        $ dcos package install cockroachdb
         ~~~
     - If you created a custom `cockroach.json` configuration, run:
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ dcos package install cockroachdb --package-version=1.0.0-1.0.2 --options=cockroach.json
+        $ dcos package install cockroachdb --options=cockroach.json
         ~~~
 
 3. Monitor the cluster's deployment from the **Services** tab of the DC/OS UI.
@@ -212,11 +212,11 @@ $ docker run -it cockroachdb/cockroach:{{ page.release_info.version }} node stat
 +----+--------------------------------------------------------------------------+--------+---------------------+---------------------+------------+-----------+-------------+--------------+--------------+------------------+-----------------------+--------+--------------------+------------------------+
 | id |                                 address                                  | build  |     updated_at      |     started_at      | live_bytes | key_bytes | value_bytes | intent_bytes | system_bytes | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
 +----+--------------------------------------------------------------------------+--------+---------------------+---------------------+------------+-----------+-------------+--------------+--------------+------------------+-----------------------+--------+--------------------+------------------------+
-|  1 | cockroachdb-0-node-init.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:12 | 2017-12-11 19:14:42 |   41183973 |      1769 |    41187432 |            0 |         6018 |                2 |                     2 |      2 |                  0 |                      0 |
-|  2 | cockroachdb-1-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:12 | 2017-12-11 19:14:52 |     115448 |     71037 |      209282 |            0 |         6218 |                4 |                     4 |      4 |                  0 |                      0 |
-|  3 | cockroachdb-2-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:03 | 2017-12-11 19:14:53 |     120325 |     72652 |      217422 |            0 |         6732 |                4 |                     3 |      4 |                  0 |                      0 |
-|  4 | cockroachdb-3-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:03 | 2017-12-11 20:21:43 |   41248030 |     79147 |    41338632 |            0 |         6569 |                1 |                     1 |      1 |                  0 |                      0 |
-|  5 | cockroachdb-4-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:04 | 2017-12-11 20:56:54 |   41211967 |     30550 |    41181417 |            0 |         6854 |                1 |                     1 |      1 |                  0 |                      0 |
+|  1 | cockroachdb-0-node-init.cockroachdb.autoip.dcos.thisdcos.directory:26257 | {{ page.release_info.version }} | 2017-12-11 20:59:12 | 2017-12-11 19:14:42 |   41183973 |      1769 |    41187432 |            0 |         6018 |                2 |                     2 |      2 |                  0 |                      0 |
+|  2 | cockroachdb-1-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | {{ page.release_info.version }} | 2017-12-11 20:59:12 | 2017-12-11 19:14:52 |     115448 |     71037 |      209282 |            0 |         6218 |                4 |                     4 |      4 |                  0 |                      0 |
+|  3 | cockroachdb-2-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | {{ page.release_info.version }} | 2017-12-11 20:59:03 | 2017-12-11 19:14:53 |     120325 |     72652 |      217422 |            0 |         6732 |                4 |                     3 |      4 |                  0 |                      0 |
+|  4 | cockroachdb-3-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | {{ page.release_info.version }} | 2017-12-11 20:59:03 | 2017-12-11 20:21:43 |   41248030 |     79147 |    41338632 |            0 |         6569 |                1 |                     1 |      1 |                  0 |                      0 |
+|  5 | cockroachdb-4-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | {{ page.release_info.version }} | 2017-12-11 20:59:04 | 2017-12-11 20:56:54 |   41211967 |     30550 |    41181417 |            0 |         6854 |                1 |                     1 |      1 |                  0 |                      0 |
 +----+--------------------------------------------------------------------------+--------+---------------------+---------------------+------------+-----------+-------------+--------------+--------------+------------------+-----------------------+--------+--------------------+------------------------+
 (5 rows)
 ~~~

--- a/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -117,7 +117,7 @@ When using AWS CloudFormation, the launch process generally takes 10 to 15 minut
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker run -it cockroachdb/cockroach:{{ page.release_info.version }}  sql --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
+    $ docker run -it {{ page.release_info.docker_image }}:{{ page.release_info.version }}  sql --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
     ~~~
 
     ~~~
@@ -205,7 +205,7 @@ $ dcos node ssh --master-proxy --leader
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ docker run -it cockroachdb/cockroach:{{ page.release_info.version }} node status --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
+$ docker run -it {{ page.release_info.docker_image }}:{{ page.release_info.version }} node status --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
 ~~~
 
 ~~~

--- a/v2.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -61,13 +61,13 @@ When using AWS CloudFormation, the launch process generally takes 10 to 15 minut
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ dcos package install cockroachdb --package-version=1.0.0-1.0.2
+        $ dcos package install cockroachdb
         ~~~
     - If you created a custom `cockroach.json` configuration, run:
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ dcos package install cockroachdb --package-version=1.0.0-1.0.2 --options=cockroach.json
+        $ dcos package install cockroachdb --options=cockroach.json
         ~~~
 
 3. Monitor the cluster's deployment from the **Services** tab of the DC/OS UI.
@@ -212,11 +212,11 @@ $ docker run -it cockroachdb/cockroach:{{ page.release_info.version }} node stat
 +----+--------------------------------------------------------------------------+--------+---------------------+---------------------+------------+-----------+-------------+--------------+--------------+------------------+-----------------------+--------+--------------------+------------------------+
 | id |                                 address                                  | build  |     updated_at      |     started_at      | live_bytes | key_bytes | value_bytes | intent_bytes | system_bytes | replicas_leaders | replicas_leaseholders | ranges | ranges_unavailable | ranges_underreplicated |
 +----+--------------------------------------------------------------------------+--------+---------------------+---------------------+------------+-----------+-------------+--------------+--------------+------------------+-----------------------+--------+--------------------+------------------------+
-|  1 | cockroachdb-0-node-init.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:12 | 2017-12-11 19:14:42 |   41183973 |      1769 |    41187432 |            0 |         6018 |                2 |                     2 |      2 |                  0 |                      0 |
-|  2 | cockroachdb-1-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:12 | 2017-12-11 19:14:52 |     115448 |     71037 |      209282 |            0 |         6218 |                4 |                     4 |      4 |                  0 |                      0 |
-|  3 | cockroachdb-2-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:03 | 2017-12-11 19:14:53 |     120325 |     72652 |      217422 |            0 |         6732 |                4 |                     3 |      4 |                  0 |                      0 |
-|  4 | cockroachdb-3-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:03 | 2017-12-11 20:21:43 |   41248030 |     79147 |    41338632 |            0 |         6569 |                1 |                     1 |      1 |                  0 |                      0 |
-|  5 | cockroachdb-4-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.0.2 | 2017-12-11 20:59:04 | 2017-12-11 20:56:54 |   41211967 |     30550 |    41181417 |            0 |         6854 |                1 |                     1 |      1 |                  0 |                      0 |
+|  1 | cockroachdb-0-node-init.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.1.3 | 2017-12-11 20:59:12 | 2017-12-11 19:14:42 |   41183973 |      1769 |    41187432 |            0 |         6018 |                2 |                     2 |      2 |                  0 |                      0 |
+|  2 | cockroachdb-1-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.1.3 | 2017-12-11 20:59:12 | 2017-12-11 19:14:52 |     115448 |     71037 |      209282 |            0 |         6218 |                4 |                     4 |      4 |                  0 |                      0 |
+|  3 | cockroachdb-2-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.1.3 | 2017-12-11 20:59:03 | 2017-12-11 19:14:53 |     120325 |     72652 |      217422 |            0 |         6732 |                4 |                     3 |      4 |                  0 |                      0 |
+|  4 | cockroachdb-3-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.1.3 | 2017-12-11 20:59:03 | 2017-12-11 20:21:43 |   41248030 |     79147 |    41338632 |            0 |         6569 |                1 |                     1 |      1 |                  0 |                      0 |
+|  5 | cockroachdb-4-node-join.cockroachdb.autoip.dcos.thisdcos.directory:26257 | v1.1.3 | 2017-12-11 20:59:04 | 2017-12-11 20:56:54 |   41211967 |     30550 |    41181417 |            0 |         6854 |                1 |                     1 |      1 |                  0 |                      0 |
 +----+--------------------------------------------------------------------------+--------+---------------------+---------------------+------------+-----------+-------------+--------------+--------------+------------------+-----------------------+--------+--------------------+------------------------+
 (5 rows)
 ~~~

--- a/v2.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -117,7 +117,7 @@ When using AWS CloudFormation, the launch process generally takes 10 to 15 minut
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker run -it cockroachdb/cockroach:{{ page.release_info.version }}  sql --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
+    $ docker run -it {{ page.release_info.docker_image }}:{{ page.release_info.version }}  sql --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
     ~~~
 
     ~~~
@@ -205,7 +205,7 @@ $ dcos node ssh --master-proxy --leader
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ docker run -it cockroachdb/cockroach:{{ page.release_info.version }} node status --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
+$ docker run -it {{ page.release_info.docker_image }}:{{ page.release_info.version }} node status --insecure --host=pg.cockroachdb.l4lb.thisdcos.directory
 ~~~
 
 ~~~


### PR DESCRIPTION
I don't know whether to include the doc in v2.0 or not - you can't
actually run unstable releases using the DC/OS package we provide, but
is it weird if we don't have the doc for it? Will we forget to add it
later? Let me know what you'd like.

The first commit is just https://github.com/cockroachdb/docs/pull/2319.