### PR TITLE
Document intervalstyle session variable

### DIFF
--- a/v2.0/set-vars.md
+++ b/v2.0/set-vars.md
@@ -33,19 +33,20 @@ The variable name is case insensitive. The value can be a list of one or more it
 
 ### Supported Variables
 
-| Variable name | Description  | Initial value | Can be viewed with [`SHOW`](show-vars.html)? |
-|---------------|--------------|---------------|----------------------------------------------|
-| `application_name` | The current application name for statistics collection. | Empty string | Yes |
-| `database` | The [current database](sql-name-resolution.html#current-database). | Database in connection string, or empty if not specified | Yes |
-| `default_transaction_isolation` | The default transaction isolation level for the current session. See [Transaction parameters](transactions.html#transaction-parameters) and [`SET TRANSACTION`](set-transaction.html) for more details. | Settings in connection string, or "`SERIALIZABLE`" if not specified  | Yes |
-| `sql_safe_updates` | If `true`, disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`. See [Allow Potentially Unsafe SQL Statements](use-the-built-in-sql-client.html#allow-potentially-unsafe-sql-statements) for more details. | `true` for interactive sessions from the [built-in SQL client](use-the-built-in-sql-client.html) unless `--safe-updates=false` is specified,<br>`false` for sessions from other clients | Yes |
-| `search_path` | <span class="version-tag">Changed in v2.0:</span> A list of schemas that will be searched to resolve unqualified table or function names. For more details, see [Name Resolution](sql-name-resolution.html). | "`{public}`" | Yes |
-| `time zone` | The default time zone for the current session.<br><br>This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`, `LOCAL`, or `0` sets the session time zone to `UTC`.</br><br>See [`SET TIME ZONE`](#set-time-zone) for more details. | `UTC` | Yes |
-| `tracing` | The trace recording state.<br><br>See [`SET TRACING`](#set-tracing) for more details. | `off` | Yes |
-| `client_encoding` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`UTF8`". | N/A | No |
-| `client_min_messages` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`on`". | N/A | No |
-| `extra_float_digits` | Ignored; recognized for compatibility with PostgreSQL clients. | N/A | No |
-| `standard_conforming_strings` | Ignored; recognized for compatibility with PostgreSQL clients. | N/A | No |
+| Variable name | Description  | Initial value |
+|---------------|--------------|---------------|
+| `application_name` | The current application name for statistics collection. | Empty string |
+| `database` | The [current database](sql-name-resolution.html#current-database). | Database in connection string, or empty if not specified |
+| `default_transaction_isolation` | The default transaction isolation level for the current session. See [Transaction parameters](transactions.html#transaction-parameters) and [`SET TRANSACTION`](set-transaction.html) for more details. | Settings in connection string, or "`SERIALIZABLE`" if not specified  |
+| `sql_safe_updates` | If `true`, disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`. See [Allow Potentially Unsafe SQL Statements](use-the-built-in-sql-client.html#allow-potentially-unsafe-sql-statements) for more details. | `true` for interactive sessions from the [built-in SQL client](use-the-built-in-sql-client.html) unless `--safe-updates=false` is specified,<br>`false` for sessions from other clients |
+| `search_path` | <span class="version-tag">Changed in v2.0:</span> A list of schemas that will be searched to resolve unqualified table or function names. For more details, see [Name Resolution](sql-name-resolution.html). | "`{public}`" |
+| `time zone` | The default time zone for the current session.<br><br>This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`, `LOCAL`, or `0` sets the session time zone to `UTC`.</br><br>See [`SET TIME ZONE`](#set-time-zone) for more details. | `UTC` |
+| `tracing` | The trace recording state.<br><br>See [`SET TRACING`](#set-tracing) for more details. | `off` |
+| `client_encoding` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`UTF8`". | N/A |
+| `client_min_messages` | Ignored; recognized for compatibility with PostgreSQL clients. | N/A |
+| `extra_float_digits` | Ignored; recognized for compatibility with PostgreSQL clients. | N/A |
+| `intervalstyle` | <span class="version-tag">New in v2.0:</span> Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`postgres`". | N/A |
+| `standard_conforming_strings` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`on`". | N/A |
 
 Special syntax cases:
 

--- a/v2.0/show-vars.md
+++ b/v2.0/show-vars.md
@@ -51,6 +51,7 @@ The variable name is case insensitive. It may be enclosed in double quotes; this
 | `client_min_messages` | (Reserved; exposed only for ORM compatibility.) | (Reserved) | No |
 | `datestyle` | (Reserved; exposed only for ORM compatibility.) | `ISO` | No |
 | `extra_float_digits` | (Reserved; exposed only for ORM compatibility.) | (Reserved) | No |
+| `intervalstyle` | <span class="version-tag">New in v2.0:</span> (Reserved; exposed only for ORM compatibility.) | `postgres` | No |
 | `max_index_keys` | (Reserved; exposed only for ORM compatibility.) | (Reserved) | No |
 | `standard_conforming_strings` | (Reserved; exposed only for ORM compatibility.) | (Reserved) | No |
 


### PR DESCRIPTION
Fixes #2288 

On `set-vars.md`, also removed the column indicating whether or not a variable could be returned with `show` because the answer for all variables seems to be `Yes` now.