### PR TITLE
Update guide for Azure Network Security Rules

### DIFF
--- a/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -47,33 +47,35 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
 
-3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
+3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachadmin** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your local network’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **8080** |
         | Protocol | **TCP** |
-        | Port range | **8080** |
         | Action | **Allow** |
-    - **Application support:**
+        | Priority | Any value > 1000 |
+    - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
-    
+
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your application’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **26257** |
         | Protocol | **TCP** |
-        | Port range | **26257** |
         | Action | **Allow** |
+        | Priority | Any value > 1000 |
 
 ## Step 2. Create VMs
 

--- a/v1.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -41,34 +41,35 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 1. [Create a Resource Group](https://azure.microsoft.com/en-us/updates/create-empty-resource-groups/).
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
-3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
+3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachadmin** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your local network’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **8080** |
         | Protocol | **TCP** |
-        | Port range | **8080** |
         | Action | **Allow** |
-    - **Application support:**
+        | Priority | Any value > 1000 |
+    - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your application’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **26257** |
         | Protocol | **TCP** |
-        | Port range | **26257** |
         | Action | **Allow** |
-
+        | Priority | Any value > 1000 |
 ## Step 2. Create VMs
 
 [Create Linux VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-quick-create-portal) for each node you plan to have in your cluster. We [recommend](recommended-production-settings.html#cluster-topology):

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -38,33 +38,35 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
 
-3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
+3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachadmin** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your local network’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **8080** |
         | Protocol | **TCP** |
-        | Port range | **8080** |
         | Action | **Allow** |
-    - **Application support:**
+        | Priority | Any value > 1000 |
+    - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your application’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **26257** |
         | Protocol | **TCP** |
-        | Port range | **26257** |
         | Action | **Allow** |
+        | Priority | Any value > 1000 |
 
 ## Step 2. Create VMs
 

--- a/v1.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -36,33 +36,35 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 1. [Create a Resource Group](https://azure.microsoft.com/en-us/updates/create-empty-resource-groups/).
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
-3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
+3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachadmin** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your local network’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **8080** |
         | Protocol | **TCP** |
-        | Port range | **8080** |
         | Action | **Allow** |
-    - **Application support:**
+        | Priority | Any value > 1000 |
+    - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your application’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **26257** |
         | Protocol | **TCP** |
-        | Port range | **26257** |
         | Action | **Allow** |
+        | Priority | Any value > 1000 |
 
 ## Step 2. Create VMs
 

--- a/v2.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -38,33 +38,36 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
 
-3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
+3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachadmin** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your local network’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **8080** |
         | Protocol | **TCP** |
-        | Port range | **8080** |
         | Action | **Allow** |
-    - **Application support:**
+        | Priority | Any value > 1000 |
+    - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your application’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **26257** |
         | Protocol | **TCP** |
-        | Port range | **26257** |
         | Action | **Allow** |
+        | Priority | Any value > 1000 |
+
 
 ## Step 2. Create VMs
 

--- a/v2.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v2.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -36,33 +36,35 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 
 1. [Create a Resource Group](https://azure.microsoft.com/en-us/updates/create-empty-resource-groups/).
 2. [Create a Virtual Network](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-vnet-arm-pportal) that uses your **Resource Group**.
-3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following rules to it:
+3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachadmin** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your local network’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **8080** |
         | Protocol | **TCP** |
-        | Port range | **8080** |
         | Action | **Allow** |
-    - **Application support:**
+        | Priority | Any value > 1000 |
+    - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you won't need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
         | Field | Recommended Value |
         |-------|-------------------|
         | Name | **cockroachapp** |
-        | Priority | Any value > 1000 |
-        | Source | **CIDR block** |
-        | IP address range | Your application’s IP ranges |
-        | Service | **Custom** |
+        | Source | **IP Addresses** |
+        | Source IP addresses/CIDR ranges | Your local network’s IP ranges |
+        | Source port ranges | * |
+        | Destination | **Any** |
+        | Destination port range | **26257** |
         | Protocol | **TCP** |
-        | Port range | **26257** |
         | Action | **Allow** |
+        | Priority | Any value > 1000 |
 
 ## Step 2. Create VMs
 


### PR DESCRIPTION
Azure has slightly modified the interface for its network security group
rules, and our cloud deployment docs no longer matched.

+ Explicitly specify that the required rules are "Inbound" rules.
+ Add Destination and Destination port fields.
+ Sort fields to match current Azure interface.

Fixes #2418 

Current Azure Interface for reference:
![screen shot 2018-03-08 at 1 24 47 pm](https://user-images.githubusercontent.com/6969858/37169901-4735467c-22d7-11e8-8036-d4a0c51c75da.png)
