### PR TITLE
openssl docs: allow multiple certificates for the same subject.

### DIFF
--- a/v1.1/create-security-certificates-openssl.md
+++ b/v1.1/create-security-certificates-openssl.md
@@ -174,13 +174,14 @@ In the following steps, replace the placeholder text in the code with the actual
 
     [ distinguished_name ]
     organizationName = Cockroach
+    # Required value for commonName, do not change.
     commonName = node
 
     [ extensions ]
     subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>
     ~~~
 
-    {{site.data.alerts.callout_info}}The <code>commonName</code> and <code>subjectAltName</code> parameters are vital for CockroachDB functions. It is also important that <code>commonName</code> be set to <code>node</code>. You can modify or omit other parameters as per your preferred OpenSSL configuration, but do not omit the <code>commonName</code> and <code>subjectAltName</code> parameters.  {{site.data.alerts.end}}
+    {{site.data.alerts.callout_danger}}The <code>commonName</code> and <code>subjectAltName</code> parameters are vital for CockroachDB functions. It is also required that <code>commonName</code> be set to <code>node</code>. You can modify or omit other parameters as per your preferred OpenSSL configuration, but do not omit the <code>commonName</code> and <code>subjectAltName</code> parameters.  {{site.data.alerts.end}}
   
 2. Create the key for the first node using the [`openssl genrsa`](https://www.openssl.org/docs/manmaster/man1/genrsa.html) command:
 

--- a/v1.1/create-security-certificates-openssl.md
+++ b/v1.1/create-security-certificates-openssl.md
@@ -84,6 +84,7 @@ Note the following:
     serial = serial.txt 
     default_md = sha256 
     copy_extensions = copy
+    unique_subject = no
 
     # Used to create the CA certificate.
     [ req ]

--- a/v2.0/create-security-certificates-openssl.md
+++ b/v2.0/create-security-certificates-openssl.md
@@ -174,13 +174,14 @@ In the following steps, replace the placeholder text in the code with the actual
 
     [ distinguished_name ]
     organizationName = Cockroach
+    # Required value for commonName, do not change.
     commonName = node
 
     [ extensions ]
     subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>
     ~~~
 
-    {{site.data.alerts.callout_info}}The <code>commonName</code> and <code>subjectAltName</code> parameters are vital for CockroachDB functions. It is also important that <code>commonName</code> be set to <code>node</code>. You can modify or omit other parameters as per your preferred OpenSSL configuration, but do not omit the <code>commonName</code> and <code>subjectAltName</code> parameters.  {{site.data.alerts.end}}
+    {{site.data.alerts.callout_danger}}The <code>commonName</code> and <code>subjectAltName</code> parameters are vital for CockroachDB functions. It is also required that <code>commonName</code> be set to <code>node</code>. You can modify or omit other parameters as per your preferred OpenSSL configuration, but do not omit the <code>commonName</code> and <code>subjectAltName</code> parameters.  {{site.data.alerts.end}}
   
 2. Create the key for the first node using the [`openssl genrsa`](https://www.openssl.org/docs/manmaster/man1/genrsa.html) command:
 

--- a/v2.0/create-security-certificates-openssl.md
+++ b/v2.0/create-security-certificates-openssl.md
@@ -84,6 +84,7 @@ Note the following:
     serial = serial.txt 
     default_md = sha256 
     copy_extensions = copy
+    unique_subject = no
 
     # Used to create the CA certificate.
     [ req ]

--- a/v2.1/create-security-certificates-openssl.md
+++ b/v2.1/create-security-certificates-openssl.md
@@ -84,6 +84,7 @@ Note the following:
     serial = serial.txt
     default_md = sha256
     copy_extensions = copy
+    unique_subject = no
 
     # Used to create the CA certificate.
     [ req ]

--- a/v2.1/create-security-certificates-openssl.md
+++ b/v2.1/create-security-certificates-openssl.md
@@ -174,13 +174,14 @@ In the following steps, replace the placeholder text in the code with the actual
 
     [ distinguished_name ]
     organizationName = Cockroach
+    # Required value for commonName, do not change.
     commonName = node
 
     [ extensions ]
     subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>
     ~~~
 
-    {{site.data.alerts.callout_info}}The <code>commonName</code> and <code>subjectAltName</code> parameters are vital for CockroachDB functions. It is also important that <code>commonName</code> be set to <code>node</code>. You can modify or omit other parameters as per your preferred OpenSSL configuration, but do not omit the <code>commonName</code> and <code>subjectAltName</code> parameters.  {{site.data.alerts.end}}
+    {{site.data.alerts.callout_danger}}The <code>commonName</code> and <code>subjectAltName</code> parameters are vital for CockroachDB functions. It is also required that <code>commonName</code> be set to <code>node</code>. You can modify or omit other parameters as per your preferred OpenSSL configuration, but do not omit the <code>commonName</code> and <code>subjectAltName</code> parameters.  {{site.data.alerts.end}}
 
 2. Create the key for the first node using the [`openssl genrsa`](https://www.openssl.org/docs/manmaster/man1/genrsa.html) command:
 


### PR DESCRIPTION
We create node certificates with subject `/O=Cockroach/CN=node`. By default,
openssl doesn't allow multiple certificates with the same subject to be
signed (is knows this by checking the local database files).

There are multiple ways of getting around this (delete/truncate the
database files, add more fields to the subject that vary for each node),
but this one is by far the easiest.