### PR TITLE
Exclude training from search results

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -59,6 +59,6 @@
 	</div>
 </section>
 
-{% if page.sidebar_data != sidebar-data-training.json %}
+{% if page.sidebar_data != "sidebar-data-training.json" %}
 	{% include newsletter-popout.html %}
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{% if page.tags %}{{ page.tags | join: ', ' | escape }}{% endif %}">
-{% if page.sidebar_data == sidebar-data-training.json %}<meta name="robots" content="noindex">{% endif %}
+{% if page.sidebar_data == "sidebar-data-training.json" %}<meta name="robots" content="noindex">{% endif %}
 <title>{{ page.title }} | {{ site.site_title }}</title>
 <link rel="canonical" href="{{ page.canonical | absolute_url }}">
 <link rel="shortcut icon" href="{{ 'images/favicon.png' | relative_url }}" type="image/png">


### PR DESCRIPTION
- Really, this time. I didn't do this right in #2443.
- Also, do not show footer email signup on training pages. This has also been in place for some time but not working.