### PR TITLE
Pause/Cancel/Resume IMPORT jobs

### DIFF
--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -241,7 +241,7 @@
             ]
           },
           {
-            "title": "<code>CANCEL JOB</code> (Enterprise)",
+            "title": "<code>CANCEL JOB</code>",
             "urls": [
               "/${VERSION}/cancel-job.html"
             ]
@@ -367,7 +367,7 @@
             ]
           },
           {
-            "title": "<code>PAUSE JOB</code> (Enterprise)",
+            "title": "<code>PAUSE JOB</code>",
             "urls": [
               "/${VERSION}/pause-job.html"
             ]
@@ -421,7 +421,7 @@
             ]
           },
           {
-            "title": "<code>RESUME JOB</code> (Enterprise)",
+            "title": "<code>RESUME JOB</code>",
             "urls": [
               "/${VERSION}/resume-job.html"
             ]

--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -264,7 +264,7 @@
             ]
           },
           {
-            "title": "<code>CANCEL JOB</code> (Enterprise)",
+            "title": "<code>CANCEL JOB</code>",
             "urls": [
               "/${VERSION}/cancel-job.html"
             ]
@@ -402,7 +402,7 @@
             ]
           },
           {
-            "title": "<code>PAUSE JOB</code> (Enterprise)",
+            "title": "<code>PAUSE JOB</code>",
             "urls": [
               "/${VERSION}/pause-job.html"
             ]
@@ -462,7 +462,7 @@
             ]
           },
           {
-            "title": "<code>RESUME JOB</code> (Enterprise)",
+            "title": "<code>RESUME JOB</code>",
             "urls": [
               "/${VERSION}/resume-job.html"
             ]

--- a/v1.1/sql-statements.md
+++ b/v1.1/sql-statements.md
@@ -113,9 +113,9 @@ Jobs in CockroachDB represent tasks that might not complete immediately, such as
 
 Statement | Usage
 ----------|------------
-[`CANCEL JOB`](pause-job.html) | <span class="version-tag">New in v1.1:</span> [*(Enterprise)*](https://www.cockroachlabs.com/pricing/) Cancel a `BACKUP` or `RESTORE` job.
-[`PAUSE JOB`](pause-job.html) | <span class="version-tag">New in v1.1:</span> [*(Enterprise)*](https://www.cockroachlabs.com/pricing/) Pause a `BACKUP` or `RESTORE` job.
-[`RESUME JOB`](resume-job.html) | <span class="version-tag">New in v1.1:</span> [*(Enterprise)*](https://www.cockroachlabs.com/pricing/) Resume paused `BACKUP` or `RESTORE` jobs.
+[`CANCEL JOB`](cancel-job.html) | <span class="version-tag">New in v1.1:</span> Cancel a `BACKUP` or `RESTORE` job.
+[`PAUSE JOB`](pause-job.html) | <span class="version-tag">New in v1.1:</span> Pause a `BACKUP` or `RESTORE` job.
+[`RESUME JOB`](resume-job.html) | <span class="version-tag">New in v1.1:</span> Resume paused `BACKUP` or `RESTORE` jobs.
 [`SHOW JOBS`](show-jobs.html) | <span class="version-tag">New in v1.1:</span> View information on jobs.
 
 ## Backup & Restore Statements (Enterprise)

--- a/v2.0/cancel-job.md
+++ b/v2.0/cancel-job.md
@@ -1,6 +1,6 @@
 ---
 title: CANCEL JOB
-summary: The CANCEL JOB statement stops long-running jobs, which include enterprise BACKUP and RESTORE tasks.
+summary: The CANCEL JOB statement stops long-running jobs.
 toc: false
 ---
 
@@ -10,8 +10,7 @@ toc: false
 
 ## Limitations
 
-- This feature currently only works with enterprise features. However, in the future, we plan to let you cancel any job, including schema changes.
-- When an enterprise [`RESTORE`](restore.html) is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.
+When an enterprise [`RESTORE`](restore.html) is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.
 
 ## Required Privileges
 

--- a/v2.0/cancel-job.md
+++ b/v2.0/cancel-job.md
@@ -4,7 +4,7 @@ summary: The CANCEL JOB statement stops long-running jobs, which include enterpr
 toc: false
 ---
 
-<span class="version-tag">New in v1.1:</span> The `CANCEL JOB` [statement](sql-statements.html) lets you stop long-running jobs, which include enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) tasks.
+<span class="version-tag">New in v1.1:</span> The `CANCEL JOB` [statement](sql-statements.html) lets you stop long-running jobs, which include [`IMPORT`](import.html) jobs and enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) tasks.
 
 <div id="toc"></div>
 
@@ -50,3 +50,4 @@ Parameter | Description
 - [`SHOW JOBS`](show-jobs.html)
 - [`BACKUP`](backup.html)
 - [`RESTORE`](restore.html)
+- [`IMPORT`](import.html)

--- a/v2.0/import.md
+++ b/v2.0/import.md
@@ -71,6 +71,8 @@ Whenever you initiate an import, CockroachDB registers it as a job, which you ca
 
 After the import has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_danger}}Pausing and then resuming an <code>`IMPORT`</code> job will cause it to restart from the beginning.{{site.data.alerts.end}}
+
 ## Synopsis
 
 {% include sql/{{ page.version.version }}/diagrams/import.html %}

--- a/v2.0/import.md
+++ b/v2.0/import.md
@@ -65,6 +65,12 @@ Imported tables are treated as new tables, so you must [`GRANT`](grant.html) pri
 
 All nodes are used during tabular data conversion into key-value data, which means all nodes' CPU and RAM will be partially consumed by the [`IMPORT`](import.html) task in addition to serving normal traffic.
 
+## Viewing and Controlling Import Jobs
+
+Whenever you initiate an import, CockroachDB registers it as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
+
+After the import has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
+
 ## Synopsis
 
 {% include sql/{{ page.version.version }}/diagrams/import.html %}

--- a/v2.0/pause-job.md
+++ b/v2.0/pause-job.md
@@ -1,14 +1,14 @@
 ---
 title: PAUSE JOB
-summary: The PAUSE JOB statement lets you temporarily halt the process of potentially long-running jobs, such as schema changes and enterprise backups.
+summary: The PAUSE JOB statement lets you temporarily halt the process of potentially long-running jobs.
 toc: false
 ---
 
-<span class="version-tag">New in v1.1:</span> The `PAUSE JOB` [statement](sql-statements.html) lets you pause [`IMPORT`](import.html), [`BACKUP`](backup.html), and [`RESTORE`](restore.html) jobs.
+<span class="version-tag">New in v1.1:</span> The `PAUSE JOB` [statement](sql-statements.html) lets you pause [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html) jobs.
 
 After pausing jobs, you can resume them with [`RESUME JOB`](resume-job.html).
 
-{{site.data.alerts.callout_info}}As of v2.0, you cannot pause schema changes.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}You cannot pause schema changes.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/v2.0/pause-job.md
+++ b/v2.0/pause-job.md
@@ -4,11 +4,11 @@ summary: The PAUSE JOB statement lets you temporarily halt the process of potent
 toc: false
 ---
 
-<span class="version-tag">New in v1.1:</span> The `PAUSE JOB` [statement](sql-statements.html) lets you pause enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs.
+<span class="version-tag">New in v1.1:</span> The `PAUSE JOB` [statement](sql-statements.html) lets you pause [`IMPORT`](import.html), [`BACKUP`](backup.html), and [`RESTORE`](restore.html) jobs.
 
 After pausing jobs, you can resume them with [`RESUME JOB`](resume-job.html).
 
-{{site.data.alerts.callout_info}}As of v1.1, you cannot pause schema changes or enterprise <code>IMPORT</code> jobs.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}As of v2.0, you cannot pause schema changes.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -51,3 +51,4 @@ Parameter | Description
 - [`CANCEL JOB`](cancel-job.html)
 - [`BACKUP`](backup.html)
 - [`RESTORE`](restore.html)
+- [`IMPORT`](import.html)

--- a/v2.0/resume-job.md
+++ b/v2.0/resume-job.md
@@ -4,9 +4,9 @@ summary: The RESUME JOB statement lets you resume jobs that were previously paus
 toc: false
 ---
 
- The `PAUSE JOB` [statement](sql-statements.html) lets you resume [paused jobs](pause-job.html), which can be either enterprise `BACKUP` or `RESTORE` jobs.
+ The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html) [`IMPORT`](import.html), [`BACKUP`](backup.html), and [`RESTORE`](restore.html) jobs.
 
-{{site.data.alerts.callout_info}}As of v1.1, you cannot pause schema changes or <code>IMPORT</code> jobs.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}As of v2.0, you cannot pause schema changes.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 
@@ -55,3 +55,4 @@ Once you're ready for the restore to resume:
 - [`CANCEL JOB`](cancel-job.html)
 - [`BACKUP`](backup.html)
 - [`RESTORE`](restore.html)
+- [`IMPORT`](import.html)

--- a/v2.0/resume-job.md
+++ b/v2.0/resume-job.md
@@ -4,7 +4,7 @@ summary: The RESUME JOB statement lets you resume jobs that were previously paus
 toc: false
 ---
 
- The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html), [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html) jobs.
+ The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html) [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html) jobs.
 
 {{site.data.alerts.callout_info}}You cannot pause schema changes.{{site.data.alerts.end}}
 

--- a/v2.0/resume-job.md
+++ b/v2.0/resume-job.md
@@ -4,9 +4,9 @@ summary: The RESUME JOB statement lets you resume jobs that were previously paus
 toc: false
 ---
 
- The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html) [`IMPORT`](import.html), [`BACKUP`](backup.html), and [`RESTORE`](restore.html) jobs.
+ The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html), [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html) jobs.
 
-{{site.data.alerts.callout_info}}As of v2.0, you cannot pause schema changes.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}You cannot pause schema changes.{{site.data.alerts.end}}
 
 <div id="toc"></div>
 

--- a/v2.0/sql-statements.md
+++ b/v2.0/sql-statements.md
@@ -120,9 +120,9 @@ Jobs in CockroachDB represent tasks that might not complete immediately, such as
 
 Statement | Usage
 ----------|------------
-[`CANCEL JOB`](pause-job.html) | [*(Enterprise)*](https://www.cockroachlabs.com/product/cockroachdb/) Cancel a `BACKUP` or `RESTORE` job.
-[`PAUSE JOB`](pause-job.html) | [*(Enterprise)*](https://www.cockroachlabs.com/product/cockroachdb/) Pause a `BACKUP` or `RESTORE` job.
-[`RESUME JOB`](resume-job.html) | [*(Enterprise)*](https://www.cockroachlabs.com/product/cockroachdb/) Resume paused `BACKUP` or `RESTORE` jobs.
+[`CANCEL JOB`](cancel-job.html) | Cancel a `BACKUP`, `RESTORE`, or `IMPORT` job.
+[`PAUSE JOB`](pause-job.html) | Pause a `BACKUP`, `RESTORE`, or `IMPORT` job.
+[`RESUME JOB`](resume-job.html) | Resume paused `BACKUP`, `RESTORE`, or `IMPORT` jobs.
 [`SHOW JOBS`](show-jobs.html) | View information on jobs.
 
 ## Backup & Restore Statements (Enterprise)


### PR DESCRIPTION
Closes #2045 

A couple of questions for @mjibson:

- Can schema changes be paused/resumed in 2.0?
- Pause/resume/cancel jobs are enterprise features..so if a user wants to pause an `IMPORT` job, would they need an enterprise license, even though `IMPORT` is not an enterprise feature?

Update: Matt's answers:
- No
- Pause/cancel/resume jobs are not enterprise features (they are wrongly labeled so in the Docs).