### PR TITLE
Document online schema changes

### DIFF
--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -1610,6 +1610,12 @@
             ]
           },
           {
+            "title": "Online Schema Changes",
+            "urls": [
+              "/${VERSION}/online-schema-changes.html"
+            ]
+          },
+          {
             "title": "Automated Scaling & Repair",
             "urls": [
               "/${VERSION}/automated-scaling-and-repair.html"

--- a/_includes/v2.1/misc/schema-changes-between-prepared-statements.md
+++ b/_includes/v2.1/misc/schema-changes-between-prepared-statements.md
@@ -1,0 +1,42 @@
+When the schema of a table targeted by a prepared statement changes before the prepared statement is executed, CockroachDB allows the prepared statement to return results based on the changed table schema, for example:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE users (id INT PRIMARY KEY);
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> PREPARE prep1 AS SELECT * FROM users;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE users ADD COLUMN name STRING;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO users VALUES (1, 'Max Roach');
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXECUTE prep1;
+~~~
+
+~~~
++----+-----------+
+| id |   name    |
++----+-----------+
+|  1 | Max Roach |
++----+-----------+
+(1 row)
+~~~
+
+It's therefore recommended to **not** use `SELECT *` in queries that will be repeated, via prepared statements or otherwise.
+
+Also, a prepared [`INSERT`](insert.html), [`UPSERT`](upsert.html), or [`DELETE`](delete.html) statement acts inconsistently when the schema of the table being written to is changed before the prepared statement is executed:
+
+- If the number of columns has increased, the prepared statement returns an error but nonetheless writes the data.
+- If the number of columns remains the same but the types have changed, the prepared statement writes the data and does not return an error.

--- a/_includes/v2.1/misc/schema-changes-within-transactions.md
+++ b/_includes/v2.1/misc/schema-changes-within-transactions.md
@@ -1,0 +1,5 @@
+Within a single [transaction](transactions.html):
+
+- DDL statements cannot follow DML statements. As a workaround, arrange DML statements before DDL statements, or split the statements into separate transactions.
+- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
+- A table cannot be dropped and then recreated with the same name. This is not possible within a single transaction because `DROP TABLE` does not immediately drop the name of the table. As a workaround, split the [`DROP TABLE`](drop-table.html) and [`CREATE TABLE`](create-table.html) statements into separate transactions.

--- a/v2.1/alter-table.md
+++ b/v2.1/alter-table.md
@@ -7,9 +7,8 @@ toc: true
 The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table.
 
 {{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
+To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes](online-schema-changes.html).
 {{site.data.alerts.end}}
-
 
 ## Subcommands
 

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -146,56 +146,11 @@ It is currently not possible to [add a column](add-column.html) to a table when 
 
 ### Schema changes within transactions
 
-Within a single [transaction](transactions.html):
-
-- DDL statements cannot follow DML statements. As a workaround, arrange DML statements before DDL statements, or split the statements into separate transactions.
-- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
-- A table cannot be dropped and then recreated with the same name. This is not possible within a single transaction because `DROP TABLE` does not immediately drop the name of the table. As a workaround, split the [`DROP TABLE`](drop-table.html) and [`CREATE TABLE`](create-table.html) statements into separate transactions.
+{% include v2.1/misc/schema-changes-within-transactions.md %}
 
 ### Schema changes between executions of prepared statements
 
-When the schema of a table targeted by a prepared statement changes before the prepared statement is executed, CockroachDB allows the prepared statement to return results based on the changed table schema, for example:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> CREATE TABLE users (id INT PRIMARY KEY);
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> PREPARE prep1 AS SELECT * FROM users;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> ALTER TABLE users ADD COLUMN name STRING;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> INSERT INTO users VALUES (1, 'Max Roach');
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> EXECUTE prep1;
-~~~
-
-~~~
-+----+-----------+
-| id |   name    |
-+----+-----------+
-|  1 | Max Roach |
-+----+-----------+
-(1 row)
-~~~
-
-It's therefore recommended to **not** use `SELECT *` in queries that will be repeated, via prepared statements or otherwise.
-
-Also, a prepared [`INSERT`](insert.html), [`UPSERT`](upsert.html), or [`DELETE`](delete.html) statement acts inconsistently when the schema of the table being written to is changed before the prepared statement is executed:
-
-- If the number of columns has increased, the prepared statement returns an error but nonetheless writes the data.
-- If the number of columns remains the same but the types have changed, the prepared statement writes the data and does not return an error.
+{% include v2.1/misc/schema-changes-between-prepared-statements.md %}
 
 ### `INSERT ON CONFLICT` vs. `UPSERT`
 

--- a/v2.1/online-schema-changes.md
+++ b/v2.1/online-schema-changes.md
@@ -1,0 +1,217 @@
+---
+title: Online Schema Changes
+summary: Update table schemas without external tools or downtime.
+toc: true
+---
+
+CockroachDB's online schema changes provide a simple way to update a table schema without imposing any negative consequences on an application — including downtime. The schema change engine is a built-in feature requiring no additional tools, resources, or ad hoc sequencing of operations.
+
+Benefits of online schema changes include:
+
+- Changes to your table schema happen while the database is running.
+- The schema change runs as a [background job][show-jobs] without holding locks on the underlying table data.
+- Your application's queries can run normally, with no effect on read/write latency. The schema is cached for performance.
+- Your data is kept in a safe, [consistent][consistent] state throughout the entire schema change process.
+
+{{site.data.alerts.callout_success}}
+Support for schema changes within [transactions][txns] is [limited](#limitations). We recommend doing schema changes outside transactions where possible. When a schema management tool uses transactions on your behalf, we recommend only doing one schema change operation per transaction.
+{{site.data.alerts.end}}
+
+## How online schema changes work
+
+At a high level, online schema changes are accomplished by using a bridging strategy involving concurrent uses of multiple versions of the schema. The process is as follows:
+
+1. A user initiates a schema change by executing [`ALTER TABLE`][alter-table], [`CREATE INDEX`][create-index], [`TRUNCATE`][truncate], etc.
+
+2. The schema change engine converts the original schema to the new schema in discrete steps while ensuring that the underlying table data is always in a consistent state. These changes are executed as a [background job][show-jobs].
+
+This approach allows the schema change engine to roll out a new schema while the previous version is still in use. It then backfills or deletes the underlying table data as needed in the background, while the cluster is still running and servicing reads and writes from your application.
+
+During the backfilling process, the schema change engine updates the underlying table data to make sure all instances of the table are stored according to the requirements of the new schema.
+
+Once backfilling is complete, all nodes will switch over to the new schema, and will allow reads and writes of the table using the new schema.
+
+For more technical details, see [How online schema changes are possible in CockroachDB][blog].
+
+## Examples
+
+{{site.data.alerts.callout_success}}
+For more examples of schema change statements, see the [`ALTER TABLE`][alter-table] subcommands.
+{{site.data.alerts.end}}
+
+### Run schema changes inside a transaction with `CREATE TABLE`
+
+As noted in [Limitations](#limitations), you cannot run schema changes inside transactions in general.
+
+However, as of version 2.1, you can run schema changes inside the same transaction as a [`CREATE TABLE`][create-table] statement. For example:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BEGIN;
+  SAVEPOINT cockroach_restart;
+  CREATE TABLE fruits (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        name STRING,
+        color STRING
+    );
+  INSERT INTO fruits (name, color) VALUES ('apple', 'red');
+  ALTER TABLE fruits ADD COLUMN inventory_count INTEGER DEFAULT 5;
+  ALTER TABLE fruits ADD CONSTRAINT name CHECK (name IN ('apple', 'banana', 'orange'));
+  SELECT name, color, inventory_count FROM fruits;
+  RELEASE SAVEPOINT cockroach_restart;
+  COMMIT;
+~~~
+
+The transaction succeeds with the following output:
+
+~~~
+BEGIN
+SAVEPOINT
+CREATE TABLE
+INSERT 0 1
+ALTER TABLE
+ALTER TABLE
++-------+-------+-----------------+
+| name  | color | inventory_count |
++-------+-------+-----------------+
+| apple | red   |               5 |
++-------+-------+-----------------+
+(1 row)
+COMMIT
+COMMIT
+~~~
+
+### Show all schema change jobs
+
+You can check on the status of the schema change jobs on your system at any time using the [`SHOW JOBS`][show-jobs] statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE';
+~~~
+
+~~~
++--------------------+---------------+-----------------------------------------------------------------------------+-----------+-----------+----------------------------+----------------------------+----------------------------+----------------------------+--------------------+-------+----------------+
+|             job_id | job_type      | description                                                                 | user_name | status    | created                    | started                    | finished                   | modified                   | fraction_completed | error | coordinator_id |
+|--------------------+---------------+-----------------------------------------------------------------------------+-----------+-----------+----------------------------+----------------------------+----------------------------+----------------------------+--------------------+-------+----------------|
+| 368863345707909121 | SCHEMA CHANGE | ALTER TABLE test.public.fruits ADD COLUMN inventory_count INTEGER DEFAULT 5 | root      | succeeded | 2018-07-26 20:55:59.698793 | 2018-07-26 20:55:59.739032 | 2018-07-26 20:55:59.816007 | 2018-07-26 20:55:59.816008 |                  1 |       | NULL           |
+| 370556465994989569 | SCHEMA CHANGE | ALTER TABLE test.public.foo ADD COLUMN bar VARCHAR                          | root      | pending   | 2018-08-01 20:27:38.708813 | NULL                       | NULL                       | 2018-08-01 20:27:38.708813 |                  0 |       | NULL           |
+| 370556522386751489 | SCHEMA CHANGE | ALTER TABLE test.public.foo ADD COLUMN bar VARCHAR                          | root      | pending   | 2018-08-01 20:27:55.830832 | NULL                       | NULL                       | 2018-08-01 20:27:55.830832 |                  0 |       | NULL           |
++--------------------+---------------+-----------------------------------------------------------------------------+-----------+-----------+----------------------------+----------------------------+----------------------------+----------------------------+--------------------+-------+----------------+
+(1 row)
+~~~
+
+## Limitations
+
+### Overview
+
+Schema changes keep your data consistent at all times, but they do not run inside [transactions][txns] in the general case. This is necessary so the cluster can remain online and continue to service application reads and writes.
+
+Specifically, this behavior is necessary because making schema changes transactional would mean requiring a given schema change to propagate across all the nodes of a cluster. This would block all user-initiated transactions being run by your application, since the schema change would have to commit before any other transactions could make progress. This would prevent the cluster from servicing reads and writes during the schema change, requiring application downtime.
+
+{{site.data.alerts.callout_success}}
+As of version 2.1, you can run schema changes inside the same transaction as a [`CREATE TABLE`][create-table] statement. For more information, [see this example](#run-schema-changes-inside-a-transaction-with-create-table).
+{{site.data.alerts.end}}
+
+### No schema changes within transactions
+
+{% include v2.1/misc/schema-changes-within-transactions.md %}
+
+### No schema changes between executions of prepared statements
+
+{% include v2.1/misc/schema-changes-between-prepared-statements.md %}
+
+### Examples of statements that fail
+
+The following statements fail due to the [no schema changes within transactions](#no-schema-changes-within-transactions) limitation.
+
+#### Create an index and then run a select against that index inside a transaction
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE foo (id INT PRIMARY KEY, name VARCHAR);
+  BEGIN;
+  SAVEPOINT cockroach_restart;
+  CREATE INDEX foo_idx ON foo (id, name);
+  SELECT * from foo_idx;
+  RELEASE SAVEPOINT cockroach_restart;
+  COMMIT;
+~~~
+
+~~~
+CREATE TABLE
+BEGIN
+SAVEPOINT
+CREATE INDEX
+ERROR:  relation "foo_idx" does not exist
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK
+~~~
+
+#### Add a column and then add a constraint against that column inside a transaction
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE foo ();
+  BEGIN;
+  SAVEPOINT cockroach_restart;
+  ALTER TABLE foo ADD COLUMN bar VARCHAR;
+  ALTER TABLE foo ADD CONSTRAINT bar CHECK (foo IN ('a', 'b', 'c', 'd'));
+  RELEASE SAVEPOINT cockroach_restart;
+  COMMIT;
+~~~
+
+~~~
+CREATE TABLE
+BEGIN
+SAVEPOINT
+ALTER TABLE
+ERROR:  column "foo" not found for constraint "foo"
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK
+~~~
+
+#### Add a column and then select against that column inside a transaction
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE foo ();
+  BEGIN;
+  SAVEPOINT cockroach_restart;
+  ALTER TABLE foo ADD COLUMN bar VARCHAR;
+  SELECT bar FROM foo;
+  RELEASE SAVEPOINT cockroach_restart;
+  COMMIT;
+~~~
+
+~~~
+CREATE TABLE
+BEGIN
+SAVEPOINT
+ALTER TABLE
+ERROR:  column name "bar" not found
+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ROLLBACK
+~~~
+
+## See Also
+
++ [How online schema changes are possible in CockroachDB][blog]: Blog post with more technical details about how our schema change engine works.
++ [`ALTER TABLE`][alter-table]
++ [`CREATE INDEX`][create-index]
++ [`DROP INDEX`][drop-index]
++ [`TRUNCATE`][truncate]
+
+<!-- Reference Links -->
+
+[alter-table]: alter-table.html
+[blog]: https://cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/
+[consistent]: strong-consistency.html
+[create-index]: create-index.html
+[drop-index]: drop-index.html
+[create-table]: create-table.html
+[select]: selection-queries.html
+[show-jobs]: show-jobs.html
+[sql-client]: use-the-built-in-sql-client.html
+[txns]: transactions.html
+[truncate]: truncate.html

--- a/v2.1/truncate.md
+++ b/v2.1/truncate.md
@@ -6,8 +6,9 @@ toc: true
 
 The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
 
-{{site.data.alerts.callout_info}}The <code>TRUNCATE</code> removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a <a href="delete.html#delete-all-rows"><code>DELETE</code> statement without a <code>WHERE</code> clause</a>.{{site.data.alerts.end}}
-
+{{site.data.alerts.callout_info}}
+`TRUNCATE` removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows).
+{{site.data.alerts.end}}
 
 ## Synopsis
 
@@ -26,6 +27,10 @@ Parameter | Description
 `table_name` | The name of the table to truncate.
 `CASCADE` | Truncate all tables with [Foreign Key](foreign-key.html) dependencies on the table being truncated.<br><br>`CASCADE` does not list dependent tables it truncates, so should be used cautiously.
 `RESTRICT`    | _(Default)_ Do not truncate the table if any other tables have [Foreign Key](foreign-key.html) dependencies on it.
+
+## Limitations
+
+`TRUNCATE` is a schema change, and as such is not transactional. For more information about how schema changes work, see [Online Schema Changes](online-schema-changes.html).
 
 ## Examples
 


### PR DESCRIPTION
Partially addresses #2940 and #1340.

Fixes #3430.

Summary of changes:

- Add a page 'Online Schema Changes', which describes how online schema
  changes work at a high level, including their limitations.

- Update `TRUNCATE` documentation to note that it is technically a
  schema change, and is thus not purely transactional.

- Add links from various schema change statement reference pages to the
  new schema changes overview page.