### PR TITLE
Withdraw v2.0-alpha.20180116 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,10 +36,10 @@ release_info:
     start_time: 2018-01-08 15:10:52.34274101 +0000 UTC
   v2.0:
     name: v2.0-alpha
-    version: v2.0-alpha.20180116
+    version: v2.0-alpha.20171218
     docker_image: cockroachdb/cockroach-unstable
-    build_time: 2018/01/16 14:48:26 (go1.9)
-    start_time: 2017-01-16 15:10:52.34274101 +0000 UTC
+    build_time: 2017/12/18 14:48:26 (go1.9)
+    start_time: 2017-12-18 15:10:52.34274101 +0000 UTC
 
 training:
   ccl_license: crl-0-ELzpyNMFGAIiF0NvY2tyb2FjaCBMYWJzIFRyYWluaW5n

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -29,6 +29,7 @@
   releases:
     - date: Jan 16, 2018
       version: v2.0-alpha.20180116
+      withdrawn: true
     - date: Dec 18, 2017
       version: v2.0-alpha.20171218
     - date: Dec 11, 2017

--- a/releases/v2.0-alpha.20180116.md
+++ b/releases/v2.0-alpha.20180116.md
@@ -21,15 +21,10 @@ Get future release notes emailed to you:
     </script>
 </div>
 
-### Downloads
+{{site.data.alerts.callout_danger}}A bug that could trigger an assertion failure was discovered in this
+release. Bringing up a node too soon after the assertion fired could introduce consistency problems, so this release has been withdrawn.{{site.data.alerts.end}}
 
-<div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180116.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180116.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180116.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180116.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
-</div>
-
+<!--
 ### Backwards-Incompatible Changes
 
 - Removed the obsolete `kv.gc.batch_size` [cluster setting](../v2.0/cluster-settings.html). [#21070](https://github.com/cockroachdb/cockroach/pull/21070)
@@ -145,3 +140,4 @@ Get future release notes emailed to you:
 - Added guidance on [reducing or disabling the storage of timeseries data](../v2.0/operational-faqs.html#can-i-reduce-or-disable-the-storage-of-timeseries-data-new-in-v2-0). [#2361](https://github.com/cockroachdb/docs/pull/2361)
 - Added docs on the [`CREATE SEQUENCE`](../v2.0/create-sequence.html), [`ALTER SEQUENCE`](../v2.0/alter-sequence.html), and [`DROP SEQUENCE`](../v2.0/drop-sequence.html) statements. [#2292](https://github.com/cockroachdb/docs/pull/2292)
 - Improved the font and coloring of code samples. [#2323](https://github.com/cockroachdb/docs/pull/2323)
+-->


### PR DESCRIPTION
On the release notes page, I commented out the updates so we can easily build on them for the next alpha release.