### PR TITLE
When referencing DaemonSets, link to our docs on the topic

### DIFF
--- a/_includes/v1.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v1.1/orchestration/kubernetes-limitations.md
@@ -6,4 +6,4 @@ Kubernetes 1.8 or higher is required in order to use our most up-to-date configu
 
 #### Storage
 
-At this time, orchestrations of CockroachDB with Kubernetes use external persistent volumes that are often replicated by the provider. Because CockroachDB already replicates data automatically, this additional layer of replication is unnecessary and can negatively impact performance. High-performance use cases on a private Kubernetes cluster may want to consider a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) deployment until StatefulSets support node-local storage.
+At this time, orchestrations of CockroachDB with Kubernetes use external persistent volumes that are often replicated by the provider. Because CockroachDB already replicates data automatically, this additional layer of replication is unnecessary and can negatively impact performance. High-performance use cases on a private Kubernetes cluster may want to consider a [DaemonSet](kubernetes-performance.html#running-in-a-daemonset) deployment until StatefulSets support node-local storage.

--- a/_includes/v2.0/orchestration/kubernetes-limitations.md
+++ b/_includes/v2.0/orchestration/kubernetes-limitations.md
@@ -6,4 +6,4 @@ Kubernetes 1.8 or higher is required in order to use our most up-to-date configu
 
 #### Storage
 
-At this time, orchestrations of CockroachDB with Kubernetes use external persistent volumes that are often replicated by the provider. Because CockroachDB already replicates data automatically, this additional layer of replication is unnecessary and can negatively impact performance. High-performance use cases on a private Kubernetes cluster may want to consider a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) deployment until StatefulSets support node-local storage.
+At this time, orchestrations of CockroachDB with Kubernetes use external persistent volumes that are often replicated by the provider. Because CockroachDB already replicates data automatically, this additional layer of replication is unnecessary and can negatively impact performance. High-performance use cases on a private Kubernetes cluster may want to consider a [DaemonSet](kubernetes-performance.html#running-in-a-daemonset) deployment until StatefulSets support node-local storage.

--- a/_includes/v2.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v2.1/orchestration/kubernetes-limitations.md
@@ -6,4 +6,4 @@ Kubernetes 1.8 or higher is required in order to use our most up-to-date configu
 
 #### Storage
 
-At this time, orchestrations of CockroachDB with Kubernetes use external persistent volumes that are often replicated by the provider. Because CockroachDB already replicates data automatically, this additional layer of replication is unnecessary and can negatively impact performance. High-performance use cases on a private Kubernetes cluster may want to consider a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) deployment until StatefulSets support node-local storage.
+At this time, orchestrations of CockroachDB with Kubernetes use external persistent volumes that are often replicated by the provider. Because CockroachDB already replicates data automatically, this additional layer of replication is unnecessary and can negatively impact performance. High-performance use cases on a private Kubernetes cluster may want to consider a [DaemonSet](kubernetes-performance.html#running-in-a-daemonset) deployment until StatefulSets support node-local storage.


### PR DESCRIPTION
Rather than the less-specific upstream Kubernetes docs.