### PR TITLE
Fix clock synch instructions in on-premises tutorials

### DIFF
--- a/_includes/prod_deployment/synchronize-clocks.md
+++ b/_includes/prod_deployment/synchronize-clocks.md
@@ -1,6 +1,6 @@
 CockroachDB requires moderate levels of [clock synchronization](recommended-production-settings.html#clock-synchronization) to preserve data consistency. For this reason, when a node detects that its clock is out of synch with at least half of the other nodes in the cluster by 80% of the maximum offset allowed (500ms by default), it spontaneously shuts down. This avoids the risk of consistency anomalies, but it's best to prevent clocks from drifting too far in the first place by running clock synchronization software on each node.
 
-{% if page.title contains "Digital Ocean" or page.title contains "Manual" %}
+{% if page.title contains "Digital Ocean" or page.title contains "On-Premises" %}
 
 [`ntpd`](http://doc.ntp.org/) should keep offsets in the single-digit milliseconds, so that software is featured here, but other methods of clock synchronization are suitable as well.
 


### PR DESCRIPTION
In https://github.com/cockroachdb/docs/pull/2564, I renamed
Manual Deployment to On-Premises Deployment but neglected
to update the clock synch include, which was targeting content
based on page title.