### PR TITLE
proxy the releases page correctly

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -5,3 +5,5 @@ layout: null
 {% for version in site.versions %}
 {{ version[0]|relative_url }}/* {{ version[1]|relative_url }}/:splat 200
 {% endfor %}
+
+/docs/releases/ /docs/releases/index.html 200!


### PR DESCRIPTION
This is needed because netlify serves /foo.html if a users hits /foo/,
even if /foo/index.html exists. Releases is the only page we could find
that had both a foo.html and /foo/index.html, so everything else should
be fine.