### PR TITLE
Remove pgweb mention in v2.0-beta.20180319 release notes

### DIFF
--- a/releases/v2.0-beta.20180319.md
+++ b/releases/v2.0-beta.20180319.md
@@ -8,7 +8,6 @@ summary: Additions and changes in CockroachDB version v2.0-beta.20180319 since v
 
 In this release, we’ve improved CockroachDB’s ability to run in orchestrated environments and closed several Postgres capability gaps.
 
-- [Pgweb](http://sosedoff.github.io/pgweb/) now runs successfully with CockroachDB. [#23518][#23518]
 - Better [`/health`](../v2.0/monitoring-and-alerting.html) behavior to support orchestrated deployments. [#23551][#23551]
 
 Get future release notes emailed to you:


### PR DESCRIPTION
Pgweb compatibility wasn't introduced until https://github.com/cockroachdb/cockroach/pull/23839,
which did not make it into this release. This should be added to the next set of release notes.

Discovered in https://github.com/cockroachdb/cockroach/pull/23518.