### PR TITLE
Add client-side redirect from /training/overview.html to current training home

### DIFF
--- a/v1.1/training/index.md
+++ b/v1.1/training/index.md
@@ -3,7 +3,9 @@ title: CockroachDB Training
 summary: Learn how to use CockroachDB for your applications
 toc: false
 sidebar_data: sidebar-data-training.json
-redirect_from: /training/index.html
+redirect_from:
+- /training/index.html
+- /training/overview.html
 ---
 
 <iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSKpZ0NQThuSIlU3yG9usgoxPcU9zCS7u3DhxOlt0I1bCkzsYKNw7pxGyRnNpoRFVfx8EZTAKuY3uPg/embed?start=false&loop=false" frameborder="0" width="756" height="454" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>


### PR DESCRIPTION
Fixes #2615 