### PR TITLE
add Enterprise Trial - Get Started doc

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -44,4 +44,5 @@ var pageConfig = {
   <script src="{{ 'js/select2.min.js' | relative_url }}"></script>
 {% endif %}
 {% if page.asciicast == true %}<script src="{{ 'js/asciinema-player.js' | relative_url }}"></script>{% endif %}
+{% if page.license == true %}<script src="{{ 'js/license-on-page.js' | relative_url }}"></script>{% endif %}
 <script src="//js.hsforms.net/forms/v2.js"></script>

--- a/js/license-on-page.js
+++ b/js/license-on-page.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+
+	var params = new URLSearchParams(new URL(window.location.href).search);
+
+	var organization = params.get('organization');
+	var license = params.get('license');
+
+	if (organization){
+		$( "span:contains('Acme Company')" ).text(`'${decodeURIComponent(organization)}'`)
+	}
+
+	if (license){
+		$( "span:contains(xxxxxxxxxxxx)" ).text(`'${decodeURIComponent(license)}'`)
+	}
+});

--- a/v2.0/enterprise-licensing.md
+++ b/v2.0/enterprise-licensing.md
@@ -91,3 +91,4 @@ To renew an expired license, <a href="mailto:sales@cockroachlabs.com">contact Sa
 
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
+- [Enterprise Trial –– Get Started](get-started-with-enterprise-trial.html)

--- a/v2.0/get-started-with-enterprise-trial.md
+++ b/v2.0/get-started-with-enterprise-trial.md
@@ -1,0 +1,56 @@
+---
+title: Enterprise Trial –– Get Started
+summary: Check out this page to get started with your CockroachDB Enterprise Trial
+toc: true
+license: true
+---
+
+Congratulations on starting your CockroachDB Enterprise Trial! With it, you'll not only get access to CockroachDB's core capabilities like [high availability](high-availability.html) and [`SERIALIZABLE` isolation](strong-consistency.html), but also our Enterprise-only features like distributed [`BACKUP`](backup.html) and [`RESTORE`](restore.html).
+
+## Install CockroachDB
+
+If you haven't already, you'll need to [locally install](install-cockroachdb.html), [remotely deploy](manual-deployment.html), or [orchestrate](orchestration.html) CockroachDB.
+
+## Enable Enterprise features
+
+As the CockroachDB `root` user, open the [built-in SQL shell](use-the-built-in-sql-client.html) in insecure or secure mode, as per your CockroachDB setup. In the following example, we assume that CockroachDB is running in insecure mode. 
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --insecure
+~~~
+
+{{site.data.alerts.callout_info}}If you've secured your deployment, you'll need to <a href="create-security-certificates.html">include the flags for your certificates</a> instead of the <code>--insecure</code> flag.{{site.data.alerts.end}}
+
+Now, use the `SET CLUSTER SETTING` command to set the name of your organization and the license key:
+
+{% include copy-clipboard.html %}
+~~~ sql
+>  SET CLUSTER SETTING cluster.organization = 'Acme Company'; SET CLUSTER SETTING enterprise.license = 'xxxxxxxxxxxx';
+~~~
+
+Then verify your organization in response to the following query:
+
+{% include copy-clipboard.html %}
+~~~ sql
+>  SHOW CLUSTER SETTING cluster.organization;
+~~~
+
+## Use Enterprise features
+
+Your cluster now has access to all of CockroachDB's enterprise features for the length of the trial:
+
+- [`BACKUP`](backup.html) & [`RESTORE`](restore.html), which leverage your entirely cluster to create and consume consistent backups.
+- [Geo-partitioning](partitioning.html) to control the physical location of your data with row-level granularity.
+- [Node Maps](enable-node-map.html), which provides enhanced visuals of your cluster's nodes.
+- [Use role-based access management (RBAC)](create-role.html) for simplified user management.
+
+## Getting help
+
+If you or your team need any help during your trial, our engineers are available on [Gitter](https://gitter.im/cockroachdb/cockroach), [our forum](https://forum.cockroachlabs.com/), or [GitHub](https://github.com/cockroachdb/cockroach).</p>
+
+## See also
+
+- [Enterprise Licensing](enterprise-licensing.html)
+- [`SET CLUSTER SETTING`](set-cluster-setting.html)
+- [`SHOW CLUSTER SETTING`](show-cluster-setting.html)

--- a/v2.1/enterprise-licensing.md
+++ b/v2.1/enterprise-licensing.md
@@ -91,3 +91,4 @@ To renew an expired license, <a href="mailto:sales@cockroachlabs.com">contact Sa
 
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
+- [Enterprise Trial –– Get Started](get-started-with-enterprise-trial.html)

--- a/v2.1/get-started-with-enterprise-trial.md
+++ b/v2.1/get-started-with-enterprise-trial.md
@@ -1,0 +1,58 @@
+---
+title: Enterprise Trial –– Get Started
+summary: Check out this page to get started with your CockroachDB Enterprise Trial
+toc: true
+license: true
+---
+
+Congratulations on starting your CockroachDB Enterprise Trial! With it, you'll not only get access to CockroachDB's core capabilities like [high availability](high-availability.html) and [`SERIALIZABLE` isolation](strong-consistency.html), but also our Enterprise-only features like distributed [`BACKUP`](backup.html) and [`RESTORE`](restore.html).
+
+## Install CockroachDB
+
+If you haven't already, you'll need to [locally install](install-cockroachdb.html), [remotely deploy](manual-deployment.html), or [orchestrate](orchestration.html) CockroachDB.
+
+## Enable Enterprise features
+
+As the CockroachDB `root` user, open the [built-in SQL shell](use-the-built-in-sql-client.html) in insecure or secure mode, as per your CockroachDB setup. In the following example, we assume that CockroachDB is running in insecure mode. 
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --insecure
+~~~
+
+{{site.data.alerts.callout_info}}
+If you've secured your deployment, you'll need to [include the flags for your certificates](create-security-certificates.html) instead of the `--insecure` flag.
+{{site.data.alerts.end}}
+
+Now, use the `SET CLUSTER SETTING` command to set the name of your organization and the license key:
+
+{% include copy-clipboard.html %}
+~~~ sql
+>  SET CLUSTER SETTING cluster.organization = 'Acme Company'; SET CLUSTER SETTING enterprise.license = 'xxxxxxxxxxxx';
+~~~
+
+Then verify your organization in response to the following query:
+
+{% include copy-clipboard.html %}
+~~~ sql
+>  SHOW CLUSTER SETTING cluster.organization;
+~~~
+
+## Use Enterprise features
+
+Your cluster now has access to all of CockroachDB's enterprise features for the length of the trial:
+
+- [`BACKUP`](backup.html) & [`RESTORE`](restore.html), which leverage your entirely cluster to create and consume consistent backups.
+- [Geo-partitioning](partitioning.html) to control the physical location of your data with row-level granularity.
+- [Node Maps](enable-node-map.html), which provides enhanced visuals of your cluster's nodes.
+- [Use role-based access management (RBAC)](create-role.html) for simplified user management.
+
+## Getting help
+
+If you or your team need any help during your trial, our engineers are available on [Gitter](https://gitter.im/cockroachdb/cockroach), [our forum](https://forum.cockroachlabs.com/), or [GitHub](https://github.com/cockroachdb/cockroach).</p>
+
+## See also
+
+- [Enterprise Licensing](enterprise-licensing.html)
+- [`SET CLUSTER SETTING`](set-cluster-setting.html)
+- [`SHOW CLUSTER SETTING`](show-cluster-setting.html)


### PR DESCRIPTION
Closes #3667

This PR also includes JavaScript so you can link to it with parameters to include a user's actual license information on the page, e.g. `.../docs/stable/get-started-with-enterprise-trial.html?license=1234&organization=Not%20CRL`

In the case the page doesn't have any parameters passed to it, it loads just like the [Enterprise Licensing page](https://www.cockroachlabs.com/docs/stable/enterprise-licensing.html).

@jseldess I don't think this necessarily needs a link in the side nav since it's really only designed to be linked to from an email, but if you or anyone on your team has any suggestions for where to place it, I'm glad to oblige.