### PR TITLE
Add computed column to existing table

### DIFF
--- a/_includes/v2.1/computed-columns/add-computed-column.md
+++ b/_includes/v2.1/computed-columns/add-computed-column.md
@@ -1,0 +1,55 @@
+In this example, create a table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE x (
+    a INT NULL,
+    b INT NULL AS (a * 2) STORED,
+    c INT NULL AS (a + 4) STORED,
+    FAMILY "primary" (a, b, rowid, c)
+  );
+~~~
+
+Then, insert a row of data:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO x VALUES (6);
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM x;
+~~~
+
+~~~
++---+----+----+
+| a | b  | c  |
++---+----+----+
+| 6 | 12 | 10 |
++---+----+----+
+(1 row)
+~~~
+
+Now add another computed column to the table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE x ADD COLUMN d INT AS (a // 2) STORED;
+~~~
+
+The `d` column is added to the table and computed from the `a` column divided by 2.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM x;
+~~~
+
+~~~
++---+----+----+---+
+| a | b  | c  | d |
++---+----+----+---+
+| 6 | 12 | 10 | 3 |
++---+----+----+---+
+(1 row)
+~~~

--- a/_includes/v2.1/computed-columns/jsonb.md
+++ b/_includes/v2.1/computed-columns/jsonb.md
@@ -1,4 +1,4 @@
-In this example, let's create a table with a `JSONB` column and a computed column:
+In this example, create a table with a `JSONB` column and a computed column:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/_includes/v2.1/computed-columns/partitioning.md
+++ b/_includes/v2.1/computed-columns/partitioning.md
@@ -1,6 +1,6 @@
 {{site.data.alerts.callout_info}}Partioning is an enterprise feature. To request and enable a trial or full enterprise license, see <a href="enterprise-licensing.html">Enterprise Licensing</a>.{{site.data.alerts.end}}
 
-In this example, let's create a table with geo-partitioning and a computed column:
+In this example, create a table with geo-partitioning and a computed column:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/_includes/v2.1/computed-columns/secondary-index.md
+++ b/_includes/v2.1/computed-columns/secondary-index.md
@@ -1,4 +1,4 @@
-In this example, let's create a table with a computed columns and an index on that column:
+In this example, create a table with a computed columns and an index on that column:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -42,7 +42,7 @@ Then, insert a few rows a data:
 +--------------------------------------+------------------+--------+--------+--------+--------+----------------+
 ~~~
 
-Now, let's run a query using the secondary index:
+Now, run a query using the secondary index:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/_includes/v2.1/computed-columns/simple.md
+++ b/_includes/v2.1/computed-columns/simple.md
@@ -10,7 +10,7 @@ In this example, let's create a simple table with a computed column:
   );
 ~~~
 
-Then, insert a few rows a data:
+Then, insert a few rows of data:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v2.1/computed-columns.md
+++ b/v2.1/computed-columns.md
@@ -21,7 +21,6 @@ Computed columns are especially useful when used with [partitioning](partitionin
 
 Computed columns:
 
-- Cannot be added after a table is created. Follow the [GitHub issue](https://github.com/cockroachdb/cockroach/issues/22652) for updates on this limitation.
 - Cannot be used to generate other computed columns.
 - Cannot be a [foreign key](foreign-key.html) reference.
 - Behave like any other column, with the exception that they cannot be written to directly.
@@ -59,6 +58,12 @@ Parameter | Description
 ### Create a table with a secondary index on a computed column
 
 {% include {{ page.version.version }}/computed-columns/secondary-index.md %}
+
+### Add a computed column to an existing table
+
+{% include {{ page.version.version }}/computed-columns/add-computed-column.md %}
+
+For more information, see [`ADD COLUMN`](add-column.html).
 
 ## See also
 


### PR DESCRIPTION
Computed columns can now be added to an existing table, using the `ALTER TABLE...ADD COLUMN` statement.

Closes #3067.