### PR TITLE
Bump version number in version flag

### DIFF
--- a/v2.0/cluster-setup-troubleshooting.md
+++ b/v2.0/cluster-setup-troubleshooting.md
@@ -44,10 +44,10 @@ Proceed through the following steps until you locate the source of the issue wit
 
     Errors at this stage potentially include:
     - CPU incompatibility
-    - Other services running on port `26257` or `8080` (CockroachDB's default `port` and `http-port` respectively). You can either stop those services or start your node with different ports, specified with the [`--port` and   `--http-port`](start-a-node.html#flags-changed-in-v1-1).
+    - Other services running on port `26257` or `8080` (CockroachDB's default `port` and `http-port` respectively). You can either stop those services or start your node with different ports, specified with the [`--port` and   `--http-port`](start-a-node.html#flags-changed-in-v2-0).
 
         If you change the port, you will need to include the `--port=[specified port]` flag in each subsequent `cockroach` command or change the `COCKROACH_PORT` environment variable.
-    - Networking issues that prevent the node from communicating with itself on its hostname. You can control the hostname CockroachDB uses with the [`--host` flag](start-a-node.html#flags-changed-in-v1-1).
+    - Networking issues that prevent the node from communicating with itself on its hostname. You can control the hostname CockroachDB uses with the [`--host` flag](start-a-node.html#flags-changed-in-v2-0).
 
         If you change the host, you will need to include `--host=[specified host]` in each subsequent `cockroach` command.
 
@@ -119,7 +119,7 @@ Most networking-related issues are caused by one of two issues:
 
 - Firewall rules, which require your network administrator to investigate
 
-- Inaccessible hostnames on your nodes, which can be controlled with the `--host` and `--advertise-host` flags on [`cockroach start`](start-a-node.html#flags-changed-in-v1-1)
+- Inaccessible hostnames on your nodes, which can be controlled with the `--host` and `--advertise-host` flags on [`cockroach start`](start-a-node.html#flags-changed-in-v2-0)
 
 However, to efficiently troubleshoot the issue, it's important to understand where and why it's occurring. We recommend checking the following network-related issues:
 

--- a/v2.0/known-limitations.md
+++ b/v2.0/known-limitations.md
@@ -93,7 +93,7 @@ When executing an [`ALTER TABLE ADD COLUMN`](add-column.html) statement with a [
 
 ### Load-based lease rebalancing in uneven latency deployments
 
-When nodes are started with the [`--locality`](start-a-node.html#flags-changed-in-v1-1) flag, CockroachDB attempts to place the replica lease holder (the replica that client requests are forwarded to) on the node closest to the source of the request. This means as client requests move geographically, so too does the replica lease holder.
+When nodes are started with the [`--locality`](start-a-node.html#flags-changed-in-v2-0) flag, CockroachDB attempts to place the replica lease holder (the replica that client requests are forwarded to) on the node closest to the source of the request. This means as client requests move geographically, so too does the replica lease holder.
 
 However, you might see increased latency caused by a consistently high rate of lease transfers between datacenters in the following case:
 

--- a/v2.0/recommended-production-settings.md
+++ b/v2.0/recommended-production-settings.md
@@ -86,7 +86,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 - Increasing a node's **cache size** will improve the node's read performance.
 - Increasing a node's **SQL memory size** will increase the number of simultaneous client connections it allows (the `128MiB` default allows a maximum of 6200 simultaneous connections) as well as the node's capacity for in-memory processing of rows when using `ORDER BY`, `GROUP BY`, `DISTINCT`, joins, and window functions.
 
-To manually increase a node's cache size and SQL memory size, start the node using the [`--cache`](start-a-node.html#flags-changed-in-v1-1) and [`--max-sql-memory`](start-a-node.html#flags-changed-in-v1-1) flags:
+To manually increase a node's cache size and SQL memory size, start the node using the [`--cache`](start-a-node.html#flags-changed-in-v2-0) and [`--max-sql-memory`](start-a-node.html#flags-changed-in-v2-0) flags:
 
 ~~~ shell
 $ cockroach start --cache=25% --max-sql-memory=25% <other start flags>

--- a/v2.0/start-a-node.md
+++ b/v2.0/start-a-node.md
@@ -27,7 +27,7 @@ $ cockroach start <flags, including --join>
 $ cockroach start --help
 ~~~
 
-## Flags <span class="version-tag">Changed in v1.1</span>
+## Flags <span class="version-tag">Changed in v2.0</span>
 
 The `start` command supports the following [general-use](#general) and
 [logging](#logging) flags. All flags must be specified each time the


### PR DESCRIPTION
These flags were also updated in 2.0 so it makes sense to report the
most recent change.