### PR TITLE
Correct managed home page title

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,12 +9,13 @@
 <meta name="robots" content="noarchive">
 <meta name="robots" content="nocache">
 {% endif %}
-<title>{{ page.title }} | {{ site.site_title }}</title>
 <!-- TODO: All managed pages are excluded from search indexes for now. Eventually,
 for managed-only pages, we'll need to NOT do this replacement. -->
 {% if site.managed %}
+{% if page.homepage == true %}<title>{{ page.managed_title }} | {{ site.site_title }}</title>{% else %}<title>{{ page.title }} | {{ site.site_title }}</title>{% endif %}
 <link rel="canonical" href="{{ page.canonical | absolute_url | replace: "/managed", "" }}">
 {% else %}
+<title>{{ page.title }} | {{ site.site_title }}</title>
 <link rel="canonical" href="{{ page.canonical | absolute_url }}">
 {% endif %}
 <link rel="shortcut icon" href="{{ 'images/favicon.png' | relative_url }}" type="image/png">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="post-header">
-  <h1 class="post-title-main">{% if page.homepage == true %} {{site.homepage_title}} {% else %}{{ page.title }}{% endif %}</h1>
+  <h1 class="post-title-main">{% if page.managed_title %}{{page.managed_title}}{% else %}{{ page.title }}{% endif %}</h1>
   {% unless page.contribute == false %}
       {% include contribute-options.html %}
   {% endunless %}

--- a/v2.1/index.md
+++ b/v2.1/index.md
@@ -1,7 +1,7 @@
 ---
 title: CockroachDB Docs
+managed_title: Managed CockroachDB Docs
 summary: CockroachDB user documentation.
-type: first_page
 homepage: true
 toc: true
 twitter: false


### PR DESCRIPTION
This fix causes the page title to be unique in browser tabs
and also helps us differentiate between standard docs home
and managed docs home in analytics data.