### PR TITLE
Withdraw the v2.0-alpha.20180122 release

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -38,6 +38,7 @@
       no_windows: true
     - date: Jan 22, 2018
       version: v2.0-alpha.20180122
+      withdrawn: true
     - date: Jan 16, 2018
       version: v2.0-alpha.20180116
       withdrawn: true

--- a/releases/v2.0-alpha.20180122.md
+++ b/releases/v2.0-alpha.20180122.md
@@ -21,14 +21,7 @@ Get future release notes emailed to you:
     </script>
 </div>
 
-### Downloads
-
-<div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180122.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180122.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180122.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180122.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
-</div>
+{{site.data.alerts.callout_danger}}A bug that could trigger range splits in a tight loop was discovered in this release, so this release has been withdrawn.{{site.data.alerts.end}}
 
 ### Backwards-Incompatible Changes
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/22947

I chose not to comment out the release notes as was done in #2366 because I didn't want to have to roll them all forward into the next alpha's release notes, but let me know if you think we should do that instead.

Also, is this all that we do to withdraw a release?