### PR TITLE
Update install-client-drivers.md with appropriate Ruby on Rails adapter specific instructions.

### DIFF
--- a/v2.0/install-client-drivers.md
+++ b/v2.0/install-client-drivers.md
@@ -14,7 +14,7 @@ App Language | Recommended Driver
 -------------|-------------------
 Go | [pq](https://godoc.org/github.com/lib/pq)
 Python | [psycopg2](http://initd.org/psycopg/)
-Ruby | [pg](https://rubygems.org/gems/pg)
+Ruby | [pg](https://rubygems.org/gems/pg) or [activerecord-cockroachdb-adapter](https://github.com/cockroachdb/activerecord-cockroachdb-adapter) if using Ruby on Rails
 Java | [jdbc](https://jdbc.postgresql.org)
 Node.js | [pg](https://www.npmjs.com/package/pg)
 C | [libpq](http://www.postgresql.org/docs/9.5/static/libpq.html)


### PR DESCRIPTION
On the CockroachDB blog https://www.cockroachlabs.com/blog/cockroachdb-hearts-activerecord-ruby-on-rails/ it is recommended that Ruby on Rails users use the `activerecord-cockroachdb-adapter` if using Ruby on Rails. This is not clearly communicated on the `Install Client Drivers` page where it should be.