### PR TITLE
Make a couple simplifications to the Kubernetes scaling docs

### DIFF
--- a/_includes/v1.1/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v1.1/orchestration/kubernetes-scale-cluster.md
@@ -1,6 +1,7 @@
 The Kubernetes cluster we created contains 3 nodes that pods can be run on. To ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new node and then edit your StatefulSet configuration to add another pod.
 
 1. Add a worker node:
+    - On GKE, [resize your cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster).
     - On GCE, resize your [Managed Instance Group](https://cloud.google.com/compute/docs/instance-groups/).
     - On AWS, resize your [Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/latest/userguide/as-manual-scaling.html).
 

--- a/_includes/v1.1/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v1.1/orchestration/kubernetes-scale-cluster.md
@@ -1,4 +1,4 @@
-The Kubernetes cluster contains 4 nodes, one master and 3 workers. Pods get placed only on worker nodes, so to ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new worker node and then edit your StatefulSet configuration to add another pod.
+The Kubernetes cluster we created contains 3 nodes that pods can be run on. To ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new node and then edit your StatefulSet configuration to add another pod.
 
 1. Add a worker node:
     - On GCE, resize your [Managed Instance Group](https://cloud.google.com/compute/docs/instance-groups/).

--- a/_includes/v2.0/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v2.0/orchestration/kubernetes-scale-cluster.md
@@ -1,6 +1,7 @@
 The Kubernetes cluster we created contains 3 nodes that pods can be run on. To ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new node and then edit your StatefulSet configuration to add another pod.
 
 1. Add a worker node:
+    - On GKE, [resize your cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster).
     - On GCE, resize your [Managed Instance Group](https://cloud.google.com/compute/docs/instance-groups/).
     - On AWS, resize your [Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/latest/userguide/as-manual-scaling.html).
 

--- a/_includes/v2.0/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v2.0/orchestration/kubernetes-scale-cluster.md
@@ -1,4 +1,4 @@
-The Kubernetes cluster contains 4 nodes, one master and 3 workers. Pods get placed only on worker nodes, so to ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new worker node and then edit your StatefulSet configuration to add another pod.
+The Kubernetes cluster we created contains 3 nodes that pods can be run on. To ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new node and then edit your StatefulSet configuration to add another pod.
 
 1. Add a worker node:
     - On GCE, resize your [Managed Instance Group](https://cloud.google.com/compute/docs/instance-groups/).

--- a/_includes/v2.1/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v2.1/orchestration/kubernetes-scale-cluster.md
@@ -1,4 +1,5 @@
 The Kubernetes cluster contains 4 nodes, one master and 3 workers. Pods get placed only on worker nodes, so to ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new worker node and then edit your StatefulSet configuration to add another pod.
+The Kubernetes cluster we created contains 3 nodes that pods can be run on. To ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new node and then edit your StatefulSet configuration to add another pod.
 
 1. Add a worker node:
     - On GCE, resize your [Managed Instance Group](https://cloud.google.com/compute/docs/instance-groups/).

--- a/_includes/v2.1/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v2.1/orchestration/kubernetes-scale-cluster.md
@@ -2,6 +2,7 @@ The Kubernetes cluster contains 4 nodes, one master and 3 workers. Pods get plac
 The Kubernetes cluster we created contains 3 nodes that pods can be run on. To ensure that you don't have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new node and then edit your StatefulSet configuration to add another pod.
 
 1. Add a worker node:
+    - On GKE, [resize your cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster).
     - On GCE, resize your [Managed Instance Group](https://cloud.google.com/compute/docs/instance-groups/).
     - On AWS, resize your [Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/latest/userguide/as-manual-scaling.html).
 


### PR DESCRIPTION
As called out in #3558.

-----------

**Simplify explanation of the number of nodes in a Kubernetes cluster**

----------

**Provide link to instructions for resizing GKE cluster.**

There's also a single command that we could simply show the user:

gcloud container clusters resize cockroachdb --size=4

...but I'm not sure how to fit it in next to the links for GCE and AWS
without it looking out of place. Suggestions appreciated.