### PR TITLE
RENAME / DROP DATABASE update

### DIFF
--- a/v2.1/drop-database.md
+++ b/v2.1/drop-database.md
@@ -20,7 +20,7 @@ The user must have the `DROP` [privilege](privileges.html) on the database and o
 Parameter | Description
 ----------|------------
 `IF EXISTS`   | Drop the database if it exists; if it does not exist, do not return an error.
-`name`  | The name of the database you want to drop.
+`name`  | The name of the database you want to drop. You cannot drop a database if it is set as the [current database](sql-name-resolution.html#current-database) or if [`sql_safe_updates = true`](set-vars.html).
 `CASCADE` | _(Default)_ Drop all tables and views in the database as well as all objects (such as [constraints](constraints.html) and [views](views.html)) that depend on those tables.<br><br>`CASCADE` does not list objects it drops, so should be used cautiously.
 `RESTRICT` | Do not drop the database if it contains any [tables](create-table.html) or [views](create-view.html).
 

--- a/v2.1/rename-database.md
+++ b/v2.1/rename-database.md
@@ -21,7 +21,7 @@ Only the `root` user can rename databases.
 
 Parameter | Description
 ----------|------------
-`name` | The first instance of `name` is the current name of the database. The second instance is the new name for the database. The new name [must be unique](#rename-fails-new-name-already-in-use) and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
+`name` | The first instance of `name` is the current name of the database. The second instance is the new name for the database. The new name [must be unique](#rename-fails-new-name-already-in-use) and follow these [identifier rules](keywords-and-identifiers.html#identifiers). You cannot rename a database if it is set as the [current database](sql-name-resolution.html#current-database) or if [`sql_safe_updates = true`](set-vars.html).
 
 ## Examples
 

--- a/v2.1/rename-database.md
+++ b/v2.1/rename-database.md
@@ -11,7 +11,9 @@ The `RENAME DATABASE` [statement](sql-statements.html) changes the name of a dat
 
 ## Synopsis
 
+<div>
 {% include {{ page.version.version }}/sql/diagrams/rename_database.html %}
+</div>
 
 ## Required privileges
 


### PR DESCRIPTION
You cannot rename / drop a database if it is set as the current database.

Closes #3090.