### PR TITLE
Extend the JSONB field access example

### DIFF
--- a/v2.1/jsonb.md
+++ b/v2.1/jsonb.md
@@ -65,7 +65,7 @@ For the full list of supported `JSONB` functions, see [Functions and Operators](
 
 Operator | Description | Example |
 ---------|-------------|---------|
-`->` | Access a `JSONB` field, returning a `JSONB` value. | `SELECT '{"foo":"bar"}'::JSONB->'foo' = '"bar"'::JSONB;`
+`->` | Access a `JSONB` field, returning a `JSONB` value. | `SELECT '[{"foo":"bar"}]'::JSONB->0->'foo' = '"bar"'::JSONB;`
 `->>` | Access a `JSONB` field, returning a string. | `SELECT '{"foo":"bar"}'::JSONB->>'foo' = 'bar'::STRING;`
 `@>` | Tests whether the left `JSONB` field contains the right `JSONB` field. | `SELECT ('{"foo": {"baz": 3}, "bar": 2}'::JSONB @> '{"foo": {"baz":3}}'::JSONB ) = true;`
 


### PR DESCRIPTION
Extend the JSONB field access example to include accessing an array element.