### PR TITLE
Exclude GitHub link in footer from link checking

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
 			<ul class="footer-nav">
 				<li class="header">Support Channels<span class="blue-arrow blue-arrow--down"></span></li>
 				<ul class="footer-sub-nav">
-					<li><a href="https://github.com/cockroachdb/cockroach/">Github</a></li>
+					<li><a href="https://github.com/cockroachdb/cockroach/" data-proofer-ignore>Github</a></li>
 					<li><a href="https://stackoverflow.com/questions/tagged/cockroachdb">Stack Overflow</a></li>
 					<li><a href="https://forum.cockroachlabs.com/">Forum</a></li>
 					<li><a href="https://gitter.im/cockroachdb/cockroach" class="ft-btn-facebook">Gitter</a></li>


### PR DESCRIPTION
In our nightly docs test, GitHub is throttling us with a 429 status.