### PR TITLE
Fix ycsb rate limit flag in training

### DIFF
--- a/v1.0/demo-automatic-cloud-migration.md
+++ b/v1.0/demo-automatic-cloud-migration.md
@@ -113,10 +113,10 @@ In a new terminal, start `ycsb`, pointing it at HAProxy's port:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -rate-limit 100 'postgresql://root@localhost:26000?sslmode=disable'
+$ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -max-rate 1000 'postgresql://root@localhost:26000?sslmode=disable'
 ~~~
 
-This command initiates 10 concurrent client workloads for 20 minutes, but limits each worker to 100 operations per second (since you're running everything on a single machine).
+This command initiates 10 concurrent client workloads for 20 minutes, but limits the total load to 1000 operations per second (since you're running everything on a single machine).
 
 ## Step 5. Watch data balance across all 3 nodes
 

--- a/v1.1/demo-automatic-cloud-migration.md
+++ b/v1.1/demo-automatic-cloud-migration.md
@@ -133,10 +133,10 @@ In a new terminal, start `ycsb`, pointing it at HAProxy's port:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -rate-limit 100 'postgresql://root@localhost:26000?sslmode=disable'
+$ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -max-rate 1000 'postgresql://root@localhost:26000?sslmode=disable'
 ~~~
 
-This command initiates 10 concurrent client workloads for 20 minutes, but limits each worker to 100 operations per second (since you're running everything on a single machine).
+This command initiates 10 concurrent client workloads for 20 minutes, but limits the total load to 1000 operations per second (since you're running everything on a single machine).
 
 ## Step 6. Watch data balance across all 3 nodes
 

--- a/v1.1/training/fault-tolerance-and-automated-repair.md
+++ b/v1.1/training/fault-tolerance-and-automated-repair.md
@@ -128,7 +128,7 @@ Now that you have a load balancer running in front of your cluster, download and
     -tolerate-errors \
     -concurrency 3 \
     -splits 50 \
-    -rate-limit 100 \
+    -max-rate 100 \
     'postgresql://root@localhost:26000?sslmode=disable'
     ~~~
 

--- a/v2.0/demo-automatic-cloud-migration.md
+++ b/v2.0/demo-automatic-cloud-migration.md
@@ -133,10 +133,10 @@ In a new terminal, start `ycsb`, pointing it at HAProxy's port:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -rate-limit 100 'postgresql://root@localhost:26000?sslmode=disable'
+$ $HOME/go/bin/ycsb -duration 20m -tolerate-errors -concurrency 10 -max-rate 1000 'postgresql://root@localhost:26000?sslmode=disable'
 ~~~
 
-This command initiates 10 concurrent client workloads for 20 minutes, but limits each worker to 100 operations per second (since you're running everything on a single machine).
+This command initiates 10 concurrent client workloads for 20 minutes, but limits the total load to 1000 operations per second (since you're running everything on a single machine).
 
 ## Step 6. Watch data balance across all 3 nodes
 


### PR DESCRIPTION
This was changed in the ycsb binary in
https://github.com/cockroachdb/loadgen/pull/120, and I even mostly
updated the training docs in #2536 but forgot to actually change the
flag used.