### PR TITLE
Make units consistent with text

### DIFF
--- a/v1.1/architecture/distribution-layer.md
+++ b/v1.1/architecture/distribution-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution Layer
-summary: 
+summary:
 toc: true
 ---
 
@@ -29,9 +29,9 @@ The monolithic sorted map is comprised of two fundamental elements:
 
 The locations of all ranges in your cluster are stored in a two-level index at the beginning of your key-space, known as meta ranges, where the first level (`meta1`) addresses the second, and the second (`meta2`) addresses data in the cluster. Importantly, every node has information on where to locate the `meta1` range (known as its Range Descriptor, detailed below), and the range is never split.
 
-This meta range structure lets us address up to 4EB of user data by default: we can address 2^(18 + 18) = 2^36 ranges; each range addresses 2^26 B, and altogether we address 2^(36+26) B = 2^62 B = 4EB. However, with larger range sizes, it's possible to expand this capacity even further.
+This meta range structure lets us address up to 4EiB of user data by default: we can address 2^(18 + 18) = 2^36 ranges; each range addresses 2^26 B, and altogether we address 2^(36+26) B = 2^62 B = 4EiB. However, with larger range sizes, it's possible to expand this capacity even further.
 
-Meta ranges are treated mostly like normal ranges and are accessed and replicated just like other elements of your cluster's KV data. 
+Meta ranges are treated mostly like normal ranges and are accessed and replicated just like other elements of your cluster's KV data.
 
 Each node caches values of the `meta2` range it has accessed before, which optimizes access of that data in the future. Whenever a node discovers that its `meta2` cache is invalid for a specific key, the cache is updated by performing a regular read on the `meta2` range.
 
@@ -66,7 +66,7 @@ gRPC is the software nodes use to communicate with one another. Because the Dist
 
 gRPC requires inputs and outputs to be formatted as protocol buffers (protobufs). To leverage gRPC, CockroachDB implements a protocol-buffer-based API defined in `api.proto`.
 
-For more information about gRPC, see the [official gRPC documentation](http://www.grpc.io/docs/guides/). 
+For more information about gRPC, see the [official gRPC documentation](http://www.grpc.io/docs/guides/).
 
 ### BatchRequest
 
@@ -106,7 +106,7 @@ In this case, the replica on `node1` is the Leaseholder, and nodes 2 and 3 also 
 
 #### Example
 
-Let's imagine we have an alphabetically sorted column, which we use for lookups. Here are what the meta ranges would approximately look like: 
+Let's imagine we have an alphabetically sorted column, which we use for lookups. Here are what the meta ranges would approximately look like:
 
 1. `meta1` contains the address for the nodes containing the `meta2` replicas.
 

--- a/v2.1/architecture/distribution-layer.md
+++ b/v2.1/architecture/distribution-layer.md
@@ -31,7 +31,7 @@ The monolithic sorted map is comprised of two fundamental elements:
 
 The locations of all ranges in your cluster are stored in a two-level index at the beginning of your key-space, known as meta ranges, where the first level (`meta1`) addresses the second, and the second (`meta2`) addresses data in the cluster. Importantly, every node has information on where to locate the `meta1` range (known as its range descriptor, detailed below), and the range is never split.
 
-This meta range structure lets us address up to 4EB of user data by default: we can address 2^(18 + 18) = 2^36 ranges; each range addresses 2^26 B, and altogether we address 2^(36+26) B = 2^62 B = 4EB. However, with larger range sizes, it's possible to expand this capacity even further.
+This meta range structure lets us address up to 4EiB of user data by default: we can address 2^(18 + 18) = 2^36 ranges; each range addresses 2^26 B, and altogether we address 2^(36+26) B = 2^62 B = 4EiB. However, with larger range sizes, it's possible to expand this capacity even further.
 
 Meta ranges are treated mostly like normal ranges and are accessed and replicated just like other elements of your cluster's KV data.
 


### PR DESCRIPTION
Follow-up to https://github.com/cockroachdb/docs/pull/3565.