### PR TITLE
openssl instructions: re-instate warning about key usages.

### DIFF
--- a/v2.1/create-security-certificates-openssl.md
+++ b/v2.1/create-security-certificates-openssl.md
@@ -116,6 +116,8 @@ Note the following:
     extendedKeyUsage = clientAuth
     ~~~
 
+    {{site.data.alerts.callout_danger}}The <code>keyUsage</code> and <code>extendedkeyUsage</code> parameters are vital for CockroachDB functions. You can modify or omit other parameters as per your preferred OpenSSL configuration and you can add additional usages, but do not omit <code>keyUsage</code> and <code>extendedkeyUsage</code> parameters or remove the listed usages. {{site.data.alerts.end}}
+
 3. Create the CA key using the [`openssl genrsa`](https://www.openssl.org/docs/manmaster/man1/genrsa.html) command:
 
     {% include copy-clipboard.html %}


### PR DESCRIPTION
Reinstate the warning about not changing the certificate key usage for
2.1 and make it "danger" category. Also emphasize that you can't remove
any of the key usages either.

Ironically, Go started enforcing key usages to be what we have in the
docs.
Starting with 2.1, nodes and clients will not be able to communicate if
those settings are changed.