### PR TITLE
Withdraw the v2.0-alpha.20180212 release

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -33,6 +33,7 @@
   releases:
     - date: Feb 12, 2018
       version: v2.0-alpha.20180212
+      withdrawn: true
     - date: Jan 29, 2018
       version: v2.0-alpha.20180129
       no_windows: true

--- a/releases/v2.0-alpha.20180212.md
+++ b/releases/v2.0-alpha.20180212.md
@@ -21,14 +21,7 @@ Get future release notes emailed to you:
     </script>
 </div>
 
-### Downloads
-
-<div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180212.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180212.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180212.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20180212.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
-</div>
+{{site.data.alerts.callout_danger}}A bug that could cause transactional anomalies was introduced in this release, so this release has been withdrawn.{{site.data.alerts.end}}
 
 ### Enterprise Edition Changes
 


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/pull/23034.