### PR TITLE
Clarify go version requirement for our load generators

### DIFF
--- a/v1.0/demo-automatic-cloud-migration.md
+++ b/v1.0/demo-automatic-cloud-migration.md
@@ -18,7 +18,7 @@ In this tutorial, you'll use CockroachDB, the HAProxy load balancer, and Cockroa
 
 - Install the latest version of [CockroachDB](install-cockroachdb.html).
 - Install [HAProxy](http://www.haproxy.org/). If you're on a Mac and using Homebrew, use `brew install haproxy`.
-- Install [Go](https://golang.org/dl/). If you're on a Mac and using Homebrew, use `brew install go`.
+- Install [Go](https://golang.org/doc/install) version 1.9 or higher. If you're on a Mac and using Homebrew, use `brew install go`. You can check your local version by running `go version`.
 - Install the [CockroachDB version of YCSB](https://github.com/cockroachdb/loadgen/tree/master/ycsb): `go get github.com/cockroachdb/loadgen/ycsb`
 
 Also, to keep track of the data files and logs for your cluster, you may want to create a new directory (e.g., `mkdir cloud-migration`) and start all your nodes in that directory.

--- a/v1.1/demo-automatic-cloud-migration.md
+++ b/v1.1/demo-automatic-cloud-migration.md
@@ -18,7 +18,7 @@ In this tutorial, you'll use CockroachDB, the HAProxy load balancer, and Cockroa
 
 - Install the latest version of [CockroachDB](install-cockroachdb.html).
 - Install [HAProxy](http://www.haproxy.org/). If you're on a Mac and using Homebrew, use `brew install haproxy`.
-- Install [Go](https://golang.org/dl/). If you're on a Mac and using Homebrew, use `brew install go`.
+- Install [Go](https://golang.org/doc/install) version 1.9 or higher. If you're on a Mac and using Homebrew, use `brew install go`. You can check your local version by running `go version`.
 - Install the [CockroachDB version of YCSB](https://github.com/cockroachdb/loadgen/tree/master/ycsb): `go get github.com/cockroachdb/loadgen/ycsb`
 
 Also, to keep track of the data files and logs for your cluster, you may want to create a new directory (e.g., `mkdir cloud-migration`) and start all your nodes in that directory.

--- a/v1.1/demo-follow-the-workload.md
+++ b/v1.1/demo-follow-the-workload.md
@@ -47,7 +47,7 @@ However, if the nodes were started with the [`--locality`](start-a-node.html#loc
 In this tutorial, you'll use CockroachDB, the `comcast` network tool to simulate network latency on your local workstation, and the `kv` load generator to simulate client workloads. Before you begin, make sure these applications are installed:
 
 - Install the latest version of [CockroachDB](install-cockroachdb.html).
-- Install [Go](https://golang.org/dl/). If you're on a Mac and using Homebrew, use `brew install go`.
+- Install [Go](https://golang.org/doc/install) version 1.9 or higher. If you're on a Mac and using Homebrew, use `brew install go`. You can check your local version by running `go version`.
 - Install the [`comcast`](https://github.com/tylertreat/comcast) network simulation tool: `go get github.com/tylertreat/comcast`
 - Install the [`kv`](https://github.com/cockroachdb/loadgen/tree/master/kv) load generator: `go get github.com/cockroachdb/loadgen/kv`
 

--- a/v2.0/demo-automatic-cloud-migration.md
+++ b/v2.0/demo-automatic-cloud-migration.md
@@ -18,7 +18,7 @@ In this tutorial, you'll use CockroachDB, the HAProxy load balancer, and Cockroa
 
 - Install the latest version of [CockroachDB](install-cockroachdb.html).
 - Install [HAProxy](http://www.haproxy.org/). If you're on a Mac and using Homebrew, use `brew install haproxy`.
-- Install [Go](https://golang.org/dl/). If you're on a Mac and using Homebrew, use `brew install go`.
+- Install [Go](https://golang.org/doc/install) version 1.9 or higher. If you're on a Mac and using Homebrew, use `brew install go`. You can check your local version by running `go version`.
 - Install the [CockroachDB version of YCSB](https://github.com/cockroachdb/loadgen/tree/master/ycsb): `go get github.com/cockroachdb/loadgen/ycsb`
 
 Also, to keep track of the data files and logs for your cluster, you may want to create a new directory (e.g., `mkdir cloud-migration`) and start all your nodes in that directory.

--- a/v2.0/demo-follow-the-workload.md
+++ b/v2.0/demo-follow-the-workload.md
@@ -47,7 +47,7 @@ However, if the nodes were started with the [`--locality`](start-a-node.html#loc
 In this tutorial, you'll use CockroachDB, the `comcast` network tool to simulate network latency on your local workstation, and the `kv` load generator to simulate client workloads. Before you begin, make sure these applications are installed:
 
 - Install the latest version of [CockroachDB](install-cockroachdb.html).
-- Install [Go](https://golang.org/dl/). If you're on a Mac and using Homebrew, use `brew install go`.
+- Install [Go](https://golang.org/doc/install) version 1.9 or higher. If you're on a Mac and using Homebrew, use `brew install go`. You can check your local version by running `go version`.
 - Install the [`comcast`](https://github.com/tylertreat/comcast) network simulation tool: `go get github.com/tylertreat/comcast`
 - Install the [`kv`](https://github.com/cockroachdb/loadgen/tree/master/kv) load generator: `go get github.com/cockroachdb/loadgen/kv`
 


### PR DESCRIPTION
Also link to the actual Go installation instructions, not just the
tarball download page.

Fixes #2332