### PR TITLE
Managed fixes

### DIFF
--- a/v2.1/managed-connect-to-your-cluster.md
+++ b/v2.1/managed-connect-to-your-cluster.md
@@ -65,7 +65,7 @@ On the machine where you want to run the CockroachDB SQL client:
     ~~~
     </section>
 
-3. Use the `cockroach sql` command to open an interactive SQL shell, replacing placeholders in the connection string with the [connection details](managed-sign-up-for-a-cluster.html#connection-details) you received from Cockroach Labs:
+3. Use the `cockroach sql` command to open an interactive SQL shell, replacing placeholders in the connection string with the [connection details](managed-sign-up-for-a-cluster.html#connection-details) you received from Cockroach Labs and the appropriate user and password:
 
     {{site.data.alerts.callout_info}}
     For the hostname portion of your connection URL, use the "global hostname" you received in the initial confirmation email. This address will direct you to one of the regional load balancers for you cluster.
@@ -116,7 +116,7 @@ On the machine where you want to run your application:
 
 2. Run code to execute basic SQL statements, creating a table, inserting some rows, and reading and printing the rows.
 
-    1. Create a `basic-sample.py` file and copy the code into it, replacing placeholders in the connection parameters with the [connection details](managed-sign-up-for-a-cluster.html#connection-details) you received from Cockroach Labs:
+    1. Create a `basic-sample.py` file and copy the code into it, replacing placeholders in the connection parameters with the [connection details](managed-sign-up-for-a-cluster.html#connection-details) you received from Cockroach Labs and the appropriate user and password:
 
         {{site.data.alerts.callout_info}}
         For `host`, be sure to use the load balancer hostname for the region closest to your client. Load balancer hostnames are identified in the initial confirmation details you received from Cockroach Labs.
@@ -179,7 +179,7 @@ On the machine where you want to run your application:
 
 3. Now run code to connect to your cluster, this time executing a batch of statements as an [atomic transaction](transactions.html) to transfer funds from one account to another, where all included statements are either committed or aborted.
 
-    1. Create a `txn-sample.py` file and copy the code into it, replacing placeholders in the connection parameters with the [connection details](managed-sign-up-for-a-cluster.html#connection-details) you received from Cockroach Labs:
+    1. Create a `txn-sample.py` file and copy the code into it, replacing placeholders in the connection parameters with the [connection details](managed-sign-up-for-a-cluster.html#connection-details) you received from Cockroach Labs and the appropriate user and password:
 
         {{site.data.alerts.callout_info}}
         For `host`, be sure to use the load balancer hostname for the region closest to your client. Load balancer hostnames are identified in the initial confirmation details you received from Cockroach Labs.

--- a/v2.1/managed-sign-up-for-a-cluster.md
+++ b/v2.1/managed-sign-up-for-a-cluster.md
@@ -46,9 +46,9 @@ Detail | Description
 -------|------------
 Hosts | The hostnames to use in your connection strings.<br><br>Typically, you'll receive one global hostname and a load balancer hostname per region. The global hostname will route connections to one of the regional load balancers and so is suitable for ad-hoc querying via the CockroachDB SQL client. Applications, on the other hand, should always use the load balancer hostname that is closest to the client.
 Ports | The ports to use for SQL connections and for reaching the [Admin UI](managed-use-the-admin-ui.html), usually `26257` and `8080` respectively.
-User | Your initial user. This user has "admin" privilges and can [create databases](learn-cockroachdb-sql.html#create-a-database), [import data](migration-overview.html), and [create and grant privileges to other users](managed-user-management.html).   
-Password | The password for your initial user.
-Database name | The initial database created for you. Your initial "admin" user can [create additional databases](learn-cockroachdb-sql.html#create-a-database).
+User | Your initial user. This user has "admin" privileges and can [create databases](learn-cockroachdb-sql.html#create-a-database), [import data](migration-overview.html), and [create and grant privileges to other users](managed-user-management.html).   
+Password | The password for your "admin" user. Be sure to [connect to the CockroachSQL shell](managed-connect-to-your-cluster.html#use-the-cockroachdb-sql-client) and [change this password](managed-user-management.html#managing-users) right away.
+Database name | The initial database created for you. Your "admin" user can [create additional databases](learn-cockroachdb-sql.html#create-a-database).
 CA Certificate | The `ca.crt` file that must be available on every machine from which you want to connect the cluster and referenced in connection strings.
 
 **SQL connection URL with placeholders**

--- a/v2.1/managed-sign-up-for-a-cluster.md
+++ b/v2.1/managed-sign-up-for-a-cluster.md
@@ -54,13 +54,13 @@ CA Certificate | The `ca.crt` file that must be available on every machine from 
 **SQL connection URL with placeholders**
 
 ~~~
-postgres://<username>:<password>@<host>:26257/<database>?sslmode=verify-full&sslrootcert=certs-dir/ca.crt'
+postgres://<username>:<password>@<host>:26257/<database>?sslmode=verify-full&sslrootcert=certs/ca.crt'
 ~~~
 
 **SQL connection URL with example details**
 
 ~~~
-postgres://maxroach:LeiCisGclLcmaWOls@gcp-us-east1.company-domain.cockroachcloud.com:26257/firstdb?sslmode=verify-full&sslrootcert=certs-dir/ca.crt'
+postgres://maxroach:LeiCisGclLcmaWOls@gcp-us-east1.company-domain.cockroachcloud.com:26257/firstdb?sslmode=verify-full&sslrootcert=certs/ca.crt'
 ~~~
 
 ### Admin UI URL

--- a/v2.1/managed-user-management.md
+++ b/v2.1/managed-user-management.md
@@ -9,7 +9,7 @@ The "admin" user identified in your initial [confirmation email](managed-sign-up
 
 ## Before you begin
 
-Make sure you have already [connected the CockroachDB SQL client](managed-connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to your cluster, using the "admin" user and password in your initial [confirmation email](managed-sign-up-for-a-cluster.html#confirmation-email).
+Make sure you have already [connected the CockroachDB SQL client](managed-connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to your cluster with your "admin" user.
 
 ## Creating users
 
@@ -45,6 +45,13 @@ To assign a user more limited privileges for one table in a database:
 For more details, see [Privileges](privileges.html) and [`GRANT`](grant.html).
 
 ## Managing users
+
+- To change a users password, use the [`ALTER USER`](alter-user.html) statement:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > ALTER USER <user> WITH PASSWORD '<new password>';
+    ~~~
 
 - To list all the users in your cluster, use the [`SHOW USERS`](show-users.html) statement:
 


### PR DESCRIPTION
- Fix path to `ca.crt` in example connection strings.
- Emphasize that admin password must be changed right away.
- Tweak other user/password-related content.