### PR TITLE
Update 2.0, 2.1 docs to use `SHOW TESTING_RANGES`

### DIFF
--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -618,9 +618,9 @@
             ]
           },
           {
-            "title": "<code>SHOW EXPERIMENTAL_RANGES</code>",
+            "title": "<code>SHOW TESTING_RANGES</code>",
             "urls": [
-              "/${VERSION}/show-experimental-ranges.html"
+              "/${VERSION}/show-testing-ranges.html"
             ]
           },
           {

--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -618,9 +618,9 @@
             ]
           },
           {
-            "title": "<code>SHOW EXPERIMENTAL_RANGES</code>",
+            "title": "<code>SHOW TESTING_RANGES</code>",
             "urls": [
-              "/${VERSION}/show-experimental-ranges.html"
+              "/${VERSION}/show-testing-ranges.html"
             ]
           },
           {

--- a/_includes/sql/v2.0/diagrams/show_ranges.html
+++ b/_includes/sql/v2.0/diagrams/show_ranges.html
@@ -1,32 +1,32 @@
-<div><svg width="710" height="80">
+<div><svg width="664" height="80">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="62" height="32" rx="10"></rect>
 <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">SHOW</text>
-<rect x="113" y="3" width="188" height="32" rx="10"></rect>
-<rect x="111" y="1" width="188" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="121" y="21">EXPERIMENTAL_RANGES</text>
-<rect x="321" y="3" width="58" height="32" rx="10"></rect>
-<rect x="319" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="329" y="21">FROM</text>
-<rect x="419" y="3" width="62" height="32" rx="10"></rect>
-<rect x="417" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="427" y="21">TABLE</text>
+<rect x="113" y="3" width="142" height="32" rx="10"></rect>
+<rect x="111" y="1" width="142" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">TESTING_RANGES</text>
+<rect x="275" y="3" width="58" height="32" rx="10"></rect>
+<rect x="273" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="283" y="21">FROM</text>
+<rect x="373" y="3" width="62" height="32" rx="10"></rect>
+<rect x="371" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="381" y="21">TABLE</text>
 <a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="501" y="3" width="90" height="32"></rect>
-<rect x="499" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="509" y="21">table_name</text>
+<rect x="455" y="3" width="90" height="32"></rect>
+<rect x="453" y="1" width="90" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="463" y="21">table_name</text>
 </a>
-<rect x="419" y="47" width="62" height="32" rx="10"></rect>
-<rect x="417" y="45" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="427" y="65">INDEX</text>
+<rect x="373" y="47" width="62" height="32" rx="10"></rect>
+<rect x="371" y="45" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="381" y="65">INDEX</text>
 <a xlink:href="sql-grammar.html#table_name_with_index" xlink:title="table_name_with_index">
-<rect x="501" y="47" width="162" height="32"></rect>
-<rect x="499" y="45" width="162" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="509" y="65">table_name_with_index</text>
+<rect x="455" y="47" width="162" height="32"></rect>
+<rect x="453" y="45" width="162" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="463" y="65">table_name_with_index</text>
 </a>
-<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m188 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
-<polygon points="701 17 709 13 709 21"></polygon>
-<polygon points="701 17 693 13 693 21"></polygon>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m142 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
+<polygon points="655 17 663 13 663 21"></polygon>
+<polygon points="655 17 647 13 647 21"></polygon>
 </svg></div>

--- a/_includes/sql/v2.1/diagrams/show_ranges.html
+++ b/_includes/sql/v2.1/diagrams/show_ranges.html
@@ -1,32 +1,32 @@
-<div><svg width="710" height="80">
+<div><svg width="664" height="80">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="62" height="32" rx="10"></rect>
 <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">SHOW</text>
-<rect x="113" y="3" width="188" height="32" rx="10"></rect>
-<rect x="111" y="1" width="188" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="121" y="21">EXPERIMENTAL_RANGES</text>
-<rect x="321" y="3" width="58" height="32" rx="10"></rect>
-<rect x="319" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="329" y="21">FROM</text>
-<rect x="419" y="3" width="62" height="32" rx="10"></rect>
-<rect x="417" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="427" y="21">TABLE</text>
+<rect x="113" y="3" width="142" height="32" rx="10"></rect>
+<rect x="111" y="1" width="142" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">TESTING_RANGES</text>
+<rect x="275" y="3" width="58" height="32" rx="10"></rect>
+<rect x="273" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="283" y="21">FROM</text>
+<rect x="373" y="3" width="62" height="32" rx="10"></rect>
+<rect x="371" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="381" y="21">TABLE</text>
 <a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="501" y="3" width="90" height="32"></rect>
-<rect x="499" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="509" y="21">table_name</text>
+<rect x="455" y="3" width="90" height="32"></rect>
+<rect x="453" y="1" width="90" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="463" y="21">table_name</text>
 </a>
-<rect x="419" y="47" width="62" height="32" rx="10"></rect>
-<rect x="417" y="45" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="427" y="65">INDEX</text>
+<rect x="373" y="47" width="62" height="32" rx="10"></rect>
+<rect x="371" y="45" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="381" y="65">INDEX</text>
 <a xlink:href="sql-grammar.html#table_name_with_index" xlink:title="table_name_with_index">
-<rect x="501" y="47" width="162" height="32"></rect>
-<rect x="499" y="45" width="162" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="509" y="65">table_name_with_index</text>
+<rect x="455" y="47" width="162" height="32"></rect>
+<rect x="453" y="45" width="162" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="463" y="65">table_name_with_index</text>
 </a>
-<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m188 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
-<polygon points="701 17 709 13 709 21"></polygon>
-<polygon points="701 17 693 13 693 21"></polygon>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m142 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h72 m-284 0 h20 m264 0 h20 m-304 0 q10 0 10 10 m284 0 q0 -10 10 -10 m-294 10 v24 m284 0 v-24 m-284 24 q0 10 10 10 m264 0 q10 0 10 -10 m-274 10 h10 m62 0 h10 m0 0 h10 m162 0 h10 m23 -44 h-3"></path>
+<polygon points="655 17 663 13 663 21"></polygon>
+<polygon points="655 17 647 13 647 21"></polygon>
 </svg></div>

--- a/v2.0/demo-follow-the-workload.md
+++ b/v2.0/demo-follow-the-workload.md
@@ -188,7 +188,7 @@ The load generator created a `kv` table that maps to an underlying key-value ran
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
+    > SHOW TESTING_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~
@@ -250,7 +250,7 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
+    > SHOW TESTING_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~

--- a/v2.0/partitioning.md
+++ b/v2.0/partitioning.md
@@ -229,7 +229,7 @@ $ cockroach zone set roachlearn.students_by_list.australia --insecure  -f austra
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_list;
+> SHOW TESTING_RANGES FROM TABLE students_by_list;
 ~~~
 
 You should see the following output:
@@ -335,7 +335,7 @@ $ cockroach zone set roachlearn.students_by_range.graduated --insecure  -f gradu
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_range;
+> SHOW TESTING_RANGES FROM TABLE students_by_range;
 ~~~
 
 You should see the following output:
@@ -477,7 +477,7 @@ $ cockroach zone set roachlearn.students.graduated_au --insecure -f graduated_au
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE students;
+> SHOW TESTING_RANGES FROM TABLE students;
 ~~~
 
 You should see the following output:

--- a/v2.0/show-testing-ranges.md
+++ b/v2.0/show-testing-ranges.md
@@ -1,10 +1,10 @@
 ---
-title: SHOW EXPERIMENTAL_RANGES
-summary: The SHOW EXPERIMENTAL_RANGES shows information about the ranges that make up a specific table's data.
+title: SHOW TESTING_RANGES
+summary: The SHOW TESTING_RANGES shows information about the ranges that make up a specific table's data.
 toc: false
 ---
 
-The `SHOW EXPERIMENTAL_RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that make up a specific table's data, including:
+The `SHOW TESTING_RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that make up a specific table's data, including:
 
 - The start and end keys for the range(s)
 - The range ID(s)
@@ -81,7 +81,7 @@ A `NULL` in the *End Key* column means "end of table".
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE credit_users;
+> SHOW TESTING_RANGES FROM TABLE credit_users;
 ~~~
 
 ~~~
@@ -100,7 +100,7 @@ A `NULL` in the *End Key* column means "end of table".
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM INDEX credit_users@areaCode;
+> SHOW TESTING_RANGES FROM INDEX credit_users@areaCode;
 ~~~
 
 ~~~

--- a/v2.0/split-at.md
+++ b/v2.0/split-at.md
@@ -58,7 +58,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
+> SHOW TESTING_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -88,7 +88,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
+> SHOW TESTING_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -112,7 +112,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
+> SHOW TESTING_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~
@@ -142,7 +142,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
+> SHOW TESTING_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~

--- a/v2.0/sql-statements.md
+++ b/v2.0/sql-statements.md
@@ -53,6 +53,7 @@ Statement | Usage
 [`DROP SEQUENCE`](drop-sequence.html) | <span class="version-tag">New in v2.0:</span> Remove a sequence.
 [`DROP TABLE`](drop-table.html) | Remove a table.
 [`DROP VIEW`](drop-view.html)| Remove a view.
+[`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Turn SQL audit logging on or off for a table.
 [`RENAME COLUMN`](rename-column.html) | Rename a column in a table.
 [`RENAME DATABASE`](rename-database.html) | Rename a database.
 [`RENAME INDEX`](rename-index.html) | Rename an index for a table.
@@ -67,6 +68,7 @@ Statement | Usage
 [`SHOW INDEX`](show-index.html) | View index information for a table.
 [`SHOW SCHEMAS`](show-schemas.html) | <span class="version-tag">New in v2.0:</span> List the schemas in a database.
 [`SHOW TABLES`](show-tables.html) | List tables or views in a database or virtual schema.
+[`SHOW TESTING_RANGES`](show-testing-ranges.html) | Show range information about a specific table or index.
 [`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the table or index.
 
 ## Transaction Management Statements

--- a/v2.0/training/data-unavailability-troubleshooting.md
+++ b/v2.0/training/data-unavailability-troubleshooting.md
@@ -184,13 +184,13 @@ In preparation, add a table and use a replication zone to force the table's data
     constraints: [+datacenter=us-east-3]
     ~~~
 
-3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
+3. Use the `SHOW TESTING_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -202,7 +202,7 @@ In preparation, add a table and use a replication zone to force the table's data
     (1 row)
     ~~~
 
-4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW EXPERIMENTAL_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
+4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW TESTING_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
 
     <img src="{{ 'images/v2.0/training-19.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 

--- a/v2.0/training/locality-and-replication-zones.md
+++ b/v2.0/training/locality-and-replication-zones.md
@@ -227,13 +227,13 @@ To check this, let's create a table, which initially maps to a single underlying
     (21 rows)
     ~~~
 
-3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
+3. Use the `SHOW TESTING_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -364,9 +364,9 @@ Now verify that the data for the table in the `intro` database is located on US-
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;" \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.episodes;" \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.quotes;"
+    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;" \
+    --execute="SHOW TESTING_RANGES FROM TABLE startrek.episodes;" \
+    --execute="SHOW TESTING_RANGES FROM TABLE startrek.quotes;"
     ~~~
 
     ~~~

--- a/v2.1/demo-follow-the-workload.md
+++ b/v2.1/demo-follow-the-workload.md
@@ -188,7 +188,7 @@ The load generator created a `kv` table that maps to an underlying key-value ran
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
+    > SHOW TESTING_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~
@@ -250,7 +250,7 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SHOW EXPERIMENTAL_RANGES FROM TABLE test.kv;
+    > SHOW TESTING_RANGES FROM TABLE test.kv;
     ~~~
 
     ~~~

--- a/v2.1/partitioning.md
+++ b/v2.1/partitioning.md
@@ -229,7 +229,7 @@ $ cockroach zone set roachlearn.students_by_list.australia --insecure  -f austra
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_list;
+> SHOW TESTING_RANGES FROM TABLE students_by_list;
 ~~~
 
 You should see the following output:
@@ -335,7 +335,7 @@ $ cockroach zone set roachlearn.students_by_range.graduated --insecure  -f gradu
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE students_by_range;
+> SHOW TESTING_RANGES FROM TABLE students_by_range;
 ~~~
 
 You should see the following output:
@@ -477,7 +477,7 @@ $ cockroach zone set roachlearn.students.graduated_au --insecure -f graduated_au
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE students;
+> SHOW TESTING_RANGES FROM TABLE students;
 ~~~
 
 You should see the following output:

--- a/v2.1/show-testing-ranges.md
+++ b/v2.1/show-testing-ranges.md
@@ -1,10 +1,10 @@
 ---
-title: SHOW EXPERIMENTAL_RANGES
-summary: The SHOW EXPERIMENTAL_RANGES shows information about the ranges that make up a specific table's data.
+title: SHOW TESTING_RANGES
+summary: The SHOW TESTING_RANGES shows information about the ranges that make up a specific table's data.
 toc: false
 ---
 
-The `SHOW EXPERIMENTAL_RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that make up a specific table's data, including:
+The `SHOW TESTING_RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that make up a specific table's data, including:
 
 - The start and end keys for the range(s)
 - The range ID(s)
@@ -81,7 +81,7 @@ A `NULL` in the *End Key* column means "end of table".
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE credit_users;
+> SHOW TESTING_RANGES FROM TABLE credit_users;
 ~~~
 
 ~~~
@@ -100,7 +100,7 @@ A `NULL` in the *End Key* column means "end of table".
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM INDEX credit_users@areaCode;
+> SHOW TESTING_RANGES FROM INDEX credit_users@areaCode;
 ~~~
 
 ~~~

--- a/v2.1/split-at.md
+++ b/v2.1/split-at.md
@@ -58,7 +58,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
+> SHOW TESTING_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -88,7 +88,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM TABLE kv;
+> SHOW TESTING_RANGES FROM TABLE kv;
 ~~~
 
 ~~~
@@ -112,7 +112,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
+> SHOW TESTING_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~
@@ -142,7 +142,7 @@ the ranges that store tables or indexes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW EXPERIMENTAL_RANGES FROM INDEX kv@secondary;
+> SHOW TESTING_RANGES FROM INDEX kv@secondary;
 ~~~
 
 ~~~

--- a/v2.1/sql-statements.md
+++ b/v2.1/sql-statements.md
@@ -53,6 +53,7 @@ Statement | Usage
 [`DROP SEQUENCE`](drop-sequence.html) | <span class="version-tag">New in v2.0:</span> Remove a sequence.
 [`DROP TABLE`](drop-table.html) | Remove a table.
 [`DROP VIEW`](drop-view.html)| Remove a view.
+[`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Turn SQL audit logging on or off for a table.
 [`RENAME COLUMN`](rename-column.html) | Rename a column in a table.
 [`RENAME DATABASE`](rename-database.html) | Rename a database.
 [`RENAME INDEX`](rename-index.html) | Rename an index for a table.
@@ -67,6 +68,7 @@ Statement | Usage
 [`SHOW INDEX`](show-index.html) | View index information for a table.
 [`SHOW SCHEMAS`](show-schemas.html) | <span class="version-tag">New in v2.0:</span> List the schemas in a database.
 [`SHOW TABLES`](show-tables.html) | List tables or views in a database or virtual schema.
+[`SHOW TESTING_RANGES`](show-testing-ranges.html) | Show range information about a specific table or index.
 [`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the table or index.
 
 ## Transaction Management Statements

--- a/v2.1/training/data-unavailability-troubleshooting.md
+++ b/v2.1/training/data-unavailability-troubleshooting.md
@@ -184,13 +184,13 @@ In preparation, add a table and use a replication zone to force the table's data
     constraints: [+datacenter=us-east-3]
     ~~~
 
-3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
+3. Use the `SHOW TESTING_RANGES` SQL command to determine the nodes on which the replicas for the `mytable` table are now located:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -202,7 +202,7 @@ In preparation, add a table and use a replication zone to force the table's data
     (1 row)
     ~~~
 
-4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW EXPERIMENTAL_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
+4. The node IDs above may not match the order in which we started the nodes because node IDs only get allocated after `cockroach init` is run. You can verify that the nodes listed by `SHOW TESTING_RANGES` are all in the `datacenter=us-east-3` locality by opening the **Node Diagnostics** debug page at <a href="http://localhost:8080/#/reports/nodes" data-proofer-ignore>http://localhost:8080/#/reports/nodes</a> and checking the locality for each of the 3 node IDs.
 
     <img src="{{ 'images/v2.0/training-19.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 

--- a/v2.1/training/locality-and-replication-zones.md
+++ b/v2.1/training/locality-and-replication-zones.md
@@ -227,13 +227,13 @@ To check this, let's create a table, which initially maps to a single underlying
     (21 rows)
     ~~~
 
-3. Use the `SHOW EXPERIMENTAL_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
+3. Use the `SHOW TESTING_RANGES` SQL command to find the IDs of the nodes where the new table's replicas ended up:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;"
+    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;"
     ~~~
 
     ~~~
@@ -364,9 +364,9 @@ Now verify that the data for the table in the `intro` database is located on US-
     ~~~ shell
     $ ./cockroach sql \
     --insecure \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE intro.mytable;" \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.episodes;" \
-    --execute="SHOW EXPERIMENTAL_RANGES FROM TABLE startrek.quotes;"    
+    --execute="SHOW TESTING_RANGES FROM TABLE intro.mytable;" \
+    --execute="SHOW TESTING_RANGES FROM TABLE startrek.episodes;" \
+    --execute="SHOW TESTING_RANGES FROM TABLE startrek.quotes;"    
     ~~~
 
     ~~~


### PR DESCRIPTION
Fixes #2954

Summary of changes:

- `SHOW EXPERIMENTAL_RANGES` is not supported in current releases of 2.0
  or 2.1, so we update all uses back to `SHOW TESTING_RANGES`, which
  does work on both versions.

- Rename files to `show-testing-ranges.html`

- Add `SHOW TESTING_RANGES` to 'SQL Statements' page.

- Add `EXPERIMENTAL_AUDIT` to 'SQL Statements' page while we're in here.