### PR TITLE
clarify install docker directions.

### DIFF
--- a/v2.0/start-a-local-cluster-in-docker.md
+++ b/v2.0/start-a-local-cluster-in-docker.md
@@ -33,7 +33,7 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 <div class="filter-content" markdown="1" data-scope="os-windows">
 ## Before You Begin
 
-Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
+Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html). If not, follow the instructions to install CockroachDB in Docker by clicking the "Use Docker" tab.
 
 ## Step 1. Create a bridge network
 


### PR DESCRIPTION
The "Make Sure You Use Docker" instructions could be a little more
user-error proofed, as by default, the link takes you to
the "install via homebrew" instructions.

If there was a way to link directly to the "use docker" link, that
would be better, but I could not figure it out.

I have not wordsmithed it, happy to take suggestions (and then I can add it to the other versions of the doc page).