### PR TITLE
Clarify provided geo-coordinates are AWS-only, make example match them

### DIFF
--- a/_includes/azure-locations.md
+++ b/_includes/azure-locations.md
@@ -1,0 +1,30 @@
+|  Location | SQL Statement |
+|  -------- | ------------- |
+|  eastasia (East Asia) | `INSERT into system.locations VALUES ('region', 'eastasia', 22.267, 114.188)` |
+|  southeastasia (Southeast Asia) | `INSERT into system.locations VALUES ('region', 'southeastasia', 1.283, 103.833)` |
+|  centralus (Central US) | `INSERT into system.locations VALUES ('region', 'centralus', 41.5908, -93.6208)` |
+|  eastus (East US) | `INSERT into system.locations VALUES ('region', 'eastus', 37.3719, -79.8164)` |
+|  eastus2 (East US 2) | `INSERT into system.locations VALUES ('region', 'eastus2', 36.6681, -78.3889)` |
+|  westus (West US) | `INSERT into system.locations VALUES ('region', 'westus', 37.783, -122.417)` |
+|  northcentralus (North Central US) | `INSERT into system.locations VALUES ('region', 'northcentralus', 41.8819, -87.6278)` |
+|  southcentralus (South Central US) | `INSERT into system.locations VALUES ('region', 'southcentralus', 29.4167, -98.5)` |
+|  northeurope (North Europe) | `INSERT into system.locations VALUES ('region', 'northeurope', 53.3478, -6.2597)` |
+|  westeurope (West Europe) | `INSERT into system.locations VALUES ('region', 'westeurope', 52.3667, 4.9)` |
+|  japanwest (Japan West) | `INSERT into system.locations VALUES ('region', 'japanwest', 34.6939, 135.5022)` |
+|  japaneast (Japan East) | `INSERT into system.locations VALUES ('region', 'japaneast', 35.68, 139.77)` |
+|  brazilsouth (Brazil South) | `INSERT into system.locations VALUES ('region', 'brazilsouth', -23.55, -46.633)` |
+|  australiaeast (Australia East) | `INSERT into system.locations VALUES ('region', 'australiaeast', -33.86, 151.2094)` |
+|  australiasoutheast (Australia Southeast) | `INSERT into system.locations VALUES ('region', 'australiasoutheast', -37.8136, 144.9631)` |
+|  southindia (South India) | `INSERT into system.locations VALUES ('region', 'southindia', 12.9822, 80.1636)` |
+|  centralindia (Central India) | `INSERT into system.locations VALUES ('region', 'centralindia', 18.5822, 73.9197)` |
+|  westindia (West India) | `INSERT into system.locations VALUES ('region', 'westindia', 19.088, 72.868)` |
+|  canadacentral (Canada Central) | `INSERT into system.locations VALUES ('region', 'canadacentral', 43.653, -79.383)` |
+|  canadaeast (Canada East) | `INSERT into system.locations VALUES ('region', 'canadaeast', 46.817, -71.217)` |
+|  uksouth (UK South) | `INSERT into system.locations VALUES ('region', 'uksouth', 50.941, -0.799)` |
+|  ukwest (UK West) | `INSERT into system.locations VALUES ('region', 'ukwest', 53.427, -3.084)` |
+|  westcentralus (West Central US) | `INSERT into system.locations VALUES ('region', 'westcentralus', 40.890, -110.234)` |
+|  westus2 (West US 2) | `INSERT into system.locations VALUES ('region', 'westus2', 47.233, -119.852)` |
+|  koreacentral (Korea Central) | `INSERT into system.locations VALUES ('region', 'koreacentral', 37.5665, 126.9780)` |
+|  koreasouth (Korea South) | `INSERT into system.locations VALUES ('region', 'koreasouth', 35.1796, 129.0756)` |
+|  francecentral (France Central) | `INSERT into system.locations VALUES ('region', 'francecentral', 46.3772, 2.3730)` |
+|  francesouth (France South) | `INSERT into system.locations VALUES ('region', 'francesouth', 43.8345, 2.1972)` |

--- a/scripts/azure-locations.py
+++ b/scripts/azure-locations.py
@@ -1,0 +1,13 @@
+import json
+import sys
+
+"""
+Run via `azure location list --json | python scripts/azure-locations.py > _includes/azure-locations.md`
+You may have to first log in to Azure via the `azure login` command.
+"""
+
+print "|  Location | SQL Statement |"
+print "|  -------- | ------------- |"
+data = json.load(sys.stdin)
+for location in data:
+    print "|  %s (%s) | `INSERT into system.locations VALUES ('region', '%s', %s, %s)` |" % (location['name'], location['displayName'], location['name'], location['latitude'], location['longitude'])

--- a/v2.0/enable-node-map.md
+++ b/v2.0/enable-node-map.md
@@ -135,14 +135,14 @@ Insert the approximate latitudes and longitudes of each region into the `system.
 {% include copy-clipboard.html %}
 ~~~ sql
 > INSERT INTO system.locations VALUES
-  ('region', 'us-east-1', 40.367474, -82.996216),
-  ('region', 'us-west-1', 43.8041334, -120.55420119999997),
-  ('region', 'eu-west-1', 48.856614, 2.3522219000000177);
+  ('region', 'us-east-1', 37.478397, -76.453077),
+  ('region', 'us-west-1', 38.837522, -120.895824),
+  ('region', 'eu-west-1', 53.142367, -7.692054);
 ~~~
 
 {{site.data.alerts.callout_info}}The <b>Node Map</b> won't be displayed until all regions are assigned the corresponding latitudes and longitudes. {{site.data.alerts.end}}
 
-To get the latitudes and longitudes of common AWS/Azure/GC regions, see [Locations Coordinates for Reference](#location-coordinates-for-reference).
+For the latitudes and longitudes of AWS regions, see [Locations Coordinates for Reference](#location-coordinates-for-reference).
 
 ### Step 5. View the Node Map
 
@@ -195,11 +195,12 @@ The **Node Map** is displayed only for the locality levels that have latitude/lo
 
 ## Location Coordinates for Reference
 
+For AWS regions, you can use these locations to populate your `system.locations` table. Other cloud provider's region locations are similar enough that you can still use these as approximations, but they're not always the same.
+
 |  Location | SQL Statement |  
 |  ------ | ------ |
 |  US East (N. Virginia) | `INSERT into system.locations VALUES ('region', 'us-east-1', 37.478397, -76.453077)`|
 |  US East (Ohio) | `INSERT into system.locations VALUES ('region', 'us-east-2', 40.417287, -76.453077)` |
-|  US Central (Iowa) | `INSERT into system.locations VALUES ('region', 'us-central', 42.032974, -93.581543)` |
 |  US West (N. California) | `INSERT into system.locations VALUES ('region', 'us-west-1', 38.837522, -120.895824)` |
 |  US West (Oregon) | `INSERT into system.locations VALUES ('region', 'us-west-2', 43.804133, -120.554201)` |
 |  Canada (Central) | `INSERT into system.locations VALUES ('region', 'ca-central-1', 56.130366, -106.346771)` |

--- a/v2.0/enable-node-map.md
+++ b/v2.0/enable-node-map.md
@@ -142,7 +142,7 @@ Insert the approximate latitudes and longitudes of each region into the `system.
 
 {{site.data.alerts.callout_info}}The <b>Node Map</b> won't be displayed until all regions are assigned the corresponding latitudes and longitudes. {{site.data.alerts.end}}
 
-For the latitudes and longitudes of AWS regions, see [Locations Coordinates for Reference](#location-coordinates-for-reference).
+For the latitudes and longitudes of AWS and Azure regions, see [Locations Coordinates for Reference](#location-coordinates-for-reference).
 
 ### Step 5. View the Node Map
 
@@ -195,9 +195,9 @@ The **Node Map** is displayed only for the locality levels that have latitude/lo
 
 ## Location Coordinates for Reference
 
-For AWS regions, you can use these locations to populate your `system.locations` table. Other cloud provider's region locations are similar enough that you can still use these as approximations, but they're not always the same.
+### AWS locations
 
-|  Location | SQL Statement |  
+|  Location | SQL Statement |
 |  ------ | ------ |
 |  US East (N. Virginia) | `INSERT into system.locations VALUES ('region', 'us-east-1', 37.478397, -76.453077)`|
 |  US East (Ohio) | `INSERT into system.locations VALUES ('region', 'us-east-2', 40.417287, -76.453077)` |
@@ -215,3 +215,7 @@ For AWS regions, you can use these locations to populate your `system.locations`
 |  Asia Pacific (Sydney) | `INSERT into system.locations VALUES ('region', 'ap-southeast-2', -33.86882, 151.209296)` |
 |  Asia Pacific (Mumbai) | `INSERT into system.locations VALUES ('region', 'ap-south-1', 19.075984, 72.877656)` |
 |  South America (São Paulo) | `INSERT into system.locations VALUES ('region', 'sa-east-1', -23.55052, -46.633309)` |
+
+### Azure locations
+
+{% include azure-locations.md %}


### PR DESCRIPTION
We should follow-up with coordinates for the GCE and Azure regions, but
these are not correct for anything other than AWS - for example, AWS's
us-east-1 is in Northern Virginia, while GCE's us-east1 is in South Carolina.