### PR TITLE
Add scoping rules to Vale's configuration

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,7 +1,7 @@
 StylesPath = ci/vale
 MinAlertLevel = suggestion
 
-[*.{md,html}]
+[*.md]
 BasedOnStyles = CockroachDB
 
 vale.GenderBias = YES
@@ -10,3 +10,24 @@ vale.Redundancy = YES
 vale.Repetition = YES
 vale.Uncomparables = YES
 CockroachDB.Hyperbolic = NO
+
+# Custom block scoping (see the regex101 links for unit tests):
+# 
+# Rule #1 (https://regex101.com/r/TJQLJ4/2/tests): Ignore `{%comment%}` blocks. This
+# keeps Vale from flagging 'endcomment' as a spelling mistake.
+#
+# Rule #2 (https://regex101.com/r/7VA2lV/2/tests): Ignore `<div>`s and `<section>`s 
+# that specify `markdown="1"` since it isn't supported by Vale's Markdown 
+# parser (https://github.com/russross/blackfriday/issues/184).
+# 
+# Rule #3 (https://regex101.com/r/NxFflU/1/tests): Ignore `{% include %}`-codeblock
+# pairs.
+BlockIgnores = (?s)({%\s?comment\s?%}.+?{%\s?endcomment\s?%}), \
+(?s)(<(?:div|section)[^>]*markdown="1"[^>]*>.*?</(?:div|section)>), \
+(?s)((?: *{% include [^%]+ %}\n)? *~~~.*?~~~~?)
+
+# Custom inline scoping (see the regex101 links for unit tests):
+# 
+# Rule #1 (https://regex101.com/r/cTiITH/2/tests): Ignore `{% include %}`s, which
+# contain file paths.
+TokenIgnores = ({%\s?include\s? {{ [^}]+ }}[^%]+\s?%})


### PR DESCRIPTION
Hi,

I'm the author of [Vale](https://github.com/errata-ai/vale), the natural language linter that you've recently included in your CI suite. 

I noticed that you mentioned having some trouble with code blocks (be9af9075f6072080bec461ee319d52096aa0d28). After looking through v2.1 of your documentation, it appears the issue is that non-standard markup syntax supported by Jekyll (e.g., [`includes`](https://jekyllrb.com/docs/includes/)) is causing some parsing confusion.

This isn't an uncommon issue (most static site generators introduce their own syntax) and Vale addresses it by including [customizable support for non-standard markup](https://errata.ai/vale/markup/#non-standard-markup).

I've updated your `.vale.ini` file to include 4 scoping rules (3 block-level and 1 inline-level) that seem to fix the problems. Each rule includes a link to a regex101 session that includes a detailed description of the pattern and a few unit tests.