### PR TITLE
Fix docker network names in partition troubleshooting exercise

### DIFF
--- a/v1.1/training/network-partition-troubleshooting.md
+++ b/v1.1/training/network-partition-troubleshooting.md
@@ -66,12 +66,12 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network disconnect cockroachdbtraining_shared roach-4
+    $ docker network disconnect cockroachdb-training-shared roach-4
     ~~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network disconnect cockroachdbtraining_shared roach-5
+    $ docker network disconnect cockroachdb-training-shared roach-5
     ~~~~
 
 ## Step 3. Troubleshoot the problem
@@ -155,12 +155,12 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network connect cockroachdbtraining_shared roach-4
+    $ docker network connect cockroachdb-training-shared roach-4
     ~~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network connect cockroachdbtraining_shared roach-5
+    $ docker network connect cockroachdb-training-shared roach-5
     ~~~~
 
 2. After a few seconds, you should see the nodes go back to healthy again.
@@ -171,22 +171,11 @@ You won't be using this Docker cluster in any other labs, so take a moment to cl
 
 1. In the terminal where you ran `docker-compose up`, press **CTRL-C** to stop all the CockroachDB nodes.
 
-2. Delete the Docker containers:
+2. Delete all Docker resources created by the tutorial:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker rm roach-0 roach-1 roach-2 roach-3 roach-4 roach-5
-    ~~~
-
-3. Delete the Docker networks:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ docker network rm \
-    cockroachdbtraining_shared \
-    cockroachdbtraining_dc0 \
-    cockroachdbtraining_dc1 \
-    cockroachdbtraining_dc2
+    $ docker-compose down
     ~~~
 
 ## What's Next?

--- a/v1.1/training/resources/docker-compose.yaml
+++ b/v1.1/training/resources/docker-compose.yaml
@@ -1,13 +1,17 @@
-version: '2.1'
+version: '3.5'
 
 networks:
-  shared:
+  cockroachdb-training-shared:
+    name: cockroachdb-training-shared
     driver: bridge
-  dc0:
+  cockroachdb-training-dc0:
+    name: cockroachdb-training-dc0
     driver: bridge
-  dc1:
+  cockroachdb-training-dc1:
+    name: cockroachdb-training-dc1
     driver: bridge
-  dc2:
+  cockroachdb-training-dc2:
+    name: cockroachdb-training-dc2
     driver: bridge
 
 services:
@@ -17,10 +21,10 @@ services:
   roach-0:
     container_name: roach-0
     hostname: roach-0
-    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.5}
+    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.8}
     networks:
-      - shared
-      - dc0
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc0
     command: start --logtostderr --insecure --locality=datacenter=dc-0 --join=roach-0,roach-1,roach-2
     ports:
       - 8080:8080
@@ -29,10 +33,10 @@ services:
   roach-1:
     container_name: roach-1
     hostname: roach-1
-    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.5}
+    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.8}
     networks:
-      - shared
-      - dc0
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc0
     command: start --logtostderr --insecure --locality=datacenter=dc-0 --join=roach-0,roach-1,roach-2
     ports:
       - 8081:8080
@@ -43,10 +47,10 @@ services:
   roach-2:
     container_name: roach-2
     hostname: roach-2
-    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.5}
+    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.8}
     networks:
-      - shared
-      - dc1
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc1
     command: start --logtostderr --insecure --locality=datacenter=dc-1 --join=roach-0,roach-1,roach-2
     ports:
       - 8082:8080
@@ -55,10 +59,10 @@ services:
   roach-3:
     container_name: roach-3
     hostname: roach-3
-    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.5}
+    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.8}
     networks:
-      - shared
-      - dc1
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc1
     command: start --logtostderr --insecure --locality=datacenter=dc-1 --join=roach-0,roach-1,roach-2
     ports:
       - 8083:8080
@@ -69,10 +73,10 @@ services:
   roach-4:
     container_name: roach-4
     hostname: roach-4
-    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.5}
+    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.8}
     networks:
-      - shared
-      - dc2
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc2
     command: start --logtostderr --insecure --locality=datacenter=dc-2 --join=roach-0,roach-1,roach-2
     ports:
       - 8084:8080
@@ -81,10 +85,10 @@ services:
   roach-5:
     container_name: roach-5
     hostname: roach-5
-    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.5}
+    image: cockroachdb/cockroach:${COCKROACH_VERSION:-v1.1.8}
     networks:
-      - shared
-      - dc2
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc2
     command: start --logtostderr --insecure --locality=datacenter=dc-2 --join=roach-0,roach-1,roach-2
     ports:
       - 8085:8080

--- a/v2.0/training/network-partition-troubleshooting.md
+++ b/v2.0/training/network-partition-troubleshooting.md
@@ -66,12 +66,12 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network disconnect cockroachdbtraining_shared roach-4
+    $ docker network disconnect cockroachdb-training-shared roach-4
     ~~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network disconnect cockroachdbtraining_shared roach-5
+    $ docker network disconnect cockroachdb-training-shared roach-5
     ~~~~
 
 ## Step 3. Troubleshoot the problem
@@ -155,12 +155,12 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network connect cockroachdbtraining_shared roach-4
+    $ docker network connect cockroachdb-training-shared roach-4
     ~~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network connect cockroachdbtraining_shared roach-5
+    $ docker network connect cockroachdb-training-shared roach-5
     ~~~~
 
 2. After a few seconds, you should see the nodes go back to healthy again.
@@ -171,22 +171,11 @@ You won't be using this Docker cluster in any other labs, so take a moment to cl
 
 1. In the terminal where you ran `docker-compose up`, press **CTRL-C** to stop all the CockroachDB nodes.
 
-2. Delete the Docker containers:
+2. Delete all Docker resources created by the tutorial:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker rm roach-0 roach-1 roach-2 roach-3 roach-4 roach-5
-    ~~~
-
-3. Delete the Docker networks:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ docker network rm \
-    cockroachdbtraining_shared \
-    cockroachdbtraining_dc0 \
-    cockroachdbtraining_dc1 \
-    cockroachdbtraining_dc2
+    $ docker-compose down
     ~~~
 
 ## What's Next?

--- a/v2.0/training/resources/docker-compose.yaml
+++ b/v2.0/training/resources/docker-compose.yaml
@@ -1,13 +1,17 @@
-version: '2.1'
+version: '3.5'
 
 networks:
-  shared:
+  cockroachdb-training-shared:
+    name: cockroachdb-training-shared
     driver: bridge
-  dc0:
+  cockroachdb-training-dc0:
+    name: cockroachdb-training-dc0
     driver: bridge
-  dc1:
+  cockroachdb-training-dc1:
+    name: cockroachdb-training-dc1
     driver: bridge
-  dc2:
+  cockroachdb-training-dc2:
+    name: cockroachdb-training-dc2
     driver: bridge
 
 services:
@@ -19,8 +23,8 @@ services:
     hostname: roach-0
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc0
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc0
     command: start --logtostderr --insecure --locality=datacenter=dc-0 --join=roach-0,roach-1,roach-2
     ports:
       - 8080:8080
@@ -31,8 +35,8 @@ services:
     hostname: roach-1
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc0
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc0
     command: start --logtostderr --insecure --locality=datacenter=dc-0 --join=roach-0,roach-1,roach-2
     ports:
       - 8081:8080
@@ -45,8 +49,8 @@ services:
     hostname: roach-2
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc1
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc1
     command: start --logtostderr --insecure --locality=datacenter=dc-1 --join=roach-0,roach-1,roach-2
     ports:
       - 8082:8080
@@ -57,8 +61,8 @@ services:
     hostname: roach-3
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc1
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc1
     command: start --logtostderr --insecure --locality=datacenter=dc-1 --join=roach-0,roach-1,roach-2
     ports:
       - 8083:8080
@@ -71,8 +75,8 @@ services:
     hostname: roach-4
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc2
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc2
     command: start --logtostderr --insecure --locality=datacenter=dc-2 --join=roach-0,roach-1,roach-2
     ports:
       - 8084:8080
@@ -83,8 +87,8 @@ services:
     hostname: roach-5
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc2
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc2
     command: start --logtostderr --insecure --locality=datacenter=dc-2 --join=roach-0,roach-1,roach-2
     ports:
       - 8085:8080

--- a/v2.1/training/network-partition-troubleshooting.md
+++ b/v2.1/training/network-partition-troubleshooting.md
@@ -66,12 +66,12 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network disconnect cockroachdbtraining_shared roach-4
+    $ docker network disconnect cockroachdb-training-shared roach-4
     ~~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network disconnect cockroachdbtraining_shared roach-5
+    $ docker network disconnect cockroachdb-training-shared roach-5
     ~~~~
 
 ## Step 3. Troubleshoot the problem
@@ -155,12 +155,12 @@ Note that this lab involves running a cluster in Docker so that you can use it t
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network connect cockroachdbtraining_shared roach-4
+    $ docker network connect cockroachdb-training-shared roach-4
     ~~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker network connect cockroachdbtraining_shared roach-5
+    $ docker network connect cockroachdb-training-shared roach-5
     ~~~~
 
 2. After a few seconds, you should see the nodes go back to healthy again.
@@ -171,22 +171,11 @@ You won't be using this Docker cluster in any other labs, so take a moment to cl
 
 1. In the terminal where you ran `docker-compose up`, press **CTRL-C** to stop all the CockroachDB nodes.
 
-2. Delete the Docker containers:
+2. Delete all Docker resources created by the tutorial:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ docker rm roach-0 roach-1 roach-2 roach-3 roach-4 roach-5
-    ~~~
-
-3. Delete the Docker networks:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ docker network rm \
-    cockroachdbtraining_shared \
-    cockroachdbtraining_dc0 \
-    cockroachdbtraining_dc1 \
-    cockroachdbtraining_dc2
+    $ docker-compose down
     ~~~
 
 ## What's Next?

--- a/v2.1/training/resources/docker-compose.yaml
+++ b/v2.1/training/resources/docker-compose.yaml
@@ -1,13 +1,17 @@
-version: '2.1'
+version: '3.5'
 
 networks:
-  shared:
+  cockroachdb-training-shared:
+    name: cockroachdb-training-shared
     driver: bridge
-  dc0:
+  cockroachdb-training-dc0:
+    name: cockroachdb-training-dc0
     driver: bridge
-  dc1:
+  cockroachdb-training-dc1:
+    name: cockroachdb-training-dc1
     driver: bridge
-  dc2:
+  cockroachdb-training-dc2:
+    name: cockroachdb-training-dc2
     driver: bridge
 
 services:
@@ -19,8 +23,8 @@ services:
     hostname: roach-0
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc0
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc0
     command: start --logtostderr --insecure --locality=datacenter=dc-0 --join=roach-0,roach-1,roach-2
     ports:
       - 8080:8080
@@ -31,8 +35,8 @@ services:
     hostname: roach-1
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc0
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc0
     command: start --logtostderr --insecure --locality=datacenter=dc-0 --join=roach-0,roach-1,roach-2
     ports:
       - 8081:8080
@@ -45,8 +49,8 @@ services:
     hostname: roach-2
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc1
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc1
     command: start --logtostderr --insecure --locality=datacenter=dc-1 --join=roach-0,roach-1,roach-2
     ports:
       - 8082:8080
@@ -57,8 +61,8 @@ services:
     hostname: roach-3
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc1
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc1
     command: start --logtostderr --insecure --locality=datacenter=dc-1 --join=roach-0,roach-1,roach-2
     ports:
       - 8083:8080
@@ -71,8 +75,8 @@ services:
     hostname: roach-4
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc2
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc2
     command: start --logtostderr --insecure --locality=datacenter=dc-2 --join=roach-0,roach-1,roach-2
     ports:
       - 8084:8080
@@ -83,8 +87,8 @@ services:
     hostname: roach-5
     image: cockroachdb/cockroach:${COCKROACH_VERSION:-v2.0.0}
     networks:
-      - shared
-      - dc2
+      - cockroachdb-training-shared
+      - cockroachdb-training-dc2
     command: start --logtostderr --insecure --locality=datacenter=dc-2 --join=roach-0,roach-1,roach-2
     ports:
       - 8085:8080


### PR DESCRIPTION
As reported on Slack, Docker Compose changed the way that it names
networks when there's a hyphen in your current directory's name.

To avoid this version-dependent confusion, use a new-ish Docker Compose
feature to assign the full name of the network using the `name` field
and bump the version of the compose file appropriately to use the
feature: https://docs.docker.com/compose/compose-file/#name-1

Thanks @tim-o! 