### PR TITLE
Scroll monospaced output instead of wrapping

### DIFF
--- a/css/theme-blue.css
+++ b/css/theme-blue.css
@@ -148,3 +148,9 @@ body.print h1 {color: #015CAE !important; font-size:28px;}
 body.print h2 {color: #595959 !important; font-size:24px;}
 body.print h3 {color: #E50E51 !important; font-size:14px;}
 body.print h4 {color: #679DCE !important; font-size:14px; font-style: italic;}
+
+pre {
+    overflow-x: scroll;
+    overflow-y: hidden;
+    white-space: nowrap;
+}


### PR DESCRIPTION
We currently wrap monospaced tabular output which makes it unreadable. This patch turns on scrolling in such cases.

Our highlighted code samples appear to already have the scrolling turned on, so this change brings the non-highlighted output in line.