### PR TITLE
Fix Markdown error in unsorted list

### DIFF
--- a/v1.1/architecture/distribution-layer.md
+++ b/v1.1/architecture/distribution-layer.md
@@ -156,6 +156,7 @@ Each range in CockroachDB contains metadata, known as a Range Descriptor. A Rang
 Because Range Descriptors comprise the key-value data of the `meta2` range, each node's `meta2` cache also stores Range Descriptors.
 
 Range Descriptors are updated whenever there are:
+
 - Membership changes to a range's Raft group (discussed in more detail in the [Replication Layer](replication-layer.html#membership-changes-rebalance-repair))
 - Leaseholder changes
 - Range splits

--- a/v2.0/architecture/distribution-layer.md
+++ b/v2.0/architecture/distribution-layer.md
@@ -156,6 +156,7 @@ Each range in CockroachDB contains metadata, known as a Range Descriptor. A Rang
 Because Range Descriptors comprise the key-value data of the `meta2` range, each node's `meta2` cache also stores Range Descriptors.
 
 Range Descriptors are updated whenever there are:
+
 - Membership changes to a range's Raft group (discussed in more detail in the [Replication Layer](replication-layer.html#membership-changes-rebalance-repair))
 - Leaseholder changes
 - Range splits


### PR DESCRIPTION
There was a missing blank line between the text describing the list, and
the first list item.  Adding the blank line caused the renderer to build
the list correctly.

It wasn't clear why from reading the below (unless I missed it):

https://daringfireball.net/projects/markdown/syntax#list

¯\_(ツ)_/¯