### PR TITLE
Updates to 2.0 array docs

### DIFF
--- a/v1.1/array.md
+++ b/v1.1/array.md
@@ -1,6 +1,6 @@
 ---
-title: ARRAYS
-summary: The ARRAYS data type stores 
+title: ARRAY
+summary: The ARRAY data type stores one-dimensional, 1-indexed, homogenous arrays of any non-array data types
 toc: false
 ---
 
@@ -22,11 +22,11 @@ A value of data type `ARRAY` can be expressed in the following ways:
 
 ## Size
 
-The size of a `ARRAY` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](https://en.wikipedia.org/wiki/Write_amplification) and other considerations may cause significant performance degradation.  
+The size of an `ARRAY` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](https://en.wikipedia.org/wiki/Write_amplification) and other considerations may cause significant performance degradation.  
 
 ## Examples
 
-### Creating an array column by appending square brackets 
+### Creating an array column by appending square brackets
 
 ~~~ sql
 > CREATE TABLE a (b STRING[]);

--- a/v2.0/array.md
+++ b/v2.0/array.md
@@ -1,6 +1,6 @@
 ---
-title: ARRAYS
-summary: The ARRAYS data type stores
+title: ARRAY
+summary: The ARRAY data type stores one-dimensional, 1-indexed, homogenous arrays of any non-array data types.
 toc: false
 ---
 

--- a/v2.0/array.md
+++ b/v2.0/array.md
@@ -1,6 +1,6 @@
 ---
 title: ARRAYS
-summary: The ARRAYS data type stores 
+summary: The ARRAYS data type stores
 toc: false
 ---
 
@@ -22,19 +22,27 @@ A value of data type `ARRAY` can be expressed in the following ways:
 
 ## Size
 
-The size of a `ARRAY` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](https://en.wikipedia.org/wiki/Write_amplification) and other considerations may cause significant performance degradation.  
+The size of an `ARRAY` value is variable, but it's recommended to keep values under 1 MB to ensure performance. Above that threshold, [write amplification](https://en.wikipedia.org/wiki/Write_amplification) and other considerations may cause significant performance degradation.  
 
 ## Examples
 
-### Creating an array column by appending square brackets 
+### Creating an array column by appending square brackets
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > CREATE TABLE a (b STRING[]);
+~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
 > INSERT INTO a VALUES (ARRAY['sky', 'road', 'car']);
+~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
 > SELECT * FROM a;
 ~~~
+
 ~~~
 +----------------------+
 |          b           |
@@ -46,13 +54,21 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 
 ### Creating an array column by adding the term `ARRAY`
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > CREATE TABLE c (d INT ARRAY);
+~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
 > INSERT INTO c VALUES (ARRAY[10,20,30]);
+~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
 > SELECT * FROM c;
 ~~~
+
 ~~~
 +------------+
 |     d      |
@@ -65,9 +81,11 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 ### Accessing an array element using array index
 {{site.data.alerts.callout_info}} Arrays in CockroachDB are 1-indexed. {{site.data.alerts.end}}
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > SELECT * FROM c;
 ~~~
+
 ~~~
 +------------+
 |     d      |
@@ -77,9 +95,11 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 (1 row)
 ~~~
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > SELECT d[2] FROM c;
 ~~~
+
 ~~~
 +------+
 | d[2] |
@@ -93,9 +113,11 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 
 #### Using the `array_append` function
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > SELECT * FROM c;
 ~~~
+
 ~~~
 +------------+
 |     d      |
@@ -104,11 +126,17 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 +------------+
 (1 row)
 ~~~
+
+{% include copy-clipboard.html %}
 ~~~ sql
 > UPDATE c SET d = array_append(d, 40) WHERE d[3] = 30;
+~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
 > SELECT * FROM c;
 ~~~
+
 ~~~
 +---------------+
 |       d       |
@@ -120,9 +148,11 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 
 #### Using the append (`||`) operator
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > SELECT * FROM c;
 ~~~
+
 ~~~
 +---------------+
 |       d       |
@@ -131,11 +161,17 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 +---------------+
 (1 row)
 ~~~
+
+{% include copy-clipboard.html %}
 ~~~ sql
 > UPDATE c SET d = d || 50 WHERE d[4] = 40;
+~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
 > SELECT * FROM c;
 ~~~
+
 ~~~
 +------------------+
 |        d         |
@@ -145,6 +181,33 @@ The size of a `ARRAY` value is variable, but it's recommended to keep values und
 (1 row)
 ~~~
 
+## Supported Casting & Conversion<span class="version-tag">New in v2.0</span>
+
+[Casting](data-types.html#data-type-conversions-casts) between `ARRAY` values is supported when the data types of the arrays support casting. For example, it is possible to cast from a `BOOL` array to an `INT` array but not from a `BOOL` array to a `TIMESTAMP` array:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT ARRAY[true,false,true]::INT[];
+~~~
+
+~~~
++--------------------------------+
+|       ARRAY[true, false,       |
+|          true]::INT[]          |
++--------------------------------+
+| {1,0,1}                        |
++--------------------------------+
+(1 row)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT ARRAY[true,false,true]::TIMESTAMP[];
+~~~
+
+~~~
+pq: invalid cast: bool[] -> TIMESTAMP[]
+~~~
 
 ## See Also
 


### PR DESCRIPTION
- Add details about supported casting; fixes #2517.
- Reformat examples to use copy-to-clipboard.