### PR TITLE
Add redirect for collation page

### DIFF
--- a/v1.0/collate.md
+++ b/v1.0/collate.md
@@ -2,6 +2,7 @@
 title: COLLATE
 summary: The COLLATE feature lets you sort strings according to language- and country-specific rules.
 toc: false
+redirect_from: collatedstring.html
 ---
 
 The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.
@@ -14,11 +15,11 @@ Collated strings are important because different languages have [different rules
 
 - Operations on collated strings cannot involve strings with a different collation or strings with no collation. However, it is possible to <a href="#ad-hoc-collation-casting">add or overwrite a collation on the fly</a>.
 
-- Only use the collation feature when you need to sort strings by a specific collation. We recommend this because every time a collated string is constructed or loaded into memory, CockroachDB computes its collation key, whose size is linear in relationship to the length of the collated string, which requires additional resources. 
+- Only use the collation feature when you need to sort strings by a specific collation. We recommend this because every time a collated string is constructed or loaded into memory, CockroachDB computes its collation key, whose size is linear in relationship to the length of the collated string, which requires additional resources.
 
 - Collated strings can be considerably larger than the corresponding uncollated strings, depending on the language and the string content. For example, strings containing the character `é` produce larger collation keys in the French locale than in Chinese.
 
-- Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead. 
+- Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead.
 
 ## Supported Collations
 

--- a/v1.0/deploy-a-test-cluster.md
+++ b/v1.0/deploy-a-test-cluster.md
@@ -49,7 +49,7 @@ Before getting started, it's important to review some limitations and requiremen
 
     The launch process generally takes 10 to 15 minutes. Once you see the `CREATE_COMPLETE` status in the CloudFormation UI, the cluster is ready for testing.
 
-    {{site.data.alerts.callout_info}}If the launch process times out or fails, you could be running into an <a href="https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">AWS service limit</a>. You can view any errors in the <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-monitor-stack.html">event history</a>.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}If the launch process times out or fails, you could be running into an <a href="https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">AWS service limit</a>. You can view any errors in the <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-monitor-stack.html" data-proofer-ignore>event history</a>.{{site.data.alerts.end}}
 
 ## Step 2. Test the cluster
 

--- a/v1.1/collate.md
+++ b/v1.1/collate.md
@@ -2,6 +2,7 @@
 title: COLLATE
 summary: The COLLATE feature lets you sort strings according to language- and country-specific rules.
 toc: false
+redirect_from: collatedstring.html
 ---
 
 The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.
@@ -14,11 +15,11 @@ Collated strings are important because different languages have [different rules
 
 - Operations on collated strings cannot involve strings with a different collation or strings with no collation. However, it is possible to <a href="#ad-hoc-collation-casting">add or overwrite a collation on the fly</a>.
 
-- Only use the collation feature when you need to sort strings by a specific collation. We recommend this because every time a collated string is constructed or loaded into memory, CockroachDB computes its collation key, whose size is linear in relationship to the length of the collated string, which requires additional resources. 
+- Only use the collation feature when you need to sort strings by a specific collation. We recommend this because every time a collated string is constructed or loaded into memory, CockroachDB computes its collation key, whose size is linear in relationship to the length of the collated string, which requires additional resources.
 
 - Collated strings can be considerably larger than the corresponding uncollated strings, depending on the language and the string content. For example, strings containing the character `é` produce larger collation keys in the French locale than in Chinese.
 
-- Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead. 
+- Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead.
 
 ## Supported Collations
 

--- a/v1.1/deploy-a-test-cluster.md
+++ b/v1.1/deploy-a-test-cluster.md
@@ -49,7 +49,7 @@ Before getting started, it's important to review some limitations and requiremen
 
     The launch process generally takes 10 to 15 minutes. Once you see the `CREATE_COMPLETE` status in the CloudFormation UI, the cluster is ready for testing.
 
-    {{site.data.alerts.callout_info}}If the launch process times out or fails, you could be running into an <a href="https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">AWS service limit</a>. You can view any errors in the <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-monitor-stack.html">event history</a>.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}If the launch process times out or fails, you could be running into an <a href="https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">AWS service limit</a>. You can view any errors in the <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-monitor-stack.html" data-proofer-ignore>event history</a>.{{site.data.alerts.end}}
 
 ## Step 2. Test the cluster
 

--- a/v2.0/collate.md
+++ b/v2.0/collate.md
@@ -2,6 +2,7 @@
 title: COLLATE
 summary: The COLLATE feature lets you sort strings according to language- and country-specific rules.
 toc: false
+redirect_from: collatedstring.html
 ---
 
 The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.
@@ -14,11 +15,11 @@ Collated strings are important because different languages have [different rules
 
 - Operations on collated strings cannot involve strings with a different collation or strings with no collation. However, it is possible to <a href="#ad-hoc-collation-casting">add or overwrite a collation on the fly</a>.
 
-- Only use the collation feature when you need to sort strings by a specific collation. We recommend this because every time a collated string is constructed or loaded into memory, CockroachDB computes its collation key, whose size is linear in relationship to the length of the collated string, which requires additional resources. 
+- Only use the collation feature when you need to sort strings by a specific collation. We recommend this because every time a collated string is constructed or loaded into memory, CockroachDB computes its collation key, whose size is linear in relationship to the length of the collated string, which requires additional resources.
 
 - Collated strings can be considerably larger than the corresponding uncollated strings, depending on the language and the string content. For example, strings containing the character `é` produce larger collation keys in the French locale than in Chinese.
 
-- Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead. 
+- Collated strings that are indexed require additional disk space as compared to uncollated strings. In case of indexed collated strings, collation keys must be stored in addition to the strings from which they are derived, creating a constant factor overhead.
 
 ## Supported Collations
 

--- a/v2.0/deploy-a-test-cluster.md
+++ b/v2.0/deploy-a-test-cluster.md
@@ -49,7 +49,7 @@ Before getting started, it's important to review some limitations and requiremen
 
     The launch process generally takes 10 to 15 minutes. Once you see the `CREATE_COMPLETE` status in the CloudFormation UI, the cluster is ready for testing.
 
-    {{site.data.alerts.callout_info}}If the launch process times out or fails, you could be running into an <a href="https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">AWS service limit</a>. You can view any errors in the <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-monitor-stack.html">event history</a>.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}If the launch process times out or fails, you could be running into an <a href="https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">AWS service limit</a>. You can view any errors in the <a href=" https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-monitor-stack.html" data-proofer-ignore>event history</a>.{{site.data.alerts.end}}
 
 ## Step 2. Test the cluster
 


### PR DESCRIPTION
The auto-generated functions docs expect a page called
`collatedstring.html`. The existing page is called `collate.html`. This
client-side redirect should suffice.

Fixes https://github.com/cockroachdb/cockroach/issues/21394