### PR TITLE
Add docs for SHOW EXPERIMENTAL_RANGES

### DIFF
--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -618,6 +618,12 @@
             ]
           },
           {
+            "title": "<code>SHOW EXPERIMENTAL_RANGES</code>",
+            "urls": [
+              "/${VERSION}/show-experimental-ranges.html"
+            ]
+          },
+          {
             "title": "<code>SHOW GRANTS</code>",
             "urls": [
               "/${VERSION}/show-grants.html"

--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -618,6 +618,12 @@
             ]
           },
           {
+            "title": "<code>SHOW EXPERIMENTAL_RANGES</code>",
+            "urls": [
+              "/${VERSION}/show-experimental-ranges.html"
+            ]
+          },
+          {
             "title": "<code>SHOW GRANTS</code>",
             "urls": [
               "/${VERSION}/show-grants.html"

--- a/_includes/sql/v2.0/diagrams/show_ranges.html
+++ b/_includes/sql/v2.0/diagrams/show_ranges.html
@@ -1,0 +1,32 @@
+<div><svg width="710" height="80">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">SHOW</text>
+<rect x="113" y="3" width="188" height="32" rx="10"></rect>
+<rect x="111" y="1" width="188" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">EXPERIMENTAL_RANGES</text>
+<rect x="321" y="3" width="58" height="32" rx="10"></rect>
+<rect x="319" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="329" y="21">FROM</text>
+<rect x="419" y="3" width="62" height="32" rx="10"></rect>
+<rect x="417" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="427" y="21">TABLE</text>
+<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="501" y="3" width="90" height="32"></rect>
+<rect x="499" y="1" width="90" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="509" y="21">table_name</text>
+</a>
+<rect x="419" y="47" width="62" height="32" rx="10"></rect>
+<rect x="417" y="45" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="427" y="65">INDEX</text>
+<a xlink:href="sql-grammar.html#table_name_with_index" xlink:title="table_name_with_index">
+<rect x="501" y="47" width="162" height="32"></rect>
+<rect x="499" y="45" width="162" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="509" y="65">table_name_with_index</text>
+</a>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m188 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
+<polygon points="701 17 709 13 709 21"></polygon>
+<polygon points="701 17 693 13 693 21"></polygon>
+</svg></div>

--- a/_includes/sql/v2.0/diagrams/stmt_block.html
+++ b/_includes/sql/v2.0/diagrams/stmt_block.html
@@ -37,8 +37,8 @@
             <li><a href="#stmt_block" title="stmt_block">stmt_block</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="stmt" href="#stmt">stmt:</a></p>
-      <svg width="220" height="1376">
-         
+      <svg width="220" height="1420">
+
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
          <rect x="51" y="23" width="100" height="32" rx="10"></rect>
@@ -99,102 +99,107 @@
             <rect x="49" y="505" width="96" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="525">explain_stmt</text>
          </a>
+         <a xlink:href="#export_stmt" xlink:title="export_stmt">
+            <rect x="51" y="551" width="94" height="32"></rect>
+            <rect x="49" y="549" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="569">export_stmt</text>
+         </a>
          <a xlink:href="#grant_stmt" xlink:title="grant_stmt">
-            <rect x="51" y="551" width="86" height="32"></rect>
-            <rect x="49" y="549" width="86" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="569">grant_stmt</text>
+            <rect x="51" y="595" width="86" height="32"></rect>
+            <rect x="49" y="593" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="613">grant_stmt</text>
          </a>
          <a xlink:href="#insert_stmt" xlink:title="insert_stmt">
-            <rect x="51" y="595" width="88" height="32"></rect>
-            <rect x="49" y="593" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="613">insert_stmt</text>
+            <rect x="51" y="639" width="88" height="32"></rect>
+            <rect x="49" y="637" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="657">insert_stmt</text>
          </a>
          <a xlink:href="#import_stmt" xlink:title="import_stmt">
-            <rect x="51" y="639" width="94" height="32"></rect>
-            <rect x="49" y="637" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="657">import_stmt</text>
+            <rect x="51" y="683" width="94" height="32"></rect>
+            <rect x="49" y="681" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="701">import_stmt</text>
          </a>
          <a xlink:href="#pause_stmt" xlink:title="pause_stmt">
-            <rect x="51" y="683" width="90" height="32"></rect>
-            <rect x="49" y="681" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="701">pause_stmt</text>
+            <rect x="51" y="727" width="90" height="32"></rect>
+            <rect x="49" y="725" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="745">pause_stmt</text>
          </a>
          <a xlink:href="#prepare_stmt" xlink:title="prepare_stmt">
-            <rect x="51" y="727" width="102" height="32"></rect>
-            <rect x="49" y="725" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="745">prepare_stmt</text>
+            <rect x="51" y="771" width="102" height="32"></rect>
+            <rect x="49" y="769" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="789">prepare_stmt</text>
          </a>
          <a xlink:href="#restore_stmt" xlink:title="restore_stmt">
-            <rect x="51" y="771" width="98" height="32"></rect>
-            <rect x="49" y="769" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="789">restore_stmt</text>
+            <rect x="51" y="815" width="98" height="32"></rect>
+            <rect x="49" y="813" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="833">restore_stmt</text>
          </a>
          <a xlink:href="#resume_stmt" xlink:title="resume_stmt">
-            <rect x="51" y="815" width="100" height="32"></rect>
-            <rect x="49" y="813" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="833">resume_stmt</text>
+            <rect x="51" y="859" width="100" height="32"></rect>
+            <rect x="49" y="857" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="877">resume_stmt</text>
          </a>
          <a xlink:href="#revoke_stmt" xlink:title="revoke_stmt">
-            <rect x="51" y="859" width="98" height="32"></rect>
-            <rect x="49" y="857" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="877">revoke_stmt</text>
+            <rect x="51" y="903" width="98" height="32"></rect>
+            <rect x="49" y="901" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="921">revoke_stmt</text>
          </a>
          <a xlink:href="#savepoint_stmt" xlink:title="savepoint_stmt">
-            <rect x="51" y="903" width="114" height="32"></rect>
-            <rect x="49" y="901" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="921">savepoint_stmt</text>
+            <rect x="51" y="947" width="114" height="32"></rect>
+            <rect x="49" y="945" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="965">savepoint_stmt</text>
          </a>
          <a xlink:href="#scrub_stmt" xlink:title="scrub_stmt">
-            <rect x="51" y="947" width="88" height="32"></rect>
-            <rect x="49" y="945" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="965">scrub_stmt</text>
+            <rect x="51" y="991" width="88" height="32"></rect>
+            <rect x="49" y="989" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1009">scrub_stmt</text>
          </a>
          <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="51" y="991" width="90" height="32"></rect>
-            <rect x="49" y="989" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1009">select_stmt</text>
+            <rect x="51" y="1035" width="90" height="32"></rect>
+            <rect x="49" y="1033" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1053">select_stmt</text>
          </a>
          <a xlink:href="#release_stmt" xlink:title="release_stmt">
-            <rect x="51" y="1035" width="98" height="32"></rect>
-            <rect x="49" y="1033" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1053">release_stmt</text>
+            <rect x="51" y="1079" width="98" height="32"></rect>
+            <rect x="49" y="1077" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1097">release_stmt</text>
          </a>
          <a xlink:href="#reset_stmt" xlink:title="reset_stmt">
-            <rect x="51" y="1079" width="86" height="32"></rect>
-            <rect x="49" y="1077" width="86" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1097">reset_stmt</text>
+            <rect x="51" y="1123" width="86" height="32"></rect>
+            <rect x="49" y="1121" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1141">reset_stmt</text>
          </a>
          <a xlink:href="#set_stmt" xlink:title="set_stmt">
-            <rect x="51" y="1123" width="74" height="32"></rect>
-            <rect x="49" y="1121" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1141">set_stmt</text>
+            <rect x="51" y="1167" width="74" height="32"></rect>
+            <rect x="49" y="1165" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1185">set_stmt</text>
          </a>
          <a xlink:href="#show_stmt" xlink:title="show_stmt">
-            <rect x="51" y="1167" width="88" height="32"></rect>
-            <rect x="49" y="1165" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1185">show_stmt</text>
+            <rect x="51" y="1211" width="88" height="32"></rect>
+            <rect x="49" y="1209" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1229">show_stmt</text>
          </a>
          <a xlink:href="#transaction_stmt" xlink:title="transaction_stmt">
-            <rect x="51" y="1211" width="122" height="32"></rect>
-            <rect x="49" y="1209" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1229">transaction_stmt</text>
+            <rect x="51" y="1255" width="122" height="32"></rect>
+            <rect x="49" y="1253" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1273">transaction_stmt</text>
          </a>
          <a xlink:href="#truncate_stmt" xlink:title="truncate_stmt">
-            <rect x="51" y="1255" width="106" height="32"></rect>
-            <rect x="49" y="1253" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1273">truncate_stmt</text>
+            <rect x="51" y="1299" width="106" height="32"></rect>
+            <rect x="49" y="1297" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1317">truncate_stmt</text>
          </a>
          <a xlink:href="#update_stmt" xlink:title="update_stmt">
-            <rect x="51" y="1299" width="96" height="32"></rect>
-            <rect x="49" y="1297" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1317">update_stmt</text>
+            <rect x="51" y="1343" width="96" height="32"></rect>
+            <rect x="49" y="1341" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1361">update_stmt</text>
          </a>
          <a xlink:href="#upsert_stmt" xlink:title="upsert_stmt">
-            <rect x="51" y="1343" width="94" height="32"></rect>
-            <rect x="49" y="1341" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1361">upsert_stmt</text>
+            <rect x="51" y="1387" width="94" height="32"></rect>
+            <rect x="49" y="1385" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1405">upsert_stmt</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m116 0 h10 m0 0 h6 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m114 0 h10 m0 0 h8 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m74 0 h10 m0 0 h48 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m106 0 h10 m0 0 h16 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m23 -1352 h-3"></path>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m116 0 h10 m0 0 h6 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m114 0 h10 m0 0 h8 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m74 0 h10 m0 0 h48 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m106 0 h10 m0 0 h16 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m23 -1396 h-3"></path>
          <polygon points="211 5 219 1 219 9"></polygon>
          <polygon points="211 5 203 1 203 9"></polygon>
       </svg>
@@ -271,7 +276,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_stmt" href="#cancel_stmt">cancel_stmt:</a></p>
-      <svg width="232" height="80">
+      <svg width="242" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -285,9 +290,14 @@
             <rect x="49" y="45" width="134" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="65">cancel_query_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h14 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m23 -44 h-3"></path>
-         <polygon points="223 17 231 13 231 21"></polygon>
-         <polygon points="223 17 215 13 215 21"></polygon>
+         <a xlink:href="#cancel_session_stmt" xlink:title="cancel_session_stmt">
+            <rect x="51" y="91" width="144" height="32"></rect>
+            <rect x="49" y="89" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">cancel_session_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h24 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m134 0 h10 m0 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m23 -88 h-3"></path>
+         <polygon points="233 17 241 13 241 21"></polygon>
+         <polygon points="233 17 225 13 225 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -537,6 +547,46 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h232 m-262 0 h20 m242 0 h20 m-282 0 q10 0 10 10 m262 0 q0 -10 10 -10 m-272 10 v12 m262 0 v-12 m-262 12 q0 10 10 10 m242 0 q10 0 10 -10 m-252 10 h10 m26 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m120 0 h10 m3 0 h-3"></path>
          <polygon points="549 17 557 13 557 21"></polygon>
          <polygon points="549 17 541 13 541 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#stmt" title="stmt">stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="export_stmt" href="#export_stmt">export_stmt:</a></p>
+      <svg width="656" height="102">
+
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">EXPORT</text>
+         <rect x="125" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="123" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="21">INTO</text>
+         <rect x="199" y="3" width="46" height="32" rx="10"></rect>
+         <rect x="197" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="207" y="21">CSV</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="265" y="3" width="148" height="32"></rect>
+            <rect x="263" y="1" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="273" y="21">string_or_placeholder</text>
+         </a>
+         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
+            <rect x="433" y="3" width="124" height="32"></rect>
+            <rect x="431" y="1" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="441" y="21">opt_with_options</text>
+         </a>
+         <rect x="577" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="575" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="585" y="21">FROM</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="539" y="69" width="90" height="32"></rect>
+            <rect x="537" y="67" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="547" y="87">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m148 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
+         <polygon points="647 83 655 79 655 87"></polygon>
+         <polygon points="647 83 639 79 639 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -959,6 +1009,7 @@
             <li><a href="#alter_split_stmt" title="alter_split_stmt">alter_split_stmt</a></li>
             <li><a href="#create_table_as_stmt" title="create_table_as_stmt">create_table_as_stmt</a></li>
             <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#insert_rest" title="insert_rest">insert_rest</a></li>
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
             <li><a href="#stmt" title="stmt">stmt</a></li>
@@ -1042,7 +1093,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stmt" href="#show_stmt">show_stmt:</a></p>
-      <svg width="296" height="916">
+      <svg width="296" height="960">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1111,47 +1162,52 @@
             <rect x="49" y="529" width="138" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="549">show_queries_stmt</text>
          </a>
+         <a xlink:href="#show_ranges_stmt" xlink:title="show_ranges_stmt">
+            <rect x="51" y="575" width="136" height="32"></rect>
+            <rect x="49" y="573" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="593">show_ranges_stmt</text>
+         </a>
          <a xlink:href="#show_roles_stmt" xlink:title="show_roles_stmt">
-            <rect x="51" y="575" width="124" height="32"></rect>
-            <rect x="49" y="573" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="593">show_roles_stmt</text>
+            <rect x="51" y="619" width="124" height="32"></rect>
+            <rect x="49" y="617" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="637">show_roles_stmt</text>
          </a>
          <a xlink:href="#show_schemas_stmt" xlink:title="show_schemas_stmt">
-            <rect x="51" y="619" width="148" height="32"></rect>
-            <rect x="49" y="617" width="148" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="637">show_schemas_stmt</text>
+            <rect x="51" y="663" width="148" height="32"></rect>
+            <rect x="49" y="661" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="681">show_schemas_stmt</text>
          </a>
          <a xlink:href="#show_session_stmt" xlink:title="show_session_stmt">
-            <rect x="51" y="663" width="140" height="32"></rect>
-            <rect x="49" y="661" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="681">show_session_stmt</text>
+            <rect x="51" y="707" width="140" height="32"></rect>
+            <rect x="49" y="705" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="725">show_session_stmt</text>
          </a>
          <a xlink:href="#show_sessions_stmt" xlink:title="show_sessions_stmt">
-            <rect x="51" y="707" width="146" height="32"></rect>
-            <rect x="49" y="705" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="725">show_sessions_stmt</text>
+            <rect x="51" y="751" width="146" height="32"></rect>
+            <rect x="49" y="749" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="769">show_sessions_stmt</text>
          </a>
          <a xlink:href="#show_stats_stmt" xlink:title="show_stats_stmt">
-            <rect x="51" y="751" width="126" height="32"></rect>
-            <rect x="49" y="749" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="769">show_stats_stmt</text>
+            <rect x="51" y="795" width="126" height="32"></rect>
+            <rect x="49" y="793" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="813">show_stats_stmt</text>
          </a>
          <a xlink:href="#show_tables_stmt" xlink:title="show_tables_stmt">
-            <rect x="51" y="795" width="130" height="32"></rect>
-            <rect x="49" y="793" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="813">show_tables_stmt</text>
+            <rect x="51" y="839" width="130" height="32"></rect>
+            <rect x="49" y="837" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="857">show_tables_stmt</text>
          </a>
          <a xlink:href="#show_trace_stmt" xlink:title="show_trace_stmt">
-            <rect x="51" y="839" width="126" height="32"></rect>
-            <rect x="49" y="837" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="857">show_trace_stmt</text>
+            <rect x="51" y="883" width="126" height="32"></rect>
+            <rect x="49" y="881" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="901">show_trace_stmt</text>
          </a>
          <a xlink:href="#show_users_stmt" xlink:title="show_users_stmt">
-            <rect x="51" y="883" width="128" height="32"></rect>
-            <rect x="49" y="881" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="901">show_users_stmt</text>
+            <rect x="51" y="927" width="128" height="32"></rect>
+            <rect x="49" y="925" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="945">show_users_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m138 0 h10 m0 0 h60 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m162 0 h10 m0 0 h36 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m170 0 h10 m0 0 h28 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m168 0 h10 m0 0 h30 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m198 0 h10 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m134 0 h10 m0 0 h64 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m122 0 h10 m0 0 h76 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m138 0 h10 m0 0 h60 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m124 0 h10 m0 0 h74 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m130 0 h10 m0 0 h68 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m128 0 h10 m0 0 h70 m23 -880 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m138 0 h10 m0 0 h60 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m162 0 h10 m0 0 h36 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m170 0 h10 m0 0 h28 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m168 0 h10 m0 0 h30 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m198 0 h10 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m134 0 h10 m0 0 h64 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m122 0 h10 m0 0 h76 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m138 0 h10 m0 0 h60 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m136 0 h10 m0 0 h62 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m124 0 h10 m0 0 h74 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m130 0 h10 m0 0 h68 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m128 0 h10 m0 0 h70 m23 -924 h-3"></path>
          <polygon points="287 17 295 13 295 21"></polygon>
          <polygon points="287 17 279 13 279 21"></polygon>
       </svg>
@@ -1378,37 +1434,63 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="targets" href="#targets">targets:</a></p>
-      <svg width="344" height="112">
+      <svg width="426" height="300">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="35" width="62" height="32" rx="10"></rect>
-         <rect x="69" y="33" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="53">TABLE</text>
+         <rect x="51" y="3" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">identifier</text>
+         <a xlink:href="#col_name_keyword" xlink:title="col_name_keyword">
+            <rect x="51" y="47" width="138" height="32"></rect>
+            <rect x="49" y="45" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">col_name_keyword</text>
+         </a>
+         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
+            <rect x="51" y="91" width="146" height="32"></rect>
+            <rect x="49" y="89" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">unreserved_keyword</text>
+         </a>
+         <a xlink:href="#complex_table_pattern" xlink:title="complex_table_pattern">
+            <rect x="51" y="135" width="158" height="32"></rect>
+            <rect x="49" y="133" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">complex_table_pattern</text>
+         </a>
+         <a xlink:href="#table_pattern" xlink:title="table_pattern">
+            <rect x="71" y="179" width="100" height="32"></rect>
+            <rect x="69" y="177" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="197">table_pattern</text>
+         </a>
+         <rect x="191" y="179" width="24" height="32" rx="10"></rect>
+         <rect x="189" y="177" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="199" y="197">,</text>
+         <rect x="71" y="223" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="221" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="241">TABLE</text>
          <a xlink:href="#table_pattern_list" xlink:title="table_pattern_list">
-            <rect x="173" y="3" width="124" height="32"></rect>
-            <rect x="171" y="1" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="181" y="21">table_pattern_list</text>
+            <rect x="255" y="179" width="124" height="32"></rect>
+            <rect x="253" y="177" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="263" y="197">table_pattern_list</text>
          </a>
-         <rect x="51" y="79" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="77" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="97">DATABASE</text>
+         <rect x="51" y="267" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">DATABASE</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="163" y="79" width="78" height="32"></rect>
-            <rect x="161" y="77" width="78" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="171" y="97">name_list</text>
+            <rect x="163" y="267" width="78" height="32"></rect>
+            <rect x="161" y="265" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="171" y="285">name_list</text>
          </a>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -32 h10 m124 0 h10 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v56 m286 0 v-56 m-286 56 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m92 0 h10 m0 0 h10 m78 0 h10 m0 0 h56 m23 -76 h-3"></path>
-         <polygon points="335 17 343 13 343 21"></polygon>
-         <polygon points="335 17 327 13 327 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m78 0 h10 m0 0 h250 m-368 0 h20 m348 0 h20 m-388 0 q10 0 10 10 m368 0 q0 -10 10 -10 m-378 10 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m138 0 h10 m0 0 h190 m-358 -10 v20 m368 0 v-20 m-368 20 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m146 0 h10 m0 0 h182 m-358 -10 v20 m368 0 v-20 m-368 20 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m158 0 h10 m0 0 h170 m-358 -10 v20 m368 0 v-20 m-368 20 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-338 10 h10 m100 0 h10 m0 0 h10 m24 0 h10 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m62 0 h10 m0 0 h82 m20 -44 h10 m124 0 h10 m-358 -10 v20 m368 0 v-20 m-368 20 v68 m368 0 v-68 m-368 68 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m92 0 h10 m0 0 h10 m78 0 h10 m0 0 h138 m23 -264 h-3"></path>
+         <polygon points="417 17 425 13 425 21"></polygon>
+         <polygon points="417 17 409 13 409 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
-            <li><a href="#on_privilege_target_clause" title="on_privilege_target_clause">on_privilege_target_clause</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
+            <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="string_or_placeholder" href="#string_or_placeholder">string_or_placeholder:</a></p>
       <svg width="306" height="80">
@@ -1433,6 +1515,7 @@
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#create_role_stmt" title="create_role_stmt">create_role_stmt</a></li>
             <li><a href="#create_user_stmt" title="create_user_stmt">create_user_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
             <li><a href="#kv_option" title="kv_option">kv_option</a></li>
             <li><a href="#opt_password" title="opt_password">opt_password</a></li>
@@ -1518,6 +1601,7 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
          </ul>
@@ -1546,7 +1630,7 @@
             <li><a href="#cancel_stmt" title="cancel_stmt">cancel_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_query_stmt" href="#cancel_query_stmt">cancel_query_stmt:</a></p>
-      <svg width="298" height="36">
+      <svg width="480" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1556,14 +1640,50 @@
          <rect x="123" y="3" width="66" height="32" rx="10"></rect>
          <rect x="121" y="1" width="66" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="131" y="21">QUERY</text>
+         <rect x="229" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="227" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="237" y="53">IF</text>
+         <rect x="283" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="281" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="291" y="53">EXISTS</text>
          <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="209" y="3" width="62" height="32"></rect>
-            <rect x="207" y="1" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="217" y="21">a_expr</text>
+            <rect x="391" y="3" width="62" height="32"></rect>
+            <rect x="389" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="399" y="21">a_expr</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m62 0 h10 m3 0 h-3"></path>
-         <polygon points="289 17 297 13 297 21"></polygon>
-         <polygon points="289 17 281 13 281 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m62 0 h10 m3 0 h-3"></path>
+         <polygon points="471 17 479 13 479 21"></polygon>
+         <polygon points="471 17 463 13 463 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#cancel_stmt" title="cancel_stmt">cancel_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_session_stmt" href="#cancel_session_stmt">cancel_session_stmt:</a></p>
+      <svg width="494" height="68">
+
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CANCEL</text>
+         <rect x="123" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="121" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="131" y="21">SESSION</text>
+         <rect x="243" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="241" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="251" y="53">IF</text>
+         <rect x="297" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="295" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="305" y="53">EXISTS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="405" y="3" width="62" height="32"></rect>
+            <rect x="403" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="413" y="21">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m62 0 h10 m3 0 h-3"></path>
+         <polygon points="485 17 493 13 493 21"></polygon>
+         <polygon points="485 17 477 13 477 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1604,6 +1724,7 @@
             <li><a href="#show_constraints_stmt" title="show_constraints_stmt">show_constraints_stmt</a></li>
             <li><a href="#show_create_table_stmt" title="show_create_table_stmt">show_create_table_stmt</a></li>
             <li><a href="#show_indexes_stmt" title="show_indexes_stmt">show_indexes_stmt</a></li>
+            <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
             <li><a href="#show_stats_stmt" title="show_stats_stmt">show_stats_stmt</a></li>
             <li><a href="#sortby" title="sortby">sortby</a></li>
             <li><a href="#table_name_list" title="table_name_list">table_name_list</a></li>
@@ -1824,9 +1945,10 @@
             <li><a href="#column_name" title="column_name">column_name</a></li>
             <li><a href="#column_path" title="column_path">column_path</a></li>
             <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
+            <li><a href="#complex_db_object_name" title="complex_db_object_name">complex_db_object_name</a></li>
+            <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
             <li><a href="#constraint_name" title="constraint_name">constraint_name</a></li>
             <li><a href="#database_name" title="database_name">database_name</a></li>
-            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
             <li><a href="#deallocate_stmt" title="deallocate_stmt">deallocate_stmt</a></li>
             <li><a href="#family_name" title="family_name">family_name</a></li>
             <li><a href="#kv_option" title="kv_option">kv_option</a></li>
@@ -1840,9 +1962,9 @@
             <li><a href="#savepoint_stmt" title="savepoint_stmt">savepoint_stmt</a></li>
             <li><a href="#show_schemas_stmt" title="show_schemas_stmt">show_schemas_stmt</a></li>
             <li><a href="#show_tables_stmt" title="show_tables_stmt">show_tables_stmt</a></li>
+            <li><a href="#simple_db_object_name" title="simple_db_object_name">simple_db_object_name</a></li>
             <li><a href="#statistics_name" title="statistics_name">statistics_name</a></li>
             <li><a href="#table_alias_name" title="table_alias_name">table_alias_name</a></li>
-            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
             <li><a href="#var_name" title="var_name">var_name</a></li>
             <li><a href="#window_name" title="window_name">window_name</a></li>
          </ul>
@@ -2251,12 +2373,12 @@
             <li><a href="#opt_column_list" title="opt_column_list">opt_column_list</a></li>
             <li><a href="#opt_conf_expr" title="opt_conf_expr">opt_conf_expr</a></li>
             <li><a href="#opt_interleave" title="opt_interleave">opt_interleave</a></li>
-            <li><a href="#opt_name_list" title="opt_name_list">opt_name_list</a></li>
             <li><a href="#opt_storing" title="opt_storing">opt_storing</a></li>
             <li><a href="#partition_by" title="partition_by">partition_by</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
             <li><a href="#scrub_option" title="scrub_option">scrub_option</a></li>
             <li><a href="#targets" title="targets">targets</a></li>
+            <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="privilege_list" href="#privilege_list">privilege_list:</a></p>
       <svg width="166" height="80">
@@ -3141,9 +3263,11 @@
          </p><ul>
             <li><a href="#a_expr" title="a_expr">a_expr</a></li>
             <li><a href="#alter_column_default" title="alter_column_default">alter_column_default</a></li>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
             <li><a href="#array_subscript" title="array_subscript">array_subscript</a></li>
             <li><a href="#cancel_job_stmt" title="cancel_job_stmt">cancel_job_stmt</a></li>
             <li><a href="#cancel_query_stmt" title="cancel_query_stmt">cancel_query_stmt</a></li>
+            <li><a href="#cancel_session_stmt" title="cancel_session_stmt">cancel_session_stmt</a></li>
             <li><a href="#case_arg" title="case_arg">case_arg</a></li>
             <li><a href="#case_default" title="case_default">case_default</a></li>
             <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
@@ -3938,7 +4062,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_grants_stmt" href="#show_grants_stmt">show_grants_stmt:</a></p>
-      <svg width="670" height="80">
+      <svg width="538" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -3948,30 +4072,19 @@
          <rect x="113" y="3" width="74" height="32" rx="10"></rect>
          <rect x="111" y="1" width="74" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="121" y="21">GRANTS</text>
-         <rect x="227" y="3" width="40" height="32" rx="10"></rect>
-         <rect x="225" y="1" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="235" y="21">ON</text>
-         <rect x="287" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="285" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="295" y="21">ROLE</text>
-         <a xlink:href="#opt_name_list" xlink:title="opt_name_list">
-            <rect x="363" y="3" width="106" height="32"></rect>
-            <rect x="361" y="1" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="371" y="21">opt_name_list</text>
-         </a>
-         <a xlink:href="#on_privilege_target_clause" xlink:title="on_privilege_target_clause">
-            <rect x="227" y="47" width="180" height="32"></rect>
-            <rect x="225" y="45" width="180" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="235" y="65">on_privilege_target_clause</text>
+         <a xlink:href="#opt_on_targets_roles" xlink:title="opt_on_targets_roles">
+            <rect x="207" y="3" width="150" height="32"></rect>
+            <rect x="205" y="1" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="215" y="21">opt_on_targets_roles</text>
          </a>
          <a xlink:href="#for_grantee_clause" xlink:title="for_grantee_clause">
-            <rect x="509" y="3" width="134" height="32"></rect>
-            <rect x="507" y="1" width="134" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="517" y="21">for_grantee_clause</text>
+            <rect x="377" y="3" width="134" height="32"></rect>
+            <rect x="375" y="1" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="385" y="21">for_grantee_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m106 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v24 m282 0 v-24 m-282 24 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m180 0 h10 m0 0 h62 m20 -44 h10 m134 0 h10 m3 0 h-3"></path>
-         <polygon points="661 17 669 13 669 21"></polygon>
-         <polygon points="661 17 653 13 653 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m150 0 h10 m0 0 h10 m134 0 h10 m3 0 h-3"></path>
+         <polygon points="529 17 537 13 537 21"></polygon>
+         <polygon points="529 17 521 13 521 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4076,6 +4189,46 @@
          </p><ul>
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_ranges_stmt" href="#show_ranges_stmt">show_ranges_stmt:</a></p>
+      <svg width="608" height="80">
+
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <a xlink:href="#ranges_kw" xlink:title="ranges_kw">
+            <rect x="113" y="3" width="86" height="32"></rect>
+            <rect x="111" y="1" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="121" y="21">ranges_kw</text>
+         </a>
+         <rect x="219" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="217" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="227" y="21">FROM</text>
+         <rect x="317" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="315" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="325" y="21">TABLE</text>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="399" y="3" width="90" height="32"></rect>
+            <rect x="397" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="21">table_name</text>
+         </a>
+         <rect x="317" y="47" width="62" height="32" rx="10"></rect>
+         <rect x="315" y="45" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="325" y="65">INDEX</text>
+         <a xlink:href="#table_name_with_index" xlink:title="table_name_with_index">
+            <rect x="399" y="47" width="162" height="32"></rect>
+            <rect x="397" y="45" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="65">table_name_with_index</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
+         <polygon points="599 17 607 13 607 21"></polygon>
+         <polygon points="599 17 591 13 591 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_roles_stmt" href="#show_roles_stmt">show_roles_stmt:</a></p>
       <svg width="204" height="36">
          
@@ -4172,7 +4325,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stats_stmt" href="#show_stats_stmt">show_stats_stmt:</a></p>
-      <svg width="502" height="36">
+      <svg width="700" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -4182,20 +4335,26 @@
          <rect x="113" y="3" width="102" height="32" rx="10"></rect>
          <rect x="111" y="1" width="102" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="121" y="21">STATISTICS</text>
-         <rect x="235" y="3" width="48" height="32" rx="10"></rect>
-         <rect x="233" y="1" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="243" y="21">FOR</text>
-         <rect x="303" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="301" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="311" y="21">TABLE</text>
+         <rect x="255" y="35" width="64" height="32" rx="10"></rect>
+         <rect x="253" y="33" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="263" y="53">USING</text>
+         <rect x="339" y="35" width="54" height="32" rx="10"></rect>
+         <rect x="337" y="33" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="347" y="53">JSON</text>
+         <rect x="433" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="431" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="441" y="21">FOR</text>
+         <rect x="501" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="499" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="21">TABLE</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="385" y="3" width="90" height="32"></rect>
-            <rect x="383" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="393" y="21">table_name</text>
+            <rect x="583" y="3" width="90" height="32"></rect>
+            <rect x="581" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="591" y="21">table_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="493 17 501 13 501 21"></polygon>
-         <polygon points="493 17 485 13 485 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m64 0 h10 m0 0 h10 m54 0 h10 m20 -32 h10 m48 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></path>
+         <polygon points="691 17 699 13 699 21"></polygon>
+         <polygon points="691 17 683 13 683 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4641,6 +4800,869 @@
          </p><ul>
             <li><a href="#alter_user_stmt" title="alter_user_stmt">alter_user_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_name_keyword" href="#col_name_keyword">col_name_keyword:</a></p>
+      <svg width="260" height="1796">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="134" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ANNOTATE_TYPE</text>
+         <rect x="51" y="47" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">BETWEEN</text>
+         <rect x="51" y="91" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">BIGINT</text>
+         <rect x="51" y="135" width="42" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="42" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">BIT</text>
+         <rect x="51" y="179" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">BOOLEAN</text>
+         <rect x="51" y="223" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">CHAR</text>
+         <rect x="51" y="267" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">CHARACTER</text>
+         <rect x="51" y="311" width="148" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="148" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">CHARACTERISTICS</text>
+         <rect x="51" y="355" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">COALESCE</text>
+         <rect x="51" y="399" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">DEC</text>
+         <rect x="51" y="443" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">DECIMAL</text>
+         <rect x="51" y="487" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">EXISTS</text>
+         <rect x="51" y="531" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">EXTRACT</text>
+         <rect x="51" y="575" width="162" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="162" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">EXTRACT_DURATION</text>
+         <rect x="51" y="619" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">FLOAT</text>
+         <rect x="51" y="663" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">GREATEST</text>
+         <rect x="51" y="707" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">GROUPING</text>
+         <rect x="51" y="751" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">IF</text>
+         <rect x="51" y="795" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">IFNULL</text>
+         <rect x="51" y="839" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">INT</text>
+         <rect x="51" y="883" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">INTEGER</text>
+         <rect x="51" y="927" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">INTERVAL</text>
+         <rect x="51" y="971" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">LEAST</text>
+         <rect x="51" y="1015" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">NULLIF</text>
+         <rect x="51" y="1059" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">NUMERIC</text>
+         <rect x="51" y="1103" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">OUT</text>
+         <rect x="51" y="1147" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">OVERLAY</text>
+         <rect x="51" y="1191" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">POSITION</text>
+         <rect x="51" y="1235" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">PRECISION</text>
+         <rect x="51" y="1279" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">REAL</text>
+         <rect x="51" y="1323" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">ROW</text>
+         <rect x="51" y="1367" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">SMALLINT</text>
+         <rect x="51" y="1411" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">SUBSTRING</text>
+         <rect x="51" y="1455" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">TIME</text>
+         <rect x="51" y="1499" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">TIMESTAMP</text>
+         <rect x="51" y="1543" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">TREAT</text>
+         <rect x="51" y="1587" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">TRIM</text>
+         <rect x="51" y="1631" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">VALUES</text>
+         <rect x="51" y="1675" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">VARCHAR</text>
+         <rect x="51" y="1719" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">VIRTUAL</text>
+         <rect x="51" y="1763" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">WORK</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m134 0 h10 m0 0 h28 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m148 0 h10 m0 0 h14 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m23 -1760 h-3"></path>
+         <polygon points="251 17 259 13 259 21"></polygon>
+         <polygon points="251 17 243 13 243 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#name" title="name">name</a></li>
+            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
+      <svg width="332" height="9452">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ABORT</text>
+         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">ACTION</text>
+         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">ADD</text>
+         <rect x="51" y="135" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">ADMIN</text>
+         <rect x="51" y="179" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">ALTER</text>
+         <rect x="51" y="223" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">AT</text>
+         <rect x="51" y="267" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">BACKUP</text>
+         <rect x="51" y="311" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">BEGIN</text>
+         <rect x="51" y="355" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">BIGSERIAL</text>
+         <rect x="51" y="399" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">BLOB</text>
+         <rect x="51" y="443" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">BOOL</text>
+         <rect x="51" y="487" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">BY</text>
+         <rect x="51" y="531" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">BYTEA</text>
+         <rect x="51" y="575" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">BYTES</text>
+         <rect x="51" y="619" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">CACHE</text>
+         <rect x="51" y="663" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">CANCEL</text>
+         <rect x="51" y="707" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">CASCADE</text>
+         <rect x="51" y="751" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">CLUSTER</text>
+         <rect x="51" y="795" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">COLUMNS</text>
+         <rect x="51" y="839" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">COMMENT</text>
+         <rect x="51" y="883" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">COMMIT</text>
+         <rect x="51" y="927" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">COMMITTED</text>
+         <rect x="51" y="971" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">COMPACT</text>
+         <rect x="51" y="1015" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">CONFLICT</text>
+         <rect x="51" y="1059" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">CONFIGURATION</text>
+         <rect x="51" y="1103" width="144" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="144" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">CONFIGURATIONS</text>
+         <rect x="51" y="1147" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">CONFIGURE</text>
+         <rect x="51" y="1191" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">CONSTRAINTS</text>
+         <rect x="51" y="1235" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">COPY</text>
+         <rect x="51" y="1279" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">COVERING</text>
+         <rect x="51" y="1323" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">CSV</text>
+         <rect x="51" y="1367" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">CUBE</text>
+         <rect x="51" y="1411" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">CURRENT</text>
+         <rect x="51" y="1455" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">CYCLE</text>
+         <rect x="51" y="1499" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">DATA</text>
+         <rect x="51" y="1543" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">DATABASE</text>
+         <rect x="51" y="1587" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">DATABASES</text>
+         <rect x="51" y="1631" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">DATE</text>
+         <rect x="51" y="1675" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">DAY</text>
+         <rect x="51" y="1719" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">DEALLOCATE</text>
+         <rect x="51" y="1763" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">DELETE</text>
+         <rect x="51" y="1807" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">DISCARD</text>
+         <rect x="51" y="1851" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="1849" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1869">DOUBLE</text>
+         <rect x="51" y="1895" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">DROP</text>
+         <rect x="51" y="1939" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">EMIT</text>
+         <rect x="51" y="1983" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">ENCODING</text>
+         <rect x="51" y="2027" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="2025" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2045">EXECUTE</text>
+         <rect x="51" y="2071" width="124" height="32" rx="10"></rect>
+         <rect x="49" y="2069" width="124" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2089">EXPERIMENTAL</text>
+         <rect x="51" y="2115" width="176" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="176" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">EXPERIMENTAL_AUDIT</text>
+         <rect x="51" y="2159" width="222" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="222" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">EXPERIMENTAL_CHANGEFEED</text>
+         <rect x="51" y="2203" width="234" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="234" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">EXPERIMENTAL_FINGERPRINTS</text>
+         <rect x="51" y="2247" width="188" height="32" rx="10"></rect>
+         <rect x="49" y="2245" width="188" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2265">EXPERIMENTAL_RANGES</text>
+         <rect x="51" y="2291" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="2289" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2309">EXPERIMENTAL_RELOCATE</text>
+         <rect x="51" y="2335" width="192" height="32" rx="10"></rect>
+         <rect x="49" y="2333" width="192" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2353">EXPERIMENTAL_REPLICA</text>
+         <rect x="51" y="2379" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="2377" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2397">EXPLAIN</text>
+         <rect x="51" y="2423" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2421" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2441">EXPORT</text>
+         <rect x="51" y="2467" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="2465" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2485">FILTER</text>
+         <rect x="51" y="2511" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="2509" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2529">FIRST</text>
+         <rect x="51" y="2555" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2553" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2573">FLOAT4</text>
+         <rect x="51" y="2599" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2597" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2617">FLOAT8</text>
+         <rect x="51" y="2643" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="2641" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2661">FOLLOWING</text>
+         <rect x="51" y="2687" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="2685" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2705">FORCE_INDEX</text>
+         <rect x="51" y="2731" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="2729" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2749">GIN</text>
+         <rect x="51" y="2775" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">GRANTS</text>
+         <rect x="51" y="2819" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">HIGH</text>
+         <rect x="51" y="2863" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">HISTOGRAM</text>
+         <rect x="51" y="2907" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">HOUR</text>
+         <rect x="51" y="2951" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">IMPORT</text>
+         <rect x="51" y="2995" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">INCREMENT</text>
+         <rect x="51" y="3039" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">INCREMENTAL</text>
+         <rect x="51" y="3083" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">INDEXES</text>
+         <rect x="51" y="3127" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">INET</text>
+         <rect x="51" y="3171" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">INJECT</text>
+         <rect x="51" y="3215" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">INSERT</text>
+         <rect x="51" y="3259" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3257" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3277">INT2</text>
+         <rect x="51" y="3303" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">INT2VECTOR</text>
+         <rect x="51" y="3347" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">INT4</text>
+         <rect x="51" y="3391" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">INT8</text>
+         <rect x="51" y="3435" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">INT64</text>
+         <rect x="51" y="3479" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">INTERLEAVE</text>
+         <rect x="51" y="3523" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">INVERTED</text>
+         <rect x="51" y="3567" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">ISOLATION</text>
+         <rect x="51" y="3611" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="3609" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3629">JOB</text>
+         <rect x="51" y="3655" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3653" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3673">JOBS</text>
+         <rect x="51" y="3699" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3697" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3717">JSON</text>
+         <rect x="51" y="3743" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3741" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3761">JSONB</text>
+         <rect x="51" y="3787" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="3785" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3805">KEY</text>
+         <rect x="51" y="3831" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3829" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3849">KEYS</text>
+         <rect x="51" y="3875" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="3873" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3893">KV</text>
+         <rect x="51" y="3919" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="3917" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3937">LC_COLLATE</text>
+         <rect x="51" y="3963" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="3961" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3981">LC_CTYPE</text>
+         <rect x="51" y="4007" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="4005" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4025">LESS</text>
+         <rect x="51" y="4051" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="4049" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4069">LEVEL</text>
+         <rect x="51" y="4095" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="4093" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4113">LIST</text>
+         <rect x="51" y="4139" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="4137" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4157">LOCAL</text>
+         <rect x="51" y="4183" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="4181" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4201">LOW</text>
+         <rect x="51" y="4227" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="4225" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4245">MATCH</text>
+         <rect x="51" y="4271" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="4269" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4289">MINUTE</text>
+         <rect x="51" y="4315" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="4313" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4333">MONTH</text>
+         <rect x="51" y="4359" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="4357" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4377">NAMES</text>
+         <rect x="51" y="4403" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="4401" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4421">NAN</text>
+         <rect x="51" y="4447" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="4445" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4465">NAME</text>
+         <rect x="51" y="4491" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="4489" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4509">NEXT</text>
+         <rect x="51" y="4535" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="4533" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4553">NO</text>
+         <rect x="51" y="4579" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="4577" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4597">NORMAL</text>
+         <rect x="51" y="4623" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="4621" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4641">NO_INDEX_JOIN</text>
+         <rect x="51" y="4667" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="4665" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4685">NULLS</text>
+         <rect x="51" y="4711" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="4709" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4729">OF</text>
+         <rect x="51" y="4755" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4753" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4773">OFF</text>
+         <rect x="51" y="4799" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4797" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4817">OID</text>
+         <rect x="51" y="4843" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="4841" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4861">OIDVECTOR</text>
+         <rect x="51" y="4887" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4885" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4905">OPTION</text>
+         <rect x="51" y="4931" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="4929" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4949">OPTIONS</text>
+         <rect x="51" y="4975" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="4973" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4993">ORDINALITY</text>
+         <rect x="51" y="5019" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5017" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5037">OVER</text>
+         <rect x="51" y="5063" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="5061" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5081">OWNED</text>
+         <rect x="51" y="5107" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="5105" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5125">PARENT</text>
+         <rect x="51" y="5151" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5149" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5169">PARTIAL</text>
+         <rect x="51" y="5195" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="5193" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5213">PARTITION</text>
+         <rect x="51" y="5239" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5237" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5257">PASSWORD</text>
+         <rect x="51" y="5283" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5281" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5301">PAUSE</text>
+         <rect x="51" y="5327" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="5325" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5345">PHYSICAL</text>
+         <rect x="51" y="5371" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5369" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5389">PLANS</text>
+         <rect x="51" y="5415" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5413" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5433">PRECEDING</text>
+         <rect x="51" y="5459" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="5457" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5477">PREPARE</text>
+         <rect x="51" y="5503" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="5501" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5521">PRIORITY</text>
+         <rect x="51" y="5547" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5545" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5565">QUERIES</text>
+         <rect x="51" y="5591" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5589" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5609">QUERY</text>
+         <rect x="51" y="5635" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5633" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5653">RANGE</text>
+         <rect x="51" y="5679" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5677" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5697">READ</text>
+         <rect x="51" y="5723" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5721" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5741">RECURSIVE</text>
+         <rect x="51" y="5767" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="5765" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5785">REF</text>
+         <rect x="51" y="5811" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="5809" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5829">REGCLASS</text>
+         <rect x="51" y="5855" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="5853" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5873">REGPROC</text>
+         <rect x="51" y="5899" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="5897" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5917">REGPROCEDURE</text>
+         <rect x="51" y="5943" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="5941" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5961">REGNAMESPACE</text>
+         <rect x="51" y="5987" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5985" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6005">REGTYPE</text>
+         <rect x="51" y="6031" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="6029" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6049">RELEASE</text>
+         <rect x="51" y="6075" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="6073" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6093">RENAME</text>
+         <rect x="51" y="6119" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="6117" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6137">REPEATABLE</text>
+         <rect x="51" y="6163" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="6161" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6181">RESET</text>
+         <rect x="51" y="6207" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="6205" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6225">RESTORE</text>
+         <rect x="51" y="6251" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="6249" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6269">RESTRICT</text>
+         <rect x="51" y="6295" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6293" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6313">RESUME</text>
+         <rect x="51" y="6339" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6337" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6357">REVOKE</text>
+         <rect x="51" y="6383" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="6381" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6401">ROLE</text>
+         <rect x="51" y="6427" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="6425" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6445">ROLES</text>
+         <rect x="51" y="6471" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="6469" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6489">ROLLBACK</text>
+         <rect x="51" y="6515" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6513" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6533">ROLLUP</text>
+         <rect x="51" y="6559" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="6557" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6577">ROWS</text>
+         <rect x="51" y="6603" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6601" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6621">SETTING</text>
+         <rect x="51" y="6647" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="6645" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6665">SETTINGS</text>
+         <rect x="51" y="6691" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6689" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6709">STATUS</text>
+         <rect x="51" y="6735" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="6733" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6753">SAVEPOINT</text>
+         <rect x="51" y="6779" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="6777" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6797">SCATTER</text>
+         <rect x="51" y="6823" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="6821" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6841">SCHEMA</text>
+         <rect x="51" y="6867" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="6865" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6885">SCHEMAS</text>
+         <rect x="51" y="6911" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="6909" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6929">SCRUB</text>
+         <rect x="51" y="6955" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6953" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6973">SEARCH</text>
+         <rect x="51" y="6999" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6997" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7017">SECOND</text>
+         <rect x="51" y="7043" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7041" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7061">SERIAL</text>
+         <rect x="51" y="7087" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="7085" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7105">SERIALIZABLE</text>
+         <rect x="51" y="7131" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7129" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7149">SERIAL2</text>
+         <rect x="51" y="7175" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7173" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7193">SERIAL4</text>
+         <rect x="51" y="7219" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7217" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7237">SERIAL8</text>
+         <rect x="51" y="7263" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="7261" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7281">SEQUENCE</text>
+         <rect x="51" y="7307" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="7305" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7325">SEQUENCES</text>
+         <rect x="51" y="7351" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="7349" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7369">SESSION</text>
+         <rect x="51" y="7395" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="7393" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7413">SESSIONS</text>
+         <rect x="51" y="7439" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="7437" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7457">SET</text>
+         <rect x="51" y="7483" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="7481" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7501">SHOW</text>
+         <rect x="51" y="7527" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7525" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7545">SIMPLE</text>
+         <rect x="51" y="7571" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="7569" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7589">SMALLSERIAL</text>
+         <rect x="51" y="7615" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="7613" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7633">SNAPSHOT</text>
+         <rect x="51" y="7659" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="7657" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7677">SQL</text>
+         <rect x="51" y="7703" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7701" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7721">START</text>
+         <rect x="51" y="7747" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="7745" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7765">STATISTICS</text>
+         <rect x="51" y="7791" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="7789" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7809">STDIN</text>
+         <rect x="51" y="7835" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7833" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7853">STORE</text>
+         <rect x="51" y="7879" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="7877" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7897">STORING</text>
+         <rect x="51" y="7923" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7921" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7941">STRICT</text>
+         <rect x="51" y="7967" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="7965" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7985">STRING</text>
+         <rect x="51" y="8011" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="8009" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8029">SPLIT</text>
+         <rect x="51" y="8055" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8053" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8073">SYNTAX</text>
+         <rect x="51" y="8099" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8097" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8117">SYSTEM</text>
+         <rect x="51" y="8143" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="8141" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8161">TABLES</text>
+         <rect x="51" y="8187" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8185" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8205">TEMP</text>
+         <rect x="51" y="8231" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8229" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8249">TEMPLATE</text>
+         <rect x="51" y="8275" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="8273" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8293">TEMPORARY</text>
+         <rect x="51" y="8319" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="8317" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8337">TESTING_RANGES</text>
+         <rect x="51" y="8363" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="8361" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8381">TESTING_RELOCATE</text>
+         <rect x="51" y="8407" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="8405" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8425">TEXT</text>
+         <rect x="51" y="8451" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8449" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8469">THAN</text>
+         <rect x="51" y="8495" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="8493" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8513">TIMESTAMPTZ</text>
+         <rect x="51" y="8539" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="8537" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8557">TRACE</text>
+         <rect x="51" y="8583" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="8581" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8601">TRANSACTION</text>
+         <rect x="51" y="8627" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8625" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8645">TRUNCATE</text>
+         <rect x="51" y="8671" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="8669" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8689">TYPE</text>
+         <rect x="51" y="8715" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="8713" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8733">UNBOUNDED</text>
+         <rect x="51" y="8759" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="8757" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8777">UNCOMMITTED</text>
+         <rect x="51" y="8803" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8801" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8821">UNKNOWN</text>
+         <rect x="51" y="8847" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8845" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8865">UPDATE</text>
+         <rect x="51" y="8891" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="8889" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8909">UPSERT</text>
+         <rect x="51" y="8935" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="8933" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8953">UUID</text>
+         <rect x="51" y="8979" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="8977" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8997">USE</text>
+         <rect x="51" y="9023" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9021" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9041">USERS</text>
+         <rect x="51" y="9067" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="9065" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9085">VALID</text>
+         <rect x="51" y="9111" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="9109" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9129">VALIDATE</text>
+         <rect x="51" y="9155" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9153" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9173">VALUE</text>
+         <rect x="51" y="9199" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="9197" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9217">VARYING</text>
+         <rect x="51" y="9243" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="9241" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9261">WITHIN</text>
+         <rect x="51" y="9287" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="9285" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9305">WITHOUT</text>
+         <rect x="51" y="9331" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9329" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9349">WRITE</text>
+         <rect x="51" y="9375" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="9373" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9393">YEAR</text>
+         <rect x="51" y="9419" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="9417" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9437">ZONE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m144 0 h10 m0 0 h90 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m176 0 h10 m0 0 h58 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m222 0 h10 m0 0 h12 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m188 0 h10 m0 0 h46 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m202 0 h10 m0 0 h32 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m192 0 h10 m0 0 h42 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m132 0 h10 m0 0 h102 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m142 0 h10 m0 0 h92 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -9416 h-3"></path>
+         <polygon points="323 17 331 13 331 21"></polygon>
+         <polygon points="323 17 315 13 315 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#name" title="name">name</a></li>
+            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+            <li><a href="#type_function_name" title="type_function_name">type_function_name</a></li>
+            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="complex_table_pattern" href="#complex_table_pattern">complex_table_pattern:</a></p>
+      <svg width="520" height="144">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#complex_db_object_name" xlink:title="complex_db_object_name">
+            <rect x="51" y="3" width="180" height="32"></rect>
+            <rect x="49" y="1" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">complex_db_object_name</text>
+         </a>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="71" y="79" width="54" height="32"></rect>
+            <rect x="69" y="77" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="97">name</text>
+         </a>
+         <rect x="145" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="143" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="97">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="209" y="111" width="132" height="32"></rect>
+            <rect x="207" y="109" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="129">unrestricted_name</text>
+         </a>
+         <rect x="361" y="111" width="24" height="32" rx="10"></rect>
+         <rect x="359" y="109" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="369" y="129">.</text>
+         <rect x="445" y="47" width="28" height="32" rx="10"></rect>
+         <rect x="443" y="45" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="453" y="65">*</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m180 0 h10 m0 0 h242 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-432 10 h10 m0 0 h344 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v12 m374 0 v-12 m-374 12 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m54 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m132 0 h10 m0 0 h10 m24 0 h10 m40 -64 h10 m28 0 h10 m23 -44 h-3"></path>
+         <polygon points="511 17 519 13 519 21"></polygon>
+         <polygon points="511 17 503 13 503 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_pattern" href="#table_pattern">table_pattern:</a></p>
+      <svg width="264" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#simple_db_object_name" xlink:title="simple_db_object_name">
+            <rect x="51" y="3" width="166" height="32"></rect>
+            <rect x="49" y="1" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">simple_db_object_name</text>
+         </a>
+         <a xlink:href="#complex_table_pattern" xlink:title="complex_table_pattern">
+            <rect x="51" y="47" width="158" height="32"></rect>
+            <rect x="49" y="45" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">complex_table_pattern</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m166 0 h10 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m158 0 h10 m0 0 h8 m23 -44 h-3"></path>
+         <polygon points="255 17 263 13 263 21"></polygon>
+         <polygon points="255 17 247 13 247 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#table_pattern_list" title="table_pattern_list">table_pattern_list</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_pattern_list" href="#table_pattern_list">table_pattern_list:</a></p>
       <svg width="198" height="80">
          
@@ -4709,40 +5731,28 @@
             <li><a href="#opt_with_options" title="opt_with_options">opt_with_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="db_object_name" href="#db_object_name">db_object_name:</a></p>
-      <svg width="584" height="100">
+      <svg width="278" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#name" xlink:title="name">
-            <rect x="31" y="3" width="54" height="32"></rect>
-            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">name</text>
+         <a xlink:href="#simple_db_object_name" xlink:title="simple_db_object_name">
+            <rect x="51" y="3" width="166" height="32"></rect>
+            <rect x="49" y="1" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">simple_db_object_name</text>
          </a>
-         <rect x="125" y="35" width="24" height="32" rx="10"></rect>
-         <rect x="123" y="33" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="133" y="53">.</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="169" y="35" width="132" height="32"></rect>
-            <rect x="167" y="33" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="177" y="53">unrestricted_name</text>
+         <a xlink:href="#complex_db_object_name" xlink:title="complex_db_object_name">
+            <rect x="51" y="47" width="180" height="32"></rect>
+            <rect x="49" y="45" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">complex_db_object_name</text>
          </a>
-         <rect x="341" y="67" width="24" height="32" rx="10"></rect>
-         <rect x="339" y="65" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="349" y="85">.</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="385" y="67" width="132" height="32"></rect>
-            <rect x="383" y="65" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="393" y="85">unrestricted_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h422 m-452 0 h20 m432 0 h20 m-472 0 q10 0 10 10 m452 0 q0 -10 10 -10 m-462 10 v12 m452 0 v-12 m-452 12 q0 10 10 10 m432 0 q10 0 10 -10 m-442 10 h10 m24 0 h10 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m24 0 h10 m0 0 h10 m132 0 h10 m43 -64 h-3"></path>
-         <polygon points="575 17 583 13 583 21"></polygon>
-         <polygon points="575 17 567 13 567 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m166 0 h10 m0 0 h14 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m23 -44 h-3"></path>
+         <polygon points="269 17 277 13 277 21"></polygon>
+         <polygon points="269 17 261 13 261 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#sequence_name" title="sequence_name">sequence_name</a></li>
             <li><a href="#table_name" title="table_name">table_name</a></li>
-            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_password" href="#opt_password">opt_password:</a></p>
       <svg width="456" height="56">
@@ -5146,778 +6156,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_stats_stmt" title="create_stats_stmt">create_stats_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
-      <svg width="332" height="8132">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ABORT</text>
-         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">ACTION</text>
-         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">ADD</text>
-         <rect x="51" y="135" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">ADMIN</text>
-         <rect x="51" y="179" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">ALTER</text>
-         <rect x="51" y="223" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">AT</text>
-         <rect x="51" y="267" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">BACKUP</text>
-         <rect x="51" y="311" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">BEGIN</text>
-         <rect x="51" y="355" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">BLOB</text>
-         <rect x="51" y="399" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">BY</text>
-         <rect x="51" y="443" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">CACHE</text>
-         <rect x="51" y="487" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">CANCEL</text>
-         <rect x="51" y="531" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">CASCADE</text>
-         <rect x="51" y="575" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">CLUSTER</text>
-         <rect x="51" y="619" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">COLUMNS</text>
-         <rect x="51" y="663" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">COMMENT</text>
-         <rect x="51" y="707" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">COMMIT</text>
-         <rect x="51" y="751" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">COMMITTED</text>
-         <rect x="51" y="795" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">COMPACT</text>
-         <rect x="51" y="839" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">CONFLICT</text>
-         <rect x="51" y="883" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">CONFIGURATION</text>
-         <rect x="51" y="927" width="144" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="144" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">CONFIGURATIONS</text>
-         <rect x="51" y="971" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">CONFIGURE</text>
-         <rect x="51" y="1015" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">CONSTRAINTS</text>
-         <rect x="51" y="1059" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">COPY</text>
-         <rect x="51" y="1103" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">COVERING</text>
-         <rect x="51" y="1147" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">CSV</text>
-         <rect x="51" y="1191" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">CUBE</text>
-         <rect x="51" y="1235" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">CURRENT</text>
-         <rect x="51" y="1279" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">CYCLE</text>
-         <rect x="51" y="1323" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">DATA</text>
-         <rect x="51" y="1367" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">DATABASE</text>
-         <rect x="51" y="1411" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">DATABASES</text>
-         <rect x="51" y="1455" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">DAY</text>
-         <rect x="51" y="1499" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">DEALLOCATE</text>
-         <rect x="51" y="1543" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">DELETE</text>
-         <rect x="51" y="1587" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">DISCARD</text>
-         <rect x="51" y="1631" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">DOUBLE</text>
-         <rect x="51" y="1675" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">DROP</text>
-         <rect x="51" y="1719" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">ENCODING</text>
-         <rect x="51" y="1763" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">EXECUTE</text>
-         <rect x="51" y="1807" width="124" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="124" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">EXPERIMENTAL</text>
-         <rect x="51" y="1851" width="176" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="176" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">EXPERIMENTAL_AUDIT</text>
-         <rect x="51" y="1895" width="234" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="234" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">EXPERIMENTAL_FINGERPRINTS</text>
-         <rect x="51" y="1939" width="192" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="192" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">EXPERIMENTAL_REPLICA</text>
-         <rect x="51" y="1983" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">EXPLAIN</text>
-         <rect x="51" y="2027" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">FILTER</text>
-         <rect x="51" y="2071" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">FIRST</text>
-         <rect x="51" y="2115" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">FOLLOWING</text>
-         <rect x="51" y="2159" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">FORCE_INDEX</text>
-         <rect x="51" y="2203" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">GIN</text>
-         <rect x="51" y="2247" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">GRANTS</text>
-         <rect x="51" y="2291" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">HIGH</text>
-         <rect x="51" y="2335" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">HISTOGRAM</text>
-         <rect x="51" y="2379" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">HOUR</text>
-         <rect x="51" y="2423" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">IMPORT</text>
-         <rect x="51" y="2467" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">INCREMENT</text>
-         <rect x="51" y="2511" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">INCREMENTAL</text>
-         <rect x="51" y="2555" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">INDEXES</text>
-         <rect x="51" y="2599" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">INSERT</text>
-         <rect x="51" y="2643" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">INT2VECTOR</text>
-         <rect x="51" y="2687" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">INTERLEAVE</text>
-         <rect x="51" y="2731" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="2729" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">INVERTED</text>
-         <rect x="51" y="2775" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">ISOLATION</text>
-         <rect x="51" y="2819" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">JOB</text>
-         <rect x="51" y="2863" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">JOBS</text>
-         <rect x="51" y="2907" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">KEY</text>
-         <rect x="51" y="2951" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">KEYS</text>
-         <rect x="51" y="2995" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">KV</text>
-         <rect x="51" y="3039" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">LC_COLLATE</text>
-         <rect x="51" y="3083" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">LC_CTYPE</text>
-         <rect x="51" y="3127" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">LESS</text>
-         <rect x="51" y="3171" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">LEVEL</text>
-         <rect x="51" y="3215" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">LIST</text>
-         <rect x="51" y="3259" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="3257" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">LOCAL</text>
-         <rect x="51" y="3303" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">LOW</text>
-         <rect x="51" y="3347" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">MATCH</text>
-         <rect x="51" y="3391" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">MINUTE</text>
-         <rect x="51" y="3435" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">MONTH</text>
-         <rect x="51" y="3479" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">NAMES</text>
-         <rect x="51" y="3523" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">NAN</text>
-         <rect x="51" y="3567" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">NEXT</text>
-         <rect x="51" y="3611" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">NO</text>
-         <rect x="51" y="3655" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">NORMAL</text>
-         <rect x="51" y="3699" width="132" height="32" rx="10"></rect>
-         <rect x="49" y="3697" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">NO_INDEX_JOIN</text>
-         <rect x="51" y="3743" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="3741" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3761">NULLS</text>
-         <rect x="51" y="3787" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="3785" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3805">OF</text>
-         <rect x="51" y="3831" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="3829" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3849">OFF</text>
-         <rect x="51" y="3875" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="3873" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3893">OID</text>
-         <rect x="51" y="3919" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="3917" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3937">OIDVECTOR</text>
-         <rect x="51" y="3963" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3961" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3981">OPTION</text>
-         <rect x="51" y="4007" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="4005" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4025">OPTIONS</text>
-         <rect x="51" y="4051" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="4049" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4069">ORDINALITY</text>
-         <rect x="51" y="4095" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4093" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4113">OVER</text>
-         <rect x="51" y="4139" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="4137" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4157">OWNED</text>
-         <rect x="51" y="4183" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="4181" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4201">PARENT</text>
-         <rect x="51" y="4227" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4225" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4245">PARTIAL</text>
-         <rect x="51" y="4271" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="4269" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4289">PARTITION</text>
-         <rect x="51" y="4315" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4313" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4333">PASSWORD</text>
-         <rect x="51" y="4359" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="4357" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4377">PAUSE</text>
-         <rect x="51" y="4403" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="4401" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4421">PHYSICAL</text>
-         <rect x="51" y="4447" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="4445" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4465">PLANS</text>
-         <rect x="51" y="4491" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4489" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4509">PRECEDING</text>
-         <rect x="51" y="4535" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="4533" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4553">PREPARE</text>
-         <rect x="51" y="4579" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="4577" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4597">PRIORITY</text>
-         <rect x="51" y="4623" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4621" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4641">QUERIES</text>
-         <rect x="51" y="4667" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="4665" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4685">QUERY</text>
-         <rect x="51" y="4711" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="4709" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4729">RANGE</text>
-         <rect x="51" y="4755" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4753" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4773">READ</text>
-         <rect x="51" y="4799" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4797" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4817">RECURSIVE</text>
-         <rect x="51" y="4843" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="4841" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4861">REF</text>
-         <rect x="51" y="4887" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="4885" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4905">REGCLASS</text>
-         <rect x="51" y="4931" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="4929" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4949">REGPROC</text>
-         <rect x="51" y="4975" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="4973" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4993">REGPROCEDURE</text>
-         <rect x="51" y="5019" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="5017" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5037">REGNAMESPACE</text>
-         <rect x="51" y="5063" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="5061" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5081">REGTYPE</text>
-         <rect x="51" y="5107" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="5105" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5125">RELEASE</text>
-         <rect x="51" y="5151" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="5149" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5169">RENAME</text>
-         <rect x="51" y="5195" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="5193" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5213">REPEATABLE</text>
-         <rect x="51" y="5239" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="5237" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5257">RESET</text>
-         <rect x="51" y="5283" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="5281" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5301">RESTORE</text>
-         <rect x="51" y="5327" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="5325" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5345">RESTRICT</text>
-         <rect x="51" y="5371" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5369" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5389">RESUME</text>
-         <rect x="51" y="5415" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5413" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5433">REVOKE</text>
-         <rect x="51" y="5459" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="5457" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5477">ROLES</text>
-         <rect x="51" y="5503" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="5501" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5521">ROLLBACK</text>
-         <rect x="51" y="5547" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5545" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5565">ROLLUP</text>
-         <rect x="51" y="5591" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="5589" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5609">ROWS</text>
-         <rect x="51" y="5635" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="5633" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5653">SETTING</text>
-         <rect x="51" y="5679" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="5677" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5697">SETTINGS</text>
-         <rect x="51" y="5723" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="5721" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5741">STATUS</text>
-         <rect x="51" y="5767" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="5765" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5785">SAVEPOINT</text>
-         <rect x="51" y="5811" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="5809" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5829">SCATTER</text>
-         <rect x="51" y="5855" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="5853" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5873">SCHEMA</text>
-         <rect x="51" y="5899" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="5897" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5917">SCHEMAS</text>
-         <rect x="51" y="5943" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5941" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5961">SCRUB</text>
-         <rect x="51" y="5987" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5985" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6005">SEARCH</text>
-         <rect x="51" y="6031" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6029" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6049">SECOND</text>
-         <rect x="51" y="6075" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="6073" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6093">SERIALIZABLE</text>
-         <rect x="51" y="6119" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6117" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6137">SEQUENCE</text>
-         <rect x="51" y="6163" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="6161" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6181">SEQUENCES</text>
-         <rect x="51" y="6207" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="6205" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6225">SESSION</text>
-         <rect x="51" y="6251" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6249" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6269">SESSIONS</text>
-         <rect x="51" y="6295" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="6293" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6313">SET</text>
-         <rect x="51" y="6339" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="6337" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6357">SHOW</text>
-         <rect x="51" y="6383" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="6381" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6401">SIMPLE</text>
-         <rect x="51" y="6427" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="6425" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6445">SNAPSHOT</text>
-         <rect x="51" y="6471" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="6469" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6489">SQL</text>
-         <rect x="51" y="6515" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6513" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6533">START</text>
-         <rect x="51" y="6559" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="6557" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6577">STATISTICS</text>
-         <rect x="51" y="6603" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="6601" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6621">STDIN</text>
-         <rect x="51" y="6647" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6645" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6665">STORE</text>
-         <rect x="51" y="6691" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="6689" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6709">STORING</text>
-         <rect x="51" y="6735" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="6733" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6753">STRICT</text>
-         <rect x="51" y="6779" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="6777" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6797">SPLIT</text>
-         <rect x="51" y="6823" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6821" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6841">SYNTAX</text>
-         <rect x="51" y="6867" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6865" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6885">SYSTEM</text>
-         <rect x="51" y="6911" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="6909" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6929">TABLES</text>
-         <rect x="51" y="6955" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6953" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6973">TEMP</text>
-         <rect x="51" y="6999" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6997" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7017">TEMPLATE</text>
-         <rect x="51" y="7043" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="7041" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7061">TEMPORARY</text>
-         <rect x="51" y="7087" width="142" height="32" rx="10"></rect>
-         <rect x="49" y="7085" width="142" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7105">TESTING_RANGES</text>
-         <rect x="51" y="7131" width="158" height="32" rx="10"></rect>
-         <rect x="49" y="7129" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7149">TESTING_RELOCATE</text>
-         <rect x="51" y="7175" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="7173" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7193">TEXT</text>
-         <rect x="51" y="7219" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="7217" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7237">THAN</text>
-         <rect x="51" y="7263" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7261" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7281">TRACE</text>
-         <rect x="51" y="7307" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="7305" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7325">TRANSACTION</text>
-         <rect x="51" y="7351" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="7349" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7369">TRUNCATE</text>
-         <rect x="51" y="7395" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="7393" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7413">TYPE</text>
-         <rect x="51" y="7439" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="7437" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7457">UNBOUNDED</text>
-         <rect x="51" y="7483" width="120" height="32" rx="10"></rect>
-         <rect x="49" y="7481" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7501">UNCOMMITTED</text>
-         <rect x="51" y="7527" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="7525" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7545">UNKNOWN</text>
-         <rect x="51" y="7571" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="7569" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7589">UPDATE</text>
-         <rect x="51" y="7615" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="7613" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7633">UPSERT</text>
-         <rect x="51" y="7659" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="7657" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7677">USE</text>
-         <rect x="51" y="7703" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7701" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7721">USERS</text>
-         <rect x="51" y="7747" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="7745" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7765">VALID</text>
-         <rect x="51" y="7791" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="7789" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7809">VALIDATE</text>
-         <rect x="51" y="7835" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7833" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7853">VALUE</text>
-         <rect x="51" y="7879" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="7877" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7897">VARYING</text>
-         <rect x="51" y="7923" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="7921" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7941">WITHIN</text>
-         <rect x="51" y="7967" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="7965" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7985">WITHOUT</text>
-         <rect x="51" y="8011" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8009" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8029">WRITE</text>
-         <rect x="51" y="8055" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8053" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8073">YEAR</text>
-         <rect x="51" y="8099" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8097" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8117">ZONE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m144 0 h10 m0 0 h90 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m176 0 h10 m0 0 h58 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m192 0 h10 m0 0 h42 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m132 0 h10 m0 0 h102 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m142 0 h10 m0 0 h92 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -8096 h-3"></path>
-         <polygon points="323 17 331 13 331 21"></polygon>
-         <polygon points="323 17 315 13 315 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#name" title="name">name</a></li>
-            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
-            <li><a href="#type_function_name" title="type_function_name">type_function_name</a></li>
-            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_name_keyword" href="#col_name_keyword">col_name_keyword:</a></p>
-      <svg width="260" height="2720">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="134" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="134" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ANNOTATE_TYPE</text>
-         <rect x="51" y="47" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">BETWEEN</text>
-         <rect x="51" y="91" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">BIGINT</text>
-         <rect x="51" y="135" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">BIGSERIAL</text>
-         <rect x="51" y="179" width="42" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="42" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">BIT</text>
-         <rect x="51" y="223" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">BOOL</text>
-         <rect x="51" y="267" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">BOOLEAN</text>
-         <rect x="51" y="311" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">BYTEA</text>
-         <rect x="51" y="355" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">BYTES</text>
-         <rect x="51" y="399" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">CHAR</text>
-         <rect x="51" y="443" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">CHARACTER</text>
-         <rect x="51" y="487" width="148" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="148" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">CHARACTERISTICS</text>
-         <rect x="51" y="531" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">COALESCE</text>
-         <rect x="51" y="575" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">DATE</text>
-         <rect x="51" y="619" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">DEC</text>
-         <rect x="51" y="663" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">DECIMAL</text>
-         <rect x="51" y="707" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">EXISTS</text>
-         <rect x="51" y="751" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">EXTRACT</text>
-         <rect x="51" y="795" width="162" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="162" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">EXTRACT_DURATION</text>
-         <rect x="51" y="839" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">FLOAT</text>
-         <rect x="51" y="883" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">FLOAT4</text>
-         <rect x="51" y="927" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">FLOAT8</text>
-         <rect x="51" y="971" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">GREATEST</text>
-         <rect x="51" y="1015" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">GROUPING</text>
-         <rect x="51" y="1059" width="34" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">IF</text>
-         <rect x="51" y="1103" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">IFNULL</text>
-         <rect x="51" y="1147" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">INET</text>
-         <rect x="51" y="1191" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">INT</text>
-         <rect x="51" y="1235" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">INT2</text>
-         <rect x="51" y="1279" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">INT4</text>
-         <rect x="51" y="1323" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">INT8</text>
-         <rect x="51" y="1367" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">INT64</text>
-         <rect x="51" y="1411" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">INTEGER</text>
-         <rect x="51" y="1455" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">INTERVAL</text>
-         <rect x="51" y="1499" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">JSON</text>
-         <rect x="51" y="1543" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">JSONB</text>
-         <rect x="51" y="1587" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">LEAST</text>
-         <rect x="51" y="1631" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">NAME</text>
-         <rect x="51" y="1675" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">NULLIF</text>
-         <rect x="51" y="1719" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">NUMERIC</text>
-         <rect x="51" y="1763" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">OUT</text>
-         <rect x="51" y="1807" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">OVERLAY</text>
-         <rect x="51" y="1851" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">POSITION</text>
-         <rect x="51" y="1895" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">PRECISION</text>
-         <rect x="51" y="1939" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">REAL</text>
-         <rect x="51" y="1983" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">ROW</text>
-         <rect x="51" y="2027" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">SERIAL</text>
-         <rect x="51" y="2071" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">SERIAL2</text>
-         <rect x="51" y="2115" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">SERIAL4</text>
-         <rect x="51" y="2159" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">SERIAL8</text>
-         <rect x="51" y="2203" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">SMALLINT</text>
-         <rect x="51" y="2247" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">SMALLSERIAL</text>
-         <rect x="51" y="2291" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">STRING</text>
-         <rect x="51" y="2335" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">SUBSTRING</text>
-         <rect x="51" y="2379" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">TIME</text>
-         <rect x="51" y="2423" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">TIMESTAMP</text>
-         <rect x="51" y="2467" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">TIMESTAMPTZ</text>
-         <rect x="51" y="2511" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">TREAT</text>
-         <rect x="51" y="2555" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">TRIM</text>
-         <rect x="51" y="2599" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">UUID</text>
-         <rect x="51" y="2643" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">VALUES</text>
-         <rect x="51" y="2687" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">VARCHAR</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m134 0 h10 m0 0 h28 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m148 0 h10 m0 0 h14 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m116 0 h10 m0 0 h46 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m116 0 h10 m0 0 h46 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m23 -2684 h-3"></path>
-         <polygon points="251 17 259 13 259 21"></polygon>
-         <polygon points="251 17 243 13 243 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#name" title="name">name</a></li>
-            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
-            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="with_clause" href="#with_clause">with_clause:</a></p>
       <svg width="196" height="36">
@@ -7143,19 +7381,22 @@
             <li><a href="#create_sequence_stmt" title="create_sequence_stmt">create_sequence_stmt</a></li>
             <li><a href="#show_create_sequence_stmt" title="show_create_sequence_stmt">show_create_sequence_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_name_list" href="#opt_name_list">opt_name_list:</a></p>
-      <svg width="176" height="56">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_on_targets_roles" href="#opt_on_targets_roles">opt_on_targets_roles:</a></p>
+      <svg width="256" height="56">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="51" y="23" width="78" height="32"></rect>
-            <rect x="49" y="21" width="78" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="41">name_list</text>
+         <rect x="51" y="23" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">ON</text>
+         <a xlink:href="#targets_roles" xlink:title="targets_roles">
+            <rect x="111" y="23" width="98" height="32"></rect>
+            <rect x="109" y="21" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="119" y="41">targets_roles</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -32 h-3"></path>
-         <polygon points="167 5 175 1 175 9"></polygon>
-         <polygon points="167 5 159 1 159 9"></polygon>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m40 0 h10 m0 0 h10 m98 0 h10 m23 -32 h-3"></path>
+         <polygon points="247 5 255 1 255 9"></polygon>
+         <polygon points="247 5 239 1 239 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -7182,26 +7423,55 @@
          </p><ul>
             <li><a href="#show_grants_stmt" title="show_grants_stmt">show_grants_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="on_privilege_target_clause" href="#on_privilege_target_clause">on_privilege_target_clause:</a></p>
-      <svg width="220" height="56">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="ranges_kw" href="#ranges_kw">ranges_kw:</a></p>
+      <svg width="286" height="80">
          
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">ON</text>
-         <a xlink:href="#targets" xlink:title="targets">
-            <rect x="111" y="23" width="62" height="32"></rect>
-            <rect x="109" y="21" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="119" y="41">targets</text>
-         </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m40 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
-         <polygon points="211 5 219 1 219 9"></polygon>
-         <polygon points="211 5 203 1 203 9"></polygon>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">TESTING_RANGES</text>
+         <rect x="51" y="47" width="188" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="188" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">EXPERIMENTAL_RANGES</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h46 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m188 0 h10 m23 -44 h-3"></path>
+         <polygon points="277 17 285 13 285 21"></polygon>
+         <polygon points="277 17 269 13 269 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#show_grants_stmt" title="show_grants_stmt">show_grants_stmt</a></li>
+            <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_name_with_index" href="#table_name_with_index">table_name_with_index:</a></p>
+      <svg width="350" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="31" y="3" width="90" height="32"></rect>
+            <rect x="29" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">table_name</text>
+         </a>
+         <rect x="161" y="35" width="30" height="32" rx="10"></rect>
+         <rect x="159" y="33" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="169" y="53">@</text>
+         <a xlink:href="#index_name" xlink:title="index_name">
+            <rect x="211" y="35" width="92" height="32"></rect>
+            <rect x="209" y="33" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="219" y="53">index_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m23 -32 h-3"></path>
+         <polygon points="341 17 349 13 349 21"></polygon>
+         <polygon points="341 17 333 13 333 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_oneindex_stmt" title="alter_oneindex_stmt">alter_oneindex_stmt</a></li>
+            <li><a href="#alter_rename_index_stmt" title="alter_rename_index_stmt">alter_rename_index_stmt</a></li>
+            <li><a href="#alter_scatter_index_stmt" title="alter_scatter_index_stmt">alter_scatter_index_stmt</a></li>
+            <li><a href="#alter_split_index_stmt" title="alter_split_index_stmt">alter_split_index_stmt</a></li>
+            <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
+            <li><a href="#table_name_with_index_list" title="table_name_with_index_list">table_name_with_index_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_compact" href="#opt_compact">opt_compact:</a></p>
       <svg width="184" height="56">
@@ -7822,42 +8092,103 @@
          </p><ul>
             <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_pattern" href="#table_pattern">table_pattern:</a></p>
-      <svg width="520" height="144">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="complex_db_object_name" href="#complex_db_object_name">complex_db_object_name:</a></p>
+      <svg width="544" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#db_object_name" xlink:title="db_object_name">
-            <rect x="51" y="3" width="122" height="32"></rect>
-            <rect x="49" y="1" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">db_object_name</text>
-         </a>
          <a xlink:href="#name" xlink:title="name">
-            <rect x="71" y="79" width="54" height="32"></rect>
-            <rect x="69" y="77" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="79" y="97">name</text>
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
          </a>
-         <rect x="145" y="79" width="24" height="32" rx="10"></rect>
-         <rect x="143" y="77" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="153" y="97">.</text>
+         <rect x="105" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="103" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="21">.</text>
          <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="209" y="111" width="132" height="32"></rect>
-            <rect x="207" y="109" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="217" y="129">unrestricted_name</text>
+            <rect x="149" y="3" width="132" height="32"></rect>
+            <rect x="147" y="1" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="21">unrestricted_name</text>
          </a>
-         <rect x="361" y="111" width="24" height="32" rx="10"></rect>
-         <rect x="359" y="109" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="369" y="129">.</text>
-         <rect x="445" y="47" width="28" height="32" rx="10"></rect>
-         <rect x="443" y="45" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="453" y="65">*</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m122 0 h10 m0 0 h300 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-432 10 h10 m0 0 h344 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v12 m374 0 v-12 m-374 12 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m54 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m132 0 h10 m0 0 h10 m24 0 h10 m40 -64 h10 m28 0 h10 m23 -44 h-3"></path>
-         <polygon points="511 17 519 13 519 21"></polygon>
-         <polygon points="511 17 503 13 503 21"></polygon>
+         <rect x="321" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="319" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="329" y="53">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="365" y="35" width="132" height="32"></rect>
+            <rect x="363" y="33" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="53">unrestricted_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m24 0 h10 m0 0 h10 m132 0 h10 m23 -32 h-3"></path>
+         <polygon points="535 17 543 13 543 21"></polygon>
+         <polygon points="535 17 527 13 527 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#table_pattern_list" title="table_pattern_list">table_pattern_list</a></li>
+            <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
+            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unrestricted_name" href="#unrestricted_name">unrestricted_name:</a></p>
+      <svg width="278" height="212">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">identifier</text>
+         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
+            <rect x="51" y="47" width="146" height="32"></rect>
+            <rect x="49" y="45" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">unreserved_keyword</text>
+         </a>
+         <a xlink:href="#col_name_keyword" xlink:title="col_name_keyword">
+            <rect x="51" y="91" width="138" height="32"></rect>
+            <rect x="49" y="89" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">col_name_keyword</text>
+         </a>
+         <a xlink:href="#type_func_name_keyword" xlink:title="type_func_name_keyword">
+            <rect x="51" y="135" width="180" height="32"></rect>
+            <rect x="49" y="133" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">type_func_name_keyword</text>
+         </a>
+         <a xlink:href="#reserved_keyword" xlink:title="reserved_keyword">
+            <rect x="51" y="179" width="132" height="32"></rect>
+            <rect x="49" y="177" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">reserved_keyword</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m78 0 h10 m0 0 h102 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m146 0 h10 m0 0 h34 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m138 0 h10 m0 0 h42 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m132 0 h10 m0 0 h48 m23 -176 h-3"></path>
+         <polygon points="269 17 277 13 277 21"></polygon>
+         <polygon points="269 17 261 13 261 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#attrs" title="attrs">attrs</a></li>
+            <li><a href="#collation_name" title="collation_name">collation_name</a></li>
+            <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
+            <li><a href="#complex_db_object_name" title="complex_db_object_name">complex_db_object_name</a></li>
+            <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
+            <li><a href="#index_name" title="index_name">index_name</a></li>
+            <li><a href="#partition_name" title="partition_name">partition_name</a></li>
+            <li><a href="#prefixed_column_path" title="prefixed_column_path">prefixed_column_path</a></li>
+            <li><a href="#target_name" title="target_name">target_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="simple_db_object_name" href="#simple_db_object_name">simple_db_object_name:</a></p>
+      <svg width="112" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
+         <polygon points="103 17 111 13 111 21"></polygon>
+         <polygon points="103 17 95 13 95 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
+            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="non_reserved_word" href="#non_reserved_word">non_reserved_word:</a></p>
       <svg width="278" height="168">
@@ -7919,50 +8250,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#kv_option_list" title="kv_option_list">kv_option_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unrestricted_name" href="#unrestricted_name">unrestricted_name:</a></p>
-      <svg width="278" height="212">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">identifier</text>
-         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
-            <rect x="51" y="47" width="146" height="32"></rect>
-            <rect x="49" y="45" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">unreserved_keyword</text>
-         </a>
-         <a xlink:href="#col_name_keyword" xlink:title="col_name_keyword">
-            <rect x="51" y="91" width="138" height="32"></rect>
-            <rect x="49" y="89" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="109">col_name_keyword</text>
-         </a>
-         <a xlink:href="#type_func_name_keyword" xlink:title="type_func_name_keyword">
-            <rect x="51" y="135" width="180" height="32"></rect>
-            <rect x="49" y="133" width="180" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="153">type_func_name_keyword</text>
-         </a>
-         <a xlink:href="#reserved_keyword" xlink:title="reserved_keyword">
-            <rect x="51" y="179" width="132" height="32"></rect>
-            <rect x="49" y="177" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">reserved_keyword</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m78 0 h10 m0 0 h102 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m146 0 h10 m0 0 h34 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m138 0 h10 m0 0 h42 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m132 0 h10 m0 0 h48 m23 -176 h-3"></path>
-         <polygon points="269 17 277 13 277 21"></polygon>
-         <polygon points="269 17 261 13 261 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#attrs" title="attrs">attrs</a></li>
-            <li><a href="#collation_name" title="collation_name">collation_name</a></li>
-            <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
-            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
-            <li><a href="#index_name" title="index_name">index_name</a></li>
-            <li><a href="#partition_name" title="partition_name">partition_name</a></li>
-            <li><a href="#prefixed_column_path" title="prefixed_column_path">prefixed_column_path</a></li>
-            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
-            <li><a href="#target_name" title="target_name">target_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with" href="#opt_with">opt_with:</a></p>
       <svg width="154" height="56">
@@ -9380,6 +9667,32 @@
          </p><ul>
             <li><a href="#transaction_mode_list" title="transaction_mode_list">transaction_mode_list</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="targets_roles" href="#targets_roles">targets_roles:</a></p>
+      <svg width="252" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ROLE</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="127" y="3" width="78" height="32"></rect>
+            <rect x="125" y="1" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="135" y="21">name_list</text>
+         </a>
+         <a xlink:href="#targets" xlink:title="targets">
+            <rect x="51" y="47" width="62" height="32"></rect>
+            <rect x="49" y="45" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">targets</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h10 m78 0 h10 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m62 0 h10 m0 0 h92 m23 -44 h-3"></path>
+         <polygon points="243 17 251 13 251 21"></polygon>
+         <polygon points="243 17 235 13 235 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_on_targets_roles" title="opt_on_targets_roles">opt_on_targets_roles</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="single_set_clause" href="#single_set_clause">single_set_clause:</a></p>
       <svg width="294" height="36">
          
@@ -9499,36 +9812,6 @@
             <li><a href="#insert_column_item" title="insert_column_item">insert_column_item</a></li>
             <li><a href="#single_set_clause" title="single_set_clause">single_set_clause</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_name_with_index" href="#table_name_with_index">table_name_with_index:</a></p>
-      <svg width="350" height="68">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="31" y="3" width="90" height="32"></rect>
-            <rect x="29" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">table_name</text>
-         </a>
-         <rect x="161" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="159" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="169" y="53">@</text>
-         <a xlink:href="#index_name" xlink:title="index_name">
-            <rect x="211" y="35" width="92" height="32"></rect>
-            <rect x="209" y="33" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="219" y="53">index_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m23 -32 h-3"></path>
-         <polygon points="341 17 349 13 349 21"></polygon>
-         <polygon points="341 17 333 13 333 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_oneindex_stmt" title="alter_oneindex_stmt">alter_oneindex_stmt</a></li>
-            <li><a href="#alter_rename_index_stmt" title="alter_rename_index_stmt">alter_rename_index_stmt</a></li>
-            <li><a href="#alter_scatter_index_stmt" title="alter_scatter_index_stmt">alter_scatter_index_stmt</a></li>
-            <li><a href="#alter_split_index_stmt" title="alter_split_index_stmt">alter_split_index_stmt</a></li>
-            <li><a href="#table_name_with_index_list" title="table_name_with_index_list">table_name_with_index_list</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_index_cmds" href="#alter_index_cmds">alter_index_cmds:</a></p>
       <svg width="216" height="80">
          
@@ -9642,7 +9925,7 @@
             <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="reserved_keyword" href="#reserved_keyword">reserved_keyword:</a></p>
-      <svg width="270" height="3732">
+      <svg width="270" height="3600">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -9832,76 +10115,67 @@
          <rect x="51" y="2687" width="100" height="32" rx="10"></rect>
          <rect x="49" y="2685" width="100" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="2705">RETURNING</text>
-         <rect x="51" y="2731" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="2729" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">ROLE</text>
-         <rect x="51" y="2775" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">SELECT</text>
-         <rect x="51" y="2819" width="126" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="126" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">SESSION_USER</text>
-         <rect x="51" y="2863" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">SOME</text>
-         <rect x="51" y="2907" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">STORED</text>
-         <rect x="51" y="2951" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">SYMMETRIC</text>
-         <rect x="51" y="2995" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">TABLE</text>
-         <rect x="51" y="3039" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">THEN</text>
-         <rect x="51" y="3083" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">TO</text>
-         <rect x="51" y="3127" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">TRAILING</text>
-         <rect x="51" y="3171" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">TRUE</text>
-         <rect x="51" y="3215" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">UNION</text>
-         <rect x="51" y="3259" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3257" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">UNIQUE</text>
-         <rect x="51" y="3303" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">USER</text>
-         <rect x="51" y="3347" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">USING</text>
-         <rect x="51" y="3391" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">VARIADIC</text>
-         <rect x="51" y="3435" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">VIEW</text>
-         <rect x="51" y="3479" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">VIRTUAL</text>
-         <rect x="51" y="3523" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">WHEN</text>
-         <rect x="51" y="3567" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">WHERE</text>
-         <rect x="51" y="3611" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">WINDOW</text>
-         <rect x="51" y="3655" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">WITH</text>
-         <rect x="51" y="3699" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="3697" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">WORK</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m46 0 h10 m0 0 h126 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m110 0 h10 m0 0 h62 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m78 0 h10 m0 0 h94 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m108 0 h10 m0 0 h64 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m72 0 h10 m0 0 h100 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m156 0 h10 m0 0 h16 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m148 0 h10 m0 0 h24 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m52 0 h10 m0 0 h120 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m36 0 h10 m0 0 h136 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m90 0 h10 m0 0 h82 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m94 0 h10 m0 0 h78 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m98 0 h10 m0 0 h74 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m144 0 h10 m0 0 h28 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m84 0 h10 m0 0 h88 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m88 0 h10 m0 0 h84 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m23 -3696 h-3"></path>
+         <rect x="51" y="2731" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2729" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2749">SELECT</text>
+         <rect x="51" y="2775" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">SESSION_USER</text>
+         <rect x="51" y="2819" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">SOME</text>
+         <rect x="51" y="2863" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">STORED</text>
+         <rect x="51" y="2907" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">SYMMETRIC</text>
+         <rect x="51" y="2951" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">TABLE</text>
+         <rect x="51" y="2995" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">THEN</text>
+         <rect x="51" y="3039" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">TO</text>
+         <rect x="51" y="3083" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">TRAILING</text>
+         <rect x="51" y="3127" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">TRUE</text>
+         <rect x="51" y="3171" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">UNION</text>
+         <rect x="51" y="3215" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">UNIQUE</text>
+         <rect x="51" y="3259" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3257" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3277">USER</text>
+         <rect x="51" y="3303" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">USING</text>
+         <rect x="51" y="3347" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">VARIADIC</text>
+         <rect x="51" y="3391" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">VIEW</text>
+         <rect x="51" y="3435" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">WHEN</text>
+         <rect x="51" y="3479" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">WHERE</text>
+         <rect x="51" y="3523" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">WINDOW</text>
+         <rect x="51" y="3567" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">WITH</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m46 0 h10 m0 0 h126 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m110 0 h10 m0 0 h62 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m78 0 h10 m0 0 h94 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m108 0 h10 m0 0 h64 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m72 0 h10 m0 0 h100 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m156 0 h10 m0 0 h16 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m148 0 h10 m0 0 h24 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m52 0 h10 m0 0 h120 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m36 0 h10 m0 0 h136 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m90 0 h10 m0 0 h82 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m94 0 h10 m0 0 h78 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m98 0 h10 m0 0 h74 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m144 0 h10 m0 0 h28 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m84 0 h10 m0 0 h88 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m88 0 h10 m0 0 h84 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m23 -3564 h-3"></path>
          <polygon points="261 17 269 13 269 21"></polygon>
          <polygon points="261 17 253 13 253 21"></polygon>
       </svg>
@@ -11297,7 +11571,7 @@
             <li><a href="#transaction_mode" title="transaction_mode">transaction_mode</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_cmd" href="#alter_table_cmd">alter_table_cmd:</a></p>
-      <svg width="800" height="484">
+      <svg width="800" height="528">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -11423,7 +11697,18 @@
             <rect x="49" y="449" width="90" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="469">partition_by</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m-518 0 h20 m498 0 h20 m-538 0 q10 0 10 10 m518 0 q0 -10 10 -10 m-528 10 v56 m518 0 v-56 m-518 56 q0 10 10 10 m498 0 q10 0 10 -10 m-508 10 h10 m116 0 h10 m0 0 h10 m152 0 h10 m0 0 h190 m20 -76 h116 m-742 0 h20 m722 0 h20 m-762 0 q10 0 10 10 m742 0 q0 -10 10 -10 m-752 10 v100 m742 0 v-100 m-742 100 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m146 0 h10 m0 0 h54 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m58 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m54 0 h10 m20 -44 h146 m-732 -10 v20 m742 0 v-20 m-742 20 v68 m742 0 v-68 m-742 68 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m58 0 h10 m20 0 h10 m90 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h34 m-470 0 h20 m450 0 h20 m-490 0 q10 0 10 10 m470 0 q0 -10 10 -10 m-480 10 v56 m470 0 v-56 m-470 56 q0 10 10 10 m450 0 q10 0 10 -10 m-460 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m120 0 h10 m20 -76 h10 m134 0 h10 m-732 -10 v20 m742 0 v-20 m-742 20 v132 m742 0 v-132 m-742 132 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m88 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m120 0 h10 m0 0 h346 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m176 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m90 0 h10 m0 0 h352 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m90 0 h10 m0 0 h612 m23 -448 h-3"></path>
+         <rect x="51" y="495" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="493" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="513">INJECT</text>
+         <rect x="137" y="495" width="102" height="32" rx="10"></rect>
+         <rect x="135" y="493" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="145" y="513">STATISTICS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="259" y="495" width="62" height="32"></rect>
+            <rect x="257" y="493" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="513">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m-518 0 h20 m498 0 h20 m-538 0 q10 0 10 10 m518 0 q0 -10 10 -10 m-528 10 v56 m518 0 v-56 m-518 56 q0 10 10 10 m498 0 q10 0 10 -10 m-508 10 h10 m116 0 h10 m0 0 h10 m152 0 h10 m0 0 h190 m20 -76 h116 m-742 0 h20 m722 0 h20 m-762 0 q10 0 10 10 m742 0 q0 -10 10 -10 m-752 10 v100 m742 0 v-100 m-742 100 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m146 0 h10 m0 0 h54 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m58 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m54 0 h10 m20 -44 h146 m-732 -10 v20 m742 0 v-20 m-742 20 v68 m742 0 v-68 m-742 68 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m58 0 h10 m20 0 h10 m90 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h34 m-470 0 h20 m450 0 h20 m-490 0 q10 0 10 10 m470 0 q0 -10 10 -10 m-480 10 v56 m470 0 v-56 m-470 56 q0 10 10 10 m450 0 q10 0 10 -10 m-460 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m120 0 h10 m20 -76 h10 m134 0 h10 m-732 -10 v20 m742 0 v-20 m-742 20 v132 m742 0 v-132 m-742 132 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m88 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m120 0 h10 m0 0 h346 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m176 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m90 0 h10 m0 0 h352 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m90 0 h10 m0 0 h612 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m66 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m62 0 h10 m0 0 h432 m23 -492 h-3"></path>
          <polygon points="791 17 799 13 799 21"></polygon>
          <polygon points="791 17 783 13 783 21"></polygon>
       </svg>

--- a/_includes/sql/v2.1/diagrams/show_ranges.html
+++ b/_includes/sql/v2.1/diagrams/show_ranges.html
@@ -1,0 +1,32 @@
+<div><svg width="710" height="80">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">SHOW</text>
+<rect x="113" y="3" width="188" height="32" rx="10"></rect>
+<rect x="111" y="1" width="188" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">EXPERIMENTAL_RANGES</text>
+<rect x="321" y="3" width="58" height="32" rx="10"></rect>
+<rect x="319" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="329" y="21">FROM</text>
+<rect x="419" y="3" width="62" height="32" rx="10"></rect>
+<rect x="417" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="427" y="21">TABLE</text>
+<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="501" y="3" width="90" height="32"></rect>
+<rect x="499" y="1" width="90" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="509" y="21">table_name</text>
+</a>
+<rect x="419" y="47" width="62" height="32" rx="10"></rect>
+<rect x="417" y="45" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="427" y="65">INDEX</text>
+<a xlink:href="sql-grammar.html#table_name_with_index" xlink:title="table_name_with_index">
+<rect x="501" y="47" width="162" height="32"></rect>
+<rect x="499" y="45" width="162" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="509" y="65">table_name_with_index</text>
+</a>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m188 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
+<polygon points="701 17 709 13 709 21"></polygon>
+<polygon points="701 17 693 13 693 21"></polygon>
+</svg></div>

--- a/_includes/sql/v2.1/diagrams/stmt_block.html
+++ b/_includes/sql/v2.1/diagrams/stmt_block.html
@@ -37,7 +37,7 @@
             <li><a href="#stmt_block" title="stmt_block">stmt_block</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="stmt" href="#stmt">stmt:</a></p>
-      <svg width="220" height="1376">
+      <svg width="220" height="1420">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
@@ -99,102 +99,107 @@
             <rect x="49" y="505" width="96" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="525">explain_stmt</text>
          </a>
+         <a xlink:href="#export_stmt" xlink:title="export_stmt">
+            <rect x="51" y="551" width="94" height="32"></rect>
+            <rect x="49" y="549" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="569">export_stmt</text>
+         </a>
          <a xlink:href="#grant_stmt" xlink:title="grant_stmt">
-            <rect x="51" y="551" width="86" height="32"></rect>
-            <rect x="49" y="549" width="86" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="569">grant_stmt</text>
+            <rect x="51" y="595" width="86" height="32"></rect>
+            <rect x="49" y="593" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="613">grant_stmt</text>
          </a>
          <a xlink:href="#insert_stmt" xlink:title="insert_stmt">
-            <rect x="51" y="595" width="88" height="32"></rect>
-            <rect x="49" y="593" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="613">insert_stmt</text>
+            <rect x="51" y="639" width="88" height="32"></rect>
+            <rect x="49" y="637" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="657">insert_stmt</text>
          </a>
          <a xlink:href="#import_stmt" xlink:title="import_stmt">
-            <rect x="51" y="639" width="94" height="32"></rect>
-            <rect x="49" y="637" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="657">import_stmt</text>
+            <rect x="51" y="683" width="94" height="32"></rect>
+            <rect x="49" y="681" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="701">import_stmt</text>
          </a>
          <a xlink:href="#pause_stmt" xlink:title="pause_stmt">
-            <rect x="51" y="683" width="90" height="32"></rect>
-            <rect x="49" y="681" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="701">pause_stmt</text>
+            <rect x="51" y="727" width="90" height="32"></rect>
+            <rect x="49" y="725" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="745">pause_stmt</text>
          </a>
          <a xlink:href="#prepare_stmt" xlink:title="prepare_stmt">
-            <rect x="51" y="727" width="102" height="32"></rect>
-            <rect x="49" y="725" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="745">prepare_stmt</text>
+            <rect x="51" y="771" width="102" height="32"></rect>
+            <rect x="49" y="769" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="789">prepare_stmt</text>
          </a>
          <a xlink:href="#restore_stmt" xlink:title="restore_stmt">
-            <rect x="51" y="771" width="98" height="32"></rect>
-            <rect x="49" y="769" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="789">restore_stmt</text>
+            <rect x="51" y="815" width="98" height="32"></rect>
+            <rect x="49" y="813" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="833">restore_stmt</text>
          </a>
          <a xlink:href="#resume_stmt" xlink:title="resume_stmt">
-            <rect x="51" y="815" width="100" height="32"></rect>
-            <rect x="49" y="813" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="833">resume_stmt</text>
+            <rect x="51" y="859" width="100" height="32"></rect>
+            <rect x="49" y="857" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="877">resume_stmt</text>
          </a>
          <a xlink:href="#revoke_stmt" xlink:title="revoke_stmt">
-            <rect x="51" y="859" width="98" height="32"></rect>
-            <rect x="49" y="857" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="877">revoke_stmt</text>
+            <rect x="51" y="903" width="98" height="32"></rect>
+            <rect x="49" y="901" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="921">revoke_stmt</text>
          </a>
          <a xlink:href="#savepoint_stmt" xlink:title="savepoint_stmt">
-            <rect x="51" y="903" width="114" height="32"></rect>
-            <rect x="49" y="901" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="921">savepoint_stmt</text>
+            <rect x="51" y="947" width="114" height="32"></rect>
+            <rect x="49" y="945" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="965">savepoint_stmt</text>
          </a>
          <a xlink:href="#scrub_stmt" xlink:title="scrub_stmt">
-            <rect x="51" y="947" width="88" height="32"></rect>
-            <rect x="49" y="945" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="965">scrub_stmt</text>
+            <rect x="51" y="991" width="88" height="32"></rect>
+            <rect x="49" y="989" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1009">scrub_stmt</text>
          </a>
          <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="51" y="991" width="90" height="32"></rect>
-            <rect x="49" y="989" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1009">select_stmt</text>
+            <rect x="51" y="1035" width="90" height="32"></rect>
+            <rect x="49" y="1033" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1053">select_stmt</text>
          </a>
          <a xlink:href="#release_stmt" xlink:title="release_stmt">
-            <rect x="51" y="1035" width="98" height="32"></rect>
-            <rect x="49" y="1033" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1053">release_stmt</text>
+            <rect x="51" y="1079" width="98" height="32"></rect>
+            <rect x="49" y="1077" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1097">release_stmt</text>
          </a>
          <a xlink:href="#reset_stmt" xlink:title="reset_stmt">
-            <rect x="51" y="1079" width="86" height="32"></rect>
-            <rect x="49" y="1077" width="86" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1097">reset_stmt</text>
+            <rect x="51" y="1123" width="86" height="32"></rect>
+            <rect x="49" y="1121" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1141">reset_stmt</text>
          </a>
          <a xlink:href="#set_stmt" xlink:title="set_stmt">
-            <rect x="51" y="1123" width="74" height="32"></rect>
-            <rect x="49" y="1121" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1141">set_stmt</text>
+            <rect x="51" y="1167" width="74" height="32"></rect>
+            <rect x="49" y="1165" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1185">set_stmt</text>
          </a>
          <a xlink:href="#show_stmt" xlink:title="show_stmt">
-            <rect x="51" y="1167" width="88" height="32"></rect>
-            <rect x="49" y="1165" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1185">show_stmt</text>
+            <rect x="51" y="1211" width="88" height="32"></rect>
+            <rect x="49" y="1209" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1229">show_stmt</text>
          </a>
          <a xlink:href="#transaction_stmt" xlink:title="transaction_stmt">
-            <rect x="51" y="1211" width="122" height="32"></rect>
-            <rect x="49" y="1209" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1229">transaction_stmt</text>
+            <rect x="51" y="1255" width="122" height="32"></rect>
+            <rect x="49" y="1253" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1273">transaction_stmt</text>
          </a>
          <a xlink:href="#truncate_stmt" xlink:title="truncate_stmt">
-            <rect x="51" y="1255" width="106" height="32"></rect>
-            <rect x="49" y="1253" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1273">truncate_stmt</text>
+            <rect x="51" y="1299" width="106" height="32"></rect>
+            <rect x="49" y="1297" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1317">truncate_stmt</text>
          </a>
          <a xlink:href="#update_stmt" xlink:title="update_stmt">
-            <rect x="51" y="1299" width="96" height="32"></rect>
-            <rect x="49" y="1297" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1317">update_stmt</text>
+            <rect x="51" y="1343" width="96" height="32"></rect>
+            <rect x="49" y="1341" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1361">update_stmt</text>
          </a>
          <a xlink:href="#upsert_stmt" xlink:title="upsert_stmt">
-            <rect x="51" y="1343" width="94" height="32"></rect>
-            <rect x="49" y="1341" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1361">upsert_stmt</text>
+            <rect x="51" y="1387" width="94" height="32"></rect>
+            <rect x="49" y="1385" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1405">upsert_stmt</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m116 0 h10 m0 0 h6 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m114 0 h10 m0 0 h8 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m74 0 h10 m0 0 h48 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m106 0 h10 m0 0 h16 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m23 -1352 h-3"></path>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m116 0 h10 m0 0 h6 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m92 0 h10 m0 0 h30 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m102 0 h10 m0 0 h20 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m100 0 h10 m0 0 h22 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m114 0 h10 m0 0 h8 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m90 0 h10 m0 0 h32 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m98 0 h10 m0 0 h24 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m86 0 h10 m0 0 h36 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m74 0 h10 m0 0 h48 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m88 0 h10 m0 0 h34 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m106 0 h10 m0 0 h16 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m96 0 h10 m0 0 h26 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m94 0 h10 m0 0 h28 m23 -1396 h-3"></path>
          <polygon points="211 5 219 1 219 9"></polygon>
          <polygon points="211 5 203 1 203 9"></polygon>
       </svg>
@@ -271,7 +276,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_stmt" href="#cancel_stmt">cancel_stmt:</a></p>
-      <svg width="232" height="80">
+      <svg width="242" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -285,9 +290,14 @@
             <rect x="49" y="45" width="134" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="65">cancel_query_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h14 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m23 -44 h-3"></path>
-         <polygon points="223 17 231 13 231 21"></polygon>
-         <polygon points="223 17 215 13 215 21"></polygon>
+         <a xlink:href="#cancel_session_stmt" xlink:title="cancel_session_stmt">
+            <rect x="51" y="91" width="144" height="32"></rect>
+            <rect x="49" y="89" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">cancel_session_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m120 0 h10 m0 0 h24 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m134 0 h10 m0 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m23 -88 h-3"></path>
+         <polygon points="233 17 241 13 241 21"></polygon>
+         <polygon points="233 17 225 13 225 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -537,6 +547,46 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h232 m-262 0 h20 m242 0 h20 m-282 0 q10 0 10 10 m262 0 q0 -10 10 -10 m-272 10 v12 m262 0 v-12 m-262 12 q0 10 10 10 m242 0 q10 0 10 -10 m-252 10 h10 m26 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m120 0 h10 m3 0 h-3"></path>
          <polygon points="549 17 557 13 557 21"></polygon>
          <polygon points="549 17 541 13 541 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#stmt" title="stmt">stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="export_stmt" href="#export_stmt">export_stmt:</a></p>
+      <svg width="656" height="102">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">EXPORT</text>
+         <rect x="125" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="123" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="21">INTO</text>
+         <rect x="199" y="3" width="46" height="32" rx="10"></rect>
+         <rect x="197" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="207" y="21">CSV</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="265" y="3" width="148" height="32"></rect>
+            <rect x="263" y="1" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="273" y="21">string_or_placeholder</text>
+         </a>
+         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
+            <rect x="433" y="3" width="124" height="32"></rect>
+            <rect x="431" y="1" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="441" y="21">opt_with_options</text>
+         </a>
+         <rect x="577" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="575" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="585" y="21">FROM</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="539" y="69" width="90" height="32"></rect>
+            <rect x="537" y="67" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="547" y="87">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m148 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
+         <polygon points="647 83 655 79 655 87"></polygon>
+         <polygon points="647 83 639 79 639 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -959,6 +1009,7 @@
             <li><a href="#alter_split_stmt" title="alter_split_stmt">alter_split_stmt</a></li>
             <li><a href="#create_table_as_stmt" title="create_table_as_stmt">create_table_as_stmt</a></li>
             <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#insert_rest" title="insert_rest">insert_rest</a></li>
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
             <li><a href="#stmt" title="stmt">stmt</a></li>
@@ -1042,7 +1093,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stmt" href="#show_stmt">show_stmt:</a></p>
-      <svg width="296" height="916">
+      <svg width="296" height="960">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1111,47 +1162,52 @@
             <rect x="49" y="529" width="138" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="549">show_queries_stmt</text>
          </a>
+         <a xlink:href="#show_ranges_stmt" xlink:title="show_ranges_stmt">
+            <rect x="51" y="575" width="136" height="32"></rect>
+            <rect x="49" y="573" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="593">show_ranges_stmt</text>
+         </a>
          <a xlink:href="#show_roles_stmt" xlink:title="show_roles_stmt">
-            <rect x="51" y="575" width="124" height="32"></rect>
-            <rect x="49" y="573" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="593">show_roles_stmt</text>
+            <rect x="51" y="619" width="124" height="32"></rect>
+            <rect x="49" y="617" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="637">show_roles_stmt</text>
          </a>
          <a xlink:href="#show_schemas_stmt" xlink:title="show_schemas_stmt">
-            <rect x="51" y="619" width="148" height="32"></rect>
-            <rect x="49" y="617" width="148" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="637">show_schemas_stmt</text>
+            <rect x="51" y="663" width="148" height="32"></rect>
+            <rect x="49" y="661" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="681">show_schemas_stmt</text>
          </a>
          <a xlink:href="#show_session_stmt" xlink:title="show_session_stmt">
-            <rect x="51" y="663" width="140" height="32"></rect>
-            <rect x="49" y="661" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="681">show_session_stmt</text>
+            <rect x="51" y="707" width="140" height="32"></rect>
+            <rect x="49" y="705" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="725">show_session_stmt</text>
          </a>
          <a xlink:href="#show_sessions_stmt" xlink:title="show_sessions_stmt">
-            <rect x="51" y="707" width="146" height="32"></rect>
-            <rect x="49" y="705" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="725">show_sessions_stmt</text>
+            <rect x="51" y="751" width="146" height="32"></rect>
+            <rect x="49" y="749" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="769">show_sessions_stmt</text>
          </a>
          <a xlink:href="#show_stats_stmt" xlink:title="show_stats_stmt">
-            <rect x="51" y="751" width="126" height="32"></rect>
-            <rect x="49" y="749" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="769">show_stats_stmt</text>
+            <rect x="51" y="795" width="126" height="32"></rect>
+            <rect x="49" y="793" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="813">show_stats_stmt</text>
          </a>
          <a xlink:href="#show_tables_stmt" xlink:title="show_tables_stmt">
-            <rect x="51" y="795" width="130" height="32"></rect>
-            <rect x="49" y="793" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="813">show_tables_stmt</text>
+            <rect x="51" y="839" width="130" height="32"></rect>
+            <rect x="49" y="837" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="857">show_tables_stmt</text>
          </a>
          <a xlink:href="#show_trace_stmt" xlink:title="show_trace_stmt">
-            <rect x="51" y="839" width="126" height="32"></rect>
-            <rect x="49" y="837" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="857">show_trace_stmt</text>
+            <rect x="51" y="883" width="126" height="32"></rect>
+            <rect x="49" y="881" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="901">show_trace_stmt</text>
          </a>
          <a xlink:href="#show_users_stmt" xlink:title="show_users_stmt">
-            <rect x="51" y="883" width="128" height="32"></rect>
-            <rect x="49" y="881" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="901">show_users_stmt</text>
+            <rect x="51" y="927" width="128" height="32"></rect>
+            <rect x="49" y="925" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="945">show_users_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m138 0 h10 m0 0 h60 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m162 0 h10 m0 0 h36 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m170 0 h10 m0 0 h28 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m168 0 h10 m0 0 h30 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m198 0 h10 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m134 0 h10 m0 0 h64 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m122 0 h10 m0 0 h76 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m138 0 h10 m0 0 h60 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m124 0 h10 m0 0 h74 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m130 0 h10 m0 0 h68 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m128 0 h10 m0 0 h70 m23 -880 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m138 0 h10 m0 0 h60 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m162 0 h10 m0 0 h36 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m170 0 h10 m0 0 h28 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m168 0 h10 m0 0 h30 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m198 0 h10 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m134 0 h10 m0 0 h64 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m156 0 h10 m0 0 h42 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m122 0 h10 m0 0 h76 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m138 0 h10 m0 0 h60 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m136 0 h10 m0 0 h62 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m124 0 h10 m0 0 h74 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m148 0 h10 m0 0 h50 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m140 0 h10 m0 0 h58 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m146 0 h10 m0 0 h52 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m130 0 h10 m0 0 h68 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m126 0 h10 m0 0 h72 m-228 -10 v20 m238 0 v-20 m-238 20 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m128 0 h10 m0 0 h70 m23 -924 h-3"></path>
          <polygon points="287 17 295 13 295 21"></polygon>
          <polygon points="287 17 279 13 279 21"></polygon>
       </svg>
@@ -1378,37 +1434,63 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="targets" href="#targets">targets:</a></p>
-      <svg width="344" height="112">
+      <svg width="426" height="300">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="35" width="62" height="32" rx="10"></rect>
-         <rect x="69" y="33" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="53">TABLE</text>
+         <rect x="51" y="3" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">identifier</text>
+         <a xlink:href="#col_name_keyword" xlink:title="col_name_keyword">
+            <rect x="51" y="47" width="138" height="32"></rect>
+            <rect x="49" y="45" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">col_name_keyword</text>
+         </a>
+         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
+            <rect x="51" y="91" width="146" height="32"></rect>
+            <rect x="49" y="89" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">unreserved_keyword</text>
+         </a>
+         <a xlink:href="#complex_table_pattern" xlink:title="complex_table_pattern">
+            <rect x="51" y="135" width="158" height="32"></rect>
+            <rect x="49" y="133" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">complex_table_pattern</text>
+         </a>
+         <a xlink:href="#table_pattern" xlink:title="table_pattern">
+            <rect x="71" y="179" width="100" height="32"></rect>
+            <rect x="69" y="177" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="197">table_pattern</text>
+         </a>
+         <rect x="191" y="179" width="24" height="32" rx="10"></rect>
+         <rect x="189" y="177" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="199" y="197">,</text>
+         <rect x="71" y="223" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="221" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="241">TABLE</text>
          <a xlink:href="#table_pattern_list" xlink:title="table_pattern_list">
-            <rect x="173" y="3" width="124" height="32"></rect>
-            <rect x="171" y="1" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="181" y="21">table_pattern_list</text>
+            <rect x="255" y="179" width="124" height="32"></rect>
+            <rect x="253" y="177" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="263" y="197">table_pattern_list</text>
          </a>
-         <rect x="51" y="79" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="77" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="97">DATABASE</text>
+         <rect x="51" y="267" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">DATABASE</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="163" y="79" width="78" height="32"></rect>
-            <rect x="161" y="77" width="78" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="171" y="97">name_list</text>
+            <rect x="163" y="267" width="78" height="32"></rect>
+            <rect x="161" y="265" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="171" y="285">name_list</text>
          </a>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -32 h10 m124 0 h10 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v56 m286 0 v-56 m-286 56 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m92 0 h10 m0 0 h10 m78 0 h10 m0 0 h56 m23 -76 h-3"></path>
-         <polygon points="335 17 343 13 343 21"></polygon>
-         <polygon points="335 17 327 13 327 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m78 0 h10 m0 0 h250 m-368 0 h20 m348 0 h20 m-388 0 q10 0 10 10 m368 0 q0 -10 10 -10 m-378 10 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m138 0 h10 m0 0 h190 m-358 -10 v20 m368 0 v-20 m-368 20 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m146 0 h10 m0 0 h182 m-358 -10 v20 m368 0 v-20 m-368 20 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m158 0 h10 m0 0 h170 m-358 -10 v20 m368 0 v-20 m-368 20 v24 m368 0 v-24 m-368 24 q0 10 10 10 m348 0 q10 0 10 -10 m-338 10 h10 m100 0 h10 m0 0 h10 m24 0 h10 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m62 0 h10 m0 0 h82 m20 -44 h10 m124 0 h10 m-358 -10 v20 m368 0 v-20 m-368 20 v68 m368 0 v-68 m-368 68 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m92 0 h10 m0 0 h10 m78 0 h10 m0 0 h138 m23 -264 h-3"></path>
+         <polygon points="417 17 425 13 425 21"></polygon>
+         <polygon points="417 17 409 13 409 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
-            <li><a href="#on_privilege_target_clause" title="on_privilege_target_clause">on_privilege_target_clause</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
+            <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="string_or_placeholder" href="#string_or_placeholder">string_or_placeholder:</a></p>
       <svg width="306" height="80">
@@ -1433,6 +1515,7 @@
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#create_role_stmt" title="create_role_stmt">create_role_stmt</a></li>
             <li><a href="#create_user_stmt" title="create_user_stmt">create_user_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
             <li><a href="#kv_option" title="kv_option">kv_option</a></li>
             <li><a href="#opt_password" title="opt_password">opt_password</a></li>
@@ -1518,6 +1601,7 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
          </ul>
@@ -1546,7 +1630,7 @@
             <li><a href="#cancel_stmt" title="cancel_stmt">cancel_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_query_stmt" href="#cancel_query_stmt">cancel_query_stmt:</a></p>
-      <svg width="298" height="36">
+      <svg width="480" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1556,14 +1640,50 @@
          <rect x="123" y="3" width="66" height="32" rx="10"></rect>
          <rect x="121" y="1" width="66" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="131" y="21">QUERY</text>
+         <rect x="229" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="227" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="237" y="53">IF</text>
+         <rect x="283" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="281" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="291" y="53">EXISTS</text>
          <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="209" y="3" width="62" height="32"></rect>
-            <rect x="207" y="1" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="217" y="21">a_expr</text>
+            <rect x="391" y="3" width="62" height="32"></rect>
+            <rect x="389" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="399" y="21">a_expr</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m62 0 h10 m3 0 h-3"></path>
-         <polygon points="289 17 297 13 297 21"></polygon>
-         <polygon points="289 17 281 13 281 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m62 0 h10 m3 0 h-3"></path>
+         <polygon points="471 17 479 13 479 21"></polygon>
+         <polygon points="471 17 463 13 463 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#cancel_stmt" title="cancel_stmt">cancel_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_session_stmt" href="#cancel_session_stmt">cancel_session_stmt:</a></p>
+      <svg width="494" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CANCEL</text>
+         <rect x="123" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="121" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="131" y="21">SESSION</text>
+         <rect x="243" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="241" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="251" y="53">IF</text>
+         <rect x="297" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="295" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="305" y="53">EXISTS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="405" y="3" width="62" height="32"></rect>
+            <rect x="403" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="413" y="21">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m62 0 h10 m3 0 h-3"></path>
+         <polygon points="485 17 493 13 493 21"></polygon>
+         <polygon points="485 17 477 13 477 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1604,6 +1724,7 @@
             <li><a href="#show_constraints_stmt" title="show_constraints_stmt">show_constraints_stmt</a></li>
             <li><a href="#show_create_table_stmt" title="show_create_table_stmt">show_create_table_stmt</a></li>
             <li><a href="#show_indexes_stmt" title="show_indexes_stmt">show_indexes_stmt</a></li>
+            <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
             <li><a href="#show_stats_stmt" title="show_stats_stmt">show_stats_stmt</a></li>
             <li><a href="#sortby" title="sortby">sortby</a></li>
             <li><a href="#table_name_list" title="table_name_list">table_name_list</a></li>
@@ -1824,9 +1945,10 @@
             <li><a href="#column_name" title="column_name">column_name</a></li>
             <li><a href="#column_path" title="column_path">column_path</a></li>
             <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
+            <li><a href="#complex_db_object_name" title="complex_db_object_name">complex_db_object_name</a></li>
+            <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
             <li><a href="#constraint_name" title="constraint_name">constraint_name</a></li>
             <li><a href="#database_name" title="database_name">database_name</a></li>
-            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
             <li><a href="#deallocate_stmt" title="deallocate_stmt">deallocate_stmt</a></li>
             <li><a href="#family_name" title="family_name">family_name</a></li>
             <li><a href="#kv_option" title="kv_option">kv_option</a></li>
@@ -1840,9 +1962,9 @@
             <li><a href="#savepoint_stmt" title="savepoint_stmt">savepoint_stmt</a></li>
             <li><a href="#show_schemas_stmt" title="show_schemas_stmt">show_schemas_stmt</a></li>
             <li><a href="#show_tables_stmt" title="show_tables_stmt">show_tables_stmt</a></li>
+            <li><a href="#simple_db_object_name" title="simple_db_object_name">simple_db_object_name</a></li>
             <li><a href="#statistics_name" title="statistics_name">statistics_name</a></li>
             <li><a href="#table_alias_name" title="table_alias_name">table_alias_name</a></li>
-            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
             <li><a href="#var_name" title="var_name">var_name</a></li>
             <li><a href="#window_name" title="window_name">window_name</a></li>
          </ul>
@@ -2251,12 +2373,12 @@
             <li><a href="#opt_column_list" title="opt_column_list">opt_column_list</a></li>
             <li><a href="#opt_conf_expr" title="opt_conf_expr">opt_conf_expr</a></li>
             <li><a href="#opt_interleave" title="opt_interleave">opt_interleave</a></li>
-            <li><a href="#opt_name_list" title="opt_name_list">opt_name_list</a></li>
             <li><a href="#opt_storing" title="opt_storing">opt_storing</a></li>
             <li><a href="#partition_by" title="partition_by">partition_by</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
             <li><a href="#scrub_option" title="scrub_option">scrub_option</a></li>
             <li><a href="#targets" title="targets">targets</a></li>
+            <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="privilege_list" href="#privilege_list">privilege_list:</a></p>
       <svg width="166" height="80">
@@ -3141,9 +3263,11 @@
          </p><ul>
             <li><a href="#a_expr" title="a_expr">a_expr</a></li>
             <li><a href="#alter_column_default" title="alter_column_default">alter_column_default</a></li>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
             <li><a href="#array_subscript" title="array_subscript">array_subscript</a></li>
             <li><a href="#cancel_job_stmt" title="cancel_job_stmt">cancel_job_stmt</a></li>
             <li><a href="#cancel_query_stmt" title="cancel_query_stmt">cancel_query_stmt</a></li>
+            <li><a href="#cancel_session_stmt" title="cancel_session_stmt">cancel_session_stmt</a></li>
             <li><a href="#case_arg" title="case_arg">case_arg</a></li>
             <li><a href="#case_default" title="case_default">case_default</a></li>
             <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
@@ -3938,7 +4062,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_grants_stmt" href="#show_grants_stmt">show_grants_stmt:</a></p>
-      <svg width="670" height="80">
+      <svg width="538" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -3948,30 +4072,19 @@
          <rect x="113" y="3" width="74" height="32" rx="10"></rect>
          <rect x="111" y="1" width="74" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="121" y="21">GRANTS</text>
-         <rect x="227" y="3" width="40" height="32" rx="10"></rect>
-         <rect x="225" y="1" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="235" y="21">ON</text>
-         <rect x="287" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="285" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="295" y="21">ROLE</text>
-         <a xlink:href="#opt_name_list" xlink:title="opt_name_list">
-            <rect x="363" y="3" width="106" height="32"></rect>
-            <rect x="361" y="1" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="371" y="21">opt_name_list</text>
-         </a>
-         <a xlink:href="#on_privilege_target_clause" xlink:title="on_privilege_target_clause">
-            <rect x="227" y="47" width="180" height="32"></rect>
-            <rect x="225" y="45" width="180" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="235" y="65">on_privilege_target_clause</text>
+         <a xlink:href="#opt_on_targets_roles" xlink:title="opt_on_targets_roles">
+            <rect x="207" y="3" width="150" height="32"></rect>
+            <rect x="205" y="1" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="215" y="21">opt_on_targets_roles</text>
          </a>
          <a xlink:href="#for_grantee_clause" xlink:title="for_grantee_clause">
-            <rect x="509" y="3" width="134" height="32"></rect>
-            <rect x="507" y="1" width="134" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="517" y="21">for_grantee_clause</text>
+            <rect x="377" y="3" width="134" height="32"></rect>
+            <rect x="375" y="1" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="385" y="21">for_grantee_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m106 0 h10 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v24 m282 0 v-24 m-282 24 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m180 0 h10 m0 0 h62 m20 -44 h10 m134 0 h10 m3 0 h-3"></path>
-         <polygon points="661 17 669 13 669 21"></polygon>
-         <polygon points="661 17 653 13 653 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m150 0 h10 m0 0 h10 m134 0 h10 m3 0 h-3"></path>
+         <polygon points="529 17 537 13 537 21"></polygon>
+         <polygon points="529 17 521 13 521 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4076,6 +4189,46 @@
          </p><ul>
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_ranges_stmt" href="#show_ranges_stmt">show_ranges_stmt:</a></p>
+      <svg width="608" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <a xlink:href="#ranges_kw" xlink:title="ranges_kw">
+            <rect x="113" y="3" width="86" height="32"></rect>
+            <rect x="111" y="1" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="121" y="21">ranges_kw</text>
+         </a>
+         <rect x="219" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="217" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="227" y="21">FROM</text>
+         <rect x="317" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="315" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="325" y="21">TABLE</text>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="399" y="3" width="90" height="32"></rect>
+            <rect x="397" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="21">table_name</text>
+         </a>
+         <rect x="317" y="47" width="62" height="32" rx="10"></rect>
+         <rect x="315" y="45" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="325" y="65">INDEX</text>
+         <a xlink:href="#table_name_with_index" xlink:title="table_name_with_index">
+            <rect x="399" y="47" width="162" height="32"></rect>
+            <rect x="397" y="45" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="65">table_name_with_index</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
+         <polygon points="599 17 607 13 607 21"></polygon>
+         <polygon points="599 17 591 13 591 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_roles_stmt" href="#show_roles_stmt">show_roles_stmt:</a></p>
       <svg width="204" height="36">
          
@@ -4172,7 +4325,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stats_stmt" href="#show_stats_stmt">show_stats_stmt:</a></p>
-      <svg width="502" height="36">
+      <svg width="700" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -4182,20 +4335,26 @@
          <rect x="113" y="3" width="102" height="32" rx="10"></rect>
          <rect x="111" y="1" width="102" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="121" y="21">STATISTICS</text>
-         <rect x="235" y="3" width="48" height="32" rx="10"></rect>
-         <rect x="233" y="1" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="243" y="21">FOR</text>
-         <rect x="303" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="301" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="311" y="21">TABLE</text>
+         <rect x="255" y="35" width="64" height="32" rx="10"></rect>
+         <rect x="253" y="33" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="263" y="53">USING</text>
+         <rect x="339" y="35" width="54" height="32" rx="10"></rect>
+         <rect x="337" y="33" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="347" y="53">JSON</text>
+         <rect x="433" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="431" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="441" y="21">FOR</text>
+         <rect x="501" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="499" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="21">TABLE</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="385" y="3" width="90" height="32"></rect>
-            <rect x="383" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="393" y="21">table_name</text>
+            <rect x="583" y="3" width="90" height="32"></rect>
+            <rect x="581" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="591" y="21">table_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="493 17 501 13 501 21"></polygon>
-         <polygon points="493 17 485 13 485 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m64 0 h10 m0 0 h10 m54 0 h10 m20 -32 h10 m48 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></path>
+         <polygon points="691 17 699 13 699 21"></polygon>
+         <polygon points="691 17 683 13 683 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4641,6 +4800,869 @@
          </p><ul>
             <li><a href="#alter_user_stmt" title="alter_user_stmt">alter_user_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_name_keyword" href="#col_name_keyword">col_name_keyword:</a></p>
+      <svg width="260" height="1796">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="134" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ANNOTATE_TYPE</text>
+         <rect x="51" y="47" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">BETWEEN</text>
+         <rect x="51" y="91" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">BIGINT</text>
+         <rect x="51" y="135" width="42" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="42" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">BIT</text>
+         <rect x="51" y="179" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">BOOLEAN</text>
+         <rect x="51" y="223" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">CHAR</text>
+         <rect x="51" y="267" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">CHARACTER</text>
+         <rect x="51" y="311" width="148" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="148" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">CHARACTERISTICS</text>
+         <rect x="51" y="355" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">COALESCE</text>
+         <rect x="51" y="399" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">DEC</text>
+         <rect x="51" y="443" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">DECIMAL</text>
+         <rect x="51" y="487" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">EXISTS</text>
+         <rect x="51" y="531" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">EXTRACT</text>
+         <rect x="51" y="575" width="162" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="162" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">EXTRACT_DURATION</text>
+         <rect x="51" y="619" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">FLOAT</text>
+         <rect x="51" y="663" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">GREATEST</text>
+         <rect x="51" y="707" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">GROUPING</text>
+         <rect x="51" y="751" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">IF</text>
+         <rect x="51" y="795" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">IFNULL</text>
+         <rect x="51" y="839" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">INT</text>
+         <rect x="51" y="883" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">INTEGER</text>
+         <rect x="51" y="927" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">INTERVAL</text>
+         <rect x="51" y="971" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">LEAST</text>
+         <rect x="51" y="1015" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">NULLIF</text>
+         <rect x="51" y="1059" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">NUMERIC</text>
+         <rect x="51" y="1103" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">OUT</text>
+         <rect x="51" y="1147" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">OVERLAY</text>
+         <rect x="51" y="1191" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">POSITION</text>
+         <rect x="51" y="1235" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">PRECISION</text>
+         <rect x="51" y="1279" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">REAL</text>
+         <rect x="51" y="1323" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">ROW</text>
+         <rect x="51" y="1367" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">SMALLINT</text>
+         <rect x="51" y="1411" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">SUBSTRING</text>
+         <rect x="51" y="1455" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">TIME</text>
+         <rect x="51" y="1499" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">TIMESTAMP</text>
+         <rect x="51" y="1543" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">TREAT</text>
+         <rect x="51" y="1587" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">TRIM</text>
+         <rect x="51" y="1631" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">VALUES</text>
+         <rect x="51" y="1675" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">VARCHAR</text>
+         <rect x="51" y="1719" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">VIRTUAL</text>
+         <rect x="51" y="1763" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">WORK</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m134 0 h10 m0 0 h28 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m148 0 h10 m0 0 h14 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m23 -1760 h-3"></path>
+         <polygon points="251 17 259 13 259 21"></polygon>
+         <polygon points="251 17 243 13 243 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#name" title="name">name</a></li>
+            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
+      <svg width="332" height="9452">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ABORT</text>
+         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">ACTION</text>
+         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">ADD</text>
+         <rect x="51" y="135" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">ADMIN</text>
+         <rect x="51" y="179" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">ALTER</text>
+         <rect x="51" y="223" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">AT</text>
+         <rect x="51" y="267" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">BACKUP</text>
+         <rect x="51" y="311" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">BEGIN</text>
+         <rect x="51" y="355" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">BIGSERIAL</text>
+         <rect x="51" y="399" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">BLOB</text>
+         <rect x="51" y="443" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">BOOL</text>
+         <rect x="51" y="487" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">BY</text>
+         <rect x="51" y="531" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">BYTEA</text>
+         <rect x="51" y="575" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">BYTES</text>
+         <rect x="51" y="619" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">CACHE</text>
+         <rect x="51" y="663" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">CANCEL</text>
+         <rect x="51" y="707" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">CASCADE</text>
+         <rect x="51" y="751" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">CLUSTER</text>
+         <rect x="51" y="795" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">COLUMNS</text>
+         <rect x="51" y="839" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">COMMENT</text>
+         <rect x="51" y="883" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">COMMIT</text>
+         <rect x="51" y="927" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">COMMITTED</text>
+         <rect x="51" y="971" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">COMPACT</text>
+         <rect x="51" y="1015" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">CONFLICT</text>
+         <rect x="51" y="1059" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">CONFIGURATION</text>
+         <rect x="51" y="1103" width="144" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="144" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">CONFIGURATIONS</text>
+         <rect x="51" y="1147" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">CONFIGURE</text>
+         <rect x="51" y="1191" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">CONSTRAINTS</text>
+         <rect x="51" y="1235" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">COPY</text>
+         <rect x="51" y="1279" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">COVERING</text>
+         <rect x="51" y="1323" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">CSV</text>
+         <rect x="51" y="1367" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">CUBE</text>
+         <rect x="51" y="1411" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">CURRENT</text>
+         <rect x="51" y="1455" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">CYCLE</text>
+         <rect x="51" y="1499" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">DATA</text>
+         <rect x="51" y="1543" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">DATABASE</text>
+         <rect x="51" y="1587" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">DATABASES</text>
+         <rect x="51" y="1631" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">DATE</text>
+         <rect x="51" y="1675" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">DAY</text>
+         <rect x="51" y="1719" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">DEALLOCATE</text>
+         <rect x="51" y="1763" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">DELETE</text>
+         <rect x="51" y="1807" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">DISCARD</text>
+         <rect x="51" y="1851" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="1849" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1869">DOUBLE</text>
+         <rect x="51" y="1895" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">DROP</text>
+         <rect x="51" y="1939" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">EMIT</text>
+         <rect x="51" y="1983" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">ENCODING</text>
+         <rect x="51" y="2027" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="2025" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2045">EXECUTE</text>
+         <rect x="51" y="2071" width="124" height="32" rx="10"></rect>
+         <rect x="49" y="2069" width="124" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2089">EXPERIMENTAL</text>
+         <rect x="51" y="2115" width="176" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="176" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">EXPERIMENTAL_AUDIT</text>
+         <rect x="51" y="2159" width="222" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="222" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">EXPERIMENTAL_CHANGEFEED</text>
+         <rect x="51" y="2203" width="234" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="234" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">EXPERIMENTAL_FINGERPRINTS</text>
+         <rect x="51" y="2247" width="188" height="32" rx="10"></rect>
+         <rect x="49" y="2245" width="188" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2265">EXPERIMENTAL_RANGES</text>
+         <rect x="51" y="2291" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="2289" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2309">EXPERIMENTAL_RELOCATE</text>
+         <rect x="51" y="2335" width="192" height="32" rx="10"></rect>
+         <rect x="49" y="2333" width="192" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2353">EXPERIMENTAL_REPLICA</text>
+         <rect x="51" y="2379" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="2377" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2397">EXPLAIN</text>
+         <rect x="51" y="2423" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2421" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2441">EXPORT</text>
+         <rect x="51" y="2467" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="2465" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2485">FILTER</text>
+         <rect x="51" y="2511" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="2509" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2529">FIRST</text>
+         <rect x="51" y="2555" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2553" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2573">FLOAT4</text>
+         <rect x="51" y="2599" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2597" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2617">FLOAT8</text>
+         <rect x="51" y="2643" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="2641" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2661">FOLLOWING</text>
+         <rect x="51" y="2687" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="2685" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2705">FORCE_INDEX</text>
+         <rect x="51" y="2731" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="2729" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2749">GIN</text>
+         <rect x="51" y="2775" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">GRANTS</text>
+         <rect x="51" y="2819" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">HIGH</text>
+         <rect x="51" y="2863" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">HISTOGRAM</text>
+         <rect x="51" y="2907" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">HOUR</text>
+         <rect x="51" y="2951" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">IMPORT</text>
+         <rect x="51" y="2995" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">INCREMENT</text>
+         <rect x="51" y="3039" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">INCREMENTAL</text>
+         <rect x="51" y="3083" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">INDEXES</text>
+         <rect x="51" y="3127" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">INET</text>
+         <rect x="51" y="3171" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">INJECT</text>
+         <rect x="51" y="3215" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">INSERT</text>
+         <rect x="51" y="3259" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3257" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3277">INT2</text>
+         <rect x="51" y="3303" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">INT2VECTOR</text>
+         <rect x="51" y="3347" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">INT4</text>
+         <rect x="51" y="3391" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">INT8</text>
+         <rect x="51" y="3435" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">INT64</text>
+         <rect x="51" y="3479" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">INTERLEAVE</text>
+         <rect x="51" y="3523" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">INVERTED</text>
+         <rect x="51" y="3567" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">ISOLATION</text>
+         <rect x="51" y="3611" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="3609" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3629">JOB</text>
+         <rect x="51" y="3655" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3653" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3673">JOBS</text>
+         <rect x="51" y="3699" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3697" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3717">JSON</text>
+         <rect x="51" y="3743" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3741" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3761">JSONB</text>
+         <rect x="51" y="3787" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="3785" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3805">KEY</text>
+         <rect x="51" y="3831" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3829" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3849">KEYS</text>
+         <rect x="51" y="3875" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="3873" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3893">KV</text>
+         <rect x="51" y="3919" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="3917" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3937">LC_COLLATE</text>
+         <rect x="51" y="3963" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="3961" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3981">LC_CTYPE</text>
+         <rect x="51" y="4007" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="4005" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4025">LESS</text>
+         <rect x="51" y="4051" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="4049" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4069">LEVEL</text>
+         <rect x="51" y="4095" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="4093" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4113">LIST</text>
+         <rect x="51" y="4139" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="4137" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4157">LOCAL</text>
+         <rect x="51" y="4183" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="4181" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4201">LOW</text>
+         <rect x="51" y="4227" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="4225" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4245">MATCH</text>
+         <rect x="51" y="4271" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="4269" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4289">MINUTE</text>
+         <rect x="51" y="4315" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="4313" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4333">MONTH</text>
+         <rect x="51" y="4359" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="4357" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4377">NAMES</text>
+         <rect x="51" y="4403" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="4401" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4421">NAN</text>
+         <rect x="51" y="4447" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="4445" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4465">NAME</text>
+         <rect x="51" y="4491" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="4489" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4509">NEXT</text>
+         <rect x="51" y="4535" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="4533" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4553">NO</text>
+         <rect x="51" y="4579" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="4577" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4597">NORMAL</text>
+         <rect x="51" y="4623" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="4621" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4641">NO_INDEX_JOIN</text>
+         <rect x="51" y="4667" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="4665" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4685">NULLS</text>
+         <rect x="51" y="4711" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="4709" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4729">OF</text>
+         <rect x="51" y="4755" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4753" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4773">OFF</text>
+         <rect x="51" y="4799" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4797" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4817">OID</text>
+         <rect x="51" y="4843" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="4841" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4861">OIDVECTOR</text>
+         <rect x="51" y="4887" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4885" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4905">OPTION</text>
+         <rect x="51" y="4931" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="4929" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4949">OPTIONS</text>
+         <rect x="51" y="4975" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="4973" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4993">ORDINALITY</text>
+         <rect x="51" y="5019" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5017" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5037">OVER</text>
+         <rect x="51" y="5063" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="5061" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5081">OWNED</text>
+         <rect x="51" y="5107" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="5105" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5125">PARENT</text>
+         <rect x="51" y="5151" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5149" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5169">PARTIAL</text>
+         <rect x="51" y="5195" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="5193" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5213">PARTITION</text>
+         <rect x="51" y="5239" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5237" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5257">PASSWORD</text>
+         <rect x="51" y="5283" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5281" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5301">PAUSE</text>
+         <rect x="51" y="5327" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="5325" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5345">PHYSICAL</text>
+         <rect x="51" y="5371" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5369" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5389">PLANS</text>
+         <rect x="51" y="5415" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5413" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5433">PRECEDING</text>
+         <rect x="51" y="5459" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="5457" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5477">PREPARE</text>
+         <rect x="51" y="5503" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="5501" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5521">PRIORITY</text>
+         <rect x="51" y="5547" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5545" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5565">QUERIES</text>
+         <rect x="51" y="5591" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5589" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5609">QUERY</text>
+         <rect x="51" y="5635" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5633" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5653">RANGE</text>
+         <rect x="51" y="5679" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5677" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5697">READ</text>
+         <rect x="51" y="5723" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5721" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5741">RECURSIVE</text>
+         <rect x="51" y="5767" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="5765" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5785">REF</text>
+         <rect x="51" y="5811" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="5809" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5829">REGCLASS</text>
+         <rect x="51" y="5855" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="5853" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5873">REGPROC</text>
+         <rect x="51" y="5899" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="5897" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5917">REGPROCEDURE</text>
+         <rect x="51" y="5943" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="5941" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5961">REGNAMESPACE</text>
+         <rect x="51" y="5987" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5985" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6005">REGTYPE</text>
+         <rect x="51" y="6031" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="6029" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6049">RELEASE</text>
+         <rect x="51" y="6075" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="6073" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6093">RENAME</text>
+         <rect x="51" y="6119" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="6117" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6137">REPEATABLE</text>
+         <rect x="51" y="6163" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="6161" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6181">RESET</text>
+         <rect x="51" y="6207" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="6205" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6225">RESTORE</text>
+         <rect x="51" y="6251" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="6249" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6269">RESTRICT</text>
+         <rect x="51" y="6295" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6293" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6313">RESUME</text>
+         <rect x="51" y="6339" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6337" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6357">REVOKE</text>
+         <rect x="51" y="6383" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="6381" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6401">ROLE</text>
+         <rect x="51" y="6427" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="6425" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6445">ROLES</text>
+         <rect x="51" y="6471" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="6469" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6489">ROLLBACK</text>
+         <rect x="51" y="6515" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6513" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6533">ROLLUP</text>
+         <rect x="51" y="6559" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="6557" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6577">ROWS</text>
+         <rect x="51" y="6603" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6601" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6621">SETTING</text>
+         <rect x="51" y="6647" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="6645" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6665">SETTINGS</text>
+         <rect x="51" y="6691" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6689" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6709">STATUS</text>
+         <rect x="51" y="6735" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="6733" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6753">SAVEPOINT</text>
+         <rect x="51" y="6779" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="6777" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6797">SCATTER</text>
+         <rect x="51" y="6823" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="6821" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6841">SCHEMA</text>
+         <rect x="51" y="6867" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="6865" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6885">SCHEMAS</text>
+         <rect x="51" y="6911" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="6909" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6929">SCRUB</text>
+         <rect x="51" y="6955" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6953" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6973">SEARCH</text>
+         <rect x="51" y="6999" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6997" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7017">SECOND</text>
+         <rect x="51" y="7043" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7041" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7061">SERIAL</text>
+         <rect x="51" y="7087" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="7085" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7105">SERIALIZABLE</text>
+         <rect x="51" y="7131" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7129" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7149">SERIAL2</text>
+         <rect x="51" y="7175" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7173" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7193">SERIAL4</text>
+         <rect x="51" y="7219" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7217" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7237">SERIAL8</text>
+         <rect x="51" y="7263" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="7261" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7281">SEQUENCE</text>
+         <rect x="51" y="7307" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="7305" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7325">SEQUENCES</text>
+         <rect x="51" y="7351" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="7349" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7369">SESSION</text>
+         <rect x="51" y="7395" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="7393" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7413">SESSIONS</text>
+         <rect x="51" y="7439" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="7437" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7457">SET</text>
+         <rect x="51" y="7483" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="7481" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7501">SHOW</text>
+         <rect x="51" y="7527" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7525" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7545">SIMPLE</text>
+         <rect x="51" y="7571" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="7569" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7589">SMALLSERIAL</text>
+         <rect x="51" y="7615" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="7613" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7633">SNAPSHOT</text>
+         <rect x="51" y="7659" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="7657" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7677">SQL</text>
+         <rect x="51" y="7703" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7701" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7721">START</text>
+         <rect x="51" y="7747" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="7745" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7765">STATISTICS</text>
+         <rect x="51" y="7791" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="7789" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7809">STDIN</text>
+         <rect x="51" y="7835" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7833" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7853">STORE</text>
+         <rect x="51" y="7879" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="7877" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7897">STORING</text>
+         <rect x="51" y="7923" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7921" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7941">STRICT</text>
+         <rect x="51" y="7967" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="7965" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7985">STRING</text>
+         <rect x="51" y="8011" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="8009" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8029">SPLIT</text>
+         <rect x="51" y="8055" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8053" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8073">SYNTAX</text>
+         <rect x="51" y="8099" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8097" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8117">SYSTEM</text>
+         <rect x="51" y="8143" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="8141" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8161">TABLES</text>
+         <rect x="51" y="8187" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8185" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8205">TEMP</text>
+         <rect x="51" y="8231" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8229" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8249">TEMPLATE</text>
+         <rect x="51" y="8275" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="8273" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8293">TEMPORARY</text>
+         <rect x="51" y="8319" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="8317" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8337">TESTING_RANGES</text>
+         <rect x="51" y="8363" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="8361" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8381">TESTING_RELOCATE</text>
+         <rect x="51" y="8407" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="8405" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8425">TEXT</text>
+         <rect x="51" y="8451" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8449" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8469">THAN</text>
+         <rect x="51" y="8495" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="8493" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8513">TIMESTAMPTZ</text>
+         <rect x="51" y="8539" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="8537" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8557">TRACE</text>
+         <rect x="51" y="8583" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="8581" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8601">TRANSACTION</text>
+         <rect x="51" y="8627" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8625" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8645">TRUNCATE</text>
+         <rect x="51" y="8671" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="8669" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8689">TYPE</text>
+         <rect x="51" y="8715" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="8713" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8733">UNBOUNDED</text>
+         <rect x="51" y="8759" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="8757" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8777">UNCOMMITTED</text>
+         <rect x="51" y="8803" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8801" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8821">UNKNOWN</text>
+         <rect x="51" y="8847" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8845" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8865">UPDATE</text>
+         <rect x="51" y="8891" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="8889" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8909">UPSERT</text>
+         <rect x="51" y="8935" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="8933" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8953">UUID</text>
+         <rect x="51" y="8979" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="8977" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8997">USE</text>
+         <rect x="51" y="9023" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9021" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9041">USERS</text>
+         <rect x="51" y="9067" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="9065" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9085">VALID</text>
+         <rect x="51" y="9111" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="9109" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9129">VALIDATE</text>
+         <rect x="51" y="9155" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9153" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9173">VALUE</text>
+         <rect x="51" y="9199" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="9197" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9217">VARYING</text>
+         <rect x="51" y="9243" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="9241" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9261">WITHIN</text>
+         <rect x="51" y="9287" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="9285" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9305">WITHOUT</text>
+         <rect x="51" y="9331" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9329" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9349">WRITE</text>
+         <rect x="51" y="9375" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="9373" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9393">YEAR</text>
+         <rect x="51" y="9419" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="9417" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9437">ZONE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m144 0 h10 m0 0 h90 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m176 0 h10 m0 0 h58 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m222 0 h10 m0 0 h12 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m188 0 h10 m0 0 h46 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m202 0 h10 m0 0 h32 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m192 0 h10 m0 0 h42 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m132 0 h10 m0 0 h102 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m142 0 h10 m0 0 h92 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -9416 h-3"></path>
+         <polygon points="323 17 331 13 331 21"></polygon>
+         <polygon points="323 17 315 13 315 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#name" title="name">name</a></li>
+            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+            <li><a href="#type_function_name" title="type_function_name">type_function_name</a></li>
+            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="complex_table_pattern" href="#complex_table_pattern">complex_table_pattern:</a></p>
+      <svg width="520" height="144">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#complex_db_object_name" xlink:title="complex_db_object_name">
+            <rect x="51" y="3" width="180" height="32"></rect>
+            <rect x="49" y="1" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">complex_db_object_name</text>
+         </a>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="71" y="79" width="54" height="32"></rect>
+            <rect x="69" y="77" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="79" y="97">name</text>
+         </a>
+         <rect x="145" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="143" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="97">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="209" y="111" width="132" height="32"></rect>
+            <rect x="207" y="109" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="129">unrestricted_name</text>
+         </a>
+         <rect x="361" y="111" width="24" height="32" rx="10"></rect>
+         <rect x="359" y="109" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="369" y="129">.</text>
+         <rect x="445" y="47" width="28" height="32" rx="10"></rect>
+         <rect x="443" y="45" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="453" y="65">*</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m180 0 h10 m0 0 h242 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-432 10 h10 m0 0 h344 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v12 m374 0 v-12 m-374 12 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m54 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m132 0 h10 m0 0 h10 m24 0 h10 m40 -64 h10 m28 0 h10 m23 -44 h-3"></path>
+         <polygon points="511 17 519 13 519 21"></polygon>
+         <polygon points="511 17 503 13 503 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_pattern" href="#table_pattern">table_pattern:</a></p>
+      <svg width="264" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#simple_db_object_name" xlink:title="simple_db_object_name">
+            <rect x="51" y="3" width="166" height="32"></rect>
+            <rect x="49" y="1" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">simple_db_object_name</text>
+         </a>
+         <a xlink:href="#complex_table_pattern" xlink:title="complex_table_pattern">
+            <rect x="51" y="47" width="158" height="32"></rect>
+            <rect x="49" y="45" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">complex_table_pattern</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m166 0 h10 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m158 0 h10 m0 0 h8 m23 -44 h-3"></path>
+         <polygon points="255 17 263 13 263 21"></polygon>
+         <polygon points="255 17 247 13 247 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#table_pattern_list" title="table_pattern_list">table_pattern_list</a></li>
+            <li><a href="#targets" title="targets">targets</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_pattern_list" href="#table_pattern_list">table_pattern_list:</a></p>
       <svg width="198" height="80">
          
@@ -4709,40 +5731,28 @@
             <li><a href="#opt_with_options" title="opt_with_options">opt_with_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="db_object_name" href="#db_object_name">db_object_name:</a></p>
-      <svg width="584" height="100">
+      <svg width="278" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#name" xlink:title="name">
-            <rect x="31" y="3" width="54" height="32"></rect>
-            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">name</text>
+         <a xlink:href="#simple_db_object_name" xlink:title="simple_db_object_name">
+            <rect x="51" y="3" width="166" height="32"></rect>
+            <rect x="49" y="1" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">simple_db_object_name</text>
          </a>
-         <rect x="125" y="35" width="24" height="32" rx="10"></rect>
-         <rect x="123" y="33" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="133" y="53">.</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="169" y="35" width="132" height="32"></rect>
-            <rect x="167" y="33" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="177" y="53">unrestricted_name</text>
+         <a xlink:href="#complex_db_object_name" xlink:title="complex_db_object_name">
+            <rect x="51" y="47" width="180" height="32"></rect>
+            <rect x="49" y="45" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">complex_db_object_name</text>
          </a>
-         <rect x="341" y="67" width="24" height="32" rx="10"></rect>
-         <rect x="339" y="65" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="349" y="85">.</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="385" y="67" width="132" height="32"></rect>
-            <rect x="383" y="65" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="393" y="85">unrestricted_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h422 m-452 0 h20 m432 0 h20 m-472 0 q10 0 10 10 m452 0 q0 -10 10 -10 m-462 10 v12 m452 0 v-12 m-452 12 q0 10 10 10 m432 0 q10 0 10 -10 m-442 10 h10 m24 0 h10 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m24 0 h10 m0 0 h10 m132 0 h10 m43 -64 h-3"></path>
-         <polygon points="575 17 583 13 583 21"></polygon>
-         <polygon points="575 17 567 13 567 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m166 0 h10 m0 0 h14 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m23 -44 h-3"></path>
+         <polygon points="269 17 277 13 277 21"></polygon>
+         <polygon points="269 17 261 13 261 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#sequence_name" title="sequence_name">sequence_name</a></li>
             <li><a href="#table_name" title="table_name">table_name</a></li>
-            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_password" href="#opt_password">opt_password:</a></p>
       <svg width="456" height="56">
@@ -5146,778 +6156,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_stats_stmt" title="create_stats_stmt">create_stats_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
-      <svg width="332" height="8132">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ABORT</text>
-         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">ACTION</text>
-         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">ADD</text>
-         <rect x="51" y="135" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">ADMIN</text>
-         <rect x="51" y="179" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">ALTER</text>
-         <rect x="51" y="223" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">AT</text>
-         <rect x="51" y="267" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">BACKUP</text>
-         <rect x="51" y="311" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">BEGIN</text>
-         <rect x="51" y="355" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">BLOB</text>
-         <rect x="51" y="399" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">BY</text>
-         <rect x="51" y="443" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">CACHE</text>
-         <rect x="51" y="487" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">CANCEL</text>
-         <rect x="51" y="531" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">CASCADE</text>
-         <rect x="51" y="575" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">CLUSTER</text>
-         <rect x="51" y="619" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">COLUMNS</text>
-         <rect x="51" y="663" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">COMMENT</text>
-         <rect x="51" y="707" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">COMMIT</text>
-         <rect x="51" y="751" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">COMMITTED</text>
-         <rect x="51" y="795" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">COMPACT</text>
-         <rect x="51" y="839" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">CONFLICT</text>
-         <rect x="51" y="883" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">CONFIGURATION</text>
-         <rect x="51" y="927" width="144" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="144" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">CONFIGURATIONS</text>
-         <rect x="51" y="971" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">CONFIGURE</text>
-         <rect x="51" y="1015" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">CONSTRAINTS</text>
-         <rect x="51" y="1059" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">COPY</text>
-         <rect x="51" y="1103" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">COVERING</text>
-         <rect x="51" y="1147" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">CSV</text>
-         <rect x="51" y="1191" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">CUBE</text>
-         <rect x="51" y="1235" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">CURRENT</text>
-         <rect x="51" y="1279" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">CYCLE</text>
-         <rect x="51" y="1323" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">DATA</text>
-         <rect x="51" y="1367" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">DATABASE</text>
-         <rect x="51" y="1411" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">DATABASES</text>
-         <rect x="51" y="1455" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">DAY</text>
-         <rect x="51" y="1499" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">DEALLOCATE</text>
-         <rect x="51" y="1543" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">DELETE</text>
-         <rect x="51" y="1587" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">DISCARD</text>
-         <rect x="51" y="1631" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">DOUBLE</text>
-         <rect x="51" y="1675" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">DROP</text>
-         <rect x="51" y="1719" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">ENCODING</text>
-         <rect x="51" y="1763" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">EXECUTE</text>
-         <rect x="51" y="1807" width="124" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="124" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">EXPERIMENTAL</text>
-         <rect x="51" y="1851" width="176" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="176" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">EXPERIMENTAL_AUDIT</text>
-         <rect x="51" y="1895" width="234" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="234" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">EXPERIMENTAL_FINGERPRINTS</text>
-         <rect x="51" y="1939" width="192" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="192" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">EXPERIMENTAL_REPLICA</text>
-         <rect x="51" y="1983" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">EXPLAIN</text>
-         <rect x="51" y="2027" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">FILTER</text>
-         <rect x="51" y="2071" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">FIRST</text>
-         <rect x="51" y="2115" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">FOLLOWING</text>
-         <rect x="51" y="2159" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">FORCE_INDEX</text>
-         <rect x="51" y="2203" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">GIN</text>
-         <rect x="51" y="2247" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">GRANTS</text>
-         <rect x="51" y="2291" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">HIGH</text>
-         <rect x="51" y="2335" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">HISTOGRAM</text>
-         <rect x="51" y="2379" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">HOUR</text>
-         <rect x="51" y="2423" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">IMPORT</text>
-         <rect x="51" y="2467" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">INCREMENT</text>
-         <rect x="51" y="2511" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">INCREMENTAL</text>
-         <rect x="51" y="2555" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">INDEXES</text>
-         <rect x="51" y="2599" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">INSERT</text>
-         <rect x="51" y="2643" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">INT2VECTOR</text>
-         <rect x="51" y="2687" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">INTERLEAVE</text>
-         <rect x="51" y="2731" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="2729" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">INVERTED</text>
-         <rect x="51" y="2775" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">ISOLATION</text>
-         <rect x="51" y="2819" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">JOB</text>
-         <rect x="51" y="2863" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">JOBS</text>
-         <rect x="51" y="2907" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">KEY</text>
-         <rect x="51" y="2951" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">KEYS</text>
-         <rect x="51" y="2995" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">KV</text>
-         <rect x="51" y="3039" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">LC_COLLATE</text>
-         <rect x="51" y="3083" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">LC_CTYPE</text>
-         <rect x="51" y="3127" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">LESS</text>
-         <rect x="51" y="3171" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">LEVEL</text>
-         <rect x="51" y="3215" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">LIST</text>
-         <rect x="51" y="3259" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="3257" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">LOCAL</text>
-         <rect x="51" y="3303" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">LOW</text>
-         <rect x="51" y="3347" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">MATCH</text>
-         <rect x="51" y="3391" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">MINUTE</text>
-         <rect x="51" y="3435" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">MONTH</text>
-         <rect x="51" y="3479" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">NAMES</text>
-         <rect x="51" y="3523" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">NAN</text>
-         <rect x="51" y="3567" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">NEXT</text>
-         <rect x="51" y="3611" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">NO</text>
-         <rect x="51" y="3655" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">NORMAL</text>
-         <rect x="51" y="3699" width="132" height="32" rx="10"></rect>
-         <rect x="49" y="3697" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">NO_INDEX_JOIN</text>
-         <rect x="51" y="3743" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="3741" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3761">NULLS</text>
-         <rect x="51" y="3787" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="3785" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3805">OF</text>
-         <rect x="51" y="3831" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="3829" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3849">OFF</text>
-         <rect x="51" y="3875" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="3873" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3893">OID</text>
-         <rect x="51" y="3919" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="3917" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3937">OIDVECTOR</text>
-         <rect x="51" y="3963" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3961" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3981">OPTION</text>
-         <rect x="51" y="4007" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="4005" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4025">OPTIONS</text>
-         <rect x="51" y="4051" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="4049" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4069">ORDINALITY</text>
-         <rect x="51" y="4095" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4093" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4113">OVER</text>
-         <rect x="51" y="4139" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="4137" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4157">OWNED</text>
-         <rect x="51" y="4183" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="4181" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4201">PARENT</text>
-         <rect x="51" y="4227" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4225" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4245">PARTIAL</text>
-         <rect x="51" y="4271" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="4269" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4289">PARTITION</text>
-         <rect x="51" y="4315" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4313" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4333">PASSWORD</text>
-         <rect x="51" y="4359" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="4357" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4377">PAUSE</text>
-         <rect x="51" y="4403" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="4401" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4421">PHYSICAL</text>
-         <rect x="51" y="4447" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="4445" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4465">PLANS</text>
-         <rect x="51" y="4491" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4489" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4509">PRECEDING</text>
-         <rect x="51" y="4535" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="4533" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4553">PREPARE</text>
-         <rect x="51" y="4579" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="4577" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4597">PRIORITY</text>
-         <rect x="51" y="4623" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4621" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4641">QUERIES</text>
-         <rect x="51" y="4667" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="4665" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4685">QUERY</text>
-         <rect x="51" y="4711" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="4709" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4729">RANGE</text>
-         <rect x="51" y="4755" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4753" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4773">READ</text>
-         <rect x="51" y="4799" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4797" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4817">RECURSIVE</text>
-         <rect x="51" y="4843" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="4841" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4861">REF</text>
-         <rect x="51" y="4887" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="4885" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4905">REGCLASS</text>
-         <rect x="51" y="4931" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="4929" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4949">REGPROC</text>
-         <rect x="51" y="4975" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="4973" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4993">REGPROCEDURE</text>
-         <rect x="51" y="5019" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="5017" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5037">REGNAMESPACE</text>
-         <rect x="51" y="5063" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="5061" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5081">REGTYPE</text>
-         <rect x="51" y="5107" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="5105" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5125">RELEASE</text>
-         <rect x="51" y="5151" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="5149" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5169">RENAME</text>
-         <rect x="51" y="5195" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="5193" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5213">REPEATABLE</text>
-         <rect x="51" y="5239" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="5237" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5257">RESET</text>
-         <rect x="51" y="5283" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="5281" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5301">RESTORE</text>
-         <rect x="51" y="5327" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="5325" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5345">RESTRICT</text>
-         <rect x="51" y="5371" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5369" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5389">RESUME</text>
-         <rect x="51" y="5415" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5413" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5433">REVOKE</text>
-         <rect x="51" y="5459" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="5457" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5477">ROLES</text>
-         <rect x="51" y="5503" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="5501" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5521">ROLLBACK</text>
-         <rect x="51" y="5547" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5545" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5565">ROLLUP</text>
-         <rect x="51" y="5591" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="5589" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5609">ROWS</text>
-         <rect x="51" y="5635" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="5633" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5653">SETTING</text>
-         <rect x="51" y="5679" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="5677" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5697">SETTINGS</text>
-         <rect x="51" y="5723" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="5721" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5741">STATUS</text>
-         <rect x="51" y="5767" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="5765" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5785">SAVEPOINT</text>
-         <rect x="51" y="5811" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="5809" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5829">SCATTER</text>
-         <rect x="51" y="5855" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="5853" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5873">SCHEMA</text>
-         <rect x="51" y="5899" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="5897" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5917">SCHEMAS</text>
-         <rect x="51" y="5943" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5941" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5961">SCRUB</text>
-         <rect x="51" y="5987" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5985" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6005">SEARCH</text>
-         <rect x="51" y="6031" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6029" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6049">SECOND</text>
-         <rect x="51" y="6075" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="6073" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6093">SERIALIZABLE</text>
-         <rect x="51" y="6119" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6117" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6137">SEQUENCE</text>
-         <rect x="51" y="6163" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="6161" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6181">SEQUENCES</text>
-         <rect x="51" y="6207" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="6205" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6225">SESSION</text>
-         <rect x="51" y="6251" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6249" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6269">SESSIONS</text>
-         <rect x="51" y="6295" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="6293" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6313">SET</text>
-         <rect x="51" y="6339" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="6337" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6357">SHOW</text>
-         <rect x="51" y="6383" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="6381" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6401">SIMPLE</text>
-         <rect x="51" y="6427" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="6425" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6445">SNAPSHOT</text>
-         <rect x="51" y="6471" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="6469" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6489">SQL</text>
-         <rect x="51" y="6515" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6513" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6533">START</text>
-         <rect x="51" y="6559" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="6557" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6577">STATISTICS</text>
-         <rect x="51" y="6603" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="6601" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6621">STDIN</text>
-         <rect x="51" y="6647" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6645" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6665">STORE</text>
-         <rect x="51" y="6691" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="6689" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6709">STORING</text>
-         <rect x="51" y="6735" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="6733" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6753">STRICT</text>
-         <rect x="51" y="6779" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="6777" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6797">SPLIT</text>
-         <rect x="51" y="6823" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6821" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6841">SYNTAX</text>
-         <rect x="51" y="6867" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6865" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6885">SYSTEM</text>
-         <rect x="51" y="6911" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="6909" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6929">TABLES</text>
-         <rect x="51" y="6955" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6953" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6973">TEMP</text>
-         <rect x="51" y="6999" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6997" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7017">TEMPLATE</text>
-         <rect x="51" y="7043" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="7041" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7061">TEMPORARY</text>
-         <rect x="51" y="7087" width="142" height="32" rx="10"></rect>
-         <rect x="49" y="7085" width="142" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7105">TESTING_RANGES</text>
-         <rect x="51" y="7131" width="158" height="32" rx="10"></rect>
-         <rect x="49" y="7129" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7149">TESTING_RELOCATE</text>
-         <rect x="51" y="7175" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="7173" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7193">TEXT</text>
-         <rect x="51" y="7219" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="7217" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7237">THAN</text>
-         <rect x="51" y="7263" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7261" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7281">TRACE</text>
-         <rect x="51" y="7307" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="7305" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7325">TRANSACTION</text>
-         <rect x="51" y="7351" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="7349" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7369">TRUNCATE</text>
-         <rect x="51" y="7395" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="7393" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7413">TYPE</text>
-         <rect x="51" y="7439" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="7437" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7457">UNBOUNDED</text>
-         <rect x="51" y="7483" width="120" height="32" rx="10"></rect>
-         <rect x="49" y="7481" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7501">UNCOMMITTED</text>
-         <rect x="51" y="7527" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="7525" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7545">UNKNOWN</text>
-         <rect x="51" y="7571" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="7569" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7589">UPDATE</text>
-         <rect x="51" y="7615" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="7613" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7633">UPSERT</text>
-         <rect x="51" y="7659" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="7657" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7677">USE</text>
-         <rect x="51" y="7703" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7701" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7721">USERS</text>
-         <rect x="51" y="7747" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="7745" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7765">VALID</text>
-         <rect x="51" y="7791" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="7789" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7809">VALIDATE</text>
-         <rect x="51" y="7835" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7833" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7853">VALUE</text>
-         <rect x="51" y="7879" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="7877" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7897">VARYING</text>
-         <rect x="51" y="7923" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="7921" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7941">WITHIN</text>
-         <rect x="51" y="7967" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="7965" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7985">WITHOUT</text>
-         <rect x="51" y="8011" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8009" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8029">WRITE</text>
-         <rect x="51" y="8055" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8053" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8073">YEAR</text>
-         <rect x="51" y="8099" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8097" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8117">ZONE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m144 0 h10 m0 0 h90 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m176 0 h10 m0 0 h58 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m192 0 h10 m0 0 h42 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m132 0 h10 m0 0 h102 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m142 0 h10 m0 0 h92 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -8096 h-3"></path>
-         <polygon points="323 17 331 13 331 21"></polygon>
-         <polygon points="323 17 315 13 315 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#name" title="name">name</a></li>
-            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
-            <li><a href="#type_function_name" title="type_function_name">type_function_name</a></li>
-            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_name_keyword" href="#col_name_keyword">col_name_keyword:</a></p>
-      <svg width="260" height="2720">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="134" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="134" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ANNOTATE_TYPE</text>
-         <rect x="51" y="47" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">BETWEEN</text>
-         <rect x="51" y="91" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">BIGINT</text>
-         <rect x="51" y="135" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">BIGSERIAL</text>
-         <rect x="51" y="179" width="42" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="42" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">BIT</text>
-         <rect x="51" y="223" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">BOOL</text>
-         <rect x="51" y="267" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">BOOLEAN</text>
-         <rect x="51" y="311" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">BYTEA</text>
-         <rect x="51" y="355" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">BYTES</text>
-         <rect x="51" y="399" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">CHAR</text>
-         <rect x="51" y="443" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">CHARACTER</text>
-         <rect x="51" y="487" width="148" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="148" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">CHARACTERISTICS</text>
-         <rect x="51" y="531" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">COALESCE</text>
-         <rect x="51" y="575" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">DATE</text>
-         <rect x="51" y="619" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">DEC</text>
-         <rect x="51" y="663" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">DECIMAL</text>
-         <rect x="51" y="707" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">EXISTS</text>
-         <rect x="51" y="751" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">EXTRACT</text>
-         <rect x="51" y="795" width="162" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="162" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">EXTRACT_DURATION</text>
-         <rect x="51" y="839" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">FLOAT</text>
-         <rect x="51" y="883" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">FLOAT4</text>
-         <rect x="51" y="927" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">FLOAT8</text>
-         <rect x="51" y="971" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">GREATEST</text>
-         <rect x="51" y="1015" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">GROUPING</text>
-         <rect x="51" y="1059" width="34" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">IF</text>
-         <rect x="51" y="1103" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">IFNULL</text>
-         <rect x="51" y="1147" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">INET</text>
-         <rect x="51" y="1191" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">INT</text>
-         <rect x="51" y="1235" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">INT2</text>
-         <rect x="51" y="1279" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">INT4</text>
-         <rect x="51" y="1323" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">INT8</text>
-         <rect x="51" y="1367" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">INT64</text>
-         <rect x="51" y="1411" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">INTEGER</text>
-         <rect x="51" y="1455" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">INTERVAL</text>
-         <rect x="51" y="1499" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">JSON</text>
-         <rect x="51" y="1543" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">JSONB</text>
-         <rect x="51" y="1587" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">LEAST</text>
-         <rect x="51" y="1631" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">NAME</text>
-         <rect x="51" y="1675" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">NULLIF</text>
-         <rect x="51" y="1719" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">NUMERIC</text>
-         <rect x="51" y="1763" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">OUT</text>
-         <rect x="51" y="1807" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">OVERLAY</text>
-         <rect x="51" y="1851" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">POSITION</text>
-         <rect x="51" y="1895" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">PRECISION</text>
-         <rect x="51" y="1939" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">REAL</text>
-         <rect x="51" y="1983" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">ROW</text>
-         <rect x="51" y="2027" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">SERIAL</text>
-         <rect x="51" y="2071" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">SERIAL2</text>
-         <rect x="51" y="2115" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">SERIAL4</text>
-         <rect x="51" y="2159" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">SERIAL8</text>
-         <rect x="51" y="2203" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">SMALLINT</text>
-         <rect x="51" y="2247" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">SMALLSERIAL</text>
-         <rect x="51" y="2291" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">STRING</text>
-         <rect x="51" y="2335" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">SUBSTRING</text>
-         <rect x="51" y="2379" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">TIME</text>
-         <rect x="51" y="2423" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">TIMESTAMP</text>
-         <rect x="51" y="2467" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">TIMESTAMPTZ</text>
-         <rect x="51" y="2511" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">TREAT</text>
-         <rect x="51" y="2555" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">TRIM</text>
-         <rect x="51" y="2599" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">UUID</text>
-         <rect x="51" y="2643" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">VALUES</text>
-         <rect x="51" y="2687" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">VARCHAR</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m134 0 h10 m0 0 h28 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m148 0 h10 m0 0 h14 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m58 0 h10 m0 0 h104 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m116 0 h10 m0 0 h46 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m116 0 h10 m0 0 h46 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m23 -2684 h-3"></path>
-         <polygon points="251 17 259 13 259 21"></polygon>
-         <polygon points="251 17 243 13 243 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#name" title="name">name</a></li>
-            <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
-            <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="with_clause" href="#with_clause">with_clause:</a></p>
       <svg width="196" height="36">
@@ -7143,19 +7381,22 @@
             <li><a href="#create_sequence_stmt" title="create_sequence_stmt">create_sequence_stmt</a></li>
             <li><a href="#show_create_sequence_stmt" title="show_create_sequence_stmt">show_create_sequence_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_name_list" href="#opt_name_list">opt_name_list:</a></p>
-      <svg width="176" height="56">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_on_targets_roles" href="#opt_on_targets_roles">opt_on_targets_roles:</a></p>
+      <svg width="256" height="56">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="51" y="23" width="78" height="32"></rect>
-            <rect x="49" y="21" width="78" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="41">name_list</text>
+         <rect x="51" y="23" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">ON</text>
+         <a xlink:href="#targets_roles" xlink:title="targets_roles">
+            <rect x="111" y="23" width="98" height="32"></rect>
+            <rect x="109" y="21" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="119" y="41">targets_roles</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -32 h-3"></path>
-         <polygon points="167 5 175 1 175 9"></polygon>
-         <polygon points="167 5 159 1 159 9"></polygon>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m40 0 h10 m0 0 h10 m98 0 h10 m23 -32 h-3"></path>
+         <polygon points="247 5 255 1 255 9"></polygon>
+         <polygon points="247 5 239 1 239 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -7182,26 +7423,55 @@
          </p><ul>
             <li><a href="#show_grants_stmt" title="show_grants_stmt">show_grants_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="on_privilege_target_clause" href="#on_privilege_target_clause">on_privilege_target_clause:</a></p>
-      <svg width="220" height="56">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="ranges_kw" href="#ranges_kw">ranges_kw:</a></p>
+      <svg width="286" height="80">
          
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">ON</text>
-         <a xlink:href="#targets" xlink:title="targets">
-            <rect x="111" y="23" width="62" height="32"></rect>
-            <rect x="109" y="21" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="119" y="41">targets</text>
-         </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m40 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
-         <polygon points="211 5 219 1 219 9"></polygon>
-         <polygon points="211 5 203 1 203 9"></polygon>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">TESTING_RANGES</text>
+         <rect x="51" y="47" width="188" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="188" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">EXPERIMENTAL_RANGES</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h46 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m188 0 h10 m23 -44 h-3"></path>
+         <polygon points="277 17 285 13 285 21"></polygon>
+         <polygon points="277 17 269 13 269 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#show_grants_stmt" title="show_grants_stmt">show_grants_stmt</a></li>
+            <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_name_with_index" href="#table_name_with_index">table_name_with_index:</a></p>
+      <svg width="350" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="31" y="3" width="90" height="32"></rect>
+            <rect x="29" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">table_name</text>
+         </a>
+         <rect x="161" y="35" width="30" height="32" rx="10"></rect>
+         <rect x="159" y="33" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="169" y="53">@</text>
+         <a xlink:href="#index_name" xlink:title="index_name">
+            <rect x="211" y="35" width="92" height="32"></rect>
+            <rect x="209" y="33" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="219" y="53">index_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m23 -32 h-3"></path>
+         <polygon points="341 17 349 13 349 21"></polygon>
+         <polygon points="341 17 333 13 333 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_oneindex_stmt" title="alter_oneindex_stmt">alter_oneindex_stmt</a></li>
+            <li><a href="#alter_rename_index_stmt" title="alter_rename_index_stmt">alter_rename_index_stmt</a></li>
+            <li><a href="#alter_scatter_index_stmt" title="alter_scatter_index_stmt">alter_scatter_index_stmt</a></li>
+            <li><a href="#alter_split_index_stmt" title="alter_split_index_stmt">alter_split_index_stmt</a></li>
+            <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
+            <li><a href="#table_name_with_index_list" title="table_name_with_index_list">table_name_with_index_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_compact" href="#opt_compact">opt_compact:</a></p>
       <svg width="184" height="56">
@@ -7822,42 +8092,103 @@
          </p><ul>
             <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_pattern" href="#table_pattern">table_pattern:</a></p>
-      <svg width="520" height="144">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="complex_db_object_name" href="#complex_db_object_name">complex_db_object_name:</a></p>
+      <svg width="544" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#db_object_name" xlink:title="db_object_name">
-            <rect x="51" y="3" width="122" height="32"></rect>
-            <rect x="49" y="1" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">db_object_name</text>
-         </a>
          <a xlink:href="#name" xlink:title="name">
-            <rect x="71" y="79" width="54" height="32"></rect>
-            <rect x="69" y="77" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="79" y="97">name</text>
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
          </a>
-         <rect x="145" y="79" width="24" height="32" rx="10"></rect>
-         <rect x="143" y="77" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="153" y="97">.</text>
+         <rect x="105" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="103" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="21">.</text>
          <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="209" y="111" width="132" height="32"></rect>
-            <rect x="207" y="109" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="217" y="129">unrestricted_name</text>
+            <rect x="149" y="3" width="132" height="32"></rect>
+            <rect x="147" y="1" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="21">unrestricted_name</text>
          </a>
-         <rect x="361" y="111" width="24" height="32" rx="10"></rect>
-         <rect x="359" y="109" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="369" y="129">.</text>
-         <rect x="445" y="47" width="28" height="32" rx="10"></rect>
-         <rect x="443" y="45" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="453" y="65">*</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m122 0 h10 m0 0 h300 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v24 m462 0 v-24 m-462 24 q0 10 10 10 m442 0 q10 0 10 -10 m-432 10 h10 m0 0 h344 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v12 m374 0 v-12 m-374 12 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m54 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m132 0 h10 m0 0 h10 m24 0 h10 m40 -64 h10 m28 0 h10 m23 -44 h-3"></path>
-         <polygon points="511 17 519 13 519 21"></polygon>
-         <polygon points="511 17 503 13 503 21"></polygon>
+         <rect x="321" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="319" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="329" y="53">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="365" y="35" width="132" height="32"></rect>
+            <rect x="363" y="33" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="53">unrestricted_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m24 0 h10 m0 0 h10 m132 0 h10 m23 -32 h-3"></path>
+         <polygon points="535 17 543 13 543 21"></polygon>
+         <polygon points="535 17 527 13 527 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#table_pattern_list" title="table_pattern_list">table_pattern_list</a></li>
+            <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
+            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unrestricted_name" href="#unrestricted_name">unrestricted_name:</a></p>
+      <svg width="278" height="212">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">identifier</text>
+         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
+            <rect x="51" y="47" width="146" height="32"></rect>
+            <rect x="49" y="45" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">unreserved_keyword</text>
+         </a>
+         <a xlink:href="#col_name_keyword" xlink:title="col_name_keyword">
+            <rect x="51" y="91" width="138" height="32"></rect>
+            <rect x="49" y="89" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">col_name_keyword</text>
+         </a>
+         <a xlink:href="#type_func_name_keyword" xlink:title="type_func_name_keyword">
+            <rect x="51" y="135" width="180" height="32"></rect>
+            <rect x="49" y="133" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">type_func_name_keyword</text>
+         </a>
+         <a xlink:href="#reserved_keyword" xlink:title="reserved_keyword">
+            <rect x="51" y="179" width="132" height="32"></rect>
+            <rect x="49" y="177" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">reserved_keyword</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m78 0 h10 m0 0 h102 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m146 0 h10 m0 0 h34 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m138 0 h10 m0 0 h42 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m132 0 h10 m0 0 h48 m23 -176 h-3"></path>
+         <polygon points="269 17 277 13 277 21"></polygon>
+         <polygon points="269 17 261 13 261 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#attrs" title="attrs">attrs</a></li>
+            <li><a href="#collation_name" title="collation_name">collation_name</a></li>
+            <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
+            <li><a href="#complex_db_object_name" title="complex_db_object_name">complex_db_object_name</a></li>
+            <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
+            <li><a href="#index_name" title="index_name">index_name</a></li>
+            <li><a href="#partition_name" title="partition_name">partition_name</a></li>
+            <li><a href="#prefixed_column_path" title="prefixed_column_path">prefixed_column_path</a></li>
+            <li><a href="#target_name" title="target_name">target_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="simple_db_object_name" href="#simple_db_object_name">simple_db_object_name:</a></p>
+      <svg width="112" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
+         <polygon points="103 17 111 13 111 21"></polygon>
+         <polygon points="103 17 95 13 95 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
+            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="non_reserved_word" href="#non_reserved_word">non_reserved_word:</a></p>
       <svg width="278" height="168">
@@ -7919,50 +8250,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#kv_option_list" title="kv_option_list">kv_option_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unrestricted_name" href="#unrestricted_name">unrestricted_name:</a></p>
-      <svg width="278" height="212">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">identifier</text>
-         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
-            <rect x="51" y="47" width="146" height="32"></rect>
-            <rect x="49" y="45" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">unreserved_keyword</text>
-         </a>
-         <a xlink:href="#col_name_keyword" xlink:title="col_name_keyword">
-            <rect x="51" y="91" width="138" height="32"></rect>
-            <rect x="49" y="89" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="109">col_name_keyword</text>
-         </a>
-         <a xlink:href="#type_func_name_keyword" xlink:title="type_func_name_keyword">
-            <rect x="51" y="135" width="180" height="32"></rect>
-            <rect x="49" y="133" width="180" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="153">type_func_name_keyword</text>
-         </a>
-         <a xlink:href="#reserved_keyword" xlink:title="reserved_keyword">
-            <rect x="51" y="179" width="132" height="32"></rect>
-            <rect x="49" y="177" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">reserved_keyword</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m78 0 h10 m0 0 h102 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m146 0 h10 m0 0 h34 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m138 0 h10 m0 0 h42 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m132 0 h10 m0 0 h48 m23 -176 h-3"></path>
-         <polygon points="269 17 277 13 277 21"></polygon>
-         <polygon points="269 17 261 13 261 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#attrs" title="attrs">attrs</a></li>
-            <li><a href="#collation_name" title="collation_name">collation_name</a></li>
-            <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
-            <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
-            <li><a href="#index_name" title="index_name">index_name</a></li>
-            <li><a href="#partition_name" title="partition_name">partition_name</a></li>
-            <li><a href="#prefixed_column_path" title="prefixed_column_path">prefixed_column_path</a></li>
-            <li><a href="#table_pattern" title="table_pattern">table_pattern</a></li>
-            <li><a href="#target_name" title="target_name">target_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with" href="#opt_with">opt_with:</a></p>
       <svg width="154" height="56">
@@ -9380,6 +9667,32 @@
          </p><ul>
             <li><a href="#transaction_mode_list" title="transaction_mode_list">transaction_mode_list</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="targets_roles" href="#targets_roles">targets_roles:</a></p>
+      <svg width="252" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ROLE</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="127" y="3" width="78" height="32"></rect>
+            <rect x="125" y="1" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="135" y="21">name_list</text>
+         </a>
+         <a xlink:href="#targets" xlink:title="targets">
+            <rect x="51" y="47" width="62" height="32"></rect>
+            <rect x="49" y="45" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">targets</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h10 m78 0 h10 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m62 0 h10 m0 0 h92 m23 -44 h-3"></path>
+         <polygon points="243 17 251 13 251 21"></polygon>
+         <polygon points="243 17 235 13 235 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_on_targets_roles" title="opt_on_targets_roles">opt_on_targets_roles</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="single_set_clause" href="#single_set_clause">single_set_clause:</a></p>
       <svg width="294" height="36">
          
@@ -9499,36 +9812,6 @@
             <li><a href="#insert_column_item" title="insert_column_item">insert_column_item</a></li>
             <li><a href="#single_set_clause" title="single_set_clause">single_set_clause</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_name_with_index" href="#table_name_with_index">table_name_with_index:</a></p>
-      <svg width="350" height="68">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="31" y="3" width="90" height="32"></rect>
-            <rect x="29" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">table_name</text>
-         </a>
-         <rect x="161" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="159" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="169" y="53">@</text>
-         <a xlink:href="#index_name" xlink:title="index_name">
-            <rect x="211" y="35" width="92" height="32"></rect>
-            <rect x="209" y="33" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="219" y="53">index_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m23 -32 h-3"></path>
-         <polygon points="341 17 349 13 349 21"></polygon>
-         <polygon points="341 17 333 13 333 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_oneindex_stmt" title="alter_oneindex_stmt">alter_oneindex_stmt</a></li>
-            <li><a href="#alter_rename_index_stmt" title="alter_rename_index_stmt">alter_rename_index_stmt</a></li>
-            <li><a href="#alter_scatter_index_stmt" title="alter_scatter_index_stmt">alter_scatter_index_stmt</a></li>
-            <li><a href="#alter_split_index_stmt" title="alter_split_index_stmt">alter_split_index_stmt</a></li>
-            <li><a href="#table_name_with_index_list" title="table_name_with_index_list">table_name_with_index_list</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_index_cmds" href="#alter_index_cmds">alter_index_cmds:</a></p>
       <svg width="216" height="80">
          
@@ -9642,7 +9925,7 @@
             <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="reserved_keyword" href="#reserved_keyword">reserved_keyword:</a></p>
-      <svg width="270" height="3732">
+      <svg width="270" height="3600">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -9832,76 +10115,67 @@
          <rect x="51" y="2687" width="100" height="32" rx="10"></rect>
          <rect x="49" y="2685" width="100" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="2705">RETURNING</text>
-         <rect x="51" y="2731" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="2729" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">ROLE</text>
-         <rect x="51" y="2775" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">SELECT</text>
-         <rect x="51" y="2819" width="126" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="126" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">SESSION_USER</text>
-         <rect x="51" y="2863" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">SOME</text>
-         <rect x="51" y="2907" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">STORED</text>
-         <rect x="51" y="2951" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">SYMMETRIC</text>
-         <rect x="51" y="2995" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">TABLE</text>
-         <rect x="51" y="3039" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">THEN</text>
-         <rect x="51" y="3083" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">TO</text>
-         <rect x="51" y="3127" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">TRAILING</text>
-         <rect x="51" y="3171" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">TRUE</text>
-         <rect x="51" y="3215" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">UNION</text>
-         <rect x="51" y="3259" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3257" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">UNIQUE</text>
-         <rect x="51" y="3303" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">USER</text>
-         <rect x="51" y="3347" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">USING</text>
-         <rect x="51" y="3391" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">VARIADIC</text>
-         <rect x="51" y="3435" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">VIEW</text>
-         <rect x="51" y="3479" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">VIRTUAL</text>
-         <rect x="51" y="3523" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">WHEN</text>
-         <rect x="51" y="3567" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">WHERE</text>
-         <rect x="51" y="3611" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">WINDOW</text>
-         <rect x="51" y="3655" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">WITH</text>
-         <rect x="51" y="3699" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="3697" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">WORK</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m46 0 h10 m0 0 h126 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m110 0 h10 m0 0 h62 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m78 0 h10 m0 0 h94 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m108 0 h10 m0 0 h64 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m72 0 h10 m0 0 h100 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m156 0 h10 m0 0 h16 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m148 0 h10 m0 0 h24 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m52 0 h10 m0 0 h120 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m36 0 h10 m0 0 h136 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m90 0 h10 m0 0 h82 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m94 0 h10 m0 0 h78 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m98 0 h10 m0 0 h74 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m144 0 h10 m0 0 h28 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m84 0 h10 m0 0 h88 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m88 0 h10 m0 0 h84 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m23 -3696 h-3"></path>
+         <rect x="51" y="2731" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2729" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2749">SELECT</text>
+         <rect x="51" y="2775" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">SESSION_USER</text>
+         <rect x="51" y="2819" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">SOME</text>
+         <rect x="51" y="2863" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">STORED</text>
+         <rect x="51" y="2907" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">SYMMETRIC</text>
+         <rect x="51" y="2951" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">TABLE</text>
+         <rect x="51" y="2995" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">THEN</text>
+         <rect x="51" y="3039" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">TO</text>
+         <rect x="51" y="3083" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">TRAILING</text>
+         <rect x="51" y="3127" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">TRUE</text>
+         <rect x="51" y="3171" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">UNION</text>
+         <rect x="51" y="3215" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">UNIQUE</text>
+         <rect x="51" y="3259" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3257" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3277">USER</text>
+         <rect x="51" y="3303" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">USING</text>
+         <rect x="51" y="3347" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">VARIADIC</text>
+         <rect x="51" y="3391" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">VIEW</text>
+         <rect x="51" y="3435" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">WHEN</text>
+         <rect x="51" y="3479" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">WHERE</text>
+         <rect x="51" y="3523" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">WINDOW</text>
+         <rect x="51" y="3567" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">WITH</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m46 0 h10 m0 0 h126 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m110 0 h10 m0 0 h62 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m78 0 h10 m0 0 h94 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m108 0 h10 m0 0 h64 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m72 0 h10 m0 0 h100 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m156 0 h10 m0 0 h16 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m148 0 h10 m0 0 h24 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m128 0 h10 m0 0 h44 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m52 0 h10 m0 0 h120 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m46 0 h10 m0 0 h126 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m36 0 h10 m0 0 h136 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m90 0 h10 m0 0 h82 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m94 0 h10 m0 0 h78 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m98 0 h10 m0 0 h74 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m144 0 h10 m0 0 h28 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m48 0 h10 m0 0 h124 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m40 0 h10 m0 0 h132 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m84 0 h10 m0 0 h88 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m106 0 h10 m0 0 h66 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m70 0 h10 m0 0 h102 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m126 0 h10 m0 0 h46 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m58 0 h10 m0 0 h114 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m100 0 h10 m0 0 h72 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m62 0 h10 m0 0 h110 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m38 0 h10 m0 0 h134 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m86 0 h10 m0 0 h86 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m54 0 h10 m0 0 h118 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m66 0 h10 m0 0 h106 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m74 0 h10 m0 0 h98 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m64 0 h10 m0 0 h108 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m88 0 h10 m0 0 h84 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m60 0 h10 m0 0 h112 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m68 0 h10 m0 0 h104 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m82 0 h10 m0 0 h90 m-202 -10 v20 m212 0 v-20 m-212 20 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m56 0 h10 m0 0 h116 m23 -3564 h-3"></path>
          <polygon points="261 17 269 13 269 21"></polygon>
          <polygon points="261 17 253 13 253 21"></polygon>
       </svg>
@@ -11297,7 +11571,7 @@
             <li><a href="#transaction_mode" title="transaction_mode">transaction_mode</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_cmd" href="#alter_table_cmd">alter_table_cmd:</a></p>
-      <svg width="800" height="484">
+      <svg width="800" height="528">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -11423,7 +11697,18 @@
             <rect x="49" y="449" width="90" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="469">partition_by</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m-518 0 h20 m498 0 h20 m-538 0 q10 0 10 10 m518 0 q0 -10 10 -10 m-528 10 v56 m518 0 v-56 m-518 56 q0 10 10 10 m498 0 q10 0 10 -10 m-508 10 h10 m116 0 h10 m0 0 h10 m152 0 h10 m0 0 h190 m20 -76 h116 m-742 0 h20 m722 0 h20 m-762 0 q10 0 10 10 m742 0 q0 -10 10 -10 m-752 10 v100 m742 0 v-100 m-742 100 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m146 0 h10 m0 0 h54 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m58 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m54 0 h10 m20 -44 h146 m-732 -10 v20 m742 0 v-20 m-742 20 v68 m742 0 v-68 m-742 68 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m58 0 h10 m20 0 h10 m90 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h34 m-470 0 h20 m450 0 h20 m-490 0 q10 0 10 10 m470 0 q0 -10 10 -10 m-480 10 v56 m470 0 v-56 m-470 56 q0 10 10 10 m450 0 q10 0 10 -10 m-460 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m120 0 h10 m20 -76 h10 m134 0 h10 m-732 -10 v20 m742 0 v-20 m-742 20 v132 m742 0 v-132 m-742 132 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m88 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m120 0 h10 m0 0 h346 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m176 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m90 0 h10 m0 0 h352 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m90 0 h10 m0 0 h612 m23 -448 h-3"></path>
+         <rect x="51" y="495" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="493" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="513">INJECT</text>
+         <rect x="137" y="495" width="102" height="32" rx="10"></rect>
+         <rect x="135" y="493" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="145" y="513">STATISTICS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="259" y="495" width="62" height="32"></rect>
+            <rect x="257" y="493" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="513">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m-518 0 h20 m498 0 h20 m-538 0 q10 0 10 10 m518 0 q0 -10 10 -10 m-528 10 v56 m518 0 v-56 m-518 56 q0 10 10 10 m498 0 q10 0 10 -10 m-508 10 h10 m116 0 h10 m0 0 h10 m152 0 h10 m0 0 h190 m20 -76 h116 m-742 0 h20 m722 0 h20 m-762 0 q10 0 10 10 m742 0 q0 -10 10 -10 m-752 10 v100 m742 0 v-100 m-742 100 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m146 0 h10 m0 0 h54 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m58 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m54 0 h10 m20 -44 h146 m-732 -10 v20 m742 0 v-20 m-742 20 v68 m742 0 v-68 m-742 68 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m58 0 h10 m20 0 h10 m90 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h34 m-470 0 h20 m450 0 h20 m-490 0 q10 0 10 10 m470 0 q0 -10 10 -10 m-480 10 v56 m470 0 v-56 m-470 56 q0 10 10 10 m450 0 q10 0 10 -10 m-460 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m120 0 h10 m20 -76 h10 m134 0 h10 m-732 -10 v20 m742 0 v-20 m-742 20 v132 m742 0 v-132 m-742 132 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m88 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m120 0 h10 m0 0 h346 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m176 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m90 0 h10 m0 0 h352 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m90 0 h10 m0 0 h612 m-732 -10 v20 m742 0 v-20 m-742 20 v24 m742 0 v-24 m-742 24 q0 10 10 10 m722 0 q10 0 10 -10 m-732 10 h10 m66 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m62 0 h10 m0 0 h432 m23 -492 h-3"></path>
          <polygon points="791 17 799 13 799 21"></polygon>
          <polygon points="791 17 783 13 783 21"></polygon>
       </svg>

--- a/v2.0/demo-follow-the-workload.md
+++ b/v2.0/demo-follow-the-workload.md
@@ -188,7 +188,7 @@ The load generator created a `kv` table that maps to an underlying key-value ran
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW TESTING_RANGES FROM TABLE test.kv;
+    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~
@@ -250,7 +250,7 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW TESTING_RANGES FROM TABLE test.kv;
+    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~

--- a/v2.0/partitioning.md
+++ b/v2.0/partitioning.md
@@ -229,7 +229,7 @@ $ cockroach zone set roachlearn.students_by_list.australia --insecure  -f austra
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> show testing_ranges from table students_by_list;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_list;
 ~~~
 
 You should see the following output:
@@ -335,7 +335,7 @@ $ cockroach zone set roachlearn.students_by_range.graduated --insecure  -f gradu
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> show testing_ranges from table students_by_range;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_range;
 ~~~
 
 You should see the following output:
@@ -477,7 +477,7 @@ $ cockroach zone set roachlearn.students.graduated_au --insecure -f graduated_au
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> show testing_ranges from table students;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE students;
 ~~~
 
 You should see the following output:

--- a/v2.0/show-experimental-ranges.md
+++ b/v2.0/show-experimental-ranges.md
@@ -1,0 +1,125 @@
+---
+title: SHOW EXPERIMENTAL_RANGES
+summary: The SHOW EXPERIMENTAL_RANGES shows information about the ranges that make up a specific table's data.
+toc: false
+---
+
+The `SHOW EXPERIMENTAL_RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that make up a specific table's data, including:
+
+- The start and end keys for the range(s)
+- The range ID(s)
+- Which nodes contain the range [replicas](architecture/overview.html#glossary)
+- Which node contains the range that is the [leaseholder](architecture/overview.html#glossary)
+
+This information is useful for verifying that:
+
+- The ["follow-the-workload"](demo-follow-the-workload.html) feature is operating as expected.
+- Range splits specified by the [`SPLIT AT`](split-at.html) statement were created as expected.
+
+{% include experimental-warning.md %}
+
+<div id="toc"></div>
+
+## Synopsis
+
+<div>
+  {% include sql/{{ page.version.version }}/diagrams/show_ranges.html %}
+</div>
+
+## Required Privileges
+
+The user must have the `SELECT` [privilege](privileges.html) on the target table.
+
+## Parameters
+
+Parameter | Description
+----------|------------
+[`table_name`](sql-grammar.html#table_name) | The name of the table you want range information about.
+[`table_name_with_index`](sql-grammar.html#table_name_with_index) | The name of the index you want range information about.
+
+## Examples
+
+The examples in this section operate on a hypothetical "user credit information" table filled with dummy data, running on a 5-node cluster.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE credit_users (
+       id INT PRIMARY KEY,
+       area_code INTEGER NOT NULL,
+       name STRING UNIQUE NOT NULL,
+       address STRING NOT NULL,
+       zip_code INTEGER NOT NULL,
+       credit_score INTEGER NOT NULL
+);
+~~~
+
+We added a secondary [index](indexes.html) to the table on the `area_code` column:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE INDEX areaCode on credit_users(area_code);
+~~~
+
+Next, we ran a couple of [`SPLIT AT`s](split-at.html) on the table and the index:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE credit_users SPLIT AT VALUES (5), (10), (15);
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX credit_users@areaCode SPLIT AT VALUES (400), (600), (999);
+~~~
+
+{{site.data.alerts.callout_info}}
+In the example output below, a `NULL` in the *Start Key* column means "beginning of table".  
+A `NULL` in the *End Key* column means "end of table".
+{{site.data.alerts.end}}
+
+### Show Ranges for a Table (Primary Index)
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW EXPERIMENTAL_RANGES FROM TABLE credit_users;
+~~~
+
+~~~
++-----------+---------+----------+----------+--------------+
+| Start Key | End Key | Range ID | Replicas | Lease Holder |
++-----------+---------+----------+----------+--------------+
+| NULL      | /5      |      158 | {2,3,5}  |            5 |
+| /5        | /10     |      159 | {3,4,5}  |            5 |
+| /10       | /15     |      160 | {2,4,5}  |            5 |
+| /15       | NULL    |      161 | {2,3,5}  |            5 |
++-----------+---------+----------+----------+--------------+
+(4 rows)
+~~~
+
+### Show Ranges for an Index
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW EXPERIMENTAL_RANGES FROM INDEX credit_users@areaCode;
+~~~
+
+~~~
++-----------+---------+----------+-----------+--------------+
+| Start Key | End Key | Range ID | Replicas  | Lease Holder |
++-----------+---------+----------+-----------+--------------+
+| NULL      | /400    |      135 | {2,4,5}   |            2 |
+| /400      | /600    |      136 | {2,4,5}   |            4 |
+| /600      | /999    |      137 | {1,3,4,5} |            3 |
+| /999      | NULL    |       72 | {2,3,4,5} |            4 |
++-----------+---------+----------+-----------+--------------+
+(4 rows)
+~~~
+
+## See Also
+
+- [`SPLIT AT`](split-at.html)
+- [`CREATE TABLE`](create-table.html)
+- [`CREATE INDEX`](create-index.html)
+- [Indexes](indexes.html)
++ [Follow-the-Workload](demo-follow-the-workload.html)
++ [Architecture Overview](architecture/overview.html)

--- a/v2.0/split-at.md
+++ b/v2.0/split-at.md
@@ -58,7 +58,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM TABLE kv;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -88,7 +88,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM TABLE kv;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -112,7 +112,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM INDEX kv@secondary;
+> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~
@@ -142,7 +142,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM INDEX kv@secondary;
+> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~

--- a/v2.0/training/data-unavailability-troubleshooting.md
+++ b/v2.0/training/data-unavailability-troubleshooting.md
@@ -184,13 +184,13 @@ In preparation, add a table and use a replication zone to force the table's data
     constraints: [+datacenter=us-east-3]
     ~~~
 
-3. Use the `SHOW TESTING_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
+3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -202,7 +202,7 @@ In preparation, add a table and use a replication zone to force the table's data
     (1 row)
     ~~~
 
-4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW TESTING_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
+4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW EXPERIMENTAL_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
 
     <img src="{{ 'images/v2.0/training-19.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 

--- a/v2.0/training/locality-and-replication-zones.md
+++ b/v2.0/training/locality-and-replication-zones.md
@@ -227,13 +227,13 @@ To check this, let's create a table, which initially maps to a single underlying
     (21 rows)
     ~~~
 
-3. Use the `SHOW TESTING_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
+3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -364,9 +364,9 @@ Now verify that the data for the table in the `intro` database is located on US-
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;" \
-    --execute="SHOW TESTING_RANGES FROM TABLE startrek.episodes;" \
-    --execute="SHOW TESTING_RANGES FROM TABLE startrek.quotes;"    
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;" \
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.episodes;" \
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.quotes;"
     ~~~
 
     ~~~

--- a/v2.1/demo-follow-the-workload.md
+++ b/v2.1/demo-follow-the-workload.md
@@ -188,7 +188,7 @@ The load generator created a `kv` table that maps to an underlying key-value ran
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW TESTING_RANGES FROM TABLE test.kv;
+    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~
@@ -250,7 +250,7 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW TESTING_RANGES FROM TABLE test.kv;
+    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~

--- a/v2.1/partitioning.md
+++ b/v2.1/partitioning.md
@@ -229,7 +229,7 @@ $ cockroach zone set roachlearn.students_by_list.australia --insecure  -f austra
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> show testing_ranges from table students_by_list;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_list;
 ~~~
 
 You should see the following output:
@@ -335,7 +335,7 @@ $ cockroach zone set roachlearn.students_by_range.graduated --insecure  -f gradu
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> show testing_ranges from table students_by_range;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_range;
 ~~~
 
 You should see the following output:
@@ -477,7 +477,7 @@ $ cockroach zone set roachlearn.students.graduated_au --insecure -f graduated_au
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> show testing_ranges from table students;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE students;
 ~~~
 
 You should see the following output:

--- a/v2.1/show-experimental-ranges.md
+++ b/v2.1/show-experimental-ranges.md
@@ -1,0 +1,125 @@
+---
+title: SHOW EXPERIMENTAL_RANGES
+summary: The SHOW EXPERIMENTAL_RANGES shows information about the ranges that make up a specific table's data.
+toc: false
+---
+
+The `SHOW EXPERIMENTAL_RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that make up a specific table's data, including:
+
+- The start and end keys for the range(s)
+- The range ID(s)
+- Which nodes contain the range [replicas](architecture/overview.html#glossary)
+- Which node contains the range that is the [leaseholder](architecture/overview.html#glossary)
+
+This information is useful for verifying that:
+
+- The ["follow-the-workload"](demo-follow-the-workload.html) feature is operating as expected.
+- Range splits specified by the [`SPLIT AT`](split-at.html) statement were created as expected.
+
+{% include experimental-warning.md %}
+
+<div id="toc"></div>
+
+## Synopsis
+
+<div>
+  {% include sql/{{ page.version.version }}/diagrams/show_ranges.html %}
+</div>
+
+## Required Privileges
+
+The user must have the `SELECT` [privilege](privileges.html) on the target table.
+
+## Parameters
+
+Parameter | Description
+----------|------------
+[`table_name`](sql-grammar.html#table_name) | The name of the table you want range information about.
+[`table_name_with_index`](sql-grammar.html#table_name_with_index) | The name of the index you want range information about.
+
+## Examples
+
+The examples in this section operate on a hypothetical "user credit information" table filled with dummy data, running on a 5-node cluster.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE credit_users (
+       id INT PRIMARY KEY,
+       area_code INTEGER NOT NULL,
+       name STRING UNIQUE NOT NULL,
+       address STRING NOT NULL,
+       zip_code INTEGER NOT NULL,
+       credit_score INTEGER NOT NULL
+);
+~~~
+
+We added a secondary [index](indexes.html) to the table on the `area_code` column:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE INDEX areaCode on credit_users(area_code);
+~~~
+
+Next, we ran a couple of [`SPLIT AT`s](split-at.html) on the table and the index:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE credit_users SPLIT AT VALUES (5), (10), (15);
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX credit_users@areaCode SPLIT AT VALUES (400), (600), (999);
+~~~
+
+{{site.data.alerts.callout_info}}
+In the example output below, a `NULL` in the *Start Key* column means "beginning of table".  
+A `NULL` in the *End Key* column means "end of table".
+{{site.data.alerts.end}}
+
+### Show Ranges for a Table (Primary Index)
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW EXPERIMENTAL_RANGES FROM TABLE credit_users;
+~~~
+
+~~~
++-----------+---------+----------+----------+--------------+
+| Start Key | End Key | Range ID | Replicas | Lease Holder |
++-----------+---------+----------+----------+--------------+
+| NULL      | /5      |      158 | {2,3,5}  |            5 |
+| /5        | /10     |      159 | {3,4,5}  |            5 |
+| /10       | /15     |      160 | {2,4,5}  |            5 |
+| /15       | NULL    |      161 | {2,3,5}  |            5 |
++-----------+---------+----------+----------+--------------+
+(4 rows)
+~~~
+
+### Show Ranges for an Index
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW EXPERIMENTAL_RANGES FROM INDEX credit_users@areaCode;
+~~~
+
+~~~
++-----------+---------+----------+-----------+--------------+
+| Start Key | End Key | Range ID | Replicas  | Lease Holder |
++-----------+---------+----------+-----------+--------------+
+| NULL      | /400    |      135 | {2,4,5}   |            2 |
+| /400      | /600    |      136 | {2,4,5}   |            4 |
+| /600      | /999    |      137 | {1,3,4,5} |            3 |
+| /999      | NULL    |       72 | {2,3,4,5} |            4 |
++-----------+---------+----------+-----------+--------------+
+(4 rows)
+~~~
+
+## See Also
+
+- [`SPLIT AT`](split-at.html)
+- [`CREATE TABLE`](create-table.html)
+- [`CREATE INDEX`](create-index.html)
+- [Indexes](indexes.html)
++ [Follow-the-Workload](demo-follow-the-workload.html)
++ [Architecture Overview](architecture/overview.html)

--- a/v2.1/split-at.md
+++ b/v2.1/split-at.md
@@ -58,7 +58,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM TABLE kv;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -88,7 +88,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM TABLE kv;
+> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -112,7 +112,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM INDEX kv@secondary;
+> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~
@@ -142,7 +142,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TESTING_RANGES FROM INDEX kv@secondary;
+> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~

--- a/v2.1/training/data-unavailability-troubleshooting.md
+++ b/v2.1/training/data-unavailability-troubleshooting.md
@@ -184,13 +184,13 @@ In preparation, add a table and use a replication zone to force the table's data
     constraints: [+datacenter=us-east-3]
     ~~~
 
-3. Use the `SHOW TESTING_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
+3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -202,7 +202,7 @@ In preparation, add a table and use a replication zone to force the table's data
     (1 row)
     ~~~
 
-4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW TESTING_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
+4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW EXPERIMENTAL_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
 
     <img src="{{ 'images/v2.0/training-19.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 

--- a/v2.1/training/locality-and-replication-zones.md
+++ b/v2.1/training/locality-and-replication-zones.md
@@ -227,13 +227,13 @@ To check this, let's create a table, which initially maps to a single underlying
     (21 rows)
     ~~~
 
-3. Use the `SHOW TESTING_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
+3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -364,9 +364,9 @@ Now verify that the data for the table in the `intro` database is located on US-
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;" \
-    --execute="SHOW TESTING_RANGES FROM TABLE startrek.episodes;" \
-    --execute="SHOW TESTING_RANGES FROM TABLE startrek.quotes;"    
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;" \
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.episodes;" \
+    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.quotes;"    
     ~~~
 
     ~~~


### PR DESCRIPTION
Fixes #2282 

Related:
- https://github.com/cockroachdb/cockroach/pull/14390
- https://github.com/cockroachdb/cockroach/pull/24696

Specific changes:

- Add a statement page for `SHOW EXPERIMENTAL_RANGES`

- `s/TESTING_RANGES/EXPERIMENTAL_RANGES/g` wherever it was previously
  mentioned, such as in `SPLIT AT`, partitioning docs, and some of the
  trainings

- Add `SHOW EXPERIMENTAL_RANGES` page(s) to sidebar nav

- Had to update full SQL diagram so the link to the `show_stmt_ranges`
  nonterminal would work properly

- Finally, replicated all changes into v2.1 folder