### PR TITLE
Fix --warehouses argument in TPCC instructions

### DIFF
--- a/v2.0/performance-benchmarking-with-tpc-c.md
+++ b/v2.0/performance-benchmarking-with-tpc-c.md
@@ -134,7 +134,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./workload.LATEST fixtures load tpcc \
-    --warehouses=10000 \
+    --warehouses=1000 \
     "postgres://root@<node1 address>:26257?sslmode=disable"
     ~~~
 
@@ -295,7 +295,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
     {% include copy-clipboard.html %}
     ~~~ shell
     $  ./workload.LATEST fixtures load tpcc \
-    --warehouses=100000 \
+    --warehouses=10000 \
     "postgres://root@<node1 address>:26257?sslmode=disable"
     ~~~
 

--- a/v2.1/performance-benchmarking-with-tpc-c.md
+++ b/v2.1/performance-benchmarking-with-tpc-c.md
@@ -99,7 +99,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
     {% include copy-clipboard.html %}
     ~~~ shell
     $ ./workload.LATEST fixtures load tpcc \
-    --warehouses=10000 \
+    --warehouses=1000 \
     "postgres://root@<node1 address>:26257?sslmode=disable"
     ~~~
 
@@ -260,7 +260,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
     {% include copy-clipboard.html %}
     ~~~ shell
     $  ./workload.LATEST fixtures load tpcc \
-    --warehouses=100000 \
+    --warehouses=10000 \
     "postgres://root@<node1 address>:26257?sslmode=disable postgres://root@<node2 address>:26257?sslmode=disable postgres://root@<node3 address>:26257?sslmode=disable [...space separated list]"
     ~~~
 


### PR DESCRIPTION
The --warehouses argument for loading TPCC fixtures was off by a factor
of 10.