### PR TITLE
Add prose linter and basic rules

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,11 @@
+StylesPath = ci/vale
+MinAlertLevel = suggestion
+
+[*.{md,html}]
+BasedOnStyles = CockroachDB
+
+vale.GenderBias = YES
+# vale.Hedging = YES
+vale.Redundancy = YES
+vale.Repetition = YES
+vale.Uncomparables = YES

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --update \
     zlib \
     zlib-dev \
   && GOBIN=/usr/local/bin go get -u github.com/cockroachdb/htmltest \
+  && wget -O- https://github.com/errata-ai/vale/releases/download/v0.11.2/vale_0.11.2_Linux_64-bit.tar.gz | tar -xzC /usr/local/bin vale \
   && pip install --upgrade awscli \
   && cd /tmp/bundler && bundle install && rm -rf /tmp/bundler \
   && apk --purge del \

--- a/ci/builder
+++ b/ci/builder
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/docs-builder
-version=${COCKROACH_DOCS_BUILDER_VERSION:-20180311-222618}
+version=${COCKROACH_DOCS_BUILDER_VERSION:-20180529-163433}
 
 root=$(cd "$(dirname "$0")" && pwd)
 repo_root=$root/..

--- a/ci/pull-request
+++ b/ci/pull-request
@@ -29,5 +29,8 @@ curl \
   --data "{\"body\": \"http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/$BUILD_VCS_NUMBER/\"}" \
   "https://api.github.com/repos/cockroachdb/docs/issues/$BUILD_BRANCH/comments"
 
-# Step 4. Run htmltest, but skip checking external links to speed things up.
+# Step 4. Run vale, but don't fail the build if it reports errors.
+run vale --no-wrap v2.1 || true
+
+# Step 5. Run htmltest, but skip checking external links to speed things up.
 run htmltest --skip-external

--- a/ci/vale/CockroachDB/Contractions.yml
+++ b/ci/vale/CockroachDB/Contractions.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: Use '%s' instead of '%s'
+ignorecase: false
+level: warning
+swap:
+  "(?:can\'t)": cannot
+  "(?:don\'t)": do not
+  "(?:shouldn\'t)": should not
+  "(?:won\'t)": will not

--- a/ci/vale/CockroachDB/HeadingsCase.yml
+++ b/ci/vale/CockroachDB/HeadingsCase.yml
@@ -1,0 +1,5 @@
+extends: capitalization
+message: "'%s' should be in sentence case"
+level: warning
+scope: heading
+match: $sentence

--- a/ci/vale/CockroachDB/HeadingsPunctuation.yml
+++ b/ci/vale/CockroachDB/HeadingsPunctuation.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: Do not use end punctuation (%s) in headings
+scope: heading
+level: warning
+raw:
+  - '(?:[^a-zA-Z])$'

--- a/ci/vale/CockroachDB/OxfordComma.yml
+++ b/ci/vale/CockroachDB/OxfordComma.yml
@@ -1,0 +1,5 @@
+extends: existence
+message: 'Use the Oxford comma in a list of three or more items.'
+level: warning
+tokens:
+  - '(?:[^,]+,){1,}\s\w+\sand'


### PR DESCRIPTION
This is a WIP PR to test [valelint](https://valelint.github.io/docs/) as a possible solution for auto-checking docs against at least some of our style conventions. 

For now, I've added 4 rules to check against:
- `Abbreviations.yml`: Checks for incorrect instances of `e.g.,` and `i.e.,`.
- `Contractions.yml`: Checks for `don't`, `can't`, `won't`, and `shouldn't`.
- `Headings.yml`: Checks that all headings use title case. This rule needs work since "step" headings in tutorials are more sentence case. A topic for further discussion.
- `OxfordComma.yml`: Checks for this non-contentious convention :).

To try this out, first install vale:

```
brew tap ValeLint/vale
brew install vale
```

Then clone this PR and at the root of the docs repo, run:

```
vale v2.1
```

That'll run the checks against all files in the `v2.1` directory. 

The output is pretty intuitive, e.g.:

```
v2.1/view-node-details.md
 90:238  warning  Use 'will not' instead of       CockroachDB.Contractions
                  'won't'
 160:5   warning  'List node IDs' should be in    CockroachDB.Headings
                  title case
 179:5   warning  'Show the status of a single    CockroachDB.Headings
                  node' should be in title case
 195:5   warning  'Show the status of all nodes'  CockroachDB.Headings
                  should be in title case
 215:5   warning  'Decommission nodes' should be  CockroachDB.Headings
                  in title case
 219:5   warning  'Recommission nodes' should be  CockroachDB.Headings
                  in title case


 v2.1/views.md
 18:5  warning  'Hide query complexity' should  CockroachDB.Headings
                be in title case
 77:5  warning  'Limit access to underlying     CockroachDB.Headings
                data' should be in title case

✖ 4 errors, 789 warnings and 0 suggestions in 295 files.
```

Addresses #3125