### PR TITLE
Update CDC docs with new 2.1 changes

### DIFF
--- a/_includes/v2.1/known-limitations/cdc.md
+++ b/_includes/v2.1/known-limitations/cdc.md
@@ -2,11 +2,10 @@ The following are limitations in the v2.1 release and will be addressed in the f
 
 - The CockroachDB core changefeed is not ready for external testing.
 - Changefeeds only work on tables with a single [column family](column-families.html) (which is the default for new tables).
-- Many DDL queries (including [`TRUNCATE`](truncate.html), [`RENAME TABLE`](rename-table.html), and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. Also, any schema changes with column backfills (e.g., adding a column with a default, adding a computed column, adding a `NOT NULL` column, dropping a column) will cause the changefeed to stop and you will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).
+- Many DDL queries (including [`TRUNCATE`](truncate.html) and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. You will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html).
 - Changefeed behavior under most types of failures/degraded conditions is not yet tuned.
 - Changefeeds use a pull model, but will use a push model in the future, lowering latencies considerably.
-- Changefeeds cannot be altered. To alter, cancel the changefeed and create a new one with updated settings from where it left off.
-- Additional format options will be added, including Avro.
+- Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).
 - Additional envelope options will be added, including one that displays the old and new values for the changed row.
 - Additional target options will be added, including partitions and ranges of primary key rows.

--- a/v2.1/change-data-capture.md
+++ b/v2.1/change-data-capture.md
@@ -18,7 +18,7 @@ CDC is an [enterprise-only](enterprise-licensing.html). There will be a core ver
 
 While CockroachDB is an excellent system of record, it also needs to coexist with other systems. For example, you might want to keep your data mirrored in full-text indexes, analytics engines, or big data pipelines.
 
-The core feature of CDC is the [changefeed](create-changefeed.html). Changefeeds target a whitelist of tables, called the "watched rows". Every change to a watched row is emitted as a record in a configurable format (`JSON`) to a configurable sink ([Kafka](https://kafka.apache.org/)).
+The core feature of CDC is the [changefeed](create-changefeed.html). Changefeeds target a whitelist of tables, called the "watched rows". Every change to a watched row is emitted as a record in a configurable format (JSON or Avro) to a configurable sink ([Kafka](https://kafka.apache.org/)).
 
 ## Ordering guarantees
 
@@ -65,7 +65,7 @@ The core feature of CDC is the [changefeed](create-changefeed.html). Changefeeds
 
     For example:
 
-    ~~~ json
+    ~~~ shell
     {"__crdb__": {"updated": "1532377312562986715.0000000000"}, "id": 1, "name": "Petee H"}
     {"__crdb__": {"updated": "1532377306108205142.0000000000"}, "id": 2, "name": "Carl"}
     {"__crdb__": {"updated": "1532377358501715562.0000000000"}, "id": 3, "name": "Ernie"}
@@ -80,6 +80,39 @@ The core feature of CDC is the [changefeed](create-changefeed.html). Changefeeds
 - With duplicates removed, an individual row is emitted in the same order as the transactions that updated it. However, this is not true for updates to two different rows, even two rows in the same table. Resolved timestamp notifications on every Kafka partition can be used to provide strong ordering and global consistency guarantees by buffering records in between timestamp closures.
 
     Because CockroachDB supports transactions that can affect any part of the cluster, it is not possible to horizontally divide the transaction log into independent changefeeds.
+
+## Schema changes with column backfill
+
+When schema changes with column backfill (e.g., adding a column with a default, adding a computed column, adding a `NOT NULL` column, dropping a column) are made to watched rows, the changefeed will emit some duplicates during the backfill. When it finishes, CockroachDB outputs all watched rows using the new schema.
+
+For example, start with the changefeed created in the [example below](#create-a-changefeed-connected-to-kafka):
+
+~~~ shell
+[1]	{"id": 1, "name": "Petee H"}
+[2]	{"id": 2, "name": "Carl"}
+[3]	{"id": 3, "name": "Ernie"}
+~~~
+
+Add a column to the watched table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE office_dogs ADD COLUMN likes_treats BOOL DEFAULT TRUE;
+~~~
+
+The changefeed emits duplicate records 1, 2, and 3 before outputting the records using the new schema:
+
+~~~ shell
+[1]	{"id": 1, "name": "Petee H"}
+[2]	{"id": 2, "name": "Carl"}
+[3]	{"id": 3, "name": "Ernie"}
+[1]	{"id": 1, "name": "Petee H"}  # Duplicate
+[2]	{"id": 2, "name": "Carl"}     # Duplicate
+[3]	{"id": 3, "name": "Ernie"}    # Duplicate
+[1]	{"id": 1, "likes_treats": true, "name": "Petee H"}
+[2]	{"id": 2, "likes_treats": true, "name": "Carl"}
+[3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
+~~~
 
 ## Configure a changefeed
 
@@ -136,7 +169,7 @@ Changefeed progress is exposed as a high-water timestamp that advances as the ch
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SELECT * FROM crdb_internal.jobs WHERE job_id=<job_id>;
+    > SELECT * FROM crdb_internal.jobs WHERE job_id = <job_id>;
     ~~~
     ~~~
             job_id       |  job_type  |                              description                               | ... |      high_water_timestamp      | error | coordinator_id
@@ -271,9 +304,10 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
     --from-beginning \
     --topic=office_dogs
     ~~~
-    ~~~
-    {"id": 1, "name": "Petee H"}
-    {"id": 2, "name": "Carl"}
+
+    ~~~ shell
+    [1]	{"id": 1, "name": "Petee H"}
+    [2]	{"id": 2, "name": "Carl"}
     ~~~
 
     Note that the initial scan displays the state of the table as of when the changefeed started (therefore, the initial value of `"Petee"` is omitted).
@@ -287,8 +321,8 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
 14. Back in the terminal where you're watching the Kafka topic, the following output has appeared:
 
-    ~~~
-    {"id": 3, "name": "Ernie"}
+    ~~~ shell
+    [3]	{"id": 3, "name": "Ernie"}
     ~~~
 
 15. When you are done, exit the SQL shell (`\q`).
@@ -297,7 +331,164 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach quit
+    $ cockroach quit --insecure
+    ~~~
+
+17. To stop Kafka, move into the extracted `confluent-<version>` directory and stop Confluent:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ ./bin/confluent stop
+    ~~~
+
+### Create a changefeed with Avro
+
+In this example, you'll set up a changefeed for a single-node cluster that is connected to a Kafka sink and emits [Avro](https://avro.apache.org/docs/1.8.2/spec.html) records.
+
+1. If you don't already have one, [request a trial enterprise license](enterprise-licensing.html).
+
+2. In a terminal window, start `cockroach`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach start --insecure --listen-addr=localhost --background
+    ~~~
+
+3. Download and extract the [Confluent Open Source platform](https://www.confluent.io/download/) (which includes Kafka).
+
+4. Move into the extracted `confluent-<version>` directory and start Confluent:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ ./bin/confluent start
+    ~~~
+
+    Only `zookeeper`, `kafka`, and `schema-registry` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives).
+
+5. Create a Kafka topic:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ ./bin/kafka-topics \
+    --create \
+    --zookeeper localhost:8081 \
+    --replication-factor 1 \
+    --partitions 1 \
+    --topic office_dogs
+    ~~~
+
+    {{site.data.alerts.callout_info}}
+    You are expected to create any Kafka topics with the necessary number of replications and partitions. [Topics can be created manually](https://kafka.apache.org/documentation/#basic_ops_add_topic) or [Kafka brokers can be configured to automatically create topics](https://kafka.apache.org/documentation/#topicconfigs) with a default partition count and replication factor.
+    {{site.data.alerts.end}}
+
+6. As the `root` user, open the [built-in SQL client](use-the-built-in-sql-client.html):
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach sql --insecure
+    ~~~
+
+7. Set your organization name and [enterprise license](enterprise-licensing.html) key that you received via email:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    > SET CLUSTER SETTING cluster.organization = '<organization name>';
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    > SET CLUSTER SETTING enterprise.license = '<secret>';
+    ~~~
+
+8. Create a database called `cdc_demo`:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > CREATE DATABASE cdc_demo;
+    ~~~
+
+9. Set the database as the default:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SET DATABASE = cdc_demo;
+    ~~~
+
+10. Create a table and add data:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > CREATE TABLE office_dogs (
+         id INT PRIMARY KEY,
+         name STRING);
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO office_dogs VALUES
+       (1, 'Petee'),
+       (2, 'Carl');
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > UPDATE office_dogs SET name = 'Petee H' WHERE id = 1;
+    ~~~
+
+11. Start the changefeed:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > CREATE CHANGEFEED FOR TABLE office_dogs INTO 'kafka://localhost:9092' WITH format = experimental_avro, confluent_schema_registry = 'http://localhost:8081';
+    ~~~
+
+    ~~~
+            job_id       
+    +--------------------+
+      360645287206223873
+    (1 row)
+    ~~~
+
+    This will start up the changefeed in the background and return the `job_id`. The changefeed writes to Kafka.
+
+12. In a new terminal, move into the extracted `confluent-<version>` directory and start watching the Kafka topic:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ ./bin/kafka-avro-console-consumer \
+    --bootstrap-server=localhost:9092 \
+    --property print.key=true \
+    --from-beginning \
+    --topic=office_dogs
+    ~~~
+
+    ~~~ shell
+    {"id":1}    {"id":1,"name":{"string":"Petee H"}}
+    {"id":2}    {"id":2,"name":{"string":"Carl"}}
+    ~~~
+
+    Note that the initial scan displays the state of the table as of when the changefeed started (therefore, the initial value of `"Petee"` is omitted).
+
+13. Back in the SQL client, insert more data:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO office_dogs VALUES (3, 'Ernie');
+    ~~~
+
+14. Back in the terminal where you're watching the Kafka topic, the following output has appeared:
+
+    ~~~ shell
+    {"id":3}    {"id":3,"name":{"string":"Ernie"}}
+    ~~~
+
+15. When you are done, exit the SQL shell (`\q`).
+
+16. To stop `cockroach`, run:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach quit --insecure
     ~~~
 
 17. To stop Kafka, move into the extracted `confluent-<version>` directory and stop Confluent:
@@ -309,7 +500,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
 ## Known limitations
 
-{% include v2.1/cdc/known-limitations.md %}
+{% include v2.1/known-limitations/cdc.md %}
 
 ## See also
 

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -12,7 +12,7 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 Change data capture (CDC) provides efficient, distributed, row-level change feeds into Apache Kafka for downstream processing such as reporting, caching, or full-text indexing.
 
-{% include v2.1/cdc/known-limitations.md %}
+{% include v2.1/known-limitations/cdc.md %}
 
 ### Admin UI may become inaccessible for secure clusters
 


### PR DESCRIPTION
Updates in this PR:
- Renamed/ moved the CDC known limitations include to a new directory
- Added Avro as supported
- Added duration to the `RESOLVED` option
- Removed `RENAME TABLE` known limitation

Closes #3725.