### PR TITLE
Remove extra --join flag from cloud migration tutorial

### DIFF
--- a/v1.1/demo-automatic-cloud-migration.md
+++ b/v1.1/demo-automatic-cloud-migration.md
@@ -66,7 +66,6 @@ $ cockroach start \
 --host=localhost \
 --port=25259 \
 --http-port=8082 \
---join=localhost:26257 \
 --cache=100MB \
 --join=localhost:26257,localhost:26258,localhost:26259
 ~~~

--- a/v2.1/demo-automatic-cloud-migration.md
+++ b/v2.1/demo-automatic-cloud-migration.md
@@ -66,7 +66,6 @@ $ cockroach start \
 --host=localhost \
 --port=25259 \
 --http-port=8082 \
---join=localhost:26257 \
 --cache=100MB \
 --join=localhost:26257,localhost:26258,localhost:26259
 ~~~


### PR DESCRIPTION
Follow-up to https://github.com/cockroachdb/docs/pull/3357.