### PR TITLE
Remove options from EXPLAIN docs

### DIFF
--- a/_includes/v2.1/sql/diagrams/explain.html
+++ b/_includes/v2.1/sql/diagrams/explain.html
@@ -1,48 +1,39 @@
-<div><svg width="744" height="382">
-<polygon points="9 51 1 47 1 55"></polygon>
-<polygon points="17 51 9 47 9 55"></polygon>
-<rect x="31" y="37" width="78" height="32" rx="10"></rect>
-<rect x="29" y="35" width="78" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="39" y="55">EXPLAIN</text>
-<rect x="169" y="69" width="82" height="32" rx="10"></rect>
-<rect x="167" y="67" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="177" y="87">ANALYZE</text>
-<rect x="291" y="37" width="26" height="32" rx="10"></rect>
-<rect x="289" y="35" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="299" y="55">(</text>
-<rect x="377" y="69" width="64" height="32" rx="10"></rect>
-<rect x="375" y="67" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="87">EXPRS</text>
-<rect x="377" y="113" width="94" height="32" rx="10"></rect>
-<rect x="375" y="111" width="94" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="131">METADATA</text>
-<rect x="377" y="157" width="80" height="32" rx="10"></rect>
-<rect x="375" y="155" width="80" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="175">QUALIFY</text>
-<rect x="377" y="201" width="82" height="32" rx="10"></rect>
-<rect x="375" y="199" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="219">VERBOSE</text>
-<rect x="377" y="245" width="62" height="32" rx="10"></rect>
-<rect x="375" y="243" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="263">TYPES</text>
-<rect x="377" y="289" width="46" height="32" rx="10"></rect>
-<rect x="375" y="287" width="46" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="307">OPT</text>
-<rect x="377" y="333" width="80" height="32" rx="10"></rect>
-<rect x="375" y="331" width="80" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="351">DISTSQL</text>
+<div><svg width="730" height="228">
+<polygon points="9 61 1 57 1 65"></polygon>
+<polygon points="17 61 9 57 9 65"></polygon>
+<rect x="31" y="47" width="78" height="32" rx="10"></rect>
+<rect x="29" y="45" width="78" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="65">EXPLAIN</text>
+<rect x="169" y="79" width="82" height="32" rx="10"></rect>
+<rect x="167" y="77" width="82" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="177" y="97">ANALYZE</text>
+<rect x="291" y="47" width="26" height="32" rx="10"></rect>
+<rect x="289" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="299" y="65">(</text>
+<rect x="377" y="47" width="82" height="32" rx="10"></rect>
+<rect x="375" y="45" width="82" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="385" y="65">VERBOSE</text>
+<rect x="377" y="91" width="62" height="32" rx="10"></rect>
+<rect x="375" y="89" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="385" y="109">TYPES</text>
+<rect x="377" y="135" width="46" height="32" rx="10"></rect>
+<rect x="375" y="133" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="385" y="153">OPT</text>
+<rect x="377" y="179" width="80" height="32" rx="10"></rect>
+<rect x="375" y="177" width="80" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="385" y="197">DISTSQL</text>
 <rect x="357" y="3" width="24" height="32" rx="10"></rect>
 <rect x="355" y="1" width="24" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="365" y="21">,</text>
-<rect x="531" y="37" width="26" height="32" rx="10"></rect>
-<rect x="529" y="35" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="539" y="55">)</text>
-<a xlink:href="sql-grammar.html#explainable_stmt" xlink:title="explainable_stmt">
-<rect x="597" y="37" width="120" height="32"></rect>
-<rect x="595" y="35" width="120" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="605" y="55">explainable_stmt</text>
+<rect x="519" y="47" width="26" height="32" rx="10"></rect>
+<rect x="517" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="527" y="65">)</text>
+<a xlink:href="sql-grammar.html#preparable_stmt" xlink:title="preparable_stmt">
+<rect x="585" y="47" width="118" height="32"></rect>
+<rect x="583" y="45" width="118" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="65">preparable_stmt</text>
 </a>
-<path class="line" d="m17 51 h2 m0 0 h10 m78 0 h10 m40 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -32 h10 m26 0 h10 m40 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m64 0 h10 m0 0 h30 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m80 0 h10 m0 0 h14 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m82 0 h10 m0 0 h12 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m62 0 h10 m0 0 h32 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m46 0 h10 m0 0 h48 m-124 -10 v20 m134 0 v-20 m-134 20 v24 m134 0 v-24 m-134 24 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m80 0 h10 m0 0 h14 m-154 -296 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m154 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-154 0 h10 m24 0 h10 m0 0 h110 m20 34 h10 m26 0 h10 m-448 0 h20 m428 0 h20 m-468 0 q10 0 10 10 m448 0 q0 -10 10 -10 m-458 10 v310 m448 0 v-310 m-448 310 q0 10 10 10 m428 0 q10 0 10 -10 m-438 10 h10 m0 0 h418 m20 -330 h10 m120 0 h10 m3 0 h-3"></path>
-<polygon points="735 51 743 47 743 55"></polygon>
-<polygon points="735 51 727 47 727 55"></polygon>
+<path class="line" d="m17 61 h2 m0 0 h10 m78 0 h10 m40 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -32 h10 m26 0 h10 m40 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m62 0 h10 m0 0 h20 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m46 0 h10 m0 0 h36 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m80 0 h10 m0 0 h2 m-142 -132 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m142 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-142 0 h10 m24 0 h10 m0 0 h98 m20 44 h10 m26 0 h10 m-436 0 h20 m416 0 h20 m-456 0 q10 0 10 10 m436 0 q0 -10 10 -10 m-446 10 v146 m436 0 v-146 m-436 146 q0 10 10 10 m416 0 q10 0 10 -10 m-426 10 h10 m0 0 h406 m20 -166 h10 m118 0 h10 m3 0 h-3"></path>
+<polygon points="721 61 729 57 729 65"></polygon>
+<polygon points="721 61 713 57 713 65"></polygon>
 </svg></div>

--- a/v2.1/explain.md
+++ b/v2.1/explain.md
@@ -34,17 +34,14 @@ The user requires the appropriate [privileges](privileges.html) for the statemen
 
 ## Parameters
 
-Parameter | Description
------------|-----------
-`ANALYZE` | <span class="version-tag">New in v2.1:</span> Execute the command and show execution statistics.
-`EXPRS` | Include the SQL expressions that are involved in each processing stage.
-`QUALIFY` | Include table names when referencing columns, which might be important to verify the behavior of joins across tables with the same column names.<br/><br/>To list qualified names, `QUALIFY` requires you to include the `EXPRS` option.
-`METADATA` | Include the columns each level uses in the **Columns** column, as well as **Ordering** detail.
-`VERBOSE`  | Imply the `EXPRS`, `METADATA`, and `QUALIFY` options.
-`TYPES` | Include the intermediate [data types](data-types.html) CockroachDB chooses to evaluate intermediate SQL expressions. <br/><br/>`TYPES` also implies `METADATA` and `EXPRS` options.
-`OPT` | <span class="version-tag">New in v2.1:</span> Display a query plan tree if the query will be run with the [cost-based optimizer](sql-optimizer.html). If it returns `pq: unsupported statement: *tree.Insert`, the query will not be run with the cost-based optimizer and will be run with the heuristic planner.
-`DISTSQL` | <span class="version-tag">New in v2.1:</span> Provide a link that displays a distributed SQL plan tree.
-`explainable_stmt` | The [explainable statement](sql-grammar.html#explainable_stmt) you want details about.
+ Parameter          | Description
+--------------------+------------
+ `ANALYZE`          | <span class="version-tag">New in v2.1:</span> Execute the command and show execution statistics.
+ `VERBOSE`          | Show as much information as possible about the query plan.
+ `TYPES`            | Include the intermediate [data types](data-types.html) CockroachDB chooses to evaluate intermediate SQL expressions.
+ `OPT`              | <span class="version-tag">New in v2.1:</span> Display a query plan tree if the query will be run with the [cost-based optimizer](sql-optimizer.html). If it returns `pq: unsupported statement: *tree.Insert`, the query will not be run with the cost-based optimizer and will be run with the heuristic planner.
+ `DISTSQL`          | <span class="version-tag">New in v2.1:</span> Provide a link that displays a distributed SQL plan tree.
+ `explainable_stmt` | The [explainable statement](sql-grammar.html#explainable_stmt) you want details about.
 
 {{site.data.alerts.callout_danger}}<code>EXPLAIN</code> also includes other modes besides query plans that are useful only to CockroachDB developers, which are not documented here.{{site.data.alerts.end}}
 
@@ -57,8 +54,8 @@ Successful `EXPLAIN` statements return tables with the following columns:
 **Tree** | A tree representation showing the hierarchy of the query plan.
 **Field** | The name of a parameter relevant to the query plan node immediately above.
 **Description** | Additional information for the parameter in  **Field**.
-**Columns** | The columns provided to the processes at lower levels of the hierarchy. <br/><br>This column displays only if the `METADATA` option is specified or implied.
-**Ordering** | The order in which results are presented to the processes at each level of the hierarchy, as well as other properties of the result set at each level. <br/><br>This column displays only if the `METADATA` option is specified or implied.
+**Columns** | The columns provided to the processes at lower levels of the hierarchy.  Included in `TYPES` and `VERBOSE` output.
+**Ordering** | The order in which results are presented to the processes at each level of the hierarchy, as well as other properties of the result set at each level. Included in `TYPES` and `VERBOSE` output.
 
 ## Examples
 
@@ -73,15 +70,14 @@ useful to find out which indexes and index key ranges are used by a query:
 ~~~
 
 ~~~
-+-----------+-------+-------------+
-|   Tree    | Field | Description |
-+-----------+-------+-------------+
-| sort      |       |             |
-|  │        | order | +v          |
-|  └── scan |       |             |
-|           | table | kv@primary  |
-|           | spans | ALL         |
-+-----------+-------+-------------+
+   tree    | field | description
+-----------+-------+-------------
+ sort      |       |
+  │        | order | +v
+  └── scan |       |
+           | table | kv@primary
+           | spans | ALL
+(5 rows)
 ~~~
 
 The first column shows the tree structure of the query plan; a set of properties
@@ -91,157 +87,12 @@ index you are scanning (in this case, a full table scan). For more
 information on indexes and key ranges, see the
 [example](#find-the-indexes-and-key-ranges-a-query-uses) below.
 
-### `EXPRS` option
-
-The `EXPRS` option includes SQL expressions that are involved in each processing stage, providing more granular detail about which portion of your query is represented at each level:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> EXPLAIN (EXPRS) SELECT * FROM kv WHERE v > 3 ORDER BY v;
-~~~
-
-~~~
-+-----------+--------+-------------+
-|   Tree    | Field  | Description |
-+-----------+--------+-------------+
-| sort      |        |             |
-|  │        | order  | +v          |
-|  └── scan |        |             |
-|           | table  | kv@primary  |
-|           | spans  | ALL         |
-|           | filter | v > 3       |
-+-----------+--------+-------------+
-~~~
-
-### `METADATA` option
-
-The `METADATA` option includes detail about which columns are being used by each
-level, as well as properties of the result set on that level:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> EXPLAIN (METADATA) SELECT * FROM kv WHERE v > 3 ORDER BY v;
-~~~
-
-~~~
-+-----------+-------+------+-------+-------------+---------+------------------------------+
-|   Tree    | Level | Type | Field | Description | Columns |           Ordering           |
-+-----------+-------+------+-------+-------------+---------+------------------------------+
-| sort      |     0 | sort |       |             | (k, v)  | k!=NULL; v!=NULL; key(k); +v |
-|  │        |     0 |      | order | +v          |         |                              |
-|  └── scan |     1 | scan |       |             | (k, v)  | k!=NULL; v!=NULL; key(k)     |
-|           |     1 |      | table | kv@primary  |         |                              |
-|           |     1 |      | spans | ALL         |         |                              |
-+-----------+-------+------+-------+-------------+---------+------------------------------+
-~~~
-
-The **Ordering** column most importantly includes the ordering of the rows at
-that level (`+v` in this case), but it also includes other information about the
-result set at that level. In this case, CockroachDB was able to deduce that `k`
-and `v` cannot be `NULL`, and `k` is a "key", meaning that you cannot have more
-than one row with any given value of `k`.
-
-Note that descending (`DESC`) orderings are indicated by the `-` sign:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> EXPLAIN (METADATA) SELECT * FROM kv WHERE v > 3 ORDER BY v DESC;
-~~~
-
-~~~
-+-----------+-------+------+-------+-------------+---------+------------------------------+
-|   Tree    | Level | Type | Field | Description | Columns |           Ordering           |
-+-----------+-------+------+-------+-------------+---------+------------------------------+
-| sort      |     0 | sort |       |             | (k, v)  | k!=NULL; v!=NULL; key(k); -v |
-|  │        |     0 |      | order | -v          |         |                              |
-|  └── scan |     1 | scan |       |             | (k, v)  | k!=NULL; v!=NULL; key(k)     |
-|           |     1 |      | table | kv@primary  |         |                              |
-|           |     1 |      | spans | ALL         |         |                              |
-+-----------+-------+------+-------+-------------+---------+------------------------------+
-~~~
-
-Another property that is reported in the **Ordering** column is information
-about columns that are known to be equal on any row, and "constant" columns
-that are known to have the same value on all rows. For example:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> EXPLAIN (METADATA) SELECT * FROM abcd JOIN efg ON a=e AND c=1;
-~~~
-
-~~~
-+-----------+-------+------+----------------+--------------+-----------------------+-------------------------------+
-|   Tree    | Level | Type |     Field      | Description  |        Columns        |           Ordering            |
-+-----------+-------+------+----------------+--------------+-----------------------+-------------------------------+
-| join      |     0 | join |                |              | (a, b, c, d, e, f, g) | a=e; c=CONST; a!=NULL; key(a) |
-|  │        |     0 |      | type           | inner        |                       |                               |
-|  │        |     0 |      | equality       | (a) = (e)    |                       |                               |
-|  │        |     0 |      | mergeJoinOrder | +"(a=e)"     |                       |                               |
-|  ├── scan |     1 | scan |                |              | (a, b, c, d)          | c=CONST; a!=NULL; key(a); +a  |
-|  │        |     1 |      | table          | abcd@primary |                       |                               |
-|  │        |     1 |      | spans          | ALL          |                       |                               |
-|  └── scan |     1 | scan |                |              | (e, f, g)             | e!=NULL; key(e); +e           |
-|           |     1 |      | table          | efg@primary  |                       |                               |
-|           |     1 |      | spans          | ALL          |                       |                               |
-+-----------+-------+------+----------------+--------------+-----------------------+-------------------------------+
-~~~
-
-This indicates that on any row, column `a` has the same value with column `e`,
-and that all rows have the same value on column `c`.
-
-### `QUALIFY` option
-
-`QUALIFY` uses `<table name>.<column name>` notation for columns in the query plan. However, `QUALIFY` must be used with `EXPRS` to show the SQL values used:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> EXPLAIN (EXPRS, QUALIFY) SELECT a.v, b.v FROM t.kv AS a, t.kv AS b;
-~~~
-
-~~~
-+----------------+----------+-------------+
-|      Tree      |  Field   | Description |
-+----------------+----------+-------------+
-| render         |          |             |
-|  │             | render 0 | a.v         |
-|  │             | render 1 | b.v         |
-|  └── join      |          |             |
-|       │        | type     | cross       |
-|       ├── scan |          |             |
-|       │        | table    | kv@primary  |
-|       │        | spans    | ALL         |
-|       └── scan |          |             |
-|                | table    | kv@primary  |
-|                | spans    | ALL         |
-+----------------+----------+-------------+
-~~~
-
-You can contrast this with the same statement not including the `QUALIFY` option to see that the column references are not qualified, which can lead to ambiguity if multiple tables have columns with the same names:
-
-{% include copy-clipboard.html %}
-~~~ sql
->  EXPLAIN (EXPRS) SELECT a.v, b.v FROM kv AS a, kv AS b;
-~~~
-
-~~~
-+-------+--------+----------+-------------+
-| Level |  Type  |  Field   | Description |
-+-------+--------+----------+-------------+
-|     0 | render |          |             |
-|     0 |        | render 0 | v           |
-|     0 |        | render 1 | v           |
-|     1 | join   |          |             |
-|     1 |        | type     | cross       |
-|     2 | scan   |          |             |
-|     2 |        | table    | kv@primary  |
-|     2 | scan   |          |             |
-|     2 |        | table    | kv@primary  |
-+-------+--------+----------+-------------+
-~~~
-
 ### `VERBOSE` option
 
-The `VERBOSE` option is an alias for the combination of `EXPRS`, `METADATA`, and `QUALIFY` options:
+The `VERBOSE` option:
+
++ Includes SQL expressions that are involved in each processing stage, providing more granular detail about which portion of your query is represented at each level.
++ Includes detail about which columns are being used by each level, as well as properties of the result set on that level.
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -249,62 +100,29 @@ The `VERBOSE` option is an alias for the combination of `EXPRS`, `METADATA`, and
 ~~~
 
 ~~~
-+---------------------+----------------+------------------+-----------------------+------------------------------+
-|        Tree         |     Field      |   Description    |        Columns        |           Ordering           |
-+---------------------+----------------+------------------+-----------------------+------------------------------+
-| sort                |                |                  | (k, v, v)             | k!=NULL; key(k); -v          |
-|  │                  | order          | -v               |                       |                              |
-|  └── render         |                |                  | (k, v, v)             | k!=NULL; key(k)              |
-|       │             | render 0       | a.k              |                       |                              |
-|       │             | render 1       | a.v              |                       |                              |
-|       │             | render 2       | radu.public.kv.v |                       |                              |
-|       └── join      |                |                  | (k, v, k[omitted], v) | k=k; k!=NULL; key(k)         |
-|            │        | type           | inner            |                       |                              |
-|            │        | equality       | (k) = (k)        |                       |                              |
-|            │        | mergeJoinOrder | +"(k=k)"         |                       |                              |
-|            ├── scan |                |                  | (k, v)                | k!=NULL; v!=NULL; key(k); +k |
-|            │        | table          | kv@primary       |                       |                              |
-|            │        | spans          | ALL              |                       |                              |
-|            │        | filter         | v > 3            |                       |                              |
-|            └── scan |                |                  | (k, v)                | k!=NULL; key(k); +k          |
-|                     | table          | kv@primary       |                       |                              |
-|                     | spans          | ALL              |                       |                              |
-+---------------------+----------------+------------------+-----------------------+------------------------------+
-~~~
-
-By default, the `Level` and `Type` columns are hidden. To view, use `SELECT`:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SELECT "Level", "Type" FROM [EXPLAIN (VERBOSE) SELECT * FROM kv AS a JOIN kv USING (k) WHERE a.v > 3 ORDER BY a.v DESC];
-~~~
-~~~
-+-------+--------+
-| Level |  Type  |
-+-------+--------+
-|     0 | sort   |
-|     0 |        |
-|     1 | render |
-|     1 |        |
-|     1 |        |
-|     1 |        |
-|     2 | join   |
-|     2 |        |
-|     2 |        |
-|     2 |        |
-|     3 | scan   |
-|     3 |        |
-|     3 |        |
-|     3 |        |
-|     3 | scan   |
-|     3 |        |
-|     3 |        |
-+-------+--------+
+         tree         |  field   | description |   columns    | ordering
++---------------------+----------+-------------+--------------+----------+
+  sort                |          |             | (k, v, v)    | -v
+   │                  | order    | -v          |              |
+   └── render         |          |             | (k, v, v)    |
+        │             | render 0 | k           |              |
+        │             | render 1 | v           |              |
+        │             | render 2 | v           |              |
+        └── join      |          |             | (k, v, k, v) |
+             │        | type     | inner       |              |
+             │        | equality | (k) = (k)   |              |
+             ├── scan |          |             | (k, v)       |
+             │        | table    | kv@primary  |              |
+             │        | spans    | ALL         |              |
+             └── scan |          |             | (k, v)       |
+                      | table    | kv@v        |              |
+                      | spans    | /4-         |              |
+(15 rows)
 ~~~
 
 ### `TYPES` option
 
-The `TYPES` mode includes the types of the values used in the query plan, and implies the `METADATA` and `EXPRS` options as well:
+The `TYPES` mode includes the types of the values used in the query plan.  It also includes the SQL expressions that were involved in each processing stage, and includes the columns used by each level.
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -312,51 +130,40 @@ The `TYPES` mode includes the types of the values used in the query plan, and im
 ~~~
 
 ~~~
-+-----------+-------+------+--------+-----------------------------+----------------+------------------------------+
-|   Tree    | Level | Type | Field  |         Description         |    Columns     |           Ordering           |
-+-----------+-------+------+--------+-----------------------------+----------------+------------------------------+
-| sort      |     0 | sort |        |                             | (k int, v int) | k!=NULL; v!=NULL; key(k); +v |
-|  │        |     0 |      | order  | +v                          |                |                              |
-|  └── scan |     1 | scan |        |                             | (k int, v int) | k!=NULL; v!=NULL; key(k)     |
-|           |     1 |      | table  | kv@primary                  |                |                              |
-|           |     1 |      | spans  | ALL                         |                |                              |
-|           |     1 |      | filter | ((v)[int] > (3)[int])[bool] |                |                              |
-+-----------+-------+------+--------+-----------------------------+----------------+------------------------------+
+   tree    | field  |         description         |    columns     | ordering
+-----------+--------+-----------------------------+----------------+----------
+ sort      |        |                             | (k int, v int) | +v
+  │        | order  | +v                          |                |
+  └── scan |        |                             | (k int, v int) |
+           | table  | kv@primary                  |                |
+           | spans  | ALL                         |                |
+           | filter | ((v)[int] > (3)[int])[bool] |                |
+(6 rows)
 ~~~
 
 ### `OPT` option
 
-<span class="version-tag">New in v2.1:</span> The `OPT` option displays a query plan tree if the query will be run with the [cost-based optimizer](sql-optimizer.html). If it returns `pq: unsupported statement: *tree.Insert`, the query will not be run with the cost-based optimizer and will be run with the heuristic planner.
+<span class="version-tag">New in v2.1:</span> The `OPT` option displays a query plan tree if the query will be run with the [cost-based optimizer](sql-optimizer.html). If it returns an unsupported statement error, the query will not be run with the cost-based optimizer and will be run with the heuristic planner.
 
 For example:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> EXPLAIN (OPT) SELECT * FROM x WHERE a = 3;
+> EXPLAIN (OPT) SELECT * FROM kv WHERE k > 3;
 ~~~
 
 ~~~
-+--------------------------------------------------------------------------+
-|                                   text                                   |
-+--------------------------------------------------------------------------+
-| select                                                                   |
-|  ├── columns: a:1(int!null) b:2(jsonb)                                   |
-|  ├── stats: [rows=1.42857143, distinct(1)=1]                             |
-|  ├── cost: 1060                                                          |
-|  ├── fd: ()-->(1)                                                        |
-|  ├── prune: (2)                                                          |
-|  ├── scan x                                                              |
-|  │    ├── columns: x.a:1(int) x.b:2(jsonb)                               |
-|  │    ├── stats: [rows=1000, distinct(1)=700]                            |
-|  │    ├── cost: 1050                                                     |
-|  │    └── prune: (1,2)                                                   |
-|  └── filters [type=bool, outer=(1), constraints=(/1: [/3 - /3]; tight),  |
-| fd=()-->(1)]                                                             |
-|       └── eq [type=bool, outer=(1), constraints=(/1: [/3 - /3]; tight)]  |
-|            ├── variable: x.a [type=int, outer=(1)]                       |
-|            └── const: 3 [type=int]                                       |
-+--------------------------------------------------------------------------+
-(15 rows)
+                 text
+--------------------------------------
+ scan kv
+  ├── columns: k:1(int!null) v:2(int)
+  ├── constraint: /1: [/4 - ]
+  ├── stats: [rows=333.333333]
+  ├── cost: 346.666667
+  ├── key: (1)
+  ├── fd: (1)-->(2)
+  └── prune: (2)
+(8 rows)
 ~~~
 
 The query above will be run with the cost-based optimizer and `EXPLAIN (OPT)` returns the query plan tree.
@@ -364,7 +171,7 @@ The query above will be run with the cost-based optimizer and `EXPLAIN (OPT)` re
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> EXPLAIN (OPT) INSERT INTO x VALUES (1);
+> EXPLAIN (OPT) INSERT INTO kv VALUES (1,1);
 ~~~
 
 ~~~
@@ -383,11 +190,9 @@ The query above will not be run with the cost-based optimizer.
 ~~~
 
 ~~~
-+-----------+----------------------------------------------+
-| Automatic |                      URL                     |
-+-----------+----------------------------------------------+
-|   true    | https://cockroachdb.github.io/distsqlplan... |
-+-----------+----------------------------------------------+
+ automatic |                      url
+-----------+----------------------------------------------
+   true    | https://cockroachdb.github.io/distsqlplan...
 ~~~
 
 Point your browser to the URL provided:
@@ -402,11 +207,9 @@ To view the distributed SQL query plan with execution statistics, use `EXPLAIN A
 ~~~
 
 ~~~
-+-----------+----------------------------------------------+
-| Automatic |                      URL                     |
-+-----------+----------------------------------------------+
-|   true    | https://cockroachdb.github.io/distsqlplan... |
-+-----------+----------------------------------------------+
+ automatic |                      url
+-----------+----------------------------------------------
+   true    | https://cockroachdb.github.io/distsqlplan...
 ~~~
 
 Point your browser to the URL provided:
@@ -431,13 +234,12 @@ Because column `v` is not indexed, queries filtering on it alone scan the entire
 ~~~
 
 ~~~
-+-------+------+-------+-------------+
-| Level | Type | Field | Description |
-+-------+------+-------+-------------+
-|     0 | scan |       |             |
-|     0 |      | table | kv@primary  |
-|     0 |      | spans | ALL         |
-+-------+------+-------+-------------+
+ tree | field | description
+------+-------+-------------
+ scan |       |
+      | table | kv@primary
+      | spans | ALL
+(3 rows)
 ~~~
 
 If there were an index on `v`, CockroachDB would be able to avoid scanning the
@@ -454,13 +256,12 @@ entire table:
 ~~~
 
 ~~~
-+------+-------+-------------+
-| Tree | Field | Description |
-+------+-------+-------------+
-| scan |       |             |
-|      | table | kv@v        |
-|      | spans | /4-/6       |
-+------+-------+-------------+
+ tree | field | description
+------+-------+-------------
+ scan |       |
+      | table | kv@v
+      | spans | /4-/6
+(3 rows)
 ~~~
 
 Now, only part of the index `v` is getting scanned, specifically the key range starting


### PR DESCRIPTION
Fixes #3071

Summary of changes (all to the `EXPLAIN` page):

- Remove `METADATA`, `QUALIFY`, and `EXPR` options.  Required rewriting
  a few bits slightly to remove references to those flags.

- Updated railroad diagram