### PR TITLE
Update built-in sql client docs

### DIFF
--- a/v2.0/functions-and-operators.md
+++ b/v2.0/functions-and-operators.md
@@ -6,7 +6,7 @@ toc: false
 
 CockroachDB supports the following SQL functions and operators.
 
-{{site.data.alerts.callout_success}}In the <a href="use-the-built-in-sql-client.html#sql-shell-help-new-in-v1-1">built-in SQL shell</a>, use <code>\hf [function]</code> to get inline help about a specific function.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}In the <a href="use-the-built-in-sql-client.html#sql-shell-help">built-in SQL shell</a>, use <code>\hf [function]</code> to get inline help about a specific function.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/v2.0/sql-statements.md
+++ b/v2.0/sql-statements.md
@@ -6,7 +6,7 @@ toc: false
 
 CockroachDB supports the following SQL statements. Click a statement for more details.
 
-{{site.data.alerts.callout_success}}In the <a href="use-the-built-in-sql-client.html#sql-shell-help-new-in-v1-1">built-in SQL shell</a>, use <code>\h [statement]</code> to get inline help about a specific statement.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}In the <a href="use-the-built-in-sql-client.html#sql-shell-help">built-in SQL shell</a>, use <code>\h [statement]</code> to get inline help about a specific statement.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/v2.0/use-the-built-in-sql-client.md
+++ b/v2.0/use-the-built-in-sql-client.md
@@ -25,7 +25,7 @@ $ cockroach sql <flags> < file-containing-statements.sql
 $ cockroach sql --help
 ~~~
 
-## Flags <span class="version-tag">Changed in v1.1</span>
+## Flags
 
 The `sql` command supports the following [general-use](#general) and [logging](#logging) flags.
 
@@ -40,7 +40,7 @@ Flag | Description
 `--database`<br>`-d` | The database to connect to.<br><br>**Env Variable:** `COCKROACH_DATABASE`
 `--echo-sql` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the command-line utility. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.<br><br>This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](#sql-shell-commands).
 `--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
-`--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` for interactive sessions, `tsv` for non-interactive sessions<br><br>The `display_format` [SQL shell option](#sql-shell-options-changed-in-v1-1) can also be used to change the format within an interactive session.
+`--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` for interactive sessions, `tsv` for non-interactive sessions<br><br>The `display_format` [SQL shell option](#sql-shell-options) can also be used to change the format within an interactive session.
 `--host` | The server host to connect to. This can be the address of any node in the cluster. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost`
 `--insecure` | Run in insecure mode. If this flag is not set, the `--certs-dir` flag must point to valid certificates.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
 `--port`<br>`-p` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
@@ -54,7 +54,7 @@ By default, the `sql` command logs errors to `stderr`.
 
 If you need to troubleshoot this command's behavior, you can change its [logging behavior](debug-and-error-logs.html).
 
-## SQL Shell Welcome <span class="version-tag">Changed in v1.1</span>
+## SQL Shell Welcome
 
 When the SQL shell connects (or reconnects) to a CockroachDB node, it prints a welcome text with some tips and CockroachDB version and cluster details:
 
@@ -86,32 +86,32 @@ Command | Usage
 `\q`<br>`ctrl-d` | Exit the shell.<br><br>When no text follows the prompt, `ctrl-c` exits the shell as well; otherwise, `ctrl-c` clears the line.
 `\!` | Run an external command and print its results to `stdout`. See the [example](#run-external-commands-from-the-sql-shell) below.
 <code>&#92;&#124;</code> | Run the output of an external command as SQL statements. See the [example](#run-external-commands-from-the-sql-shell) below.
-`\set <option>` | Enable a client-side option. For available options, see [SQL Shell Options](#sql-shell-options-changed-in-v1-1).<br><br>To see current settings, use `\set` without any options.
-`\unset <option>` | Disable a client-side option. For available options, see [SQL Shell Options](#sql-shell-options-changed-in-v1-1).
+`\set <option>` | Enable a client-side option. For available options, see [SQL Shell Options](#sql-shell-options).<br><br>To view help and the current settings, use `\set` without any options.
+`\unset <option>` | Disable a client-side option. For available options, see [SQL Shell Options](#sql-shell-options).
 `\?`<br>`help` | View this help within the shell.
-`\h <statement>`<br>`\hf <function>` | <span class="version-tag">New in v1.1:</span> View help for specific SQL statements or functions. See [SQL Shell Help](#sql-shell-help-new-in-v1-1) for more details.
+`\h <statement>`<br>`\hf <function>` | <span class="version-tag">New in v1.1:</span> View help for specific SQL statements or functions. See [SQL Shell Help](#sql-shell-help) for more details.
 
-### SQL Shell Options <span class="version-tag">Changed in v1.1</span>
+### SQL Shell Options
 
-To see current settings, use `\set` without any options. To enable or disable a shell option, use `\set <option>` or `\unset <option>`.
+To view help and the current settings, use `\set` without any options. To enable or disable a shell option, use `\set <option>` or `\unset <option>`.
 
 Client Options | Description
 ---------------|------------
 `display_format` | <span class="version-tag">New in v1.1:</span> How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>This option is set to whatever value was passed to the `--format` flag when the shell was started. If the `--format` flag was not used, this option defaults to `pretty`.<br><br>To change this option, run `\set display_format <format>`. For a demonstration, see the [example](#make-the-output-of-show-statements-selectable) below.
 `echo` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the SQL shell.<br><br>This option is disabled by default. To enable it, run `\set echo`. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.
 `errexit` | Exit the SQL shell upon encountering an error.<br><br>This option is disabled by default. To enable it, run `\set errexti`.
-`check_syntax` | Validate SQL syntax on the client-side before it is sent to the server. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br><br>This option is enabled by default. To disable it, run `\unset check_syntax`.
+`check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br><br>This option is enabled by default. To disable it, run `\unset check_syntax`.
 `normalize_history` | Store normalized syntax in the shell history, e.g., capitalize keywords, normalize spacing, and recall multi-line statements as a single line.<br><br>This option is enabled by default. However, it is respected only when `check_syntax` is enabled as well. To disable this option, run `\unset normalize_history`.
 `show_times` | <span class="version-tag">New in v1.1:</span> Reveal the time a query takes to complete.<br><br>This option is enabled by default. To disable it, run `\unset show_times`.
 `smart_prompt` | <span class="version-tag">New in v1.1:</span> Query the server for the current transaction status and return it to the prompt.<br><br>This option is enabled by default. However, it is respected only when `ECHO` is enabled as well. To disable this option, run `\unset smart_prompt`.
 
-### SQL Shell Help <span class="version-tag">New in v1.1</span>
+### SQL Shell Help
 
 Within the SQL shell, you can get interactive help about statements and functions:
 
 Command | Usage
 --------|------
-`\h`<br>`?` | List all available SQL statements, by category.
+`\h`<br>`??` | List all available SQL statements, by category.
 `\hf` | List all available SQL functions, in alphabetical order.
 `\h <statement>`<br>or `<statement> ?` | View help for a specific SQL statement.
 `\hf <function>`<br>or `<function> ?` | View help for a specific SQL function.
@@ -404,7 +404,7 @@ CREATE TABLE customers (
 # 1 row
 ~~~
 
-When `--format` is not set to `raw`, you can use the `display_format` [SQL shell option](#sql-shell-options-changed-in-v1-1) to change the output format within the interactive session:
+When `--format` is not set to `raw`, you can use the `display_format` [SQL shell option](#sql-shell-options) to change the output format within the interactive session:
 
 ~~~ sql
 > \set display_format raw


### PR DESCRIPTION
- Change ? shell help command to ??.
- Remove mention of client-side execution for check_syntax.
- Remove "new/changed in 1.1" callouts from headers.

Fixes #2402