### PR TITLE
Introduce 2.1 docs alias

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ versions:
   stable: v1.1
   dev: v2.0
   v1.2: v2.0
+  v2.1: v2.0
 
 release_info:
   v1.0:


### PR DESCRIPTION
cockroachdb/cockroach has been bumped to link to
https://cockroachlabs.com/docs/v2.1. Temporarily alias the 2.0 docs as
the 2.1 docs; they are, after all, nearly identical.

When we're ready to start documenting 2.1, we can remove this alias and
copy the 2.0 folder to a 2.1 folder.