### PR TITLE
Temporarily revert encryption docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ training:
   aws_access_key: AKIAIXNAWDKXMDDNHRCA
   aws_secret_access_key: wVevB0LO5CDf5lxI9tpy%2FXuE0UZi%2Bmpahiwoa3YL
 
-exclude: ["ci", "vendor", "v1.1/training/unused", "v2.0/training/unused", "v2.1/training/unused", "hackathon.md"]
+exclude: ["ci", "vendor", "v1.1/training/unused", "v2.0/training/unused", "v2.1/training/unused", "hackathon.md", "v2.1/encryption.md"]
 
 keep_files: [_internal]
 

--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -325,12 +325,6 @@
                 "urls": [
                   "/${VERSION}/roles.html"
                 ]
-              },
-              {
-                "title": "Encryption At Rest",
-                "urls": [
-                  "/${VERSION}/encryption.html"
-                ]
               }
             ]
           }


### PR DESCRIPTION
As requested by @mberhault and @nstewart, due to encryption bug that won't be resolved until after the v2.1.0-alpha.20180604 release.