### PR TITLE
Mark limitation resolved as of 2.1

### DIFF
--- a/v2.0/known-limitations.md
+++ b/v2.0/known-limitations.md
@@ -18,6 +18,8 @@ In the upgrade process, after upgrading all binaries to v2.0, it's recommended t
 
 ### Write and update limits for a single statement
 
+{{site.data.alerts.callout_info}}Resolved as of v2.1. See <a href="https://github.com/cockroachdb/cockroach/pull/23373">#23373</a>.{{site.data.alerts.end}}
+
 A single statement can perform at most at most 64MiB of combined updates. When a statement exceeds these limits, its transaction gets aborted. `INSERT INTO ... SELECT FROM` queries commonly encounter these limits.
 
 If you need to increase these limits, you can update the [cluster-wide setting](cluster-settings.html) `kv.raft.command.max_size`, but note that increasing this setting can affect the memory utilization of nodes in the cluster. For `INSERT INTO .. SELECT FROM` queries in particular, another workaround is to manually page through the data you want to insert using separate transactions.


### PR DESCRIPTION
Follow-up to https://github.com/cockroachdb/docs/pull/3013