### PR TITLE
Backup/restore limitation during rolling upgrades

### DIFF
--- a/v2.0/known-limitations.md
+++ b/v2.0/known-limitations.md
@@ -10,6 +10,12 @@ This page describes newly identified limitations in the CockroachDB v2.0 release
 
 ## New Limitations
 
+### Enterprise backup/restore during rolling upgrades
+
+In the upgrade process, after upgrading all binaries to v2.0, it's recommended to monitor the cluster's stability and performance for at least one day and only then finalize the upgrade by increasing the `version` cluster setting. However, in the window during which binaries are running v2.0 but the cluster version is still not increased, it is not possible to run enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs.
+
+You can track this known limitation [here](https://github.com/cockroachdb/cockroach/issues/24490).
+
 ### Write and update limits for a single statement
 
 A single statement can perform at most at most 64MiB of combined updates. When a statement exceeds these limits, its transaction gets aborted. `INSERT INTO ... SELECT FROM` queries commonly encounter these limits.

--- a/v2.0/upgrade-cockroach-version.md
+++ b/v2.0/upgrade-cockroach-version.md
@@ -162,7 +162,7 @@ For each node in your cluster, complete the following steps.
 
 After upgrading all nodes in the cluster, monitor the cluster's stability and performance for at least one day.
 
-{{site.data.alerts.callout_danger}}During this phase, avoid using any new v2.0 features. Doing so will prevent you from being able to perform a rolling downgrade to v1.1, if necessary.{{site.data.alerts.end}}
+{{site.data.alerts.callout_danger}}During this phase, avoid using any new v2.0 features. Doing so may prevent you from being able to perform a rolling downgrade to v1.1, if necessary. Also, it is not currently possible to run enterprise <a href="backup.html"><code>BACKUP</code></a> and <a href="restore.html"><code>RESTORE</code></a> jobs during this phase. You can track this known limitation <a href="https://github.com/cockroachdb/cockroach/issues/24490">here</a>. {{site.data.alerts.end}}
 
 ## Step 5. Finalize or revert the upgrade
 
@@ -176,11 +176,9 @@ Once you have monitored the upgraded cluster for at least one day:
 
 {{site.data.alerts.callout_info}}These final steps are required after upgrading from v1.1.x to v2.0. For upgrades within the v2.0.x series, you don't need to take any further action.{{site.data.alerts.end}}
 
-1. [Back up the cluster](back-up-data.html).
+1. Start the [`cockroach sql`](use-the-built-in-sql-client.html) shell against any node in the cluster.
 
-2. Start the [`cockroach sql`](use-the-built-in-sql-client.html) shell against any node in the cluster.
-
-3. Use the `crdb_internal.node_executable_version()` [built-in function](functions-and-operators.html) to check the CockroachDB version running on the node:
+2. Use the `crdb_internal.node_executable_version()` [built-in function](functions-and-operators.html) to check the CockroachDB version running on the node:
 
     ~~~ sql
     > SELECT crdb_internal.node_executable_version();
@@ -188,7 +186,7 @@ Once you have monitored the upgraded cluster for at least one day:
 
     Make sure the version matches your expectations. Since you upgraded each node, this version should be running on all other nodes as well.
 
-4. Use the same function to finalize the upgrade:
+3. Use the same function to finalize the upgrade:
 
     ~~~ sql
     > SET CLUSTER SETTING version = crdb_internal.node_executable_version();


### PR DESCRIPTION
- Remove backup step post-binary upgrade from rolling upgrade docs.
- Document known limitation.
- Mention limitation in rolling upgrade docs.