### PR TITLE
Release notes for v2.1.0-alpha.20180702

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,10 +44,10 @@ release_info:
     start_time: 2018-06-18 15:10:52.34274101 +0000 UTC
   v2.1:
     name: v2.1.0
-    version: v2.1.0-alpha.20180604
+    version: v2.1.0-alpha.20180702
     docker_image: cockroachdb/cockroach-unstable
-    build_time: 2018/06/04 14:48:26 (go1.10)
-    start_time: 2018-06-04 15:10:52.34274101 +0000 UTC
+    build_time: 2018/07/02 14:48:26 (go1.10)
+    start_time: 2018-07-02 15:10:52.34274101 +0000 UTC
 
 training:
   ccl_license: crl-0-EIDA4OgGGAEiF0NvY2tyb2FjaCBMYWJzIFRyYWluaW5n

--- a/_config.yml
+++ b/_config.yml
@@ -54,7 +54,7 @@ training:
   aws_access_key: AKIAIXNAWDKXMDDNHRCA
   aws_secret_access_key: wVevB0LO5CDf5lxI9tpy%2FXuE0UZi%2Bmpahiwoa3YL
 
-exclude: ["ci", "vendor", "v1.1/training/unused", "v2.0/training/unused", "v2.1/training/unused", "hackathon.md", "v2.1/encryption.md"]
+exclude: ["ci", "vendor", "v1.1/training/unused", "v2.0/training/unused", "v2.1/training/unused", "hackathon.md"]
 include: ["_redirects"]
 
 keep_files: [_internal]

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -45,6 +45,8 @@
       version: v1.0
 - title: Testing Releases
   releases:
+    - date: Jul 02, 2018
+      version: v2.1.0-alpha.20180702
     - date: Jun 04, 2018
       version: v2.1.0-alpha.20180604
     - date: May 07, 2018

--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -327,6 +327,12 @@
                 ]
               },
               {
+                "title": "Encryption at Rest",
+                "ursl": [
+                  "/${VERSION}/encryption.html"
+                ]
+              },
+              {
                 "title": "Change Data Capture",
                 "urls": [
                   "/${VERSION}/change-data-capture.html"

--- a/releases/v2.1.0-alpha.20180702.md
+++ b/releases/v2.1.0-alpha.20180702.md
@@ -1,0 +1,231 @@
+---
+title: What&#39;s New in v2.1.0-alpha.20180702
+toc: false
+summary: Additions and changes in CockroachDB version v2.1.0-alpha.20180702 since version v2.1-alpha.20180604
+---
+
+## July 2, 2018
+
+For our July 2nd alpha release, in addition to PostgreSQL compatibility enhancements, general usability improvements, and bug fixes, we want to highlight a few major benefits:
+
+- [**Get visibility into query performance with the Statements pages**](../v2.1/admin-ui-statements-page.html) - The Web UI can now surface statistics about queries along with visualizations to help identify application problems quickly.
+- [**Get up and running faster with `IMPORT MYSQLDUMP/PGDUMP`**](../v2.1/import-data.html) - It is now much easier to transfer existing databases to CockroachDB.
+- [**Improved data security with Encryption at Rest (enterprise)**](../v2.1/encryption.html) - With this enhancement, you can now encrypt your CockroachDB files on disk, rotate keys, and monitor encryption status without having to make changes to your application code.
+- [**Stream changes to Kafka with CDC (enterprise)**](../v2.1/change-data-capture.html) - CockroachDB can now stream changes into Apache Kafka to support downstream processing such as reporting, caching, or full-text indexing.
+- [**Secure your Web UI with User Authentication**](../v2.1/admin-ui-access-and-navigate.html#secure-the-admin-ui) - A login page can now be enabled to control who can access the Web UI in secure clusters.
+
+Please give these features and the ones below a try. If you see something that can be improved, we’d love to hear from you on [GitHub](https://github.com/cockroachdb/cockroach/issues) or the [Forum](https://forum.cockroachlabs.com/).
+
+Get future release notes emailed to you:
+
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
+### Downloads
+
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+### Backward-incompatible changes
+
+- CockroachDB now uses a different algorithm to generate column names for complex expressions in [`SELECT`](../v2.1/select-clause.html) clauses when `AS` is not used. The results are more compatible with PostgreSQL but may appear different to client applications. This does not impact most uses of SQL, where the rendered expressions are sufficiently simple (simple function applications, reuses of existing columns) or when `AS` is used explicitly. [#26550][#26550]
+- The output columns for the statement [`SHOW CONSTRAINTS`](../v2.1/show-constraints.html) were changed. The previous interface was experimental; the new interface will now be considered stable. [#26478][#26478] {% comment %}doc{% endcomment %}
+
+### General changes
+
+- Metrics can now be sent to a Graphite endpoint specified using the `external.graphite.endpoint` [cluster setting](../v2.1/cluster-settings.html). The `external.graphite.interval` setting controls the interval at which this happens. [#25227][#25227]
+- Added a [config file and instructions](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/performance/cockroachdb-daemonset-secure.yaml) for running CockroachDB in secure mode in a Kubernetes DaemonSet. [#26816][#26816] {% comment %}doc{% endcomment %}
+
+### Enterprise edition changes
+
+- The new `SHOW BACKUP RANGES` and `SHOW BACKUP FILES` statements show details about the ranges and files, respectively, that comprise a backup. [#26450][#26450] {% comment %}doc{% endcomment %}
+
+### SQL language changes
+
+- If a computed column's expression results in an error, the name of the computed column is now added to the error returned to the user. This makes it easier for users to understand why an otherwise valid operation might fail. [#26054][#26054]
+- Implemented the minus operation between a JSON Object and a text array. [#26183][#26183] {% comment %}doc{% endcomment %}
+- Fixed some error messages to more closely match PostgreSQL error messages, including the corresponding PostgreSQL
+  error codes. [#26290][#26290]
+- Added an empty `pg_stat_activity` virtual table for compatibility with DBeaver and other SQL clients that require it. [#26249][#26249]
+- The new `EXPLAIN (DISTSQL, ANALYZE)` statement annotates DistSQL execution plans with collected execution statistics. [#25849][#25849] {% comment %}doc{% endcomment %}
+- [`IMPORT`](../v2.1/import.html) now supports the PostgreSQL `COPY` format. [#26334][#26334] {% comment %}doc{% endcomment %}
+- The output of [`SHOW SESSIONS`](../v2.1/show-sessions.html) now includes the number of currently allocated bytes by the session, and the maximum number of allocated bytes that the session ever owned at once. Note that these numbers don't include the bytes allocated for the session by remote nodes. [#25395][#25395] {% comment %}doc{% endcomment %}
+- The `bytea_output` [session variable](../v2.1/set-vars.html) now controls how byte arrays are converted to strings and reported back to clients, for compatibility with PostgreSQL. [#25835][#25835] {% comment %}doc{% endcomment %}
+- Added placeholder `information_schema.routines` and `information_schema.parameters` for compatibility with Navicat, PGAdmin, and other clients that require them. [#26327][#26327] {% comment %}doc{% endcomment %}
+- CockroachDB now recognizes aggregates in `ORDER BY` clauses even when there is no `GROUP BY` clause nor aggregation performed, for compatibility with PostgreSQL. [#26425][#26425] {% comment %}doc{% endcomment %}
+- Added the `pg_is_in_recovery()` [function](../v2.1/functions-and-operators.html) for compatibility with PostgreSQL tools. [#26445][#26445] {% comment %}doc{% endcomment %}
+- CockroachDB now supports simple forms of PostgreSQL's `ROWS FROM(...)` syntax. [#26223][#26223] {% comment %}doc{% endcomment %}
+- CockroachDB now generates a simple column name when using an SRF that produces multiple columns. [#26223][#26223]
+- CockroachDB now properly handles some uses of multiple SRFs in the same `SELECT` clause in a way compatible with
+  PostgreSQL. [#26223][#26223]
+- Added the `pg_is_xlog_replay_paused()` [function](../v2.1/functions-and-operators.html) for compatibility with PostgreSQL tools. [#26462][#26462] {% comment %}doc{% endcomment %}
+- Added the `pg_catalog.pg_seclabel` and `pg_catalog.pg_shseclabel` tables for compatibility with Postgres tools. Note that we do not support adding security labels. [#26515][#26515]
+- CockroachDB now supports [`INSERT ... ON CONFLICT DO NOTHING`](../v2.1/insert.html) without any specified columns; on a conflict with any [`UNIQUE`](../v2.1/unique.html) column, the insert will not continue. [#26465][#26465] {% comment %}doc{% endcomment %}
+- CockroachDB now supports the `bit_length()`, `quote_ident()`, `quote_literal()`, and `quote_nullable()` [built-in functions](../v2.1/functions-and-operators.html), and the aliases `char_length()` and `character_length()` for `length()`, for compatibility with PostgreSQL. [#26586][#26586] {% comment %}doc{% endcomment %}
+- If a function name is typed in with an invalid schema or invalid case, the error message now tries to provides a suggestion for alternate spelling. [#26588][#26588]
+- CockroachDB now can evaluate set-generating functions with arguments that refer to the `FROM` clause. In particular, this makes it possible to use functions like `json_each()` and `json_object_keys()` over [`JSONB`](../v2.1/jsonb.html) columns. [#26503][#26503] {% comment %}doc{% endcomment %}
+- Added prototype support for [`IMPORT ... MYSQLDUMP`](../v2.1/import.html), including the ability to import entire (multi-table) mysqldump files. [#26164][#26164] {% comment %}doc{% endcomment %}
+- [`CHECK`](../v2.1/check.html) constraints are now checked when updating a conflicting row in [`INSERT ... ON CONFLICT DO UPDATE`](../v2.1/insert.html) statements. [#26642][#26642] {% comment %}doc{% endcomment %}
+- Labeled tuples can now be accessed using their labels (e.g., `SELECT (x).word FROM (SELECT pg_expand_keywords() AS x)` or a star (e.g., `SELECT (x).* FROM (SELECT pg_expand_keywords() AS x)`). [#26628][#26628] {% comment %}doc{% endcomment %}
+- An error is now returned to the user instead of panicking when trying to add a column with a [`UNIQUE`](../v2.1/unique.html) constraint when that column's type is not indexable. [#26684][#26684] {% comment %}doc{% endcomment %}
+- Introduced the `sql.failure.count` metric, which counts the number of queries that result in an error. [#26731][#26731]
+- Added support for de-compressing [`IMPORT`](../v2.1/import.html) files with gzip or bzip. [#26796][#26796] {% comment %}doc{% endcomment %}
+- Added initial support for `IMPORT` with pg_dump files. [#26740][#26740] {% comment %}doc{% endcomment %}
+- Added the `like_escape()`, `ilike_escape()`, `not_like_escape()`, `not_ilike_escape()`, `similar_escape()`, and `not_similar_escape()` [built-in functions](../v2.1/functions-and-operators.html) for use when an optional `ESCAPE` clause is present. [#26176][#26176] {% comment %}doc{% endcomment %}
+- Added support for set-returning functions in distributed SQL execution. [#26739][#26739]
+- Added a cluster setting to enable the experimental cost-based optimizer. [#26299][#26299]
+- Added the `pg_catalog.pg_shdescription` table for compatibility with PostgreSQL tools. Note that CockroachDB does not support adding descriptions to shared database objects. [#26474][#26474]
+
+### Command-line changes
+
+- [`cockroach quit`](../v2.1/stop-a-node.html) now emits warning messages on its standard error stream, not standard output. [#26158][#26158] {% comment %}doc{% endcomment %}
+- [`cockroach sql`](../v2.1/use-the-built-in-sql-client.html) now recognizes the values `on`, `off`, `0`, `1`, `true` and `false` to set client-side boolean parameters with `\set`. [#26287][#26287] {% comment %}doc{% endcomment %}
+- [`cockroach sql`](../v2.1/use-the-built-in-sql-client.html) now recognizes `\set option=value` as an alias to `\set option value`. [#26287][#26287] {% comment %}doc{% endcomment %}
+- `cockroach demo` now supports more options also supported by `cockroach sql`, including `--execute`, `--format`,
+  `--echo-sql` and `--safe-updates`. [#26287][#26287] {% comment %}doc{% endcomment %}
+- `cockroach demo` includes the welcome messages also printed by `cockroach sql`. [#26287][#26287]
+- `cockroach demo` now uses the standard `defaultdb` database instead of creating its own `demo` database. [#26287][#26287] {% comment %}doc{% endcomment %}
+- [`cockroach sql`](../v2.1/use-the-built-in-sql-client.html) and `cockroach demo` now accept `--set` to run `\set` commands prior to starting the shell
+  or running commands via `-e`. [#26287][#26287] {% comment %}doc{% endcomment %}
+
+### Admin UI changes
+
+- [Authentication in the Admin UI](../v2.1/admin-ui-access-and-navigate.html#secure-the-admin-ui) can now be enabled for secure clusters by setting the environment variable `COCKROACH_EXPERIMENTAL_REQUIRE_WEB_LOGIN=TRUE`. [#25005][#25005]
+- System databases are now listed after all user databases on the [**Databases** page](../v2.1/admin-ui-databases-page.html). [#25817][#25817] {% comment %}doc{% endcomment %}
+- Added **Statements** and **Statement Details** pages showing fingerprints of incoming statements and basic statistics about them. [#24485][#24485]
+- Lease transfers are now shown in the **Range Operations** graph on the [**Replication** dashboard](../v2.1/admin-ui-replication-dashboard.html). [#26653][#26653] {% comment %}doc{% endcomment %}
+- Add a debug page showing how table data is distributed across nodes, as well as the zone configs which are affecting that distribution. [#24855][#24855] {% comment %}doc{% endcomment %}
+
+### Bug fixes
+
+- Fixed an issue where the Table details page in the Admin UI would become unresponsive after some time. [#26636][#26636]
+- Fix a bug where [`cockroach quit`](../v2.1/stop-a-node.html) would erroneously fail even though the node already successfully shut down. [#26158][#26158]
+- [`UPSERT`](../v2.1/upsert.html) is now properly able to write `NULL` values to every column in tables containing more than one column family. [#26169][#26169]
+- Fixed a bug causing index creation to fail under rare circumstances. [#26265][#26265]
+- Corrected `NULL` handling during [`IMPORT`](../v2.1/import.html) of `MYSQLOUTFILE`. [#26275][#26275]
+- Fixed concurrent access to the same file when using encryption. [#26377][#26377]
+- Fixed a bug where a prepared query would not produce the right value for `current_date()` if prepared on one day and executed on the next. [#26370][#26370]
+- Rows larger than 8192 bytes are now supported by the "copy from" protocol. [#26345][#26345]
+- Trying to "copy from stdin" into a table that doesn't exist no longer drops the connection. [#26345][#26345]
+- CockroachDB now produces a clearer message when special functions (e.g., `generate_series()`) are used in an invalid context (e.g., `LIMIT`). [#26425][#26425]
+- Fixed a rare crash on node [decommissioning](../v2.1/remove-nodes.html). [#26706][#26706]
+- Commands are now abandoned earlier once a deadline has been reached. [#26643][#26643]
+- Using [`SHOW TRACE FOR SESSION`](../v2.1/show-trace.html) multiple times without an intervening `SET tracing` statement now properly outputs the trace without introducing extraneous duplicate rows. [#26746][#26746]
+- The output of debug and tracing commands is no longer corrupted when byte array values contain invalid UTF-8 sequences. [#26769][#26769]
+- Joins across two [interleaved tables](../v2.1/interleave-in-parent.html) no longer return incorrect results under certain circumstances when the equality columns aren't all part of the interleaved columns. [#26756][#26756]
+- Prepared statements using [`RETURNING NOTHING`](../v2.1/parallel-statement-execution.html) that are executed using the `EXECUTE` statement are now properly parallelized. [#26668][#26668]
+- The pretty-print code for `SHOW` now properly quotes the variable name, and the pretty-printing code for an index definition inside `CREATE TABLE` now properly indicates whether the index was inverted. [#26923][#26923]
+- Within a [transaction](../v2.1/transactions.html), DML statements are now allowed after a [`TRUNCATE`](../v2.1/truncate.html). [#26051][#26051]
+
+### Performance improvements
+
+- The performance impact of dropping a large table has been substantially reduced. [#26449][#26449]
+- Using tuples in a query no longer reverts you to single node local SQL execution. [#25860][#25860]
+- CockroachDB's internal monitoring time series are now encoded using a more efficient on-disk format to provide considerable space savings. Monitoring data written in the old format will not be converted but will still be queryable. [#26614][#26614]
+- Improved the performance of the `sortChunks` processor. [#26874][#26874]
+
+### Build Changes
+
+- Release binaries are now built with runtime AES detection. [#26649][#26649]
+
+### Doc updates
+
+- Added `systemd` configs and instructions to [deployment tutorials](../v2.1/manual-deployment.html). [#3268][#3268]
+- Added instructions for [importing data from Postgres dump files](../v2.1/import-data.html). [#3306][#3306]
+- Expanded the first level of the 2.1 docs sidenav by default. [#3270][#3270]
+- Updated the [Kubernetes tutorials](../v2.1/orchestrate-cockroachdb-with-kubernetes.html) to reflect that pods aren't "Ready" before init. [#3291][#3291]
+
+### Contributors
+
+This release includes 328 merged PRs by 35 authors. We would like to thank the following contributors from the CockroachDB community, with special thanks to first-time contributors Chris Seto and Emmanuel.
+
+- Chris Seto
+- Emmanuel
+- neeral
+
+[#24485]: https://github.com/cockroachdb/cockroach/pull/24485
+[#24855]: https://github.com/cockroachdb/cockroach/pull/24855
+[#25005]: https://github.com/cockroachdb/cockroach/pull/25005
+[#25014]: https://github.com/cockroachdb/cockroach/pull/25014
+[#25227]: https://github.com/cockroachdb/cockroach/pull/25227
+[#25395]: https://github.com/cockroachdb/cockroach/pull/25395
+[#25817]: https://github.com/cockroachdb/cockroach/pull/25817
+[#25835]: https://github.com/cockroachdb/cockroach/pull/25835
+[#25849]: https://github.com/cockroachdb/cockroach/pull/25849
+[#25860]: https://github.com/cockroachdb/cockroach/pull/25860
+[#26051]: https://github.com/cockroachdb/cockroach/pull/26051
+[#26054]: https://github.com/cockroachdb/cockroach/pull/26054
+[#26158]: https://github.com/cockroachdb/cockroach/pull/26158
+[#26164]: https://github.com/cockroachdb/cockroach/pull/26164
+[#26169]: https://github.com/cockroachdb/cockroach/pull/26169
+[#26176]: https://github.com/cockroachdb/cockroach/pull/26176
+[#26183]: https://github.com/cockroachdb/cockroach/pull/26183
+[#26223]: https://github.com/cockroachdb/cockroach/pull/26223
+[#26249]: https://github.com/cockroachdb/cockroach/pull/26249
+[#26260]: https://github.com/cockroachdb/cockroach/pull/26260
+[#26265]: https://github.com/cockroachdb/cockroach/pull/26265
+[#26275]: https://github.com/cockroachdb/cockroach/pull/26275
+[#26287]: https://github.com/cockroachdb/cockroach/pull/26287
+[#26290]: https://github.com/cockroachdb/cockroach/pull/26290
+[#26299]: https://github.com/cockroachdb/cockroach/pull/26299
+[#26327]: https://github.com/cockroachdb/cockroach/pull/26327
+[#26334]: https://github.com/cockroachdb/cockroach/pull/26334
+[#26345]: https://github.com/cockroachdb/cockroach/pull/26345
+[#26355]: https://github.com/cockroachdb/cockroach/pull/26355
+[#26370]: https://github.com/cockroachdb/cockroach/pull/26370
+[#26377]: https://github.com/cockroachdb/cockroach/pull/26377
+[#26425]: https://github.com/cockroachdb/cockroach/pull/26425
+[#26445]: https://github.com/cockroachdb/cockroach/pull/26445
+[#26447]: https://github.com/cockroachdb/cockroach/pull/26447
+[#26449]: https://github.com/cockroachdb/cockroach/pull/26449
+[#26450]: https://github.com/cockroachdb/cockroach/pull/26450
+[#26462]: https://github.com/cockroachdb/cockroach/pull/26462
+[#26465]: https://github.com/cockroachdb/cockroach/pull/26465
+[#26468]: https://github.com/cockroachdb/cockroach/pull/26468
+[#26474]: https://github.com/cockroachdb/cockroach/pull/26474
+[#26478]: https://github.com/cockroachdb/cockroach/pull/26478
+[#26503]: https://github.com/cockroachdb/cockroach/pull/26503
+[#26515]: https://github.com/cockroachdb/cockroach/pull/26515
+[#26550]: https://github.com/cockroachdb/cockroach/pull/26550
+[#26586]: https://github.com/cockroachdb/cockroach/pull/26586
+[#26588]: https://github.com/cockroachdb/cockroach/pull/26588
+[#26614]: https://github.com/cockroachdb/cockroach/pull/26614
+[#26628]: https://github.com/cockroachdb/cockroach/pull/26628
+[#26636]: https://github.com/cockroachdb/cockroach/pull/26636
+[#26642]: https://github.com/cockroachdb/cockroach/pull/26642
+[#26643]: https://github.com/cockroachdb/cockroach/pull/26643
+[#26649]: https://github.com/cockroachdb/cockroach/pull/26649
+[#26653]: https://github.com/cockroachdb/cockroach/pull/26653
+[#26668]: https://github.com/cockroachdb/cockroach/pull/26668
+[#26684]: https://github.com/cockroachdb/cockroach/pull/26684
+[#26706]: https://github.com/cockroachdb/cockroach/pull/26706
+[#26711]: https://github.com/cockroachdb/cockroach/pull/26711
+[#26731]: https://github.com/cockroachdb/cockroach/pull/26731
+[#26739]: https://github.com/cockroachdb/cockroach/pull/26739
+[#26740]: https://github.com/cockroachdb/cockroach/pull/26740
+[#26746]: https://github.com/cockroachdb/cockroach/pull/26746
+[#26756]: https://github.com/cockroachdb/cockroach/pull/26756
+[#26769]: https://github.com/cockroachdb/cockroach/pull/26769
+[#26776]: https://github.com/cockroachdb/cockroach/pull/26776
+[#26796]: https://github.com/cockroachdb/cockroach/pull/26796
+[#26816]: https://github.com/cockroachdb/cockroach/pull/26816
+[#26874]: https://github.com/cockroachdb/cockroach/pull/26874
+[#26923]: https://github.com/cockroachdb/cockroach/pull/26923
+[#3268]: https://github.com/cockroachdb/docs/pull/3268
+[#3270]: https://github.com/cockroachdb/docs/pull/3270
+[#3291]: https://github.com/cockroachdb/docs/pull/3291
+[#3306]: https://github.com/cockroachdb/docs/pull/3306


### PR DESCRIPTION
For https://github.com/cockroachdb/cockroach/issues/26951.

The output when using the tag for the last release (or its corresponding SHA) was huge and included a lot of old stuff, even from last year. But when I use the SHA initially picked for the [last alpha release](https://github.com/cockroachdb/cockroach/issues/25351#issuecomment-393646225), I get the current output, which seems correct.

```
python3 scripts/release-notes.py --from=83e98d996b3ba3537afd7bc67e439eb5d3ea1659 --until=3106615e752628fca3d446028ead653c82b6468a --hide-unambiguous-shas --hide-per-contributor-section > draft-release-notes2.md
```