### PR TITLE
Clarify where to find docker install guidance

### DIFF
--- a/_includes/start_in_docker/mac-linux-steps.md
+++ b/_includes/start_in_docker/mac-linux-steps.md
@@ -1,6 +1,6 @@
 ## Before You Begin
 
-Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
+If you have not already installed the official CockroachDB Docker image, go to [Install CockroachDB](install-cockroachdb.html) and follow the instructions under **Use Docker**.
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v1.0/start-a-local-cluster-in-docker.md
+++ b/v1.0/start-a-local-cluster-in-docker.md
@@ -33,7 +33,7 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 <div class="filter-content" markdown="1" data-scope="os-windows">
 ## Before You Begin
 
-Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
+If you have not already installed the official CockroachDB Docker image, go to [Install CockroachDB](install-cockroachdb.html) and follow the instructions under **Use Docker**.
 
 ## Step 1. Create a bridge network
 

--- a/v1.1/start-a-local-cluster-in-docker.md
+++ b/v1.1/start-a-local-cluster-in-docker.md
@@ -33,7 +33,7 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 <div class="filter-content" markdown="1" data-scope="os-windows">
 ## Before You Begin
 
-Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
+If you have not already installed the official CockroachDB Docker image, go to [Install CockroachDB](install-cockroachdb.html) and follow the instructions under **Use Docker**.
 
 ## Step 1. Create a bridge network
 

--- a/v2.0/start-a-local-cluster-in-docker.md
+++ b/v2.0/start-a-local-cluster-in-docker.md
@@ -33,7 +33,7 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 <div class="filter-content" markdown="1" data-scope="os-windows">
 ## Before You Begin
 
-Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
+If you have not already installed the official CockroachDB Docker image, go to [Install CockroachDB](install-cockroachdb.html) and follow the instructions under **Use Docker**.
 
 ## Step 1. Create a bridge network
 


### PR DESCRIPTION
This PR replaces https://github.com/cockroachdb/docs/pull/2462.