### PR TITLE
Fix Netlify managed redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,6 @@
 ---
 layout: null
+build_for: [standard, managed]
 ---
 
 {% for version in site.versions %}


### PR DESCRIPTION
The _redirects file needs to be built for both the standard and managed
docs. I think.