### PR TITLE
sql: document SPLIT AT statement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ The CockroachDB Jekyll theme can auto-generate a page-level table of contents li
 
 #### Auto-Included Content
 
-Some pages auto-include content from the [`_includes`](_includes) directory. For example, each SQL statement page inludes a syntax diagram from `_includes/sql/diagrams`, and the [build-an-app-with-cockroachdb.md](build-an-app-with-cockroachdb.md) tutorials include code samples from `_includes/app`.
+Some pages auto-include content from the [`_includes`](_includes) directory. For example, each SQL statement page includes a syntax diagram from `_includes/sql/diagrams`, and the [build-an-app-with-cockroachdb.md](build-an-app-with-cockroachdb.md) tutorials include code samples from `_includes/app`.
 
 The syntax for including content is `{% include <filepath> %}`, for example, `{% include app/basic-sample.rb %}`.
 
@@ -131,7 +131,7 @@ New and changed features should be called out in the documentation using version
 - To add a version tag to a paragraph, place `<span class="version-tag">New in vX.X:</span>` at the start of the paragraph, e.g:
 
     ```
-    <span class="version-tag">New in v1.1:</span> The `user_privileges` view identifies global priveleges.
+    <span class="version-tag">New in v1.1:</span> The `user_privileges` view identifies global privileges.
     ```
 
 - To add a version tag to a heading, place `<span class="version-tag">New in vX.X</span>` to the right of the heading, e.g.:

--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -606,6 +606,12 @@
             ]
           },
           {
+            "title": "<code>SPLIT AT</code>",
+            "urls": [
+              "/${VERSION}/split-at.html"
+            ]
+          },
+          {
             "title": "<code>TRUNCATE</code>",
             "urls": [
               "/${VERSION}/truncate.html"

--- a/_includes/sql/v2.0/diagrams/split_index_at.html
+++ b/_includes/sql/v2.0/diagrams/split_index_at.html
@@ -1,0 +1,38 @@
+<div><svg width="646" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">INDEX</text>
+         
+            <rect x="195" y="3" width="90" height="32"></rect>
+            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="21">table_name</text>
+         
+         <rect x="325" y="35" width="30" height="32" rx="10"></rect>
+         <rect x="323" y="33" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="53">@</text>
+         
+            <rect x="375" y="35" width="92" height="32"></rect>
+            <rect x="373" y="33" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="383" y="53">index_name</text>
+         
+         <rect x="507" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="505" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="515" y="21">SPLIT</text>
+         <rect x="587" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="585" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="595" y="21">AT</text>
+         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+            <rect x="529" y="101" width="90" height="32"></rect>
+            <rect x="527" y="99" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="537" y="119">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
+         <polygon points="637 115 645 111 645 119"></polygon>
+         <polygon points="637 115 629 111 629 119"></polygon>
+      </svg></div>

--- a/_includes/sql/v2.0/diagrams/split_table_at.html
+++ b/_includes/sql/v2.0/diagrams/split_table_at.html
@@ -1,0 +1,30 @@
+<div><svg width="560" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">TABLE</text>
+         
+            <rect x="195" y="3" width="90" height="32"></rect>
+            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="21">table_name</text>
+         
+         <rect x="305" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="303" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="313" y="21">SPLIT</text>
+         <rect x="385" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="383" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="393" y="21">AT</text>
+         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+            <rect x="443" y="3" width="90" height="32"></rect>
+            <rect x="441" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="451" y="21">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></path>
+         <polygon points="551 17 559 13 559 21"></polygon>
+         <polygon points="551 17 543 13 543 21"></polygon>
+      </svg></div>

--- a/v1.1/rename-index.md
+++ b/v1.1/rename-index.md
@@ -23,8 +23,8 @@ The user must have the `CREATE` [privilege](privileges.html) on the table.
 | Parameter | Description |
 |-----------|-------------|
 | `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error. |
-| `table_name` | The name of the table with the index you want to use |
-| `index_name` | The current name of the index |
+| `table_name` | The name of the table with the index you want to use. |
+| `index_name` | The current name of the index. |
 | `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers). |
 
 ## Example

--- a/v2.0/alter-index.md
+++ b/v2.0/alter-index.md
@@ -13,4 +13,4 @@ For information on using `ALTER INDEX`, see the documents for its relevant subco
 Subcommand | Description
 -----------|------------
 [`RENAME`](rename-index.html) | Change the name of an index.
-`SPLIT AT` | *(Documentation pending)* Potentially improve performance by identifying ideal locations to split data in the key-value layer.
+[`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the index.

--- a/v2.0/alter-table.md
+++ b/v2.0/alter-table.md
@@ -23,7 +23,7 @@ Subcommand | Description
 [`DROP CONSTRAINT`](drop-constraint.html) | Remove constraints from columns.
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns.
 [`RENAME TABLE`](rename-table.html) | Change the names of tables.
-`SPLIT AT` | *(Documentation pending)* Potentially improve performance by identifying ideal locations to split data in the key-value layer.
+[`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the table.
 
 ## Viewing Schema Changes <span class="version-tag">New in v1.1</span>
 

--- a/v2.0/split-at.md
+++ b/v2.0/split-at.md
@@ -1,0 +1,163 @@
+---
+title: SPLIT AT
+summary: The SPLIT AT statement forces a key-value layer range split at the specified row in a table or index.
+toc: false
+---
+
+The `SPLIT AT` [statement](sql-statements.html) forces a key-value layer range split at the specified row in a table or index.
+
+<div id="toc"></div>
+
+## Synopsis
+
+<section>{% include sql/{{ page.version.version }}/diagrams/split_table_at.html %}</section>
+
+<section>{% include sql/{{ page.version.version }}/diagrams/split_index_at.html %}</section>
+
+## Required Privileges
+
+The user must have the `INSERT` [privilege](privileges.html) on the table or index.
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `table_name`<br>`table_name @ index_name` | The name of the table or index that should be split. |
+| `select_stmt` | A [`SELECT`](selection-clauses.html) clause that produces one or more rows at which to split the table or index at. |
+
+## Why Manual Split a Range?
+
+The key-value layer of CockroachDB is broken into sections of contiguous
+key-space known as ranges. By default, CockroachDB attempts to keep ranges below
+a size of 64MiB. To do this, the system will automatically [split](architecture/distribution-layer.html#range-splits)
+a range if it grows larger than this limit. For most use cases, this automatic
+range splitting is sufficient, and you should never need to worry about
+when or where the system decides to split ranges.
+
+However, there are reasons why you may want to perform manual splits on
+the ranges that store tables or indexes:
+
+- When a table only consists of a single range, all writes and reads to the
+  table will be served by that range's [leaseholder](architecture/replication-layer.html#leases).
+  If a table only holds a small amount of data but is serving a large amount of traffic,
+  load distribution can become unbalanced. Splitting the table's ranges manually
+  can allow the load on the table to be more evenly distributed across multiple
+  nodes. For tables consisting of more than a few ranges, load will naturally
+  be distributed across multiple nodes and this will not be a concern.
+
+- When a table is created, it will only consist of a single range. If you know
+  that a new table will immediately receive significant write
+  traffic, you may want to preemptively split the table based on the expected
+  distribution of writes before applying the load. This can help avoid reduced
+  workload performance that results when automatic splits are unable to keep up
+  with write traffic.
+
+## Examples
+
+### Split a Table
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW TESTING_RANGES FROM TABLE kv;
+~~~
+
+~~~
++-----------+---------+----------+----------+--------------+
+| Start Key | End Key | Range ID | Replicas | Lease Holder |
++-----------+---------+----------+----------+--------------+
+| NULL      | NULL    |       72 | {1}      |            1 |
++-----------+---------+----------+----------+--------------+
+(1 row)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE kv SPLIT AT VALUES (10), (20), (30);
+~~~
+
+~~~
++------------+----------------+
+|    key     |     pretty     |
++------------+----------------+
+| \u0209\x92 | /Table/64/1/10 |
+| \u0209\x9c | /Table/64/1/20 |
+| \u0209\xa6 | /Table/64/1/30 |
++------------+----------------+
+(3 rows)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW TESTING_RANGES FROM TABLE kv;
+~~~
+
+~~~
++-----------+---------+----------+----------+--------------+
+| Start Key | End Key | Range ID | Replicas | Lease Holder |
++-----------+---------+----------+----------+--------------+
+| NULL      | /10     |       72 | {1}      |            1 |
+| /10       | /20     |       73 | {1}      |            1 |
+| /20       | /30     |       74 | {1}      |            1 |
+| /30       | NULL    |       75 | {1}      |            1 |
++-----------+---------+----------+----------+--------------+
+(4 rows)
+~~~
+
+### Split an Index
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE INDEX secondary ON kv (v);
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW TESTING_RANGES FROM INDEX kv@secondary;
+~~~
+
+~~~
++-----------+---------+----------+----------+--------------+
+| Start Key | End Key | Range ID | Replicas | Lease Holder |
++-----------+---------+----------+----------+--------------+
+| NULL      | NULL    |       75 | {1}      |            1 |
++-----------+---------+----------+----------+--------------+
+(1 row)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX kv@secondary SPLIT AT (SELECT v FROM kv LIMIT 3);
+~~~
+
+~~~
++---------------------+-----------------+
+|         key         |     pretty      |
++---------------------+-----------------+
+| \u020b\x12a\x00\x01 | /Table/64/3/"a" |
+| \u020b\x12b\x00\x01 | /Table/64/3/"b" |
+| \u020b\x12c\x00\x01 | /Table/64/3/"c" |
++---------------------+-----------------+
+(3 rows)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW TESTING_RANGES FROM INDEX kv@secondary;
+~~~
+
+~~~
++-----------+---------+----------+----------+--------------+
+| Start Key | End Key | Range ID | Replicas | Lease Holder |
++-----------+---------+----------+----------+--------------+
+| NULL      | /"a"    |       75 | {1}      |            1 |
+| /"a"      | /"b"    |       76 | {1}      |            1 |
+| /"b"      | /"c"    |       77 | {1}      |            1 |
+| /"c"      | NULL    |       78 | {1}      |            1 |
++-----------+---------+----------+----------+--------------+
+(4 rows)
+~~~
+
+## See Also
+
+- [Distribution Layer](architecture/distribution-layer.html)
+- [Replication Layer](architecture/replication-layer.html)

--- a/v2.0/sql-statements.md
+++ b/v2.0/sql-statements.md
@@ -63,6 +63,7 @@ Statement | Usage
 [`SHOW DATABASES`](show-databases.html) | List databases in the cluster.
 [`SHOW INDEX`](show-index.html) | View index information for a table.
 [`SHOW TABLES`](show-tables.html) | List tables in a database.
+[`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the table or index.
 
 ## Transaction Management Statements
 


### PR DESCRIPTION
Fixes #616.

This change documents the `ALTER [TABLE|INDEX] .. SPLIT AT ..`
statement. It describes how to use the statement and then provides
justification for why an operator might want to use it.

Depends on https://github.com/cockroachdb/cockroach/pull/23721.