### PR TITLE
Fix version switcher URLs

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -194,7 +194,7 @@
             {% for v in page.versions %}
               <li class="tier-2 {% if v.version == page.version %}active{% endif %}">
                 <a
-                {% if v.url %}href="{{ v.url | relative_url }}/"
+                {% if v.url %}href="{{ v.url | relative_url }}"
                 {% else %}data-tooltip data-placement="right" data-container="body" title="This page does not exist in {{ v.version.version }}."{% endif %}>
                   {{ v.version.name }}
                   {% if v.version.tag %}({{ v.version.tag | capitalize }}){% endif %}

--- a/_plugins/versions/versioned_page.rb
+++ b/_plugins/versions/versioned_page.rb
@@ -26,7 +26,7 @@ module JekyllVersions
     end
 
     def url
-      page.url.split('/')
+      page.url.split('/', -1)
         .map { |p| p.gsub(Version::REGEX, version.slug) }
         .join('/')
     end


### PR DESCRIPTION
Version switcher URLs should have a trailing slash iff they are a
directory. Jekyll already handles this logic for us, so we just need to
teach the version injector not to strip the trailing slash if it exists.