### PR TITLE
Recommend against running Kubernetes instructions from a cloud shell

### DIFF
--- a/_includes/orchestration/monitor-cluster.md
+++ b/_includes/orchestration/monitor-cluster.md
@@ -11,6 +11,8 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
     Forwarding from 127.0.0.1:8080 -> 8080
     ~~~
 
+    {{site.data.alerts.callout_info}}The <code>port-forward</code> command must be run on the same machine as the web browser in which you want to view the Admin UI. If you have been running these commands from a cloud instance or other non-local shell, you will not be able to view the UI without configuring <code>kubectl</code> locally and running the above <code>port-forward</code> command on your local machine.{{site.data.alerts.end}}
+
 {% if page.secure == true %}
 
 2. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a>.

--- a/_includes/orchestration/start-kubernetes.md
+++ b/_includes/orchestration/start-kubernetes.md
@@ -12,7 +12,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 <div class="filter-content" markdown="1" data-scope="gke-hosted">
 
-1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.
+1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation. The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.
 
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
 


### PR DESCRIPTION
This can be confusing for users because the port-forward method of
viewing the admin UI only works if you're port-forwarding from your
local machine.