### PR TITLE
Fix broken link on 'Storage Layer' page

### DIFF
--- a/v1.1/architecture/storage-layer.md
+++ b/v1.1/architecture/storage-layer.md
@@ -67,4 +67,4 @@ The Storage Layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's Next?
 
-Now that you've learned about our architecture, [start a local cluster](../install-cockroachdb.html) and start [building an app with CockroachDB](../build-an-app-with-cockroachdb.html/).
+Now that you've learned about our architecture, [start a local cluster](../install-cockroachdb.html) and start [building an app with CockroachDB](../build-an-app-with-cockroachdb.html).

--- a/v2.0/architecture/storage-layer.md
+++ b/v2.0/architecture/storage-layer.md
@@ -67,4 +67,4 @@ The Storage Layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's Next?
 
-Now that you've learned about our architecture, [start a local cluster](../install-cockroachdb.html) and start [building an app with CockroachDB](../build-an-app-with-cockroachdb.html/).
+Now that you've learned about our architecture, [start a local cluster](../install-cockroachdb.html) and start [building an app with CockroachDB](../build-an-app-with-cockroachdb.html).


### PR DESCRIPTION
The last link on the page ends with `.html/`.  The link works when
testing on a locally running Jekyll site, but fails on the live site:

```
curl -v
https://www.cockroachlabs.com/docs/stable/build-an-app-with-cockroachdb.html/
*   Trying 104.27.131.83...
* TCP_NODELAY set
* Connected to www.cockroachlabs.com (104.27.131.83) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
* Server certificate: sni212570.cloudflaressl.com
* Server certificate: COMODO ECC Domain Validation Secure Server CA 2
* Server certificate: COMODO ECC Certification Authority
> GET /docs/stable/build-an-app-with-cockroachdb.html/ HTTP/1.1
> Host: www.cockroachlabs.com
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 404 Not Found
```

Note: I searched for other links ending with `\.html/` and found only
these two.