### PR TITLE
Update existing content about correlated subqueries

### DIFF
--- a/v2.1/detailed-sql-support.md
+++ b/v2.1/detailed-sql-support.md
@@ -93,7 +93,7 @@ To understand the extent to which we support the standard SQL features, use the 
 |  E061-09 | Subqueries in comparison predicate | Yes |
 |  E061-11 | Subqueries in IN predicate | Yes |
 |  E061-12 | Subqueries in quantified comparison predicate | Yes |
-|  E061-13 | Correlated subqueries | No |
+|  E061-13 | Correlated subqueries | Partial |
 |  E061-14 | Search condition | Yes |
 |  **E071** | **Basic query expressions** | **Partial** |
 |  E071-01 | UNION DISTINCT table operator | Yes |

--- a/v2.1/sql-feature-support.md
+++ b/v2.1/sql-feature-support.md
@@ -123,7 +123,7 @@ table tr td:nth-child(2) {
  Table and View references | ✓ | Standard | [Table expressions documentation](table-expressions.html#table-or-view-names)
  `AS` in table expressions | ✓ | Standard | [Aliased table expressions documentation](table-expressions.html#aliased-table-expressions)
  `JOIN` (`INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`) | [Functional](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/) | Standard | [Join expressions documentation](table-expressions.html#join-expressions)
- Sub-queries as table expressions | Partial | Standard | Non-correlated subqueries are [supported](table-expressions.html#subqueries-as-table-expressions); correlated are not.
+ Sub-queries as table expressions | Partial | Standard | Non-correlated subqueries are [supported](table-expressions.html#subqueries-as-table-expressions); some correlated are not.
  Table generator functions | Partial | PostgreSQL Extension | [Table generator functions documentation](table-expressions.html#table-generator-functions)
  `WITH ORDINALITY` | ✓ | CockroachDB Extension | [Ordinality annotation documentation](table-expressions.html#ordinality-annotation)
 

--- a/v2.1/subqueries.md
+++ b/v2.1/subqueries.md
@@ -42,10 +42,6 @@ query only observes 1 row using [`LIMIT`](limit-offset.html).
 A subquery is said to be "correlated" when it uses table or column
 names defined in the surrounding query.
 
-At this time, CockroachDB only supports non-correlated subqueries: all the table and column names listed in the subquery must be defined in the subquery itself.
-
-If you find yourself wanting to use a correlated subquery, consider that a correlated subquery can often be transformed into a non-correlated subquery using a [join expression](joins.html).
-
 For example:
 
 {% include copy-clipboard.html %}
@@ -57,21 +53,7 @@ For example:
 ~~~
 
 The subquery is correlated because it uses `c` defined in the
-surrounding query. It is thus not yet supported by CockroachDB;
-however, it can be transformed to the equivalent query:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SELECT DISTINCT ON(c.id) c.name
-    FROM customers c CROSS JOIN orders o
-   WHERE c.id = o.customer_id;
-~~~
-
-See also [this question on Stack Overflow: Procedurally transform subquery into join](https://stackoverflow.com/questions/1772609/procedurally-transform-subquery-into-join).
-
-{{site.data.alerts.callout_info}}
-CockroachDB is currently undergoing major changes to introduce support for correlated subqueries. This limitation is expected to be lifted in a future release.
-{{site.data.alerts.end}}
+surrounding query.
 
 ## Performance best practices
 


### PR DESCRIPTION
This PR only updates what currently exists in our docs about correlated subqueries. Follow up PRs will be made by @knz or myself for the following:

1. Expanding the [Subqueries](https://www.cockroachlabs.com/docs/dev/subqueries.html) page to include information about what subqueries are not supported
2. Adding examples of correlated subqueries where necessary 

Related to #2976.