### PR TITLE
2.1 sidenav tweak

### DIFF
--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -115,6 +115,53 @@
         ]
       },
       {
+        "title": "Explore Features",
+        "items": [
+          {
+            "title": "Data Replication",
+            "urls": [
+              "/${VERSION}/demo-data-replication.html"
+            ]
+          },
+          {
+            "title": "Fault Tolerance & Recovery",
+            "urls": [
+              "/${VERSION}/demo-fault-tolerance-and-recovery.html"
+            ]
+          },
+          {
+            "title": "Automatic Rebalancing",
+            "urls": [
+              "/${VERSION}/demo-automatic-rebalancing.html"
+            ]
+          },
+          {
+            "title": "Cross-Cloud Migration",
+            "urls": [
+              "/${VERSION}/demo-automatic-cloud-migration.html"
+            ]
+          },
+          {
+            "title": "Follow-the-Workload",
+            "urls": [
+              "/${VERSION}/demo-follow-the-workload.html"
+            ]
+          },
+          {
+            "title": "Orchestration",
+            "urls": [
+              "/${VERSION}/orchestrate-a-local-cluster-with-kubernetes-insecure.html"
+            ]
+          },
+          {
+            "title": "JSON Support",
+            "urls": [
+              "/${VERSION}/demo-json-support.html"
+            ]
+          }
+        ]
+      },
+      {
         "title": "Deploy",
         "items": [
           {
@@ -256,6 +303,12 @@
                   "/${VERSION}/privileges.html"
                 ]
               }
+            ]
+          },
+          {
+            "title": "Performance Benchmarking",
+            "urls": [
+              "/${VERSION}/performance-benchmarking-with-tpc-c.html"
             ]
           },
           {
@@ -424,60 +477,6 @@
           }
         ]
       }
-    ]
-  },
-  {
-    "title": "Tutorials",
-    "is_top_level": true,
-    "items": [
-      {
-        "title": "Data Replication",
-        "urls": [
-          "/${VERSION}/demo-data-replication.html"
-        ]
-      },
-      {
-        "title": "Fault Tolerance & Recovery",
-        "urls": [
-          "/${VERSION}/demo-fault-tolerance-and-recovery.html"
-        ]
-      },
-      {
-        "title": "Automatic Rebalancing",
-        "urls": [
-          "/${VERSION}/demo-automatic-rebalancing.html"
-        ]
-      },
-      {
-        "title": "Cross-Cloud Migration",
-        "urls": [
-          "/${VERSION}/demo-automatic-cloud-migration.html"
-        ]
-      },
-      {
-        "title": "Follow-the-Workload",
-        "urls": [
-          "/${VERSION}/demo-follow-the-workload.html"
-        ]
-      },
-      {
-        "title": "Orchestration",
-        "urls": [
-          "/${VERSION}/orchestrate-a-local-cluster-with-kubernetes-insecure.html"
-        ]
-      },
-      {
-        "title": "JSON Support",
-        "urls": [
-          "/${VERSION}/demo-json-support.html"
-        ]
-      },
-      {
-        "title": "Performance Benchmarking",
-        "urls": [
-          "/${VERSION}/performance-benchmarking-with-tpc-c.html"
-        ]
-      }      
     ]
   },
   {


### PR DESCRIPTION
Change top-level Tutorials section to Guides > Explore Features.

Second "Guide" (after Get Started) feels more meaningful in terms of user flow than an entirely separate "Tutorials" sidenav section.

Plan is to look at analytics over next few weeks to see if the changed placement (compared to original placement nested inside Guides > Get Started) increases traffic to these tutorials through the sidenav. 