### PR TITLE
Add docs to describe new default database(s)

### DIFF
--- a/v2.1/connection-parameters.md
+++ b/v2.1/connection-parameters.md
@@ -48,14 +48,14 @@ A connection URL has the following format:
 postgres://<username>:<password>@<host>:<port>/<database>?<parameters>
 ~~~
 
-Component | Description | Required
-----------|-------------|----------
-`<username>` | The [SQL user](create-and-manage-users.html) that will own the client session. | ✗
-`<password>` | The user's password. It is not recommended to pass the password in the URL directly.<br><br>[Find more detail about how CockroachDB handles passwords](create-and-manage-users.html#user-authentication). | ✗
-`<host>` | The host name or address of a CockroachDB node or load balancer. | Required by most client drivers.
-`<port>` | The port number of the SQL interface of the CockroachDB node or load balancer. | Required by most client drivers.
-`<database>` | A database name to use as [current database](sql-name-resolution.html#current-database).  | ✗
-`<parameters>` | [Additional connection parameters](#additional-connection-parameters), including SSL/TLS certificate settings. | ✗
+ Component      | Description                                                                                                                                                                                               | Required
+----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------
+ `<username>`   | The [SQL user](create-and-manage-users.html) that will own the client session.                                                                                                                            | ✗
+ `<password>`   | The user's password. It is not recommended to pass the password in the URL directly.<br><br>[Find more detail about how CockroachDB handles passwords](create-and-manage-users.html#user-authentication). | ✗
+ `<host>`       | The host name or address of a CockroachDB node or load balancer.                                                                                                                                          | Required by most client drivers.
+ `<port>`       | The port number of the SQL interface of the CockroachDB node or load balancer.                                                                                                                            | Required by most client drivers.
+ `<database>`   | A database name to use as [current database](sql-name-resolution.html#current-database). Defaults to `defaultdb`.                                                                                         | ✗
+ `<parameters>` | [Additional connection parameters](#additional-connection-parameters), including SSL/TLS certificate settings.                                                                                            | ✗
 
 {{site.data.alerts.callout_info}}You can specify the URL for
 <code>cockroach</code> commands that accept a URL with the
@@ -225,14 +225,13 @@ In other words:
 
 ### Example override of the current database
 
-For example, the `cockroach start` command prints out the following connection URL:
+The `cockroach start` command prints out the following connection URL, which connects to the `defaultdb` database:
 
 ~~~
 postgres://root@servername:26257/?sslmode=disable
 ~~~
 
-It is possible to connect `cockroach sql` to this server and also
-specify `mydb` as the current database, using the following command:
+To specify `mydb` as the current database using [`cockroach sql`](use-the-built-in-sql-client.html), run the following command:
 
 ~~~
 cockroach sql \

--- a/v2.1/learn-cockroachdb-sql.md
+++ b/v2.1/learn-cockroachdb-sql.md
@@ -14,75 +14,6 @@ Use an interactive SQL shell to try out these statements. If you have a cluster 
 CockroachDB aims to provide standard SQL with extensions, but some standard SQL functionality is not yet available. See our [SQL Feature Support](sql-feature-support.html) page for more details.
 {{site.data.alerts.end}}
 
-## Create a Database
-
-CockroachDB comes with a single default `system` database, which contains CockroachDB metadata and is read-only. To create a new database, use [`CREATE DATABASE`](create-database.html) followed by a database name:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE bank;
-~~~
-
-Database names must follow [these identifier rules](keywords-and-identifiers.html#identifiers). To avoid an error in case the database already exists, you can include `IF NOT EXISTS`:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE IF NOT EXISTS bank;
-~~~
-
-When you no longer need a database, use [`DROP DATABASE`](drop-database.html) followed by the database name to remove the database and all its objects:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DROP DATABASE bank;
-~~~
-
-## Show databases
-
-To see all databases, use the [`SHOW DATABASES`](show-databases.html) statement:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SHOW DATABASES;
-~~~
-
-~~~
-+---------------+
-| database_name |
-+---------------+
-| bank          |
-| defaultdb     |
-| postgres      |
-| system        |
-+---------------+
-(3 rows)
-~~~
-
-## Set the default database
-
-To set the default database, use the [`SET`](set-vars.html#examples) statement:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET DATABASE = bank;
-~~~
-
-When working with the default database, you do not need to reference it explicitly in statements. To see which database is currently the default, use the `SHOW DATABASE` statement (note the singular form):
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SHOW DATABASE;
-~~~
-
-~~~
-+----------+
-| database |
-+----------+
-| bank     |
-+----------+
-(1 row)
-~~~
-
 ## Create a table
 
 To create a table, use [`CREATE TABLE`](create-table.html) followed by a table name, the column names, and the [data type](data-types.html) and [constraint](constraints.html), if any, for each column:
@@ -141,34 +72,12 @@ To see all tables in the active database, use the [`SHOW TABLES`](show-tables.ht
 ~~~
 
 ~~~
-+------------+
-| table_name |
-+------------+
-| accounts   |
-| users      |
-+------------+
-(2 rows)
-~~~
-
-To view tables in a database that's not active, use `SHOW TABLES FROM` followed by the name of the database:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SHOW TABLES FROM animals;
-~~~
-
-~~~
-+------------+
-| table_name |
-+------------+
-| aardvarks  |
-| elephants  |
-| frogs      |
-| moles      |
-| pandas     |
-| turtles    |
-+------------+
-(6 rows)
++----------+
+|  Table   |
++----------+
+| accounts |
++----------+
+(1 row)
 ~~~
 
 ## Insert rows into a table

--- a/v2.1/show-databases.md
+++ b/v2.1/show-databases.md
@@ -5,8 +5,7 @@ keywords: reflection
 toc: true
 ---
 
-The `SHOW DATABASES` [statement](sql-statements.html) lists all database in the CockroachDB cluster.
-
+The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the CockroachDB cluster.
 
 ## Synopsis
 
@@ -35,6 +34,18 @@ No [privileges](privileges.html) are required to list the databases in the Cockr
 +---------------+
 (3 rows)
 ~~~
+
+## Default Databases
+
+New clusters and existing clusters [upgraded](upgrade-cockroach-version.html) to v2.1 will include three auto-generated databases, with the following purposes:
+
+- The empty `defaultdb` database is used if a client does not specify a database in the [connection parameters](connection-parameters.html).
+
+- An empty database called `postgres` is provided for compatibility with Postgres client applications that require it.
+
+- The `system` database contains CockroachDB metadata and is read-only.
+
+The `postgres` and `defaultdb` databases can be [deleted](drop-database.html) if they are not needed.
 
 ## See also
 


### PR DESCRIPTION
Fixes #3206.

Summary of changes:

- Update [Client connection parameters][1] to note that `database` param
  defaults to `defaultdb` as of 2.1

- Update [Learn SQL][2] and [SHOW DATABASES][3] to describe `defaultdb`
  and `postgres`

[1]: https://www.cockroachlabs.com/docs/dev/connection-parameters.html
[2]: https://www.cockroachlabs.com/docs/dev/learn-cockroachdb-sql
[3]: https://www.cockroachlabs.com/docs/dev/show-databases