### PR TITLE
Remove K8s scaling instructions for CF template

### DIFF
--- a/v1.1/deploy-a-test-cluster.md
+++ b/v1.1/deploy-a-test-cluster.md
@@ -4,7 +4,7 @@ summary: Use CockroachDB's CloudFormation template to deploy a Kubernetes-orches
 toc: false
 ---
 
-This page shows you the easiest way to test an insecure, multi-node CockroachDB cluster, using CockroachDB's [AWS CloudFormation](https://aws.amazon.com/cloudformation/) template to simplify setup and [Kubernetes](https://kubernetes.io/) to automate deployment, scaling, maintenance, and load balancing of client workloads.
+This page shows you the easiest way to test an insecure, multi-node CockroachDB cluster, using CockroachDB's [AWS CloudFormation](https://aws.amazon.com/cloudformation/) template to simplify setup and [Kubernetes](https://kubernetes.io/) to automate deployment, maintenance, and load balancing of client workloads.
 
 {{site.data.alerts.callout_success}}To evaluate pre-release functionality from <a href="https://github.com/cockroachdb/cockroach/wiki/Roadmap">our roadmap</a>, use the <a href="../v2.0/deploy-a-test-cluster.html">v2.0 version</a> of this page.{{site.data.alerts.end}}
 
@@ -173,32 +173,7 @@ To see this in action:
 
     <img src="{{ 'images/cloudformation_admin_ui_live_node_count.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-## Step 5. Scale the cluster
-
-To scale the cluster, you need to first adjust the AWS Auto Scaling group size and then the Kubernetes replica count.
-
-1. In the **Resources** section of the CloudFormation UI, find **K8sStack** and click the corresponding **Physical ID** link.
-
-2. In the **Resources** section of the new screen, find **K8sNodeGroup** and click the corresponding **Physical ID** link.
-
-3. In the final screen, click **Edit**, update the **Desired** field to the new number of nodes you want in the cluster, and click **Save**.
-
-4. In the terminal where you SSHed into the Kubernetes master node, use `kubectl` to scale your cluster to match your Auto Scaling group size:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl scale statefulsets cockroachdb --replicas=5
-    ~~~
-
-    ~~~
-    statefulset "cockroachdb" scaled
-    ~~~
-
-5. In the Admin UI, check the **Replicas per Node** graph again to see how CockroachDB automatically rebalances your data evenly across all nodes.
-
-    <img src="{{ 'images/cloudformation_admin_ui_rebalancing.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
-
-## Step 6. Stop the cluster
+## Step 5. Stop the cluster
 
 In the CloudFormation UI, select **Other Actions** > **Delete Stack**. This is essential for deleting all AWS resources tied to your cluster. If you don't delete these resources, AWS will continue to charge you for them.
 


### PR DESCRIPTION
As written this actually doesn't work properly. The new nodes in the autoscaling group are not automatically added to the underlying k8s cluster so scaling the database just puts multiple pods on the same node. Deleting this until we can provide the proper instructions here. I believe it will involve: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks.html