### PR TITLE
Update `sql` doc with interactive session defaults

### DIFF
--- a/_includes/sql/v2.0/connection-parameters-with-url.md
+++ b/_includes/sql/v2.0/connection-parameters-with-url.md
@@ -1,2 +1,2 @@
 {% include sql/{{ page.version.version }}/connection-parameters.md %}
-`--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments.<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
+<a name="sql-flag-url" /> `--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments.<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL

--- a/_includes/sql/v2.1/connection-parameters-with-url.md
+++ b/_includes/sql/v2.1/connection-parameters-with-url.md
@@ -1,2 +1,2 @@
 {% include sql/{{ page.version.version }}/connection-parameters.md %}
-`--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments.<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
+<a name="sql-flag-url" /> `--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments.<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL

--- a/v2.0/use-the-built-in-sql-client.md
+++ b/v2.0/use-the-built-in-sql-client.md
@@ -27,20 +27,24 @@ $ cockroach sql --help
 
 ## Flags
 
-The `sql` command supports the following [general-use](#general) and [logging](#logging) flags.
+The `sql` command supports the following types of flags:
+
+- [General Use](#general)
+- [Client Connection](#client-connection)
+- [Logging](#logging)
 
 ### General
 
-- To start an interactive SQL shell, run `cockroach sql` with all appropriate connection flags or use just the `--url` flag, which includes connection details.
-- To execute SQL statements from the command line, use the `--execute` flag.
+- To start an interactive SQL shell, run `cockroach sql` with all appropriate connection flags or use just the [`--url` flag](#sql-flag-url), which includes [connection details](connection-parameters.html#connect-using-a-url).
+- To execute SQL statements from the command line, use the [`--execute` flag](#sql-flag-execute).
 
 Flag | Description
 -----|------------
 `--database`<br>`-d` | A database name to use as [current database](sql-name-resolution.html#current-database) in the newly created session.
 `--echo-sql` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the command-line utility. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.<br><br>This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](#sql-shell-commands).
-`--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
-`--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` for interactive sessions, `tsv` for non-interactive sessions<br><br>The `display_format` [SQL shell option](#sql-shell-options) can also be used to change the format within an interactive session.
-`--safe-updates` | <span class="version-tag">Changed in v2.0:</span> Disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`.<br><br>**Default:** `true`<br><br>Potentially unsafe SQL statements can also be allowed/disallowed for an entire session via the `sql_safe_updates` [session variable](set-vars.html).
+<a name="sql-flag-execute" /> `--execute`<br />`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
+<a name="sql-flag-format" /> `--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` for [interactive sessions](#interactive-sessions), `tsv` for non-interactive sessions<br /><br />Corresponds to the [`display_format`](#sql-option-display-format) SQL shell option for use in interactive sessions.
+`--safe-updates` | <span class="version-tag">Changed in v2.0:</span> Disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`.<br><br>**Default:** `true` for [interactive sessions](#interactive-sessions), `false` otherwise.<br /><br />Potentially unsafe SQL statements can also be allowed/disallowed for an entire session via the `sql_safe_updates` [session variable](set-vars.html).
 
 ### Client Connection
 
@@ -77,6 +81,21 @@ When the SQL shell connects (or reconnects) to a CockroachDB node, it prints a w
 - When the client and server versions are different, the shell prints both the `Client version` and `Server version`. In this case, you may want to [plan an upgrade](upgrade-cockroach-version.html) of older client or server versions.
 - Since every CockroachDB cluster has a unique ID, you can use the `Cluster ID` field to verify that your client is always connecting to the correct cluster.
 
+## Interactive Sessions
+
+`cockroach sql` distinguishes between an *interactive session* and other sessions that generate terminal output. An interactive session is one where there's a user manually entering queries and looking at the results.  This is detected as follows:
+
+1. The `cockroach sql` command is used
+2. Standard input is a terminal, not redirected
+3. The [`-e` flag](#sql-flag-execute) is not used
+
+When an interactive session is detected, the following options have their defaults changed:
+
++ The [`--format` flag](#sql-flag-format) (and its corresponding [`display_format` option](#sql-option-display-format)) default to `pretty`.
++ The [`errexit` option](#sql-option-errexit) defaults to `false`.
++ The [`check_syntax` option](#sql-option-check-syntax) defaults to `true`.
++ The [`smart_prompt` option](#sql-option-smart-prompt) defaults to `true`.
+
 ## SQL Shell Commands
 
 The following commands can be used within the interactive SQL shell:
@@ -97,12 +116,12 @@ To view help and the current settings, use `\set` without any options. To enable
 
 Client Options | Description
 ---------------|------------
-`display_format` | <span class="version-tag">New in v1.1:</span> How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>This option is set to whatever value was passed to the `--format` flag when the shell was started. If the `--format` flag was not used, this option defaults to `pretty`.<br><br>To change this option, run `\set display_format <format>`. For a demonstration, see the [example](#make-the-output-of-show-statements-selectable) below.
-`echo` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the SQL shell.<br><br>This option is disabled by default. To enable it, run `\set echo`. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.
-`errexit` | Exit the SQL shell upon encountering an error.<br><br>This option is disabled by default. To enable it, run `\set errexit`.
-`check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br><br>This option is enabled by default. To disable it, run `\unset check_syntax`.
-`show_times` | <span class="version-tag">New in v1.1:</span> Reveal the time a query takes to complete.<br><br>This option is enabled by default. To disable it, run `\unset show_times`.
-`smart_prompt` | <span class="version-tag">New in v1.1:</span> Query the server for the current transaction status and return it to the prompt.<br><br>This option is enabled by default. However, it is respected only when `ECHO` is enabled as well. To disable this option, run `\unset smart_prompt`.
+<a name="sql-option-display-format" /> `display_format` | <span class="version-tag">Updated in v2.0:</span> How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` when the output goes to a terminal and the [`--format` flag](#sql-flag-format) is not passed at startup, `tsv` otherwise.<br /><br />To change this option, run `\set display_format <format>`. For a demonstration, see the [example](#make-the-output-of-show-statements-selectable) below.
+`echo` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the SQL shell.<br><br>**Default:** `false`. To enable it, run `\set echo`. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.
+<a name="sql-option-errexit" /> `errexit` | <span class="version-tag">Updated in v2.0:</span> Exit the SQL shell upon encountering an error.<br /><br />**Default:** `false` for [interactive sessions](#interactive-sessions), `true` otherwise. To enable it, run `\set errexit`.
+<a name="sql-option-check-syntax" /> `check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br /><br />**Default:** `true` for [interactive sessions](#interactive-sessions), `false` otherwise. To disable it, run `\unset check_syntax`.
+`show_times` | <span class="version-tag">New in v1.1:</span> Reveal the time a query takes to complete.<br><br>**Default:** `true`. To disable it, run `\unset show_times`.
+<a name="sql-option-smart-prompt" /> `smart_prompt` | <span class="version-tag">New in v1.1:</span> Query the server for the current transaction status and return it to the prompt.<br /><br />**Default:** `true` for [interactive sessions](#interactive-sessions), `false` otherwise. However, it is respected only when `ECHO` is enabled as well. To disable this option, run `\unset smart_prompt`.
 
 ### SQL Shell Help
 

--- a/v2.1/use-the-built-in-sql-client.md
+++ b/v2.1/use-the-built-in-sql-client.md
@@ -27,20 +27,24 @@ $ cockroach sql --help
 
 ## Flags
 
-The `sql` command supports the following [general-use](#general) and [logging](#logging) flags.
+The `sql` command supports the following types of flags:
+
+- [General Use](#general)
+- [Client Connection](#client-connection)
+- [Logging](#logging)
 
 ### General
 
-- To start an interactive SQL shell, run `cockroach sql` with all appropriate connection flags or use just the `--url` flag, which includes connection details.
-- To execute SQL statements from the command line, use the `--execute` flag.
+- To start an interactive SQL shell, run `cockroach sql` with all appropriate connection flags or use just the [`--url` flag](#sql-flag-url), which includes [connection details](connection-parameters.html#connect-using-a-url).
+- To execute SQL statements from the command line, use the [`--execute` flag](#sql-flag-execute).
 
 Flag | Description
 -----|------------
 `--database`<br>`-d` | A database name to use as [current database](sql-name-resolution.html#current-database) in the newly created session.
 `--echo-sql` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the command-line utility. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.<br><br>This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](#sql-shell-commands).
-`--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
-`--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` for interactive sessions, `tsv` for non-interactive sessions<br><br>The `display_format` [SQL shell option](#sql-shell-options) can also be used to change the format within an interactive session.
-`--safe-updates` | <span class="version-tag">Changed in v2.0:</span> Disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`.<br><br>**Default:** `true`<br><br>Potentially unsafe SQL statements can also be allowed/disallowed for an entire session via the `sql_safe_updates` [session variable](set-vars.html).
+<a name="sql-flag-execute" /> `--execute`<br />`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
+<a name="sql-flag-format" /> `--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` for [interactive sessions](#interactive-sessions), `tsv` for non-interactive sessions<br /><br />Corresponds to the [`display_format`](#sql-option-display-format) SQL shell option for use in interactive sessions.
+`--safe-updates` | <span class="version-tag">Changed in v2.0:</span> Disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`.<br><br>**Default:** `true` for [interactive sessions](#interactive-sessions), `false` otherwise.<br /><br />Potentially unsafe SQL statements can also be allowed/disallowed for an entire session via the `sql_safe_updates` [session variable](set-vars.html).
 
 ### Client Connection
 
@@ -77,6 +81,21 @@ When the SQL shell connects (or reconnects) to a CockroachDB node, it prints a w
 - When the client and server versions are different, the shell prints both the `Client version` and `Server version`. In this case, you may want to [plan an upgrade](upgrade-cockroach-version.html) of older client or server versions.
 - Since every CockroachDB cluster has a unique ID, you can use the `Cluster ID` field to verify that your client is always connecting to the correct cluster.
 
+## Interactive Sessions
+
+`cockroach sql` distinguishes between an *interactive session* and other sessions that generate terminal output. An interactive session is one where there's a user manually entering queries and looking at the results.  This is detected as follows:
+
+1. The `cockroach sql` command is used
+2. Standard input is a terminal, not redirected
+3. The [`-e` flag](#sql-flag-execute) is not used
+
+When an interactive session is detected, the following options have their defaults changed:
+
++ The [`--format` flag](#sql-flag-format) (and its corresponding [`display_format` option](#sql-option-display-format)) default to `pretty`.
++ The [`errexit` option](#sql-option-errexit) defaults to `false`.
++ The [`check_syntax` option](#sql-option-check-syntax) defaults to `true`.
++ The [`smart_prompt` option](#sql-option-smart-prompt) defaults to `true`.
+
 ## SQL Shell Commands
 
 The following commands can be used within the interactive SQL shell:
@@ -97,12 +116,12 @@ To view help and the current settings, use `\set` without any options. To enable
 
 Client Options | Description
 ---------------|------------
-`display_format` | <span class="version-tag">New in v1.1:</span> How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>This option is set to whatever value was passed to the `--format` flag when the shell was started. If the `--format` flag was not used, this option defaults to `pretty`.<br><br>To change this option, run `\set display_format <format>`. For a demonstration, see the [example](#make-the-output-of-show-statements-selectable) below.
-`echo` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the SQL shell.<br><br>This option is disabled by default. To enable it, run `\set echo`. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.
-`errexit` | Exit the SQL shell upon encountering an error.<br><br>This option is disabled by default. To enable it, run `\set errexit`.
-`check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br><br>This option is enabled by default. To disable it, run `\unset check_syntax`.
-`show_times` | <span class="version-tag">New in v1.1:</span> Reveal the time a query takes to complete.<br><br>This option is enabled by default. To disable it, run `\unset show_times`.
-`smart_prompt` | <span class="version-tag">New in v1.1:</span> Query the server for the current transaction status and return it to the prompt.<br><br>This option is enabled by default. However, it is respected only when `ECHO` is enabled as well. To disable this option, run `\unset smart_prompt`.
+<a name="sql-option-display-format" /> `display_format` | <span class="version-tag">Updated in v2.0:</span> How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `pretty`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `pretty` when the output goes to a terminal and the [`--format` flag](#sql-flag-format) is not passed at startup, `tsv` otherwise.<br /><br />To change this option, run `\set display_format <format>`. For a demonstration, see the [example](#make-the-output-of-show-statements-selectable) below.
+`echo` | <span class="version-tag">New in v1.1:</span> Reveal the SQL statements sent implicitly by the SQL shell.<br><br>**Default:** `false`. To enable it, run `\set echo`. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.
+<a name="sql-option-errexit" /> `errexit` | <span class="version-tag">Updated in v2.0:</span> Exit the SQL shell upon encountering an error.<br /><br />**Default:** `false` for [interactive sessions](#interactive-sessions), `true` otherwise. To enable it, run `\set errexit`.
+<a name="sql-option-check-syntax" /> `check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br /><br />**Default:** `true` for [interactive sessions](#interactive-sessions), `false` otherwise. To disable it, run `\unset check_syntax`.
+`show_times` | <span class="version-tag">New in v1.1:</span> Reveal the time a query takes to complete.<br><br>**Default:** `true`. To disable it, run `\unset show_times`.
+<a name="sql-option-smart-prompt" /> `smart_prompt` | <span class="version-tag">New in v1.1:</span> Query the server for the current transaction status and return it to the prompt.<br /><br />**Default:** `true` for [interactive sessions](#interactive-sessions), `false` otherwise. However, it is respected only when `ECHO` is enabled as well. To disable this option, run `\unset smart_prompt`.
 
 ### SQL Shell Help
 


### PR DESCRIPTION
Fixes #2397.

Related code changes in
https://github.com/cockroachdb/cockroach/pull/20805.

Summary of changes:

- Add a new section, 'Interactive Sessions', to the 'Use the built-in
  SQL client' page.  In this section we describe the changed defaults at
  a high level, with links to the flags for details. (This required
  adding anchors to a number of the specific flag descriptions.)

- Update descriptions of the affected flags' defaults.

- Where possible, made references to flags/options into links in a few
  places (now that said flags/options have anchors).

- Unrelated edit: Made it so that all flag descriptions use the same
  "**Default**: foo" syntax for easier scanning by readers.

- Unrelated edit: Made a list of subhead links in the 'Flags' section
  since the previous version was missing the 'Client Connection'
  subsection.