### PR TITLE
[Test 4] Try to speed up htmlproofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,11 @@ task :htmlproofer do
   HTMLProofer.check_directory("./_site", {
     :allow_hash_href => true,
     :url_swap => { /^#{Regexp.quote(baseurl)}/ => '' },
-    :typhoeus => {
-      :ssl_verifypeer => false,
-      :ssl_verifyhost => 0}
+    :disable_external => true,
+    :checks_to_ignore => ["ImageCheck", "ScriptCheck"],
+    :parallel => { :in_processes => 8 }
+    # :typhoeus => {
+    #   :ssl_verifypeer => false,
+    #   :ssl_verifyhost => 0}
   }).run
 end


### PR DESCRIPTION
Same as https://github.com/cockroachdb/docs/pull/2689
but increasing to 8 cpus instead of 4. Each gce-agent
has 8 cpus.