### PR TITLE
Adding Known Limitation about write and update limits

### DIFF
--- a/v2.0/known-limitations.md
+++ b/v2.0/known-limitations.md
@@ -26,9 +26,7 @@ In the upgrade process, after upgrading all binaries to v2.0, it's recommended t
 
 ### Write and update limits for a single statement
 
-{{site.data.alerts.callout_info}}Resolved as of v2.1. See <a href="https://github.com/cockroachdb/cockroach/pull/23373">#23373</a>.{{site.data.alerts.end}}
-
-A single statement can perform at most 64MiB of combined updates. When a statement exceeds these limits, its transaction gets aborted. `INSERT INTO ... SELECT FROM` queries commonly encounter these limits.
+A single statement can perform at most 64MiB of combined updates. When a statement exceeds these limits, its transaction gets aborted. Currently, `INSERT INTO ... SELECT FROM` and `CREATE TABLE AS SELECT` queries may encounter these limits.
 
 To increase these limits, you can update the [cluster-wide setting](cluster-settings.html) `kv.raft.command.max_size`, but note that increasing this setting can affect the memory utilization of nodes in the cluster. For `INSERT INTO .. SELECT FROM` queries in particular, another workaround is to manually page through the data you want to insert using separate transactions.
 


### PR DESCRIPTION
Docs currently suggest this is fixed, but per https://github.com/cockroachdb/cockroach/issues/25828 it still applies to INSERT INTO... SELECT FROM and CREATE TABLE AS SELECT statements.