### PR TITLE
[Test 1] Try to speed up htmlproofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,11 @@ task :htmlproofer do
   HTMLProofer.check_directory("./_site", {
     :allow_hash_href => true,
     :url_swap => { /^#{Regexp.quote(baseurl)}/ => '' },
-    :typhoeus => {
-      :ssl_verifypeer => false,
-      :ssl_verifyhost => 0}
+    :disable_external => true,
+    :checks_to_ignore => ["ImageCheck", "ScriptCheck"],
+    :parallel => { :in_processes => 4 }
+    # :typhoeus => {
+    #   :ssl_verifypeer => false,
+    #   :ssl_verifyhost => 0}
   }).run
 end


### PR DESCRIPTION
- Disable external link checking.
- Disable image and script checking.
- Use 4 cpus.