### PR TITLE
Make back-to-top button an explicit front-matter setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,8 @@ Field | Description | Default
 `twitter` | Adds code required to track the page as part of a Twitter campaign | `false`
 `no_sidebar` | If `true`, removes the sidebar from a page. See [Sidebar](#sidebar) for more details. | Nothing
 `block_search` | If `true`, adds meta tags to the header that excludes the page from search indexing/caching. | Nothing
-`drift` | Set this to `true` if a Drift survey is active on the page. This excludes back-to-top and help buttons from the page, which would otherwise conflict visually with the Drift interface.
+`back_to_top` | If `true`, adds a back-to-top button to the page. This is only helpful in cases where the page is very long and there is no page toc, e.g., the Full SQL Grammar page.
+`drift` | Set this to `true` if a Drift survey is active on the page. This excludes the help button from the page, which would otherwise conflict visually with the Drift interface.
 
 #### Page TOC
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,8 @@
 <section class="footer">
-	{% unless page.drift == true %}
+	{% if page.back_to_top == true %}
 		{% include back-to-top.html %}
+	{% endif %}
+	{% unless page.drift == true %}
 		{% include help-widget.html %}
   {% endunless %}
 	<div class="container">

--- a/v1.0/sql-feature-support.md
+++ b/v1.0/sql-feature-support.md
@@ -1,10 +1,8 @@
 ---
 title: SQL Feature Support in CockroachDB v1.0
 summary: Find CockroachDB's conformance to the SQL standard and which common extensions it supports.
+toc: true
 ---
-
-
-## Overview
 
 Making CockroachDB easy to use is a top priority for us, so we chose to implement SQL. However, even though SQL has a standard, no database implements all of it, nor do any of them have standard implementations of all features.
 

--- a/v1.0/sql-grammar.md
+++ b/v1.0/sql-grammar.md
@@ -2,6 +2,7 @@
 title: SQL Grammar
 summary: The full SQL grammar for CockroachDB.
 toc: false
+back_to_top: true
 ---
 
 <style>

--- a/v1.1/sql-feature-support.md
+++ b/v1.1/sql-feature-support.md
@@ -1,10 +1,8 @@
 ---
 title: SQL Feature Support in CockroachDB v1.1
 summary: Find CockroachDB's conformance to the SQL standard and which common extensions it supports.
+toc: true
 ---
-
-
-## Overview
 
 Making CockroachDB easy to use is a top priority for us, so we chose to implement SQL. However, even though SQL has a standard, no database implements all of it, nor do any of them have standard implementations of all features.
 

--- a/v1.1/sql-grammar.md
+++ b/v1.1/sql-grammar.md
@@ -2,6 +2,7 @@
 title: SQL Grammar
 summary: The full SQL grammar for CockroachDB.
 toc: false
+back_to_top: true
 ---
 
 <style>

--- a/v2.0/sql-feature-support.md
+++ b/v2.0/sql-feature-support.md
@@ -1,10 +1,8 @@
 ---
 title: SQL Feature Support in CockroachDB v2.0
 summary: Summary of CockroachDB's conformance to the SQL standard and which common extensions it supports.
+toc: true
 ---
-
-
-## Overview
 
 Making CockroachDB easy to use is a top priority for us, so we chose to implement SQL. However, even though SQL has a standard, no database implements all of it, nor do any of them have standard implementations of all features.
 

--- a/v2.0/sql-grammar.md
+++ b/v2.0/sql-grammar.md
@@ -2,6 +2,7 @@
 title: SQL Grammar
 summary: The full SQL grammar for CockroachDB.
 toc: false
+back_to_top: true
 ---
 
 <style>

--- a/v2.1/sql-feature-support.md
+++ b/v2.1/sql-feature-support.md
@@ -1,10 +1,8 @@
 ---
 title: SQL Feature Support in CockroachDB v2.1
 summary: Summary of CockroachDB's conformance to the SQL standard and which common extensions it supports.
+toc: true
 ---
-
-
-## Overview
 
 Making CockroachDB easy to use is a top priority for us, so we chose to implement SQL. However, even though SQL has a standard, no database implements all of it, nor do any of them have standard implementations of all features.
 

--- a/v2.1/sql-grammar.md
+++ b/v2.1/sql-grammar.md
@@ -2,6 +2,7 @@
 title: SQL Grammar
 summary: The full SQL grammar for CockroachDB.
 toc: false
+back_to_top: true
 ---
 
 <style>


### PR DESCRIPTION
Now that the page toc is always in the right margin, and users
can use the toc to jump around the page, the back-to-top button
is only helpful in cases where a page is long and does not have
a toc. In these cases, writers can explicitly set
back_to_top: true in the pages front-matter.

This PR also adds a toc to sql feature support pages.