### PR TITLE
Fix incorrect SHOW KV TRACE syntax.

### DIFF
--- a/v1.1/show-trace.md
+++ b/v1.1/show-trace.md
@@ -57,7 +57,7 @@ For `SHOW TRACE FOR <stmt>`, the user must have the appropriate [privileges](pri
 
 Parameter | Description
 ----------|------------
-`KV` | If specified, the returned messages are restricted to those describing requests to and responses from the underly key-value [storage layer](architecture/storage-layer.html), including per-result-row messages.<br><br>For `SHOW KV TRACE FOR <stmt>`, per-result-row messages are included.<br><br>For `SHOW KV FOR SESSION`, per-result-row messages are included only if the session was/is recording with `SET tracing = kv;`.
+`KV` | If specified, the returned messages are restricted to those describing requests to and responses from the underly key-value [storage layer](architecture/storage-layer.html), including per-result-row messages.<br><br>For `SHOW KV TRACE FOR <stmt>`, per-result-row messages are included.<br><br>For `SHOW KV TRACE FOR SESSION`, per-result-row messages are included only if the session was/is recording with `SET tracing = kv;`.
 `explainable_stmt` | The statement to execute and trace. Only [explainable](sql-grammar.html#explainable_stmt) statements are supported.
 
 ## Trace Description

--- a/v2.0/show-trace.md
+++ b/v2.0/show-trace.md
@@ -57,7 +57,7 @@ For `SHOW TRACE FOR <stmt>`, the user must have the appropriate [privileges](pri
 
 Parameter | Description
 ----------|------------
-`KV` | If specified, the returned messages are restricted to those describing requests to and responses from the underly key-value [storage layer](architecture/storage-layer.html), including per-result-row messages.<br><br>For `SHOW KV TRACE FOR <stmt>`, per-result-row messages are included.<br><br>For `SHOW KV FOR SESSION`, per-result-row messages are included only if the session was/is recording with `SET tracing = kv;`.
+`KV` | If specified, the returned messages are restricted to those describing requests to and responses from the underly key-value [storage layer](architecture/storage-layer.html), including per-result-row messages.<br><br>For `SHOW KV TRACE FOR <stmt>`, per-result-row messages are included.<br><br>For `SHOW KV TRACE FOR SESSION`, per-result-row messages are included only if the session was/is recording with `SET tracing = kv;`.
 `explainable_stmt` | The statement to execute and trace. Only [explainable](sql-grammar.html#explainable_stmt) statements are supported.
 
 ## Trace Description


### PR DESCRIPTION
SHOW KV FOR SESSION returns an invalid syntax error. I changed it to
SHOW KV TRACE FOR SESSION.

Fixes #2667 