### PR TITLE
Add abbreviated time units

### DIFF
--- a/v2.1/interval.md
+++ b/v2.1/interval.md
@@ -24,6 +24,7 @@ Format | Description
 SQL Standard | `INTERVAL 'Y-M D H:M:S'`<br><br>`Y-M D`: Using a single value defines days only; using two values defines years and months. Values must be integers.<br><br>`H:M:S`: Using a single value defines seconds only; using two values defines hours and minutes. Values can be integers or floats.<br><br>Note that each side is optional.
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
 Traditional PostgreSQL | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`
+Abbreviated PostgreSQL | `INTERVAL 1 yr 2 mo 3 d 4 hrs 5 mins 6 secs`
 Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 
 CockroachDB also supports using uninterpreted

--- a/v2.1/interval.md
+++ b/v2.1/interval.md
@@ -24,7 +24,7 @@ Format | Description
 SQL Standard | `INTERVAL 'Y-M D H:M:S'`<br><br>`Y-M D`: Using a single value defines days only; using two values defines years and months. Values must be integers.<br><br>`H:M:S`: Using a single value defines seconds only; using two values defines hours and minutes. Values can be integers or floats.<br><br>Note that each side is optional.
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
 Traditional PostgreSQL | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`
-Abbreviated PostgreSQL | `INTERVAL 1 yr 2 mo 3 d 4 hrs 5 mins 6 secs`
+Abbreviated PostgreSQL | `INTERVAL '1 yr 2 mons 3 d 4 hrs 5 mins 6 secs'`
 Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 
 CockroachDB also supports using uninterpreted


### PR DESCRIPTION
@ivan, can you review this edit to docs? It's related to https://github.com/cockroachdb/cockroach/pull/27393.

CockroachDB now supports PostgreSQL abbreviated time units.

Closes #3458.