### PR TITLE
Run htmltest on links in the sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,8 @@ training:
 
 exclude: ["ci", "vendor", "rfc", "v1.1/training/unused", "v2.0/training/unused"]
 
+keep_files: [_internal]
+
 defaults:
   -
     scope:

--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -163,7 +163,7 @@
             "urls": [
               "/${VERSION}/demo-json-support.html"
             ]
-          },
+          }
         ]
       }
     ]
@@ -183,7 +183,7 @@
           {
             "title": "SQL Support Summary",
             "urls": [
-              "/${VERSION}/sql-feature-support.html",
+              "/${VERSION}/sql-feature-support.html"
             ]
           },
           {

--- a/_plugins/sidebar_htmltest.rb
+++ b/_plugins/sidebar_htmltest.rb
@@ -1,0 +1,36 @@
+require 'json'
+require 'liquid'
+
+module SidebarHTMLTest
+  class Generator < Jekyll::Generator
+    def generate(site)
+      @site = site
+
+      Dir[File.join(site.config['includes_dir'], 'sidebar-data-v*.json')].each do |f|
+        partial = site.liquid_renderer.file(f).parse(File.read(f))
+        json = partial.render!(site.site_payload, {registers: {site: site}})
+        version = f.match(/sidebar-data-(v.*).json/)[1]
+        render_sidebar(json, version)
+      end
+    end
+
+    def render_sidebar(json, version)
+      dest = File.join(@site.dest, "_internal", "sidebar-#{version}.html")
+      FileUtils.mkdir_p(File.dirname(dest))
+      File.open(dest, 'w') do |w|
+        w.write("<!DOCTYPE html>\n")
+        render_items(w, JSON.parse(json, symbolize_names: true), version)
+      end
+    end
+
+    def render_items(w, items, version)
+      items.each do |item|
+        item[:urls].each do |url|
+          url.gsub!('${VERSION}', version)
+          w.write("<a href='#{File.join(@site.baseurl, url)}'>#{item[:title]}</a>\n")
+        end if item[:urls]
+        render_items(w, item[:items], version) if item[:items]
+      end
+    end
+  end
+end


### PR DESCRIPTION
htmltest doesn't understand JavaScript, so it can't proof the links in
the sidebar. Work around the issue by generating stub pages with all the
links in each version's sidebar.

Fix #2809.