### PR TITLE
Add missing COPY buttons to Kubernetes docs

### DIFF
--- a/_includes/orchestration/start-kubernetes.md
+++ b/_includes/orchestration/start-kubernetes.md
@@ -10,7 +10,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 ## Step 2. Start Kubernetes
 
-<div class="filter-content" markdown="1" data-scope="gke-hosted">
+<section class="filter-content" markdown="1" data-scope="gke-hosted">
 
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation. The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.
 
@@ -58,9 +58,9 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 {% endif %}
 
-</div>
+</section>
 
-<div class="filter-content" markdown="1" data-scope="gce-manual">
+<section class="filter-content" markdown="1" data-scope="gce-manual">
 
 From your local workstation, install prerequisites and start a Kubernetes cluster as described in the [Running Kubernetes on Google Compute Engine](http://kubernetes.io/docs/getting-started-guides/gce/) documentation.
 
@@ -71,10 +71,10 @@ The process includes:
 - Creating GCE instances and joining them into a single Kubernetes cluster.
 - Installing `kubectl`, the command-line tool used to manage Kubernetes from your workstation.
 
-</div>
+</section>
 
-<div class="filter-content" markdown="1" data-scope="aws-manual">
+<section class="filter-content" markdown="1" data-scope="aws-manual">
 
 From your local workstation, install prerequisites and start a Kubernetes cluster as described in the [Running Kubernetes on AWS EC2](http://kubernetes.io/docs/getting-started-guides/aws/) documentation.
 
-</div>
+</section>

--- a/_includes/orchestration/start-kubernetes.md
+++ b/_includes/orchestration/start-kubernetes.md
@@ -12,9 +12,11 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 <section class="filter-content" markdown="1" data-scope="gke-hosted">
 
-1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation. The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.
+1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.
 
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
+
+    {{site.data.alerts.callout_success}}The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.{{site.data.alerts.end}}
 
 2. From your local workstation, start the Kubernetes cluster:
 

--- a/_includes/orchestration/start-kubernetes.md
+++ b/_includes/orchestration/start-kubernetes.md
@@ -18,8 +18,13 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 2. From your local workstation, start the Kubernetes cluster:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ gcloud container clusters create cockroachdb
+    ~~~
+
+    ~~~
+    Creating cluster cockroachdb...done.
     ~~~
 
     This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`.
@@ -30,6 +35,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 3. Get the email address associated with your Google Cloud account:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ gcloud info | grep Account
     ~~~
@@ -40,6 +46,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 4. [Create the RBAC roles](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control) CockroachDB needs for running on GKE, using the address from the previous step:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org>
     ~~~

--- a/_includes/orchestration/stop-kubernetes.md
+++ b/_includes/orchestration/stop-kubernetes.md
@@ -9,6 +9,7 @@
 
     <div class="filter-content" markdown="1" data-scope="gce-manual">
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cluster/kube-down.sh
     ~~~
@@ -17,6 +18,7 @@
 
     <div class="filter-content" markdown="1" data-scope="aws-manual">
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ cluster/kube-down.sh
     ~~~

--- a/v1.0/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v1.0/orchestrate-cockroachdb-with-kubernetes.md
@@ -57,7 +57,7 @@ The heart of this step is running a Kubernetes script that creates 4 GCE or AWS 
 
 </div>
 
-<div class="filter-content" markdown="1" data-scope="local">
+<section class="filter-content" markdown="1" data-scope="local">
 
 Follow Kubernetes' [documentation](http://kubernetes.io/docs/getting-started-guides/minikube/) to install `minikube` and `kubectl` for your OS. Then start a local Kubernetes cluster:
 
@@ -71,11 +71,11 @@ Starting local Kubernetes cluster...
 Kubectl is now configured to use the cluster.
 ~~~
 
-</div>
+</section>
 
 ## Step 3. Start the CockroachDB cluster
 
-<div class="filter-content" markdown="1" data-scope="cloud">
+<section class="filter-content" markdown="1" data-scope="cloud">
 
 2. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet:
 
@@ -112,9 +112,9 @@ Kubectl is now configured to use the cluster.
     cockroachdb-2   1/1       Running   0          2m
     ~~~
 
-</div>
+</section>
 
-<div class="filter-content" markdown="1" data-scope="local">
+<section class="filter-content" markdown="1" data-scope="local">
 
 1. Use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet:
 
@@ -122,7 +122,6 @@ Kubectl is now configured to use the cluster.
     ~~~ shell
     $ kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
-
 
 2. Use the `kubectl get` command to verify that the persistent volumes and corresponding claims were created successfully:
 
@@ -152,7 +151,7 @@ Kubectl is now configured to use the cluster.
     cockroachdb-2   1/1       Running   0          2m
     ~~~
 
-</div>
+</section>
 
 {{site.data.alerts.callout_success}}The StatefulSet configuration sets all CockroachDB nodes to write to <code>stderr</code>, so if you ever need access to a pod/node's logs to troubleshoot, use <code>kubectl logs &lt;podname&gt;</code> rather than checking the log on the pod itself.{{site.data.alerts.end}}
 
@@ -241,7 +240,7 @@ To see this in action:
 
 ## Step 6. Scale the cluster
 
-<div class="filter-content" markdown="1" data-scope="cloud">
+<section class="filter-content" markdown="1" data-scope="cloud">
 
 The Kubernetes script created 4 nodes, one master and 3 workers. Pods get placed only on worker nodes, so to ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new worker node and then edit your StatefulSet configuration to add another pod.
 
@@ -275,9 +274,9 @@ The Kubernetes script created 4 nodes, one master and 3 workers. Pods get placed
     cockroachdb-3   1/1       Running   0          46s
     ~~~
 
-</div>
+</section>
 
-<div class="filter-content" markdown="1" data-scope="local">
+<section class="filter-content" markdown="1" data-scope="local">
 
 To increase the number of pods in your cluster, use the `kubectl scale` command to alter the `replicas: 3` configuration for your StatefulSet:
 
@@ -305,11 +304,11 @@ cockroachdb-2   1/1       Running   0          9m
 cockroachdb-3   1/1       Running   0          46s
 ~~~
 
-</div>
+</section>
 
 ## Step 7. Stop the cluster
 
-<div class="filter-content" markdown="1" data-scope="cloud">
+<section class="filter-content" markdown="1" data-scope="cloud">
 
 To shut down the CockroachDB cluster:
 
@@ -325,9 +324,9 @@ To shut down the CockroachDB cluster:
 
 {{site.data.alerts.callout_danger}}If you stop Kubernetes without first deleting resources, the remote persistent volumes will still exist in your cloud project.{{site.data.alerts.end}}
 
-</div>
+</section>
 
-<div class="filter-content" markdown="1" data-scope="local">
+<section class="filter-content" markdown="1" data-scope="local">
 
 - **If you plan to restart the cluster**, use the `minikube stop` command. This shuts down the minikube virtual machine but preserves all the resources you created:
 
@@ -357,7 +356,7 @@ To shut down the CockroachDB cluster:
 
     {{site.data.alerts.callout_success}}To retain logs, copy them from each pod's <code>stderr</code> before deleting the cluster and all its resources. To access a pod's standard error stream, run <code>kubectl logs &lt;podname&gt;</code>.{{site.data.alerts.end}}
 
-</div>
+</section>
 
 ## See Also
 

--- a/v1.0/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v1.0/orchestrate-cockroachdb-with-kubernetes.md
@@ -61,8 +61,12 @@ The heart of this step is running a Kubernetes script that creates 4 GCE or AWS 
 
 Follow Kubernetes' [documentation](http://kubernetes.io/docs/getting-started-guides/minikube/) to install `minikube` and `kubectl` for your OS. Then start a local Kubernetes cluster:
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ minikube start
+~~~
+
+~~~
 Starting local Kubernetes cluster...
 Kubectl is now configured to use the cluster.
 ~~~
@@ -75,12 +79,14 @@ Kubectl is now configured to use the cluster.
 
 2. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
 
 2. Use the `kubectl get` command to verify that the persistent volumes and corresponding claims were created successfully:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get persistentvolumes
     ~~~
@@ -94,6 +100,7 @@ Kubectl is now configured to use the cluster.
 
 3. Wait a bit and then verify that three pods were created successfully. If you don't see three pods, wait longer and check again.
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pods
     ~~~
@@ -111,6 +118,7 @@ Kubectl is now configured to use the cluster.
 
 1. Use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
@@ -118,6 +126,7 @@ Kubectl is now configured to use the cluster.
 
 2. Use the `kubectl get` command to verify that the persistent volumes and corresponding claims were created successfully:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get persistentvolumes
     ~~~
@@ -131,6 +140,7 @@ Kubectl is now configured to use the cluster.
 
 3. Wait a bit and then verify that three pods were created successfully. If you don't see three pods, wait longer and check again.
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pods
     ~~~
@@ -150,6 +160,7 @@ Kubectl is now configured to use the cluster.
 
 1. Start the [built-in SQL client](use-the-built-in-sql-client.html) in a one-off interactive pod, using the `cockroachdb-public` hostname to access the CockroachDB cluster:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl run cockroachdb -it --image=cockroachdb/cockroach --rm --restart=Never \
     -- sql --insecure --host=cockroachdb-public
@@ -157,17 +168,27 @@ Kubectl is now configured to use the cluster.
 
 2. Run some [CockroachDB SQL statements](sql-statements.html):
 
+    {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE DATABASE bank;
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ sql
     > CREATE TABLE bank.accounts (id INT PRIMARY KEY, balance DECIMAL);
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ sql
     > INSERT INTO bank.accounts VALUES (1234, 10000.50);
+    ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ sql
     > SELECT * FROM bank.accounts;
     ~~~
 
-    ~~~ shell
+    ~~~
     +------+----------+
     |  id  | balance  |
     +------+----------+
@@ -186,6 +207,7 @@ To see this in action:
 
 1. Kill one of CockroachDB nodes:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl delete pod cockroachdb-2
     ~~~
@@ -196,6 +218,7 @@ To see this in action:
 
 2. Verify that the pod was restarted:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pod cockroachdb-2
     ~~~
@@ -206,6 +229,7 @@ To see this in action:
 
 3. Wait a bit and then verify that the pod is ready:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pod cockroachdb-2
     ~~~
@@ -227,6 +251,7 @@ The Kubernetes script created 4 nodes, one master and 3 workers. Pods get placed
 
 2. Use the `kubectl scale` command to add a pod to your StatefulSet:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl scale statefulset cockroachdb --replicas=4
     ~~~
@@ -237,6 +262,7 @@ The Kubernetes script created 4 nodes, one master and 3 workers. Pods get placed
 
 3. Verify that a fourth pod was added successfully:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pods
     ~~~
@@ -255,6 +281,7 @@ The Kubernetes script created 4 nodes, one master and 3 workers. Pods get placed
 
 To increase the number of pods in your cluster, use the `kubectl scale` command to alter the `replicas: 3` configuration for your StatefulSet:
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ kubectl scale statefulset cockroachdb --replicas=4
 ~~~
@@ -265,6 +292,7 @@ statefulset "cockroachdb" scaled
 
 Verify that a fourth pod was added successfully:
 
+{% include copy-clipboard.html %}
 ~~~ shell
 $ kubectl get pods
 ~~~
@@ -287,6 +315,7 @@ To shut down the CockroachDB cluster:
 
 1. Use the `kubectl delete` command to clean up all of the resources you created, including the logs and remote persistent volumes:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget \
     -l app=cockroachdb
@@ -302,6 +331,7 @@ To shut down the CockroachDB cluster:
 
 - **If you plan to restart the cluster**, use the `minikube stop` command. This shuts down the minikube virtual machine but preserves all the resources you created:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ minikube stop
     ~~~
@@ -315,6 +345,7 @@ To shut down the CockroachDB cluster:
 
 - **If you do not plan to restart the cluster**, use the `minikube delete` command. This shuts down and deletes the minikube virtual machine and all the resources you created, including persistent volumes:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
     $ minikube delete
     ~~~

--- a/v1.1/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v1.1/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -66,7 +66,12 @@ To test the cluster, launch a temporary pod for using the built-in SQL client, a
 
 5. Verify that the pod for the load generator was added successfully:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
+    $ kubectl get pods
+    ~~~
+
+    ~~~
     NAME                      READY     STATUS    RESTARTS   AGE
     cockroachdb-0             1/1       Running   0          28m
     cockroachdb-1             1/1       Running   0          27m

--- a/v2.0/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v2.0/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -66,7 +66,12 @@ To test the cluster, launch a temporary pod for using the built-in SQL client, a
 
 5. Verify that the pod for the load generator was added successfully:
 
+    {% include copy-clipboard.html %}
     ~~~ shell
+    $ kubectl get pods
+    ~~~
+
+    ~~~
     NAME                      READY     STATUS    RESTARTS   AGE
     cockroachdb-0             1/1       Running   0          28m
     cockroachdb-1             1/1       Running   0          27m


### PR DESCRIPTION
Also add a couple of missing `kubectl get pods` commands and clean up
the formatting of the commands to be entered into the SQL shell.