### PR TITLE
unnecessary line"--join=localhost:26257 \"

### DIFF
--- a/v2.0/demo-automatic-cloud-migration.md
+++ b/v2.0/demo-automatic-cloud-migration.md
@@ -66,7 +66,6 @@ $ cockroach start \
 --host=localhost \
 --port=25259 \
 --http-port=8082 \
---join=localhost:26257 \
 --cache=100MB \
 --join=localhost:26257,localhost:26258,localhost:26259
 ~~~


### PR DESCRIPTION
"--join=localhost:26257 \ "
is already exist  in the last line you don't have to add twice