### PR TITLE
[Test 6] Try to speed up htmlproofer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ task :htmlproofer do
   HTMLProofer.check_directory("./_site", {
     :allow_hash_href => true,
     :url_swap => { /^#{Regexp.quote(baseurl)}/ => '' },
+    :parallel => { :in_processes => 4 },
     :typhoeus => {
       :ssl_verifypeer => false,
       :ssl_verifyhost => 0}


### PR DESCRIPTION
- Use 4 cpus.
- Do not disable external link checking.
- Do not disable image or script checking.