### PR TITLE
mention the SEQUENCE feature with the SERIAL type

### DIFF
--- a/v2.1/serial.md
+++ b/v2.1/serial.md
@@ -114,7 +114,7 @@ To experience this for yourself, run through the following example in PostgreSQL
 
     Since each insert increased the sequence in column `a` by one, the first commited insert got the value `2`, and the second commited insert got the value `4`. As you can see, the values aren't strictly sequential, and the last value doesn't give an accurate count of rows in the table.
 
-In summary, the `SERIAL` type in PostgreSQL and CockroachDB, and the `AUTO_INCREMENT` type in MySQL, all behave the same in that they do not create strict sequences. CockroachDB will likely create more gaps than these other databases, but will generate these values much faster.
+In summary, the `SERIAL` type in PostgreSQL and CockroachDB, and the `AUTO_INCREMENT` type in MySQL, all behave the same in that they do not create strict sequences. CockroachDB will likely create more gaps than these other databases but will generate these values much faster. An alternative feature, introduced in v2.0, is the [`SEQUENCE`](create-sequence.md).
 
 ## Supported Casting & Conversion
 


### PR DESCRIPTION
The docs here explain that "Auto-Incrementing Is Not Always Sequential." Now that the SEQUENCE feature has been added to CRDB, I think it should be mentioned in this section as it achieves precisely what AUTO_INCREMENT does in MySQL and SERIAL in PostgreSQL.