### PR TITLE
Remove div tags around text include

### DIFF
--- a/v2.0/configure-replication-zones.md
+++ b/v2.0/configure-replication-zones.md
@@ -168,9 +168,7 @@ Flag | Description
 
 ### Client Connection
 
-<div>
 {% include sql/{{ page.version.version }}/connection-parameters-with-url.md %}
-</div>
 
 See [Client Connection Parameters](connection-parameters.html) for more details.
 

--- a/v2.0/create-and-manage-users.md
+++ b/v2.0/create-and-manage-users.md
@@ -60,9 +60,7 @@ Flag | Description
 
 ### Client Connection
 
-<div>
 {% include sql/{{ page.version.version }}/connection-parameters-with-url.md %}
-</div>
 
 See [Client Connection Parameters](connection-parameters.html) for more details.
 


### PR DESCRIPTION
This was leading to breakage - specifically, the included Markdown files
were not being rendered correctly as HTML.