### PR TITLE
Change CTRL + C and CTRL + D to CTRL-C and CTRL-D

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,7 +286,7 @@ Once you've installed Jekyll and have a local clone of the docs repository, you 
 
     - When you make additional changes, Jekyll automatically regenerates the HTML content. No need to stop and re-start Jekyll; just refresh your browser.
 
-    Once you're done viewing your changes, use **CTRL + C** to stop the Jekyll server.
+    Once you're done viewing your changes, use **CTRL-C** to stop the Jekyll server.
 
 3.  Run automated tests against the Jekyll-generate HTML files to check for problems (broken links, missing alt texts for images, etc.):
 

--- a/_includes/prod_deployment/secure-test-cluster.md
+++ b/_includes/prod_deployment/secure-test-cluster.md
@@ -23,7 +23,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. Use `\q` or **CTRL + C** to exit the SQL shell.
+3. Use `\q` or **CTRL-C** to exit the SQL shell.
 
 4. Launch the built-in SQL client against a different node:
 
@@ -52,4 +52,4 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	(5 rows)
 	~~~
 
-6. Use `\q` or **CTRL + C** to exit the SQL shell.
+6. Use `\q` or **CTRL-C** to exit the SQL shell.

--- a/v1.0/demo-automatic-cloud-migration.md
+++ b/v1.0/demo-automatic-cloud-migration.md
@@ -203,9 +203,9 @@ This indicates that all data has been migrated from cloud 1 to cloud 2. In a rea
 
 ## Step 10. Stop the cluster
 
-Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL + C**. Then do the same for HAProxy and each CockroachDB node.
+Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL-C**. Then do the same for HAProxy and each CockroachDB node.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores and the HAProxy config file:
 

--- a/v1.0/demo-automatic-rebalancing.md
+++ b/v1.0/demo-automatic-rebalancing.md
@@ -159,9 +159,9 @@ Back in the Admin UI, you'll now see 5 nodes listed. At first, the bytes and rep
 
 ## Step 7.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.0/demo-data-replication.md
+++ b/v1.0/demo-data-replication.md
@@ -211,9 +211,9 @@ Back in the Admin UI, you'll see that there are now 5 nodes listed. Again, at fi
 
 ## Step 8.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.0/demo-fault-tolerance-and-recovery.md
+++ b/v1.0/demo-fault-tolerance-and-recovery.md
@@ -74,7 +74,7 @@ Exit the SQL shell:
 
 ## Step 3. Remove a node temporarily
 
-In the terminal running node 2, press **CTRL + C** to stop the node.
+In the terminal running node 2, press **CTRL-C** to stop the node.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -302,7 +302,7 @@ nodeID:     4
 
 ## Step 9. Remove a node permanently
 
-Again, switch to the terminal running node 2 and press **CTRL + C** to stop it.
+Again, switch to the terminal running node 2 and press **CTRL-C** to stop it.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -328,9 +328,9 @@ After about 10 minutes, node 2 will move into a **Dead Nodes** section, indicati
 
 ## Step 11.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.0/deploy-cockroachdb-on-aws-insecure.md
+++ b/v1.0/deploy-cockroachdb-on-aws-insecure.md
@@ -210,7 +210,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Test load balancing
 
@@ -262,7 +262,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	(1 row)
 	~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+5. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-aws.md
+++ b/v1.0/deploy-cockroachdb-on-aws.md
@@ -332,7 +332,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external IP address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
@@ -363,7 +363,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     (5 rows)
     ~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Test load balancing
 
@@ -418,7 +418,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     (1 row)
     ~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v1.0/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -192,7 +192,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Test load balancing
 
@@ -244,7 +244,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	(1 row)
 	~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+5. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-digital-ocean.md
+++ b/v1.0/deploy-cockroachdb-on-digital-ocean.md
@@ -309,7 +309,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 4. Connect the built-in SQL client to node 2, with the `--host` flag set to the address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
@@ -340,7 +340,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     (5 rows)
     ~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Test load balancing
 
@@ -395,7 +395,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     (1 row)
     ~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v1.0/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -209,7 +209,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Test load balancing
 
@@ -261,7 +261,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	(1 row)
 	~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+5. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v1.0/deploy-cockroachdb-on-google-cloud-platform.md
@@ -327,7 +327,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 4. Connect the built-in SQL client to node 2, with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
@@ -358,7 +358,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Test load balancing
 
@@ -414,7 +414,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	(1 row)
 	~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -223,7 +223,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Test load balancing
 
@@ -275,7 +275,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	(1 row)
 	~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+5. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v1.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v1.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -334,7 +334,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 4. Launch built-in SQL client with the `--host` flag set to the external address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
@@ -365,7 +365,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     (5 rows)
     ~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Test load balancing
 
@@ -420,7 +420,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
     (1 row)
     ~~~
 
-4.  Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4.  Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 9. Monitor the cluster
 

--- a/v1.0/manual-deployment-insecure.md
+++ b/v1.0/manual-deployment-insecure.md
@@ -135,7 +135,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) as
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 4. Set up HAProxy load balancers
 
@@ -268,7 +268,7 @@ To test this, install CockroachDB locally and use the [built-in SQL client](use-
 	(1 row)
 	~~~
 
-5. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+5. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 6. Configure replication
 

--- a/v1.0/manual-deployment.md
+++ b/v1.0/manual-deployment.md
@@ -256,7 +256,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	> CREATE DATABASE securenodetest;
 	~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 4. Launch the built-in SQL client with the `--host` flag set to the address of node 2 and security flags pointing to the CA cert and the client cert and key:
 
@@ -287,7 +287,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	(5 rows)
 	~~~
 
-6. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+6. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 5. Set up HAProxy load balancers
 
@@ -420,7 +420,7 @@ To test this, use the [built-in SQL client](use-the-built-in-sql-client.html) lo
 	(1 row)
 	~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Configure replication
 

--- a/v1.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v1.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -247,7 +247,7 @@ $ sudo docker network create --driver overlay cockroachdb
     > CREATE DATABASE insecurenodetest;
     ~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Monitor the cluster
 

--- a/v1.0/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v1.0/orchestrate-cockroachdb-with-docker-swarm.md
@@ -467,7 +467,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     > CREATE DATABASE securenodetest;
     ~~~
 
-4. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+4. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v1.0/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v1.0/orchestrate-cockroachdb-with-kubernetes.md
@@ -196,7 +196,7 @@ Kubectl is now configured to use the cluster.
     (1 row)
     ~~~
 
-4. When you're done with the SQL shell, use **CTRL + D**, **CTRL + C**, or `\q` to exit and delete the temporary pod.
+4. When you're done with the SQL shell, use **CTRL-D**, **CTRL-C**, or `\q` to exit and delete the temporary pod.
 
 ## Step 5. Simulate node failure
 

--- a/v1.0/secure-a-cluster.md
+++ b/v1.0/secure-a-cluster.md
@@ -216,7 +216,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 6.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -248,9 +248,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.0/start-a-local-cluster.md
+++ b/v1.0/start-a-local-cluster.md
@@ -185,7 +185,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 5.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -215,9 +215,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.0/stop-a-node.md
+++ b/v1.0/stop-a-node.md
@@ -73,7 +73,7 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     $ pkill cockroach
     ~~~
 
-    If the node is running in the foreground, press `CTRL + c`.
+    If the node is running in the foreground, press `CTRL-C`.
 
 3. Verify that the `cockroach` process has stopped:
 

--- a/v1.1/demo-automatic-cloud-migration.md
+++ b/v1.1/demo-automatic-cloud-migration.md
@@ -226,9 +226,9 @@ This indicates that all data has been migrated from cloud 1 to cloud 2. In a rea
 
 ## Step 11. Stop the cluster
 
-Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL + C**. Then do the same for HAProxy and each CockroachDB node.
+Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL-C**. Then do the same for HAProxy and each CockroachDB node.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores and the HAProxy config file:
 

--- a/v1.1/demo-automatic-rebalancing.md
+++ b/v1.1/demo-automatic-rebalancing.md
@@ -190,9 +190,9 @@ Back in the Admin UI, you'll now see 5 nodes listed. At first, the bytes and rep
 
 ## Step 9.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.1/demo-data-replication.md
+++ b/v1.1/demo-data-replication.md
@@ -215,9 +215,9 @@ Back in the Admin UI, you'll see that there are now 5 nodes listed. Again, at fi
 
 ## Step 8.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.1/demo-fault-tolerance-and-recovery.md
+++ b/v1.1/demo-fault-tolerance-and-recovery.md
@@ -99,7 +99,7 @@ Exit the SQL shell:
 
 ## Step 4. Remove a node temporarily
 
-In the terminal running node 2, press **CTRL + C** to stop the node.
+In the terminal running node 2, press **CTRL-C** to stop the node.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -333,7 +333,7 @@ nodeID:     4
 
 ## Step 10. Remove a node permanently
 
-Again, switch to the terminal running node 2 and press **CTRL + C** to stop it.
+Again, switch to the terminal running node 2 and press **CTRL-C** to stop it.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -360,9 +360,9 @@ After about 10 minutes, node 2 will move into a **Dead Nodes** section, indicati
 
 ## Step 12.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.1/demo-follow-the-workload.md
+++ b/v1.1/demo-follow-the-workload.md
@@ -266,9 +266,9 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
 ### Step 9. Stop the cluster
 
-Once you're done with your cluster, press **CTRL + C** in each node's terminal.
+Once you're done with your cluster, press **CTRL-C** in each node's terminal.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v1.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -225,7 +225,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     > CREATE DATABASE insecurenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Monitor the cluster
 

--- a/v1.1/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v1.1/orchestrate-cockroachdb-with-docker-swarm.md
@@ -437,7 +437,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v1.1/secure-a-cluster.md
+++ b/v1.1/secure-a-cluster.md
@@ -218,7 +218,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 6.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -250,9 +250,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.1/start-a-local-cluster.md
+++ b/v1.1/start-a-local-cluster.md
@@ -187,7 +187,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 5.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -217,9 +217,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v1.1/stop-a-node.md
+++ b/v1.1/stop-a-node.md
@@ -91,7 +91,7 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     $ pkill cockroach
     ~~~
 
-    If the node is running in the foreground, press `CTRL + c`.
+    If the node is running in the foreground, press `CTRL-C`.
 
 3. Verify that the `cockroach` process has stopped:
 

--- a/v1.1/training/cluster-unavailability-troubleshooting.md
+++ b/v1.1/training/cluster-unavailability-troubleshooting.md
@@ -22,9 +22,9 @@ Make sure you have already completed [Under-Replication Troubleshooting](under-r
 
 ## Step 1. Simulate the problem
 
-1. In the terminal where node 2 is running, press **CTRL + C**.
+1. In the terminal where node 2 is running, press **CTRL-C**.
 
-2. In the terminal where node 3 is running, press **CTRL + C**. You may need to press **CRTL + C** a second time to force this node to stop.  
+2. In the terminal where node 3 is running, press **CTRL-C**. You may need to press **CRTL + C** a second time to force this node to stop.  
 
 ## Step 2. Troubleshoot the problem
 

--- a/v1.1/training/cluster-upgrade.md
+++ b/v1.1/training/cluster-upgrade.md
@@ -116,7 +116,7 @@ Start and initialize a cluster like you did in previous modules.
 
 ## Step 3. Upgrade the first node to v2.0
 
-1. In node 1's terminal, press **CTRL + C** to stop the `cockroach` process.
+1. In node 1's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 2. Verify that node 1 has stopped:
 
@@ -171,7 +171,7 @@ Start and initialize a cluster like you did in previous modules.
 
 ## Step 4. Upgrade the rest of the nodes
 
-1. In node 2's terminal, press **CTRL + C** to stop the `cockroach` process.
+1. In node 2's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 2. Verify that node 2 has stopped:
 
@@ -203,7 +203,7 @@ Start and initialize a cluster like you did in previous modules.
 
 4. Wait 1 minute.
 
-5. In node 3's terminal, press **CTRL + C** to stop the `cockroach` process.
+5. In node 3's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 6. Verify that node 3 has stopped:
 

--- a/v1.1/training/data-corruption-troubleshooting.md
+++ b/v1.1/training/data-corruption-troubleshooting.md
@@ -131,7 +131,7 @@ Before you can manually corrupt data, you need to import enough data so that the
 
 2. Open one of the `.sst` files and delete several lines.
 
-3. In the terminal where node 3 is running, press **CTRL + C** to stop it.
+3. In the terminal where node 3 is running, press **CTRL-C** to stop it.
 
 4. Try to restart node 3:
 

--- a/v1.1/training/network-partition-troubleshooting.md
+++ b/v1.1/training/network-partition-troubleshooting.md
@@ -169,7 +169,7 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
 You won't be using this Docker cluster in any other labs, so take a moment to clean things up.
 
-1. In the terminal where you ran `docker-compose up`, press **CTRL + C** to stop all the CockroachDB nodes.
+1. In the terminal where you ran `docker-compose up`, press **CTRL-C** to stop all the CockroachDB nodes.
 
 2. Delete the Docker containers:
 

--- a/v1.1/training/node-startup-troubleshooting.md
+++ b/v1.1/training/node-startup-troubleshooting.md
@@ -198,7 +198,7 @@ The last warning tells you that the node can't establish a connection with the a
 
 ### Step 2. Resolve the problem
 
-1. Press **CTRL + C** twice to stop the previous startup attempt.
+1. Press **CTRL-C** twice to stop the previous startup attempt.
 
 2. To successfully join the node to the cluster, start the node again, but this time include a correct `--join` address:
 
@@ -245,7 +245,7 @@ In this scenario, you try to add another node to the cluster, but the `--join` a
     nodeID:     1
     ~~~
 
-2. Press **CTRL + C** to stop the new node.
+2. Press **CTRL-C** to stop the new node.
 
 3. Start the node again, but this time include a correct `--join` address:
 

--- a/v1.1/training/planned-maintenance.md
+++ b/v1.1/training/planned-maintenance.md
@@ -105,7 +105,7 @@ Let's say you need to perform some maintenance on each of your nodes, e.g., upgr
 
 Stop, maintain, and restart one node at a time. This ensures that, at any point, the cluster has a majority of replicas and remains available.
 
-1. In the first node's terminal, press **CTRL + C** to stop the node.
+1. In the first node's terminal, press **CTRL-C** to stop the node.
 
 2. Imagine that you are doing some maintenance on the node.
 
@@ -124,7 +124,7 @@ Stop, maintain, and restart one node at a time. This ensures that, at any point,
     --join=localhost:26257,localhost:26258,localhost:26259
     ~~~~
 
-4. In the second node's terminal, press **CTRL + C** to stop the node.
+4. In the second node's terminal, press **CTRL-C** to stop the node.
 
 5. Imagine that you are doing some maintenance on the node.
 
@@ -143,7 +143,7 @@ Stop, maintain, and restart one node at a time. This ensures that, at any point,
     --join=localhost:26257,localhost:26258,localhost:26259
     ~~~~
 
-7. In the third node's terminal, press **CTRL + C** to stop the node.
+7. In the third node's terminal, press **CTRL-C** to stop the node.
 
 8. Imagine that you are doing some maintenance on the node.
 

--- a/v1.1/training/under-replication-troubleshooting.md
+++ b/v1.1/training/under-replication-troubleshooting.md
@@ -79,7 +79,7 @@ In this lab, you'll start with a fresh cluster, so make sure you've stopped and 
     --execute="SET CLUSTER SETTING server.time_until_store_dead = '1m0s';"
     ~~~
 
-2. In the terminal where node 3 is running, press **CTRL + C** to stop the node.
+2. In the terminal where node 3 is running, press **CTRL-C** to stop the node.
 
 ## Step 3. Troubleshoot the problem
 

--- a/v2.0/demo-automatic-cloud-migration.md
+++ b/v2.0/demo-automatic-cloud-migration.md
@@ -226,9 +226,9 @@ This indicates that all data has been migrated from cloud 1 to cloud 2. In a rea
 
 ## Step 11. Stop the cluster
 
-Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL + C**. Then do the same for HAProxy and each CockroachDB node.
+Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL-C**. Then do the same for HAProxy and each CockroachDB node.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores and the HAProxy config file:
 

--- a/v2.0/demo-automatic-rebalancing.md
+++ b/v2.0/demo-automatic-rebalancing.md
@@ -187,9 +187,9 @@ Back in the Admin UI, you'll now see 5 nodes listed. At first, the bytes and rep
 
 ## Step 9.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.0/demo-data-replication.md
+++ b/v2.0/demo-data-replication.md
@@ -213,9 +213,9 @@ Back in the Admin UI, you'll see that there are now 5 nodes listed. Again, at fi
 
 ## Step 8.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.0/demo-fault-tolerance-and-recovery.md
+++ b/v2.0/demo-fault-tolerance-and-recovery.md
@@ -96,7 +96,7 @@ Exit the SQL shell:
 
 ## Step 4. Remove a node temporarily
 
-In the terminal running node 2, press **CTRL + C** to stop the node.
+In the terminal running node 2, press **CTRL-C** to stop the node.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -325,7 +325,7 @@ nodeID:     4
 
 ## Step 10. Remove a node permanently
 
-Again, switch to the terminal running node 2 and press **CTRL + C** to stop it.
+Again, switch to the terminal running node 2 and press **CTRL-C** to stop it.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -352,9 +352,9 @@ After about 10 minutes, node 2 will move into a **Dead Nodes** section, indicati
 
 ## Step 12.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.0/demo-follow-the-workload.md
+++ b/v2.0/demo-follow-the-workload.md
@@ -266,9 +266,9 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
 ### Step 9. Stop the cluster
 
-Once you're done with your cluster, press **CTRL + C** in each node's terminal.
+Once you're done with your cluster, press **CTRL-C** in each node's terminal.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -225,7 +225,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     > CREATE DATABASE insecurenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Monitor the cluster
 

--- a/v2.0/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v2.0/orchestrate-cockroachdb-with-docker-swarm.md
@@ -437,7 +437,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v2.0/secure-a-cluster.md
+++ b/v2.0/secure-a-cluster.md
@@ -218,7 +218,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 6.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -250,9 +250,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.0/start-a-local-cluster.md
+++ b/v2.0/start-a-local-cluster.md
@@ -187,7 +187,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 5.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -217,9 +217,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.0/stop-a-node.md
+++ b/v2.0/stop-a-node.md
@@ -81,7 +81,7 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     $ pkill cockroach
     ~~~
 
-    If the node is running in the foreground, press `CTRL + c`.
+    If the node is running in the foreground, press `CTRL-C`.
 
 3. Verify that the `cockroach` process has stopped:
 

--- a/v2.0/training/cluster-unavailability-troubleshooting.md
+++ b/v2.0/training/cluster-unavailability-troubleshooting.md
@@ -22,9 +22,9 @@ Make sure you have already completed [Under-Replication Troubleshooting](under-r
 
 ## Step 1. Simulate the problem
 
-1. In the terminal where node 2 is running, press **CTRL + C**.
+1. In the terminal where node 2 is running, press **CTRL-C**.
 
-2. In the terminal where node 3 is running, press **CTRL + C**. You may need to press **CRTL + C** a second time to force this node to stop.  
+2. In the terminal where node 3 is running, press **CTRL-C**. You may need to press **CRTL + C** a second time to force this node to stop.  
 
 ## Step 2. Troubleshoot the problem
 

--- a/v2.0/training/cluster-upgrade.md
+++ b/v2.0/training/cluster-upgrade.md
@@ -116,7 +116,7 @@ Start and initialize a cluster like you did in previous modulesm, but this time 
 
 ## Step 3. Upgrade the first node to v2.0
 
-1. In node 1's terminal, press **CTRL + C** to stop the `cockroach` process.
+1. In node 1's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 2. Verify that node 1 has stopped:
 
@@ -171,7 +171,7 @@ Start and initialize a cluster like you did in previous modulesm, but this time 
 
 ## Step 4. Upgrade the rest of the nodes
 
-1. In node 2's terminal, press **CTRL + C** to stop the `cockroach` process.
+1. In node 2's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 2. Verify that node 2 has stopped:
 
@@ -203,7 +203,7 @@ Start and initialize a cluster like you did in previous modulesm, but this time 
 
 4. Wait 1 minute.
 
-5. In node 3's terminal, press **CTRL + C** to stop the `cockroach` process.
+5. In node 3's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 6. Verify that node 3 has stopped:
 

--- a/v2.0/training/data-corruption-troubleshooting.md
+++ b/v2.0/training/data-corruption-troubleshooting.md
@@ -131,7 +131,7 @@ Before you can manually corrupt data, you need to import enough data so that the
 
 2. Open one of the `.sst` files and delete several lines.
 
-3. In the terminal where node 3 is running, press **CTRL + C** to stop it.
+3. In the terminal where node 3 is running, press **CTRL-C** to stop it.
 
 4. Try to restart node 3:
 

--- a/v2.0/training/network-partition-troubleshooting.md
+++ b/v2.0/training/network-partition-troubleshooting.md
@@ -169,7 +169,7 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
 You won't be using this Docker cluster in any other labs, so take a moment to clean things up.
 
-1. In the terminal where you ran `docker-compose up`, press **CTRL + C** to stop all the CockroachDB nodes.
+1. In the terminal where you ran `docker-compose up`, press **CTRL-C** to stop all the CockroachDB nodes.
 
 2. Delete the Docker containers:
 

--- a/v2.0/training/node-startup-troubleshooting.md
+++ b/v2.0/training/node-startup-troubleshooting.md
@@ -198,7 +198,7 @@ The last warning tells you that the node can't establish a connection with the a
 
 ### Step 2. Resolve the problem
 
-1. Press **CTRL + C** twice to stop the previous startup attempt.
+1. Press **CTRL-C** twice to stop the previous startup attempt.
 
 2. To successfully join the node to the cluster, start the node again, but this time include a correct `--join` address:
 
@@ -245,7 +245,7 @@ In this scenario, you try to add another node to the cluster, but the `--join` a
     nodeID:     1
     ~~~
 
-2. Press **CTRL + C** to stop the new node.
+2. Press **CTRL-C** to stop the new node.
 
 3. Start the node again, but this time include a correct `--join` address:
 

--- a/v2.0/training/planned-maintenance.md
+++ b/v2.0/training/planned-maintenance.md
@@ -105,7 +105,7 @@ Let's say you need to perform some maintenance on each of your nodes, e.g., upgr
 
 Stop, maintain, and restart one node at a time. This ensures that, at any point, the cluster has a majority of replicas and remains available.
 
-1. In the first node's terminal, press **CTRL + C** to stop the node.
+1. In the first node's terminal, press **CTRL-C** to stop the node.
 
 2. Imagine that you are doing some maintenance on the node.
 
@@ -124,7 +124,7 @@ Stop, maintain, and restart one node at a time. This ensures that, at any point,
     --join=localhost:26257,localhost:26258,localhost:26259
     ~~~~
 
-4. In the second node's terminal, press **CTRL + C** to stop the node.
+4. In the second node's terminal, press **CTRL-C** to stop the node.
 
 5. Imagine that you are doing some maintenance on the node.
 
@@ -143,7 +143,7 @@ Stop, maintain, and restart one node at a time. This ensures that, at any point,
     --join=localhost:26257,localhost:26258,localhost:26259
     ~~~~
 
-7. In the third node's terminal, press **CTRL + C** to stop the node.
+7. In the third node's terminal, press **CTRL-C** to stop the node.
 
 8. Imagine that you are doing some maintenance on the node.
 

--- a/v2.0/training/under-replication-troubleshooting.md
+++ b/v2.0/training/under-replication-troubleshooting.md
@@ -79,7 +79,7 @@ In this lab, you'll start with a fresh cluster, so make sure you've stopped and 
     --execute="SET CLUSTER SETTING server.time_until_store_dead = '1m0s';"
     ~~~
 
-2. In the terminal where node 3 is running, press **CTRL + C** to stop the node.
+2. In the terminal where node 3 is running, press **CTRL-C** to stop the node.
 
 ## Step 3. Troubleshoot the problem
 

--- a/v2.1/demo-automatic-cloud-migration.md
+++ b/v2.1/demo-automatic-cloud-migration.md
@@ -226,9 +226,9 @@ This indicates that all data has been migrated from cloud 1 to cloud 2. In a rea
 
 ## Step 11. Stop the cluster
 
-Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL + C**. Then do the same for HAProxy and each CockroachDB node.
+Once you're done with your cluster, stop YCSB by switching into its terminal and pressing **CTRL-C**. Then do the same for HAProxy and each CockroachDB node.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores and the HAProxy config file:
 

--- a/v2.1/demo-automatic-rebalancing.md
+++ b/v2.1/demo-automatic-rebalancing.md
@@ -187,9 +187,9 @@ Back in the Admin UI, you'll now see 5 nodes listed. At first, the bytes and rep
 
 ## Step 9.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.1/demo-data-replication.md
+++ b/v2.1/demo-data-replication.md
@@ -213,9 +213,9 @@ Back in the Admin UI, you'll see that there are now 5 nodes listed. Again, at fi
 
 ## Step 8.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last 2 nodes, the shutdown process will take longer (about a minute) and will eventually force kill the nodes. This is because, with only 2 nodes still online, a majority of replicas are no longer available (3 of 5), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time in the nodes' terminals.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.1/demo-fault-tolerance-and-recovery.md
+++ b/v2.1/demo-fault-tolerance-and-recovery.md
@@ -96,7 +96,7 @@ Exit the SQL shell:
 
 ## Step 4. Remove a node temporarily
 
-In the terminal running node 2, press **CTRL + C** to stop the node.
+In the terminal running node 2, press **CTRL-C** to stop the node.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -325,7 +325,7 @@ nodeID:     4
 
 ## Step 10. Remove a node permanently
 
-Again, switch to the terminal running node 2 and press **CTRL + C** to stop it.
+Again, switch to the terminal running node 2 and press **CTRL-C** to stop it.
 
 Alternatively, you can open a new terminal and run the [`cockroach quit`](stop-a-node.html) command against port `26258`:
 
@@ -352,9 +352,9 @@ After about 10 minutes, node 2 will move into a **Dead Nodes** section, indicati
 
 ## Step 12.  Stop the cluster
 
-Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL + C**.
+Once you're done with your test cluster, stop each node by switching to its terminal and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.1/demo-follow-the-workload.md
+++ b/v2.1/demo-follow-the-workload.md
@@ -266,9 +266,9 @@ Verify that the range's lease moved to the node in the "US West" as follows.
 
 ### Step 9. Stop the cluster
 
-Once you're done with your cluster, press **CTRL + C** in each node's terminal.
+Once you're done with your cluster, press **CTRL-C** in each node's terminal.
 
-{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For the last node, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 node still online, a majority of replicas are no longer available (2 of 3), and so the cluster is not operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v2.1/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -225,7 +225,7 @@ The `--attachable` option enables non-swarm containers running on Docker to acce
     > CREATE DATABASE insecurenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 7. Monitor the cluster
 

--- a/v2.1/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v2.1/orchestrate-cockroachdb-with-docker-swarm.md
@@ -437,7 +437,7 @@ A secure CockroachDB cluster uses TLS certificates for encrypted inter-node and 
     > CREATE DATABASE securenodetest;
     ~~~
 
-3. Use **CTRL + D**, **CTRL + C**, or `\q` to exit the SQL shell.
+3. Use **CTRL-D**, **CTRL-C**, or `\q` to exit the SQL shell.
 
 ## Step 8. Monitor the cluster
 

--- a/v2.1/secure-a-cluster.md
+++ b/v2.1/secure-a-cluster.md
@@ -218,7 +218,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 6.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -250,9 +250,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.1/start-a-local-cluster.md
+++ b/v2.1/start-a-local-cluster.md
@@ -187,7 +187,7 @@ The replica count on each node is identical, indicating that all data in the clu
 
 ## Step 5.  Stop the cluster
 
-Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL + C** to stop the node.
+Once you're done with your test cluster, switch to the terminal running the first node and press **CTRL-C** to stop the node.
 
 At this point, with 2 nodes still online, the cluster remains operational because a majority of replicas are available. To verify that the cluster has tolerated this "failure", connect the built-in SQL shell to nodes 2 or 3. You can do this in the same terminal or in a new terminal.
 
@@ -217,9 +217,9 @@ Exit the SQL shell:
 > \q
 ~~~
 
-Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL + C**.
+Now stop nodes 2 and 3 by switching to their terminals and pressing **CTRL-C**.
 
-{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL + C</strong> a second time.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}For node 3, the shutdown process will take longer (about a minute) and will eventually force kill the node. This is because, with only 1 of 3 nodes left, a majority of replicas are not available, and so the cluster is no longer operational. To speed up the process, press <strong>CTRL-C</strong> a second time.{{site.data.alerts.end}}
 
 If you don't plan to restart the cluster, you may want to remove the nodes' data stores:
 

--- a/v2.1/stop-a-node.md
+++ b/v2.1/stop-a-node.md
@@ -86,7 +86,7 @@ If you need to troubleshoot this command's behavior, you can change its [logging
     $ pkill cockroach
     ~~~
 
-    If the node is running in the foreground, press `CTRL + c`.
+    If the node is running in the foreground, press `CTRL-C`.
 
 3. Verify that the `cockroach` process has stopped:
 

--- a/v2.1/training/cluster-unavailability-troubleshooting.md
+++ b/v2.1/training/cluster-unavailability-troubleshooting.md
@@ -22,9 +22,9 @@ Make sure you have already completed [Under-Replication Troubleshooting](under-r
 
 ## Step 1. Simulate the problem
 
-1. In the terminal where node 2 is running, press **CTRL + C**.
+1. In the terminal where node 2 is running, press **CTRL-C**.
 
-2. In the terminal where node 3 is running, press **CTRL + C**. You may need to press **CRTL + C** a second time to force this node to stop.  
+2. In the terminal where node 3 is running, press **CTRL-C**. You may need to press **CRTL + C** a second time to force this node to stop.  
 
 ## Step 2. Troubleshoot the problem
 

--- a/v2.1/training/cluster-upgrade.md
+++ b/v2.1/training/cluster-upgrade.md
@@ -116,7 +116,7 @@ Start and initialize a cluster like you did in previous modulesm, but this time 
 
 ## Step 3. Upgrade the first node to v2.0
 
-1. In node 1's terminal, press **CTRL + C** to stop the `cockroach` process.
+1. In node 1's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 2. Verify that node 1 has stopped:
 
@@ -171,7 +171,7 @@ Start and initialize a cluster like you did in previous modulesm, but this time 
 
 ## Step 4. Upgrade the rest of the nodes
 
-1. In node 2's terminal, press **CTRL + C** to stop the `cockroach` process.
+1. In node 2's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 2. Verify that node 2 has stopped:
 
@@ -203,7 +203,7 @@ Start and initialize a cluster like you did in previous modulesm, but this time 
 
 4. Wait 1 minute.
 
-5. In node 3's terminal, press **CTRL + C** to stop the `cockroach` process.
+5. In node 3's terminal, press **CTRL-C** to stop the `cockroach` process.
 
 6. Verify that node 3 has stopped:
 

--- a/v2.1/training/data-corruption-troubleshooting.md
+++ b/v2.1/training/data-corruption-troubleshooting.md
@@ -131,7 +131,7 @@ Before you can manually corrupt data, you need to import enough data so that the
 
 2. Open one of the `.sst` files and delete several lines.
 
-3. In the terminal where node 3 is running, press **CTRL + C** to stop it.
+3. In the terminal where node 3 is running, press **CTRL-C** to stop it.
 
 4. Try to restart node 3:
 

--- a/v2.1/training/network-partition-troubleshooting.md
+++ b/v2.1/training/network-partition-troubleshooting.md
@@ -169,7 +169,7 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
 You won't be using this Docker cluster in any other labs, so take a moment to clean things up.
 
-1. In the terminal where you ran `docker-compose up`, press **CTRL + C** to stop all the CockroachDB nodes.
+1. In the terminal where you ran `docker-compose up`, press **CTRL-C** to stop all the CockroachDB nodes.
 
 2. Delete the Docker containers:
 

--- a/v2.1/training/node-startup-troubleshooting.md
+++ b/v2.1/training/node-startup-troubleshooting.md
@@ -198,7 +198,7 @@ The last warning tells you that the node can't establish a connection with the a
 
 ### Step 2. Resolve the problem
 
-1. Press **CTRL + C** twice to stop the previous startup attempt.
+1. Press **CTRL-C** twice to stop the previous startup attempt.
 
 2. To successfully join the node to the cluster, start the node again, but this time include a correct `--join` address:
 
@@ -245,7 +245,7 @@ In this scenario, you try to add another node to the cluster, but the `--join` a
     nodeID:     1
     ~~~
 
-2. Press **CTRL + C** to stop the new node.
+2. Press **CTRL-C** to stop the new node.
 
 3. Start the node again, but this time include a correct `--join` address:
 

--- a/v2.1/training/planned-maintenance.md
+++ b/v2.1/training/planned-maintenance.md
@@ -105,7 +105,7 @@ Let's say you need to perform some maintenance on each of your nodes, e.g., upgr
 
 Stop, maintain, and restart one node at a time. This ensures that, at any point, the cluster has a majority of replicas and remains available.
 
-1. In the first node's terminal, press **CTRL + C** to stop the node.
+1. In the first node's terminal, press **CTRL-C** to stop the node.
 
 2. Imagine that you are doing some maintenance on the node.
 
@@ -124,7 +124,7 @@ Stop, maintain, and restart one node at a time. This ensures that, at any point,
     --join=localhost:26257,localhost:26258,localhost:26259
     ~~~~
 
-4. In the second node's terminal, press **CTRL + C** to stop the node.
+4. In the second node's terminal, press **CTRL-C** to stop the node.
 
 5. Imagine that you are doing some maintenance on the node.
 
@@ -143,7 +143,7 @@ Stop, maintain, and restart one node at a time. This ensures that, at any point,
     --join=localhost:26257,localhost:26258,localhost:26259
     ~~~~
 
-7. In the third node's terminal, press **CTRL + C** to stop the node.
+7. In the third node's terminal, press **CTRL-C** to stop the node.
 
 8. Imagine that you are doing some maintenance on the node.
 

--- a/v2.1/training/under-replication-troubleshooting.md
+++ b/v2.1/training/under-replication-troubleshooting.md
@@ -79,7 +79,7 @@ In this lab, you'll start with a fresh cluster, so make sure you've stopped and 
     --execute="SET CLUSTER SETTING server.time_until_store_dead = '1m0s';"
     ~~~
 
-2. In the terminal where node 3 is running, press **CTRL + C** to stop the node.
+2. In the terminal where node 3 is running, press **CTRL-C** to stop the node.
 
 ## Step 3. Troubleshoot the problem
 


### PR DESCRIPTION
Removing spaces ensures that these keyboard shortcuts
won't be split across linebreaks.

Follow-up to https://github.com/cockroachdb/docs/pull/3118