### PR TITLE
Fix "Back and Restore" typo

### DIFF
--- a/v1.1/training/backup-and-restore.md
+++ b/v1.1/training/backup-and-restore.md
@@ -1,5 +1,5 @@
 ---
-title: Back and Restore
+title: Backup and Restore
 toc: true
 toc_not_nested: true
 block_search: true

--- a/v2.0/training/backup-and-restore.md
+++ b/v2.0/training/backup-and-restore.md
@@ -1,5 +1,5 @@
 ---
-title: Back and Restore
+title: Backup and Restore
 toc: true
 toc_not_nested: true
 sidebar_data: sidebar-data-training.json

--- a/v2.1/training/backup-and-restore.md
+++ b/v2.1/training/backup-and-restore.md
@@ -1,5 +1,5 @@
 ---
-title: Back and Restore
+title: Backup and Restore
 toc: true
 toc_not_nested: true
 sidebar_data: sidebar-data-training.json


### PR DESCRIPTION
One of the training pages had "Back and Restore" as a title rather than
"Backup and Restore."