### PR TITLE
Initial content updates

### DIFF
--- a/_includes/v2.1/misc/admin-ui-cert.md
+++ b/_includes/v2.1/misc/admin-ui-cert.md
@@ -1,0 +1,7 @@
+On [accessing the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui), your browser will consider the CockroachDB-created certificate invalid, so you’ll need to click through a warning message to get to the UI.
+
+For secure clusters, you can avoid getting the warning message by using a certificate issued by a public CA:
+
+1. Request a certificate from a public CA (for example, [Let's Encrypt](https://letsencrypt.org/)). The certificate must have the IP addresses and DNS names used to reach the Admin UI listed in the `Subject Alternative Names` field.
+2. Rename the certificate and key as `ui.crt` and `ui.key`.
+3. Add the `ui.crt` and `ui.key` to the [certificate directory](create-security-certificates.html#certificate-directory). `ui.key` must not have group or world permissions (maximum permissions are 0700, or rwx------). This check can be disabled by setting the environment variable `COCKROACH_SKIP_KEY_PERMISSION_CHECK=true`.

--- a/v2.1/admin-ui-access-and-navigate.md
+++ b/v2.1/admin-ui-access-and-navigate.md
@@ -18,7 +18,11 @@ If `--http-addr` is not specified when starting a node, the Admin UI is reachabl
 
 For additional guidance on accessing the Admin UI in the context of cluster deployment, see [Start a Local Cluster](start-a-local-cluster.html) and [Manual Deployment](manual-deployment.html).
 
+
+
 ### Accessing the Admin UI for a secure cluster
+
+{% include {{ page.version.version }}/misc/admin-ui-cert.md %}
 
 For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
 

--- a/v2.1/create-security-certificates.md
+++ b/v2.1/create-security-certificates.md
@@ -9,7 +9,7 @@ toc: true
   <a href="create-security-certificates-openssl.html"><button style="width:28%" class="filter-button">Use openssl</button></a>
 </div>
 
-A secure CockroachDB cluster uses [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) for encrypted inter-node and client-node communication, which requires CA, node, and client certificates and keys. To create these certificates and keys, use the `cockroach cert` [commands](cockroach-commands.html) with the appropriate subcommands and flags, or use [`openssl` commands](https://wiki.openssl.org/index.php/).
+A secure CockroachDB cluster uses [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) for encrypted inter-node and client-node communication, which requires Certificate Authority (CA), node, and client certificates and keys. To create these certificates and keys, use the `cockroach cert` [commands](cockroach-commands.html) with the appropriate subcommands and flags, or use [`openssl` commands](https://wiki.openssl.org/index.php/).
 
 {{site.data.alerts.callout_success}}For details about when and how to change security certificates without restarting nodes, see <a href="rotate-certificates.html">Rotate Security Certificates</a>.{{site.data.alerts.end}}
 
@@ -21,6 +21,10 @@ A secure CockroachDB cluster uses [TLS](https://en.wikipedia.org/wiki/Transport_
 2. You then upload the appropriate node certificate and key and the CA certificate to each node, and you upload the appropriate client certificate and key and the CA certificate to each client.
 
 3. When nodes establish contact to each other, and when clients establish contact to nodes, they use the CA certificate to verify each other's identity.
+
+## Accessing the Admin UI for a secure cluster
+
+{% include {{ page.version.version }}/misc/admin-ui-cert.md %}
 
 ## Subcommands
 
@@ -44,6 +48,8 @@ File name pattern | File usage
 `node.key`   | Key for server certificate
 `client.<user>.crt` | Client certificate for `<user>` (e.g., `client.root.crt` for user `root`)
 `client.<user>.key` | Key for the client certificate
+
+If you have a certificate issued by a public CA to securely access the Admin UI, you need to place the certificate in the directory specified by the `--certs-dir` flag.
 
 Note the following:
 


### PR DESCRIPTION
Partially addresses #3415 

Summary of changes:
- New include for UI cert content
- Updated the `Create Security Certificates` doc and `Use the Admin UI` doc with the new include.


To-Do:
- Add `include` to deployment and start-a-secure-cluster guides
- Test the procedure: Figure out how to configure the DNS names on one of the cloud platforms, use the DNS name to generate a certificate from Let's Encrypt, and then run through our documented steps.