### PR TITLE
Remove help widget from the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Field | Description | Default
 `no_sidebar` | If `true`, removes the sidebar from a page. See [Sidebar](#sidebar) for more details. | Nothing
 `block_search` | If `true`, adds meta tags to the header that excludes the page from search indexing/caching. | Nothing
 `back_to_top` | If `true`, adds a back-to-top button to the page. This is only helpful in cases where the page is very long and there is no page toc, e.g., the Full SQL Grammar page.
-`drift` | Set this to `true` if a Drift survey is active on the page. This excludes the help button from the page, which would otherwise conflict visually with the Drift interface.
+<!-- `drift` | Set this to `true` if a Drift survey is active on the page. This excludes the help button from the page, which would otherwise conflict visually with the Drift interface. -->
 
 #### Page TOC
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,9 +2,11 @@
 	{% if page.back_to_top == true %}
 		{% include back-to-top.html %}
 	{% endif %}
-	{% unless page.drift == true %}
+	{% comment %}
+	{% unless page.drift == false %}
 		{% include help-widget.html %}
   {% endunless %}
+	{% endcomment %}
 	<div class="container">
 		<div class="footer__flex-wrap">
 			<ul class="footer-nav">

--- a/v2.0/deploy-cockroachdb-on-aws-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-aws-insecure.md
@@ -4,7 +4,6 @@ summary: Learn how to deploy CockroachDB on Amazon's AWS EC2 platform.
 toc: true
 toc_not_nested: true
 ssh-link: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
-drift: true
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-aws.md
+++ b/v2.0/deploy-cockroachdb-on-aws.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Amazon's AWS EC2 platform.
 toc: true
 toc_not_nested: true
 ssh-link: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Digital Ocean.
 toc: true
 toc_not_nested: true
 ssh-link: https://www.digitalocean.com/community/tutorials/how-to-connect-to-your-droplet-with-ssh
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-digital-ocean.md
+++ b/v2.0/deploy-cockroachdb-on-digital-ocean.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Digital Ocean.
 toc: true
 toc_not_nested: true
 ssh-link: https://www.digitalocean.com/community/tutorials/how-to-connect-to-your-droplet-with-ssh
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Google Cloud Platform's Compute Engi
 toc: true
 toc_not_nested: true
 ssh-link: https://cloud.google.com/compute/docs/instances/connecting-to-instance
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v2.0/deploy-cockroachdb-on-google-cloud-platform.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Google Cloud Platform's Compute Engi
 toc: true
 toc_not_nested: true
 ssh-link: https://cloud.google.com/compute/docs/instances/connecting-to-instance
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Microsoft Azure.
 toc: true
 toc_not_nested: true
 ssh-link: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v2.0/deploy-cockroachdb-on-microsoft-azure.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy CockroachDB on Microsoft Azure.
 toc: true
 toc_not_nested: true
 ssh-link: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-premises-insecure.md
+++ b/v2.0/deploy-cockroachdb-on-premises-insecure.md
@@ -4,7 +4,7 @@ summary: Learn how to manually deploy an insecure, multi-node CockroachDB cluste
 toc: true
 ssh-link: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2
 redirect_from: manual-deployment-insecure.html
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/deploy-cockroachdb-on-premises.md
+++ b/v2.0/deploy-cockroachdb-on-premises.md
@@ -3,7 +3,7 @@ title: Deploy CockroachDB On-Premises
 summary: Learn how to manually deploy a secure, multi-node CockroachDB cluster on multiple machines.
 toc: true
 ssh-link: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys--2
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/manual-deployment.md
+++ b/v2.0/manual-deployment.md
@@ -3,7 +3,7 @@ title: Manual Deployment
 summary: Learn how to deploy CockroachDB manually on-premises or on popular cloud platforms.
 toc: false
 redirect_from: cloud-deployment.html
-drift: true
+
 ---
 
 Use the following guides to deploy CockroachDB manually on-premises or on popular cloud platforms:

--- a/v2.0/monitoring-and-alerting.md
+++ b/v2.0/monitoring-and-alerting.md
@@ -2,7 +2,7 @@
 title: Monitoring and Alerting
 summary: Monitor the health and performance of a cluster and alert on critical events and metrics.
 toc: true
-drift: true
+
 ---
 
 Despite CockroachDB's various [built-in safeguards against failure](high-availability.html), it is critical to actively monitor the overall health and performance of a cluster running in production and to create alerting rules that promptly send notifications when there are events that require investigation or intervention.

--- a/v2.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -2,7 +2,7 @@
 title: Orchestrate CockroachDB with Docker Swarm
 summary: How to orchestrate the deployment and management of an insecure three-node CockroachDB cluster as a Docker swarm.
 toc: true
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/orchestrate-cockroachdb-with-docker-swarm.md
+++ b/v2.0/orchestrate-cockroachdb-with-docker-swarm.md
@@ -2,7 +2,7 @@
 title: Orchestrate CockroachDB with Docker Swarm
 summary: How to orchestrate the deployment and management of a secure three-node CockroachDB cluster as a Docker swarm.
 toc: true
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -2,7 +2,7 @@
 title: Orchestrate CockroachDB with Kubernetes (Insecure)
 summary: How to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster with Kubernetes.
 toc: true
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v2.0/orchestrate-cockroachdb-with-kubernetes.md
@@ -3,7 +3,7 @@ title: Orchestrate CockroachDB with Kubernetes
 summary: How to orchestrate the deployment, management, and monitoring of a secure 3-node CockroachDB cluster with Kubernetes.
 toc: true
 secure: true
-drift: true
+
 ---
 
 <div class="filters filters-big clearfix">

--- a/v2.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
+++ b/v2.0/orchestrate-cockroachdb-with-mesosphere-insecure.md
@@ -2,7 +2,7 @@
 title: Orchestrate CockroachDB with Mesosphere DC/OS (Insecure)
 summary: How to orchestrate the deployment and management of an insecure 3-node CockroachDB cluster with Mesosphere DC/OS.
 toc: true
-drift: true
+
 ---
 
 This page shows you how to orchestrate the deployment and management of an insecure 3-node CockroachDB cluster with [Mesosphere DC/OS](https://mesosphere.com/).

--- a/v2.0/orchestration.md
+++ b/v2.0/orchestration.md
@@ -2,7 +2,7 @@
 title: Orchestration
 summary: Learn how to run CockroachDB with popular open-source orchestration systems.
 toc: false
-drift: true
+
 ---
 
 Orchestration systems automate the deployment, scaling, and management of containerized applications. Combined with CockroachDB's [automated sharding](frequently-asked-questions.html#how-does-cockroachdb-scale) and [fault tolerance](frequently-asked-questions.html#how-does-cockroachdb-survive-failures), they have the potential to lower operator overhead to almost nothing.

--- a/v2.0/performance-benchmarking-with-tpc-c.md
+++ b/v2.0/performance-benchmarking-with-tpc-c.md
@@ -2,7 +2,7 @@
 title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C.
 toc: true
-drift: true
+
 ---
 
 <span class="version-tag">New in v2.0:</span>This page walks you through [TPC-C](http://www.tpc.org/tpcc/) performance benchmarking on CockroachDB. It measures tpmC (new order transactions/minute) on two TPC-C datasets:

--- a/v2.0/performance-tuning.md
+++ b/v2.0/performance-tuning.md
@@ -2,7 +2,7 @@
 title: Performance Tuning
 summary: Essential techniques for getting fast reads and writes in a single- and multi-region CockroachDB deployment.
 toc: true
-drift: true
+
 ---
 
 This tutorial shows you essential techniques for getting fast reads and writes in CockroachDB, starting with a single-region deployment and expanding into multiple regions.

--- a/v2.0/recommended-production-settings.md
+++ b/v2.0/recommended-production-settings.md
@@ -2,7 +2,7 @@
 title: Production Checklist
 summary: Recommended settings for production deployments.
 toc: true
-drift: true
+
 ---
 
 This page provides important recommendations for production deployments of CockroachDB.


### PR DESCRIPTION
Only 2-3% of traffic to Gitter and the Forum come
from the docs. For at least a while, we're therefore
turning off the help widget to allow us to expose
a docs satisfaction survey via Drift, which would
otherwise overlap and conflict with the help widget.