### PR TITLE
Note that Java version must be <= 9

### DIFF
--- a/v2.0/build-a-java-app-with-cockroachdb-hibernate.md
+++ b/v2.0/build-a-java-app-with-cockroachdb-hibernate.md
@@ -16,6 +16,10 @@ We have tested the [Java jdbc driver](https://jdbc.postgresql.org/) and the [Hib
 
 {{site.data.alerts.callout_success}}For a more realistic use of Hibernate with CockroachDB, see our <a href="https://github.com/cockroachdb/examples-orms"><code>examples-orms</code></a> repository.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+The examples on this page assume you are using a Java version <= 9. They don't work with Java 10.
+{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Before You Begin

--- a/v2.0/build-a-java-app-with-cockroachdb.md
+++ b/v2.0/build-a-java-app-with-cockroachdb.md
@@ -14,6 +14,10 @@ This tutorial shows you how build a simple Java application with CockroachDB usi
 
 We have tested the [Java jdbc driver](https://jdbc.postgresql.org/) and the [Hibernate ORM](http://hibernate.org/) enough to claim **beta-level** support, so those are featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
+{{site.data.alerts.callout_danger}}
+The examples on this page assume you are using a Java version <= 9. They don't work with Java 10.
+{{site.data.alerts.end}}
+
 <div id="toc"></div>
 
 ## Before You Begin


### PR DESCRIPTION
Examples don't work with Java 10 due to ... reasons.

Related:
https://github.com/cockroachdb/docs/issues/3164

tl;dr from above: Suggestion was to downgrade to 9 as 10 is breaking lots of code due to the introduction of "modules" in v10.

I think we should reassess updating the examples once Java 10/11 are more widespread (?).  Hopefully adding these notes will help at least some users avoid a frustrating experience until then.