### PR TITLE
Finish wrapping all 2.0 SQL diagrams in div tags

### DIFF
--- a/v2.0/alter-column.md
+++ b/v2.0/alter-column.md
@@ -12,7 +12,9 @@ The `ALTER COLUMN` [statement](sql-statements.html) is part of `ALTER TABLE` and
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/alter_column.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/alter-view.md
+++ b/v2.0/alter-view.md
@@ -16,7 +16,9 @@ The user must have the `DROP` [privilege](privileges.html) on the view and the `
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/alter_view.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/backup.md
+++ b/v2.0/backup.md
@@ -98,7 +98,9 @@ After the backup has been initiated, you can control it with [`PAUSE JOB`](pause
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/backup.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>BACKUP</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
 

--- a/v2.0/begin-transaction.md
+++ b/v2.0/begin-transaction.md
@@ -12,7 +12,9 @@ The `BEGIN` [statement](sql-statements.html) initiates a [transaction](transacti
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/begin_transaction.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/cancel-job.md
+++ b/v2.0/cancel-job.md
@@ -18,7 +18,9 @@ By default, only the `root` user can cancel a job.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/cancel_job.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/cancel-query.md
+++ b/v2.0/cancel-query.md
@@ -19,7 +19,9 @@ The `root` user can cancel any currently active queries, whereas non-`root` user
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/cancel_query.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/check.md
+++ b/v2.0/check.md
@@ -33,7 +33,9 @@ The `CHECK` [constraint](constraints.html) specifies that values for the column 
 
 ### Column Level
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/check_column_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|
@@ -58,7 +60,9 @@ The `CHECK` [constraint](constraints.html) specifies that values for the column 
 
 ### Table Level
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/check_table_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|

--- a/v2.0/commit-transaction.md
+++ b/v2.0/commit-transaction.md
@@ -14,7 +14,9 @@ For non-retryable transactions, if statements in the transaction [generated any 
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/commit_transaction.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/configure-replication-zones.md
+++ b/v2.0/configure-replication-zones.md
@@ -168,7 +168,9 @@ Flag | Description
 
 ### Client Connection
 
+<div>
 {% include sql/{{ page.version.version }}/connection-parameters-with-url.md %}
+</div>
 
 See [Client Connection Parameters](connection-parameters.html) for more details.
 

--- a/v2.0/create-and-manage-users.md
+++ b/v2.0/create-and-manage-users.md
@@ -60,7 +60,9 @@ Flag | Description
 
 ### Client Connection
 
+<div>
 {% include sql/{{ page.version.version }}/connection-parameters-with-url.md %}
+</div>
 
 See [Client Connection Parameters](connection-parameters.html) for more details.
 

--- a/v2.0/create-database.md
+++ b/v2.0/create-database.md
@@ -14,7 +14,9 @@ Only the `root` user can create databases.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/create_database.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/create-table-as.md
+++ b/v2.0/create-table-as.md
@@ -34,7 +34,9 @@ The user must have the `CREATE` [privilege](privileges.html) on the parent datab
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/create_table_as.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/create-table.md
+++ b/v2.0/create-table.md
@@ -25,31 +25,45 @@ The user must have the `CREATE` [privilege](privileges.html) on the parent datab
 
 <div class="filter-content" markdown="1" data-scope="expanded">
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/create_table.html %}
+</div>
 
 **column_def ::=**
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/column_def.html %}
+</div>
 
 **col_qualification ::=**
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/col_qualification.html %}
+</div>
 
 **index_def ::=**
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/index_def.html %}
+</div>
 
 **family_def ::=**
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/family_def.html %}
+</div>
 
 **table_constraint ::=**
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/table_constraint.html %}
+</div>
 
 **opt_interleave ::=**
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/opt_interleave.html %}
+</div>
 
 </div>
 

--- a/v2.0/create-view.md
+++ b/v2.0/create-view.md
@@ -14,7 +14,9 @@ The user must have the `CREATE` [privilege](privileges.html) on the parent datab
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/create_view.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/default-value.md
+++ b/v2.0/default-value.md
@@ -19,7 +19,9 @@ You can only apply the Default Value constraint to individual columns.
 
 {{site.data.alerts.callout_info}}You can also add the Default Value constraint to an existing table through <a href="alter-column.html#set-or-change-a-default-value"><code>ALTER COLUMN</code></a>. {{site.data.alerts.end}}
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/default_value_column_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|

--- a/v2.0/delete.md
+++ b/v2.0/delete.md
@@ -18,7 +18,9 @@ The user must have the `DELETE` and `SELECT` [privileges](privileges.html) on th
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/delete.html %}
+</div>
 
 <div markdown="1"></div>
 

--- a/v2.0/drop-column.md
+++ b/v2.0/drop-column.md
@@ -10,7 +10,9 @@ The `DROP COLUMN` [statement](sql-statements.html) is part of `ALTER TABLE` and 
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/drop_column.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/drop-constraint.md
+++ b/v2.0/drop-constraint.md
@@ -12,7 +12,9 @@ The `DROP CONSTRAINT` [statement](sql-statements.html) is part of `ALTER TABLE` 
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/drop_constraint.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/drop-database.md
+++ b/v2.0/drop-database.md
@@ -14,7 +14,9 @@ The user must have the `DROP` [privilege](privileges.html) on the database and o
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/drop_database.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/drop-index.md
+++ b/v2.0/drop-index.md
@@ -10,7 +10,9 @@ The `DROP INDEX` [statement](sql-statements.html) removes indexes from tables.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/drop_index.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/drop-table.md
+++ b/v2.0/drop-table.md
@@ -14,7 +14,9 @@ The user must have the `DROP` [privilege](privileges.html) on the specified tabl
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/drop_table.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/import.md
+++ b/v2.0/import.md
@@ -88,7 +88,9 @@ After the import has been initiated, you can control it with [`PAUSE JOB`](pause
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/import.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>IMPORT</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
 

--- a/v2.0/interleave-in-parent.md
+++ b/v2.0/interleave-in-parent.md
@@ -77,7 +77,9 @@ In general, reads, writes, and joins of values related through the interleave pr
 
 ## Syntax
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/interleave.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/limit-offset.md
+++ b/v2.0/limit-offset.md
@@ -14,9 +14,13 @@ as part of [`INSERT`](insert.html) or [`UPSERT`](upsert.html).
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/limit_clause.html %}
+</div>
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/offset_clause.html %}
+</div>
 
 `LIMIT` restricts the operation to only retrieve `limit_val` number of rows.
 

--- a/v2.0/not-null.md
+++ b/v2.0/not-null.md
@@ -29,7 +29,9 @@ The Not Null [constraint](constraints.html) specifies a column may not contain *
 
 You can only apply the Not Null constraint to individual columns.
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/not_null_column_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|

--- a/v2.0/pause-job.md
+++ b/v2.0/pause-job.md
@@ -18,7 +18,9 @@ By default, only the `root` user can control a job.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/pause_job.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/primary-key.md
+++ b/v2.0/primary-key.md
@@ -35,7 +35,9 @@ Primary Key constraints can be defined at the [table level](#table-level). Howev
 
 ### Column Level
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/primary_key_column_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|
@@ -60,7 +62,9 @@ Primary Key constraints can be defined at the [table level](#table-level). Howev
 
 ### Table Level
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/primary_key_table_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|

--- a/v2.0/query-order.md
+++ b/v2.0/query-order.md
@@ -15,7 +15,9 @@ statements.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/sort_clause.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/release-savepoint.md
+++ b/v2.0/release-savepoint.md
@@ -16,7 +16,9 @@ Despite committing the transaction, you must still issue a [`COMMIT`](commit-tra
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/release_savepoint.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/rename-column.md
+++ b/v2.0/rename-column.md
@@ -12,7 +12,9 @@ The `RENAME COLUMN` [statement](sql-statements.html) changes the name of a colum
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/rename_column.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/rename-database.md
+++ b/v2.0/rename-database.md
@@ -12,7 +12,9 @@ The `RENAME DATABASE` [statement](sql-statements.html) changes the name of a dat
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/rename_database.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/rename-index.md
+++ b/v2.0/rename-index.md
@@ -12,7 +12,9 @@ The `RENAME INDEX` [statement](sql-statements.html) changes the name of an index
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/rename_index.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/rename-table.md
+++ b/v2.0/rename-table.md
@@ -16,7 +16,9 @@ The user must have the `DROP` [privilege](privileges.html) on the table and the 
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/rename_table.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/reset-cluster-setting.md
+++ b/v2.0/reset-cluster-setting.md
@@ -14,7 +14,9 @@ Only the `root` user can modify cluster settings.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/reset_csetting.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/restore.md
+++ b/v2.0/restore.md
@@ -86,7 +86,9 @@ After the restore has been initiated, you can control it with [`PAUSE JOB`](paus
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/restore.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>RESTORE</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
 

--- a/v2.0/resume-job.md
+++ b/v2.0/resume-job.md
@@ -16,7 +16,9 @@ By default, only the `root` user can control a job.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/resume_job.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/rollback-transaction.md
+++ b/v2.0/rollback-transaction.md
@@ -12,7 +12,9 @@ When using [client-side transaction retries](transactions.html#client-side-trans
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/rollback_transaction.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/savepoint.md
+++ b/v2.0/savepoint.md
@@ -12,7 +12,9 @@ The `SAVEPOINT cockroach_restart` statement defines the intent to retry [transac
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/savepoint.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/select-clause.md
+++ b/v2.0/select-clause.md
@@ -18,7 +18,9 @@ with other constructs to form more complex [selection queries](selection-queries
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/simple_select_clause.html %}
+</div>
 
 <div markdown="1"></div>
 

--- a/v2.0/selection-queries.md
+++ b/v2.0/selection-queries.md
@@ -56,7 +56,9 @@ Form | Usage
 
 ### Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/select_clause.html %}
+</div>
 
 <div markdown="1"></div>
 
@@ -67,7 +69,9 @@ Form | Usage
 
 #### Syntax
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/values_clause.html %}
+</div>
 
 A `VALUES` clause defines tabular data defined by the expressions
 listed within parentheses. Each parenthesis group defines a single row
@@ -98,7 +102,9 @@ names. [These names can be modified with
 
 #### Syntax
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/table_clause.html %}
+</div>
 
 <div markdown="1"></div>
 

--- a/v2.0/set-cluster-setting.md
+++ b/v2.0/set-cluster-setting.md
@@ -16,7 +16,9 @@ Only the `root` user can modify cluster settings.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/set_cluster_setting.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>SET CLUSTER SETTING</code> statement is unrelated to the other <a href="set-transaction.html"><code>SET TRANSACTION</code></a> and <a href="set-vars.html"><code>SET (session variable)</code></a> statements.{{site.data.alerts.end}}
 

--- a/v2.0/set-vars.md
+++ b/v2.0/set-vars.md
@@ -20,7 +20,9 @@ No [privileges](privileges.html) are required to modify the session settings.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/set_var.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>SET</code> statement for session settings is unrelated to the other <a href="set-transaction.html"><code>SET TRANSACTION</code></a> and <a href="cluster-settings.html#change-a-cluster-setting"><code>SET CLUSTER SETTING</code></a> statements.{{site.data.alerts.end}}
 

--- a/v2.0/show-backup.md
+++ b/v2.0/show-backup.md
@@ -14,7 +14,9 @@ Only the `root` user can run `SHOW BACKUP`.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_backup.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-cluster-setting.md
+++ b/v2.0/show-cluster-setting.md
@@ -17,7 +17,9 @@ Only the `root` user can display cluster settings.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_cluster_setting.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>SHOW</code> statement for cluster settings is unrelated to the other <code>SHOW</code> statements: <a href="show-vars.html"><code>SHOW (session variable)</code></a>, <a href="show-create-table.html"><code>SHOW CREATE TABLE</code></a>, <a href="show-create-view.html"><code>SHOW CREATE VIEW</code></a>, <a href="show-users.html"><code>SHOW USERS</code></a>, <a href="show-databases.html"><code>SHOW DATABASES</code></a>, <a href="show-columns.html"><code>SHOW COLUMNS</code></a>, <a href="show-grants.html"><code>SHOW GRANTS</code></a>, and <a href="show-constraints.html"><code>SHOW CONSTRAINTS</code></a>.{{site.data.alerts.end}}
 

--- a/v2.0/show-columns.md
+++ b/v2.0/show-columns.md
@@ -14,7 +14,9 @@ The user must have any [privilege](privileges.html) on the target table.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_columns.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-constraints.md
+++ b/v2.0/show-constraints.md
@@ -20,7 +20,9 @@ The user must have any [privilege](privileges.html) on the target table.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_constraints.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-create-sequence.md
+++ b/v2.0/show-create-sequence.md
@@ -14,7 +14,9 @@ The user must have any [privilege](privileges.html) on the target sequence.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_create_sequence.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-create-table.md
+++ b/v2.0/show-create-table.md
@@ -14,7 +14,9 @@ The user must have any [privilege](privileges.html) on the target table.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_create_table.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-create-view.md
+++ b/v2.0/show-create-view.md
@@ -14,7 +14,9 @@ The user must have any [privilege](privileges.html) on the target view.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_create_view.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-databases.md
+++ b/v2.0/show-databases.md
@@ -11,7 +11,9 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all database in the 
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_databases.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/show-index.md
+++ b/v2.0/show-index.md
@@ -21,7 +21,9 @@ In CockroachDB, the following are aliases for `SHOW INDEX`:
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_index.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-jobs.md
+++ b/v2.0/show-jobs.md
@@ -21,7 +21,9 @@ By default, only the `root` user can execute `SHOW JOBS`.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_jobs.html %}
+</div>
 
 ## Response
 

--- a/v2.0/show-schemas.md
+++ b/v2.0/show-schemas.md
@@ -14,7 +14,9 @@ No [privileges](privileges.html) are required to list the schemas in a database.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_schemas.html %}
+</div>
 
 ## Parameters
 

--- a/v2.0/show-tables.md
+++ b/v2.0/show-tables.md
@@ -13,7 +13,9 @@ The `SHOW TABLES` [statement](sql-statements.html) lists the tables or [views](v
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_tables.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/show-users.md
+++ b/v2.0/show-users.md
@@ -10,7 +10,9 @@ The `SHOW USERS` [statement](sql-statements.html) lists the users for all databa
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_users.html %}
+</div>
 
 ## Required Privileges
 

--- a/v2.0/show-vars.md
+++ b/v2.0/show-vars.md
@@ -19,7 +19,9 @@ No [privileges](privileges.html) are required to display the session settings.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/show_var.html %}
+</div>
 
 {{site.data.alerts.callout_info}}The <code>SHOW</code> statement for session settings is unrelated to the other <code>SHOW</code> statements: <a href="cluster-settings.html#view-current-cluster-settings"><code>SHOW CLUSTER SETTING</code></a>, <a href="show-create-table.html"><code>SHOW CREATE TABLE</code></a>, <a href="show-create-view.html"><code>SHOW CREATE VIEW</code></a>, <a href="show-users.html"><code>SHOW USERS</code></a>, <a href="show-databases.html"><code>SHOW DATABASES</code></a>, <a href="show-columns.html"><code>SHOW COLUMNS</code></a>, <a href="show-grants.html"><code>SHOW GRANTS</code></a>, and <a href="show-constraints.html"><code>SHOW CONSTRAINTS</code></a>.{{site.data.alerts.end}}
 

--- a/v2.0/table.md
+++ b/v2.0/table.md
@@ -7,7 +7,9 @@ toc: true
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/table.html %}
+</div>
 
 ## Privileges
 

--- a/v2.0/unique.md
+++ b/v2.0/unique.md
@@ -24,7 +24,9 @@ Unique constraints can be defined at the [table level](#table-level). However, i
 
 ### Column Level
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/unique_column_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|
@@ -47,7 +49,9 @@ Unique constraints can be defined at the [table level](#table-level). However, i
 
 ### Table Level
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/unique_table_level.html %}
+</div>
 
 | Parameter | Description |
 |-----------|-------------|

--- a/v2.0/update.md
+++ b/v2.0/update.md
@@ -16,7 +16,9 @@ The user must have the `SELECT` and `UPDATE` [privileges](privileges.html) on th
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/update.html %}
+</div>
 
 <div markdown="1"></div>
 

--- a/v2.0/upsert.md
+++ b/v2.0/upsert.md
@@ -22,7 +22,9 @@ The user must have the `INSERT` and `UPDATE` [privileges](privileges.html) on th
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/upsert.html %}
+</div>
 
 <div markdown="1"></div>
 

--- a/v2.0/validate-constraint.md
+++ b/v2.0/validate-constraint.md
@@ -16,7 +16,9 @@ The user must have the `CREATE` [privilege](privileges.html) on the table.
 
 ## Synopsis
 
+<div>
 {% include sql/{{ page.version.version }}/diagrams/validate_constraint.html %}
+</div>
 
 ## Parameters
 


### PR DESCRIPTION
Related to need for HTML output validation as noted in #3301.

Left the diagrams which were already wrapped alone, including those with
`section` tags, to keep this commit smaller/easier to read.