### PR TITLE
Recommend decimal notation for flags that accept percentage

### DIFF
--- a/v2.0/enable-node-map.md
+++ b/v2.0/enable-node-map.md
@@ -60,8 +60,8 @@ $ cockroach start \
 --insecure \
 --locality=region=us-east-1,datacenter=us-east-1a  \
 --host=<node1 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 
@@ -73,8 +73,8 @@ $ cockroach start \
 --insecure \
 --locality=region=us-east-1,datacenter=us-east-1b \
 --host=<node2 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 
@@ -86,8 +86,8 @@ $ cockroach start \
 --insecure \
 --locality=region=us-west-1,datacenter=us-west-1a \
 --host=<node3 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 
@@ -99,8 +99,8 @@ $ cockroach start \
 --insecure \
 --locality=region=eu-west-1,datacenter=eu-west-1a \
 --host=<node4 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 

--- a/v2.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -131,8 +131,8 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     --publish 8080:8080 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --insecure
     ~~~
@@ -149,8 +149,8 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     --stop-grace-period 60s \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --insecure
     ~~~
@@ -167,8 +167,8 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     --stop-grace-period 60s \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --insecure
     ~~~

--- a/v2.0/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v2.0/orchestrate-cockroachdb-with-docker-swarm.md
@@ -331,8 +331,8 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     --secret source=cockroachdb-root-key,target=client.root.key,mode=0600 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --certs-dir=/run/secrets
     ~~~
@@ -354,8 +354,8 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     --secret source=cockroachdb-root-key,target=client.root.key,mode=0600 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --certs-dir=/run/secrets
     ~~~
@@ -377,8 +377,8 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     --secret source=cockroachdb-root-key,target=client.root.key,mode=0600 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --certs-dir=/run/secrets
     ~~~

--- a/v2.0/recommended-production-settings.md
+++ b/v2.0/recommended-production-settings.md
@@ -137,7 +137,7 @@ Environment | Featured Approach
 To manually increase a node's cache size and SQL memory size, start the node using the [`--cache`](start-a-node.html#flags-changed-in-v2-0) and [`--max-sql-memory`](start-a-node.html#flags-changed-in-v2-0) flags:
 
 ~~~ shell
-$ cockroach start --cache=25% --max-sql-memory=25% <other start flags>
+$ cockroach start --cache=.25 --max-sql-memory=.25 <other start flags>
 ~~~
 
 ## File Descriptors Limit

--- a/v2.0/start-a-node.md
+++ b/v2.0/start-a-node.md
@@ -46,7 +46,7 @@ Flag | Description
 `--advertise-host` | The hostname or IP address to advertise to other CockroachDB nodes. If it is a hostname, it must be resolvable from all nodes; if it is an IP address, it must be routable from all nodes.<br><br>When this flag is not set, the node advertises the address in the `--host` flag.
 `--attrs` | Arbitray strings, separated by colons, specifying node capability, which might include specialized hardware or number of cores, for example:<br><br>`--attrs=ram:64gb`<br><br>These can be used to influence the location of data replicas. See [Configure Replication Zones](configure-replication-zones.html#replication-constraints) for full details.
 `--background` | Set this to start the node in the background. This is better than appending `&` to the command because control is returned to the shell only once the node is ready to accept requests. <br /><br /> **Note:** `--background` is suitable for writing automated test suites or maintenance procedures that need a temporary server process running in the background. It is not intended to be used to start a long-running server, because it does not fully detach from the controlling terminal.  Consider using a service manager or a tool like [daemon(8)](https://www.freebsd.org/cgi/man.cgi?query=daemon&sektion=8) instead.
-`--cache` | The total size for caches, shared evenly if there are multiple storage devices. This can be a percentage or any bytes-based unit, for example: <br><br>`--cache=25%`<br>`--cache=1000000000 ----> 1000000000 bytes`<br>`--cache=1GB ----> 1000000000 bytes`<br>`--cache=1GiB ----> 1073741824 bytes` <br><br><strong>Note:</strong> If you enter the cache size as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default cache size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
+`--cache` | The total size for caches, shared evenly if there are multiple storage devices. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit, for example: <br><br>`--cache=.25`<br>`--cache=25%`<br>`--cache=1000000000 ----> 1000000000 bytes`<br>`--cache=1GB ----> 1000000000 bytes`<br>`--cache=1GiB ----> 1073741824 bytes` <br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default cache size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
 `--certs-dir` | The path to the [certificate directory](create-security-certificates.html). The directory must contain valid certificates if running in secure mode.<br><br>**Default:** `${HOME}/.cockroach-certs/`
 `--external-io-dir` | <span class="version-tag">New in v2.0:</span> The path of the external IO directory with which the local file access paths are prefixed while performing backup and restore operations using local node directories or NFS drives. If set to `disabled`, backups and restores using local node directories and NFS drives are disabled.<br><br>**Default:** `extern` subdirectory of the first configured [`store`](#store).<br><br>To set the `--external-io-dir` flag to the locations you want to use without needing to restart nodes, create symlinks to the desired locations from within the `extern` directory.
 `--host` | The hostname or IP address to listen on for intra-cluster and client communication. The node will also advertise itself to other nodes using this address only if `--advertise-host` is not specified; in this case, if it is a hostname, it must be resolvable from all nodes, and if it is an IP address, it must be routable from all nodes.<br><br>**Default:** Listen on all interfaces, but this flag can be set to listen on an external address
@@ -56,9 +56,9 @@ Flag | Description
 `--join`<br>`-j` | The addresses for connecting the node to a cluster.<br><br><span class="version-tag">Changed in v1.1:</span> When starting a multi-node cluster for the first time, set this flag to the addresses of 3-5 of the initial nodes. Then run the [`cockroach init`](initialize-a-cluster.html) command against any of the nodes to complete cluster startup. See the [example](#start-a-multi-node-cluster) below for more details. <br><br>When starting a singe-node cluster, leave this flag out. This will cause the node to initialize a new single-node cluster without needing to run the `cockroach init` command. See the [example](#start-a-single-node-cluster) below for more details.<br><br>When adding a node to an existing cluster, set this flag to 3-5 of the nodes already in the cluster; it's easiest to use the same list of addresses that was used to start the initial nodes.
 `--listening-url-file` | The file to which the node's SQL connection URL will be written on successful startup, in addition to being printed to the [standard output](#standard-output).<br><br>This is particularly helpful in identifying the node's port when an unused port is assigned automatically (`--port=0`).
 `--locality` | Arbitrary key-value pairs that describe the location of the node. Locality might include country, region, datacenter, rack, etc. For more details, see [Locality](#locality) below.
-`--max-disk-temp-storage` | <span class="version-tag">New in v1.1: </span>The maximum on-disk storage capacity available to store temporary data for SQL queries that exceed the memory budget (see `--max-sql-memory`). This ensures that JOINs, sorts, and other memory-intensive SQL operations are able to spill intermediate results to disk. This value can be a percentage or any bytes-based unit (e.g., `500GB`, `1TB`, `1TiB`).<br><br><strong>Note:</strong> If you enter the maximum on-disk storage capacity as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files. If expressed as a percentage, this value is interpreted relative to the size of the first store. However, the temporary space usage is never counted towards any store usage; therefore, when setting this value, it's important to ensure that the size of this temporary storage plus the size of the first store doesn't exceed the capacity of the storage device.<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br>**Default:** `32GiB`
+`--max-disk-temp-storage` | <span class="version-tag">New in v1.1: </span>The maximum on-disk storage capacity available to store temporary data for SQL queries that exceed the memory budget (see `--max-sql-memory`). This ensures that JOINs, sorts, and other memory-intensive SQL operations are able to spill intermediate results to disk. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit (e.g., `.25`, `25%`, `500GB`, `1TB`, `1TiB`).<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead. Also, if expressed as a percentage, this value is interpreted relative to the size of the first store. However, the temporary space usage is never counted towards any store usage; therefore, when setting this value, it's important to ensure that the size of this temporary storage plus the size of the first store doesn't exceed the capacity of the storage device.<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br>**Default:** `32GiB`
 `--max-offset` | The maximum allowed clock offset for the cluster. If observed clock offsets exceed this limit, servers will crash to minimize the likelihood of reading inconsistent data. Increasing this value will increase the time to recovery of failures as well as the frequency of uncertainty-based read restarts.<br><br>Note that this value must be the same on all nodes in the cluster and cannot be changed with a [rolling upgrade](upgrade-cockroach-version.html). In order to change it, first stop every node in the cluster. Then once the entire cluster is offline, restart each node with the new value.<br><br>**Default:** `500ms`
-`--max-sql-memory` | The maximum in-memory storage capacity available to store temporary data for SQL queries, including prepared queries and intermediate data rows during query execution. This value can be a percentage or any bytes-based unit, for example:<br><br>`--max-sql-memory=25%`<br>`--max-sql-memory=10000000000 ----> 1000000000 bytes`<br>`--max-sql-memory=1GB ----> 1000000000 bytes`<br>`--max-sql-memory=1GiB ----> 1073741824 bytes`<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br><strong>Note:</strong> If you enter the maximum in-memory storage capacity as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default SQL memory size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
+`--max-sql-memory` | The maximum in-memory storage capacity available to store temporary data for SQL queries, including prepared queries and intermediate data rows during query execution. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit, for example:<br><br>`--max-sql-memory=.25`<br>`--max-sql-memory=25%`<br>`--max-sql-memory=10000000000 ----> 1000000000 bytes`<br>`--max-sql-memory=1GB ----> 1000000000 bytes`<br>`--max-sql-memory=1GiB ----> 1073741824 bytes`<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default SQL memory size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
 `--pid-file` | The file to which the node's process ID will be written on successful startup. When this flag is not set, the process ID is not written to file.
 `--port`<br>`-p` | The port to bind to for internal and client communication.<br><br>To have an unused port assigned automatically, pass `--port=0`.<br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
 `--store`<br>`-s` | The file path to a storage device and, optionally, store attributes and maximum size. When using multiple storage devices for a node, this flag must be specified separately for each device, for example: <br><br>`--store=/mnt/ssd01 --store=/mnt/ssd02` <br><br>For more details, see [Store](#store) below.
@@ -98,7 +98,7 @@ Field | Description
 `type` | For in-memory storage, set this field to `mem`; otherwise, leave this field out. The `path` field must not be set when `type=mem`.
 `path` | The file path to the storage device. When not setting `attr` or `size`, the `path` field label can be left out: <br><br>`--store=/mnt/ssd01` <br><br>When either of those fields are set, however, the `path` field label must be used: <br><br>`--store=path=/mnt/ssd01,size=20GB` <br><br> **Default:** `cockroach-data`
 `attrs` | Arbitrary strings, separated by colons, specifying disk type or capability. These can be used to influence the location of data replicas. See [Configure Replication Zones](configure-replication-zones.html#replication-constraints) for full details.<br><br>In most cases, node-level `--locality` or `--attrs` are preferable to store-level attributes, but this field can be used to match capabilities for storage of individual databases or tables. For example, an OLTP database would probably want to allocate space for its tables only on solid state devices, whereas append-only time series might prefer cheaper spinning drives. Typical attributes include whether the store is flash (`ssd`) or spinny disk (`hdd`), as well as speeds and other specs, for example:<br><br> `--store=path=/mnt/hda1,attrs=hdd:7200rpm`
-`size` | The maximum size allocated to the node. When this size is reached, CockroachDB attempts to rebalance data to other nodes with available capacity. When there's no capacity elsewhere, this limit will be exceeded. Also, data may be written to the node faster than the cluster can rebalance it away; in this case, as long as capacity is available elsewhere, CockroachDB will gradually rebalance data down to the store limit.<br><br> The `size` can be specified either in a bytes-based unit or as a percentage of hard drive space, for example: <br><br>`--store=path=/mnt/ssd01,size=10000000000 ----> 10000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GB ----> 20000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=0.02TiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=20% ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=0.2 ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=.2 ----> 20% of available space`<br><br>**Default:** 100%<br><br>For an in-memory store, the `size` field is required and must be set to the true maximum bytes or percentage of available memory, for example:<br><br>`--store=type=mem,size=20GB`<br>`--store=type=mem,size=90%`<br><br><strong>Note:</strong> If you enter the size as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files.
+`size` | The maximum size allocated to the node. When this size is reached, CockroachDB attempts to rebalance data to other nodes with available capacity. When there's no capacity elsewhere, this limit will be exceeded. Also, data may be written to the node faster than the cluster can rebalance it away; in this case, as long as capacity is available elsewhere, CockroachDB will gradually rebalance data down to the store limit.<br><br> The `size` can be specified either in a bytes-based unit or as a percentage of hard drive space (notated as a decimal or with `%`), for example: <br><br>`--store=path=/mnt/ssd01,size=10000000000 ----> 10000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GB ----> 20000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=0.02TiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=20% ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=0.2 ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=.2 ----> 20% of available space`<br><br>**Default:** 100%<br><br>For an in-memory store, the `size` field is required and must be set to the true maximum bytes or percentage of available memory, for example:<br><br>`--store=type=mem,size=20GB`<br>`--store=type=mem,size=90%`<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead.
 
 ### Logging
 
@@ -168,8 +168,8 @@ To start a single-node cluster, run the `cockroach start` command without the `-
 $ cockroach start \
 --certs-dir=certs \
 --host=<node1 address> \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -178,8 +178,8 @@ $ cockroach start \
 $ cockroach start \
 --insecure \
 --host=<node1 address> \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -198,8 +198,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node1 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -207,8 +207,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node2 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -216,8 +216,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node3 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -227,8 +227,8 @@ $ cockroach start \
 --insecure \
 --host=<node1 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -236,8 +236,8 @@ $ cockroach start \
 --insecure \
 --host=<node2 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -245,8 +245,8 @@ $ cockroach start \
 --insecure \
 --host=<node3 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -283,8 +283,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node4 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -294,8 +294,8 @@ $ cockroach start \
 --insecure \
 --host=<node4 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 

--- a/v2.1/enable-node-map.md
+++ b/v2.1/enable-node-map.md
@@ -60,8 +60,8 @@ $ cockroach start \
 --insecure \
 --locality=region=us-east-1,datacenter=us-east-1a  \
 --host=<node1 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 
@@ -73,8 +73,8 @@ $ cockroach start \
 --insecure \
 --locality=region=us-east-1,datacenter=us-east-1b \
 --host=<node2 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 
@@ -86,8 +86,8 @@ $ cockroach start \
 --insecure \
 --locality=region=us-west-1,datacenter=us-west-1a \
 --host=<node3 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 
@@ -99,8 +99,8 @@ $ cockroach start \
 --insecure \
 --locality=region=eu-west-1,datacenter=eu-west-1a \
 --host=<node4 address> \
---cache=25% \
---max-sql-memory=25% \
+--cache=.25 \
+--max-sql-memory=.25 \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257,<node4 address>:26257
 ~~~
 

--- a/v2.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v2.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -131,8 +131,8 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     --publish 8080:8080 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --insecure
     ~~~
@@ -149,8 +149,8 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     --stop-grace-period 60s \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --insecure
     ~~~
@@ -167,8 +167,8 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     --stop-grace-period 60s \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --insecure
     ~~~

--- a/v2.1/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v2.1/orchestrate-cockroachdb-with-docker-swarm.md
@@ -331,8 +331,8 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     --secret source=cockroachdb-root-key,target=client.root.key,mode=0600 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --certs-dir=/run/secrets
     ~~~
@@ -354,8 +354,8 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     --secret source=cockroachdb-root-key,target=client.root.key,mode=0600 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --certs-dir=/run/secrets
     ~~~
@@ -377,8 +377,8 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     --secret source=cockroachdb-root-key,target=client.root.key,mode=0600 \
     cockroachdb/cockroach:{{page.release_info.version}} start \
     --join=cockroachdb-1:26257,cockroachdb-2:26257,cockroachdb-3:26257 \
-    --cache=25% \
-    --max-sql-memory=25% \
+    --cache=.25 \
+    --max-sql-memory=.25 \
     --logtostderr \
     --certs-dir=/run/secrets
     ~~~

--- a/v2.1/recommended-production-settings.md
+++ b/v2.1/recommended-production-settings.md
@@ -137,7 +137,7 @@ Environment | Featured Approach
 To manually increase a node's cache size and SQL memory size, start the node using the [`--cache`](start-a-node.html#flags-changed-in-v2-0) and [`--max-sql-memory`](start-a-node.html#flags-changed-in-v2-0) flags:
 
 ~~~ shell
-$ cockroach start --cache=25% --max-sql-memory=25% <other start flags>
+$ cockroach start --cache=.25 --max-sql-memory=.25 <other start flags>
 ~~~
 
 ## File Descriptors Limit

--- a/v2.1/start-a-node.md
+++ b/v2.1/start-a-node.md
@@ -46,7 +46,7 @@ Flag | Description
 `--advertise-host` | The hostname or IP address to advertise to other CockroachDB nodes. If it is a hostname, it must be resolvable from all nodes; if it is an IP address, it must be routable from all nodes.<br><br>When this flag is not set, the node advertises the address in the `--host` flag.
 `--attrs` | Arbitray strings, separated by colons, specifying node capability, which might include specialized hardware or number of cores, for example:<br><br>`--attrs=ram:64gb`<br><br>These can be used to influence the location of data replicas. See [Configure Replication Zones](configure-replication-zones.html#replication-constraints) for full details.
 `--background` | Set this to start the node in the background. This is better than appending `&` to the command because control is returned to the shell only once the node is ready to accept requests. <br /><br /> **Note:** `--background` is suitable for writing automated test suites or maintenance procedures that need a temporary server process running in the background. It is not intended to be used to start a long-running server, because it does not fully detach from the controlling terminal.  Consider using a service manager or a tool like [daemon(8)](https://www.freebsd.org/cgi/man.cgi?query=daemon&sektion=8) instead.
-`--cache` | The total size for caches, shared evenly if there are multiple storage devices. This can be a percentage or any bytes-based unit, for example: <br><br>`--cache=25%`<br>`--cache=1000000000 ----> 1000000000 bytes`<br>`--cache=1GB ----> 1000000000 bytes`<br>`--cache=1GiB ----> 1073741824 bytes` <br><br><strong>Note:</strong> If you enter the cache size as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default cache size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
+`--cache` | The total size for caches, shared evenly if there are multiple storage devices. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit, for example: <br><br>`--cache=.25`<br>`--cache=25%`<br>`--cache=1000000000 ----> 1000000000 bytes`<br>`--cache=1GB ----> 1000000000 bytes`<br>`--cache=1GiB ----> 1073741824 bytes` <br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default cache size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
 `--certs-dir` | The path to the [certificate directory](create-security-certificates.html). The directory must contain valid certificates if running in secure mode.<br><br>**Default:** `${HOME}/.cockroach-certs/`
 `--external-io-dir` | <span class="version-tag">New in v2.0:</span> The path of the external IO directory with which the local file access paths are prefixed while performing backup and restore operations using local node directories or NFS drives. If set to `disabled`, backups and restores using local node directories and NFS drives are disabled.<br><br>**Default:** `extern` subdirectory of the first configured [`store`](#store).<br><br>To set the `--external-io-dir` flag to the locations you want to use without needing to restart nodes, create symlinks to the desired locations from within the `extern` directory.
 `--host` | The hostname or IP address to listen on for intra-cluster and client communication. The node will also advertise itself to other nodes using this address only if `--advertise-host` is not specified; in this case, if it is a hostname, it must be resolvable from all nodes, and if it is an IP address, it must be routable from all nodes.<br><br>**Default:** Listen on all interfaces, but this flag can be set to listen on an external address
@@ -56,9 +56,10 @@ Flag | Description
 `--join`<br>`-j` | The addresses for connecting the node to a cluster.<br><br><span class="version-tag">Changed in v1.1:</span> When starting a multi-node cluster for the first time, set this flag to the addresses of 3-5 of the initial nodes. Then run the [`cockroach init`](initialize-a-cluster.html) command against any of the nodes to complete cluster startup. See the [example](#start-a-multi-node-cluster) below for more details. <br><br>When starting a singe-node cluster, leave this flag out. This will cause the node to initialize a new single-node cluster without needing to run the `cockroach init` command. See the [example](#start-a-single-node-cluster) below for more details.<br><br>When adding a node to an existing cluster, set this flag to 3-5 of the nodes already in the cluster; it's easiest to use the same list of addresses that was used to start the initial nodes.
 `--listening-url-file` | The file to which the node's SQL connection URL will be written on successful startup, in addition to being printed to the [standard output](#standard-output).<br><br>This is particularly helpful in identifying the node's port when an unused port is assigned automatically (`--port=0`).
 `--locality` | Arbitrary key-value pairs that describe the location of the node. Locality might include country, region, datacenter, rack, etc. For more details, see [Locality](#locality) below.
-`--max-disk-temp-storage` | <span class="version-tag">New in v1.1: </span>The maximum on-disk storage capacity available to store temporary data for SQL queries that exceed the memory budget (see `--max-sql-memory`). This ensures that JOINs, sorts, and other memory-intensive SQL operations are able to spill intermediate results to disk. This value can be a percentage or any bytes-based unit (e.g., `500GB`, `1TB`, `1TiB`).<br><br><strong>Note:</strong> If you enter the maximum on-disk storage capacity as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files. If expressed as a percentage, this value is interpreted relative to the size of the first store. However, the temporary space usage is never counted towards any store usage; therefore, when setting this value, it's important to ensure that the size of this temporary storage plus the size of the first store doesn't exceed the capacity of the storage device.<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br>**Default:** `32GiB`
+`--max-disk-temp-storage` | <span class="version-tag">New in v1.1: </span>The maximum on-disk storage capacity available to store temporary data for SQL queries that exceed the memory budget (see `--max-sql-memory`). This ensures that JOINs, sorts, and other memory-intensive SQL operations are able to spill intermediate results to disk. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit (e.g., `.25`, `25%`, `500GB`, `1TB`, `1TiB`).<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead. Also, if expressed as a percentage, this value is interpreted relative to the size of the first store. However, the temporary space usage is never counted towards any store usage; therefore, when setting this value, it's important to ensure that the size of this temporary storage plus the size of the first store doesn't exceed the capacity of the storage device.<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br>**Default:** `32GiB`
+`--max-disk-temp-storage` | <span class="version-tag">New in v1.1: </span>The maximum on-disk storage capacity available to store temporary data for SQL queries that exceed the memory budget (see `--max-sql-memory`). This ensures that JOINs, sorts, and other memory-intensive SQL operations are able to spill intermediate results to disk. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit (e.g., `.25`, `25%`, `500GB`, `1TB`, `1TiB`).<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead. Also, if expressed as a percentage, this value is interpreted relative to the size of the first store. However, the temporary space usage is never counted towards any store usage; therefore, when setting this value, it's important to ensure that the size of this temporary storage plus the size of the first store doesn't exceed the capacity of the storage device.<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br>**Default:** `32GiB`
 `--max-offset` | The maximum allowed clock offset for the cluster. If observed clock offsets exceed this limit, servers will crash to minimize the likelihood of reading inconsistent data. Increasing this value will increase the time to recovery of failures as well as the frequency of uncertainty-based read restarts.<br><br>Note that this value must be the same on all nodes in the cluster and cannot be changed with a [rolling upgrade](upgrade-cockroach-version.html). In order to change it, first stop every node in the cluster. Then once the entire cluster is offline, restart each node with the new value.<br><br>**Default:** `500ms`
-`--max-sql-memory` | The maximum in-memory storage capacity available to store temporary data for SQL queries, including prepared queries and intermediate data rows during query execution. This value can be a percentage or any bytes-based unit, for example:<br><br>`--max-sql-memory=25%`<br>`--max-sql-memory=10000000000 ----> 1000000000 bytes`<br>`--max-sql-memory=1GB ----> 1000000000 bytes`<br>`--max-sql-memory=1GiB ----> 1073741824 bytes`<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br><strong>Note:</strong> If you enter the maximum in-memory storage capacity as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default SQL memory size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
+`--max-sql-memory` | The maximum in-memory storage capacity available to store temporary data for SQL queries, including prepared queries and intermediate data rows during query execution. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit, for example:<br><br>`--max-sql-memory=.25`<br>`--max-sql-memory=25%`<br>`--max-sql-memory=10000000000 ----> 1000000000 bytes`<br>`--max-sql-memory=1GB ----> 1000000000 bytes`<br>`--max-sql-memory=1GiB ----> 1073741824 bytes`<br><br><span class="version-tag">New in v2.0:</span> The temporary files are located in the path specified by the `--temp-dir` flag, or in the subdirectory of the first store (see `--store`) by default.<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead.<br><br><span class="version-tag">Changed in v1.1: </span>**Default:** `128MiB`<br><br>The default SQL memory size is reasonable for local development clusters. For production deployments, this should be increased to 25% or higher. See [Recommended Production Settings](recommended-production-settings.html#cache-and-sql-memory-size) for more details.
 `--pid-file` | The file to which the node's process ID will be written on successful startup. When this flag is not set, the process ID is not written to file.
 `--port`<br>`-p` | The port to bind to for internal and client communication.<br><br>To have an unused port assigned automatically, pass `--port=0`.<br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
 `--store`<br>`-s` | The file path to a storage device and, optionally, store attributes and maximum size. When using multiple storage devices for a node, this flag must be specified separately for each device, for example: <br><br>`--store=/mnt/ssd01 --store=/mnt/ssd02` <br><br>For more details, see [Store](#store) below.
@@ -98,7 +99,7 @@ Field | Description
 `type` | For in-memory storage, set this field to `mem`; otherwise, leave this field out. The `path` field must not be set when `type=mem`.
 `path` | The file path to the storage device. When not setting `attr` or `size`, the `path` field label can be left out: <br><br>`--store=/mnt/ssd01` <br><br>When either of those fields are set, however, the `path` field label must be used: <br><br>`--store=path=/mnt/ssd01,size=20GB` <br><br> **Default:** `cockroach-data`
 `attrs` | Arbitrary strings, separated by colons, specifying disk type or capability. These can be used to influence the location of data replicas. See [Configure Replication Zones](configure-replication-zones.html#replication-constraints) for full details.<br><br>In most cases, node-level `--locality` or `--attrs` are preferable to store-level attributes, but this field can be used to match capabilities for storage of individual databases or tables. For example, an OLTP database would probably want to allocate space for its tables only on solid state devices, whereas append-only time series might prefer cheaper spinning drives. Typical attributes include whether the store is flash (`ssd`) or spinny disk (`hdd`), as well as speeds and other specs, for example:<br><br> `--store=path=/mnt/hda1,attrs=hdd:7200rpm`
-`size` | The maximum size allocated to the node. When this size is reached, CockroachDB attempts to rebalance data to other nodes with available capacity. When there's no capacity elsewhere, this limit will be exceeded. Also, data may be written to the node faster than the cluster can rebalance it away; in this case, as long as capacity is available elsewhere, CockroachDB will gradually rebalance data down to the store limit.<br><br> The `size` can be specified either in a bytes-based unit or as a percentage of hard drive space, for example: <br><br>`--store=path=/mnt/ssd01,size=10000000000 ----> 10000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GB ----> 20000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=0.02TiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=20% ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=0.2 ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=.2 ----> 20% of available space`<br><br>**Default:** 100%<br><br>For an in-memory store, the `size` field is required and must be set to the true maximum bytes or percentage of available memory, for example:<br><br>`--store=type=mem,size=20GB`<br>`--store=type=mem,size=90%`<br><br><strong>Note:</strong> If you enter the size as a percentage, you might need to escape the `%` sign, for instance, while configuring CockroachDB through systemd service files.
+`size` | The maximum size allocated to the node. When this size is reached, CockroachDB attempts to rebalance data to other nodes with available capacity. When there's no capacity elsewhere, this limit will be exceeded. Also, data may be written to the node faster than the cluster can rebalance it away; in this case, as long as capacity is available elsewhere, CockroachDB will gradually rebalance data down to the store limit.<br><br> The `size` can be specified either in a bytes-based unit or as a percentage of hard drive space (notated as a decimal or with `%`), for example: <br><br>`--store=path=/mnt/ssd01,size=10000000000 ----> 10000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GB ----> 20000000000 bytes`<br>`--store=path=/mnt/ssd01,size=20GiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=0.02TiB ----> 21474836480 bytes`<br>`--store=path=/mnt/ssd01,size=20% ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=0.2 ----> 20% of available space`<br>`--store=path=/mnt/ssd01,size=.2 ----> 20% of available space`<br><br>**Default:** 100%<br><br>For an in-memory store, the `size` field is required and must be set to the true maximum bytes or percentage of available memory, for example:<br><br>`--store=type=mem,size=20GB`<br>`--store=type=mem,size=90%`<br><br><strong>Note:</strong> If you use the `%` notation, you might need to escape the `%` sign, for instance, while configuring CockroachDB through `systemd` service files. For this reason, it's recommended to use the decimal notation instead.
 
 ### Logging
 
@@ -168,8 +169,8 @@ To start a single-node cluster, run the `cockroach start` command without the `-
 $ cockroach start \
 --certs-dir=certs \
 --host=<node1 address> \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -178,8 +179,8 @@ $ cockroach start \
 $ cockroach start \
 --insecure \
 --host=<node1 address> \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -198,8 +199,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node1 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -207,8 +208,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node2 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -216,8 +217,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node3 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -227,8 +228,8 @@ $ cockroach start \
 --insecure \
 --host=<node1 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -236,8 +237,8 @@ $ cockroach start \
 --insecure \
 --host=<node2 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 
 ~~~
@@ -245,8 +246,8 @@ $ cockroach start \
 --insecure \
 --host=<node3 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -283,8 +284,8 @@ $ cockroach start \
 --certs-dir=certs \
 --host=<node4 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 
@@ -294,8 +295,8 @@ $ cockroach start \
 --insecure \
 --host=<node4 address> \
 --join=<node1 address>:26257,<node2 address>:26257,<node3 address>:26257 \
---cache=25% \
---max-sql-memory=25%
+--cache=.25 \
+--max-sql-memory=.25
 ~~~
 </div>
 


### PR DESCRIPTION
Also update examples across 2.0 and 2.1 docs.

Fixes #https://github.com/cockroachdb/cockroach/issues/24950