### PR TITLE
Thin out the release sidebar

### DIFF
--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -8,30 +8,6 @@
       ]
     },
     {
-      "title": "v1.1.4",
-      "urls": [
-        "/releases/v1.1.4.html"
-      ]
-    },
-    {
-      "title": "v1.1.3",
-      "urls": [
-        "/releases/v1.1.3.html"
-      ]
-    },
-    {
-      "title": "v1.1.2",
-      "urls": [
-        "/releases/v1.1.2.html"
-      ]
-    },
-    {
-      "title": "v1.1.1",
-      "urls": [
-        "/releases/v1.1.1.html"
-      ]
-    },
-    {
       "title": "v1.1",
       "urls": [
         "/releases/v1.1.0.html"
@@ -44,62 +20,21 @@
       ]
     },
     {
-      "title": "v1.0.6",
-      "urls": [
-        "/releases/v1.0.6.html"
-      ]
-    },
-    {
-      "title": "v1.0.5",
-      "urls": [
-        "/releases/v1.0.5.html"
-      ]
-    },
-    {
-      "title": "v1.0.4",
-      "urls": [
-        "/releases/v1.0.4.html"
-      ]
-    },
-    {
-      "title": "v1.0.3",
-      "urls": [
-        "/releases/v1.0.3.html"
-      ]
-    },
-    {
-      "title": "v1.0.2",
-      "urls": [
-        "/releases/v1.0.2.html"
-      ]
-    },
-    {
-      "title": "v1.0.1",
-      "urls": [
-        "/releases/v1.0.1.html"
-      ]
-    },
-    {
       "title": "v1.0",
       "urls": [
         "/releases/v1.0.html"
       ]
     },
     {
-      "title": "All Releases",
-      "items": [
-        {
-          "title": "Production",
-          "urls": [
-            "/releases/"
-          ]
-        },
-        {
-          "title": "Testing (Alphas & Betas)",
-          "urls": [
-            "/releases/#testing-releases"
-          ]
-        }
+      "title": "All Production Releases",
+      "urls": [
+        "/releases/"
+      ]
+    },
+    {
+      "title": "Testing Releases (Alphas & Betas)",
+      "urls": [
+        "/releases/#testing-releases"
       ]
     }
   ]


### PR DESCRIPTION
Include two releases per branch: The most recent, and the original
x.y.0 (which is larger and discusses the new features of the release).
All others are in the "all releases" page (the two parts of which have
been bumped up in the tree to save a click).

What do you think of this idea? @jess-edwards and I noticed today that 1.0.7 was kind of buried in the middle of the list and easy to miss.