### PR TITLE
Remove withdrawn releases from full release list

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -37,18 +37,9 @@
       version: v2.0-beta.20180312
     - date: Mar 05, 2018
       version: v2.0-beta.20180305
-    - date: Feb 12, 2018
-      version: v2.0-alpha.20180212
-      withdrawn: true
     - date: Jan 29, 2018
       version: v2.0-alpha.20180129
       no_windows: true
-    - date: Jan 22, 2018
-      version: v2.0-alpha.20180122
-      withdrawn: true
-    - date: Jan 16, 2018
-      version: v2.0-alpha.20180116
-      withdrawn: true
     - date: Dec 18, 2017
       version: v2.0-alpha.20171218
     - date: Dec 11, 2017
@@ -96,10 +87,6 @@
     - date: Apr 13, 2017
       version: beta-20170413
       no_windows: true
-    - date: Apr 06, 2017
-      version: beta-20170406
-      no_windows: true
-      withdrawn: true
     - date: Mar 30, 2017
       version: beta-20170330
       no_windows: true
@@ -145,11 +132,6 @@
       no_windows: true
     - date: Dec 1, 2016
       version: beta-20161201
-      no_source: true
-      no_windows: true
-    - date: Nov 10, 2016
-      version: beta-20161110
-      withdrawn: true
       no_source: true
       no_windows: true
     - date: Nov 3, 2016


### PR DESCRIPTION
But leave the release note pages in place so as
not to break incoming links.