### PR TITLE
Updated Azure Backup URL

### DIFF
--- a/_includes/v2.1/misc/external-urls.md
+++ b/_includes/v2.1/misc/external-urls.md
@@ -5,7 +5,7 @@
 | Location                                                    | Scheme      | Host                                             | Parameters                                                                 |
 |-------------------------------------------------------------+-------------+--------------------------------------------------+----------------------------------------------------------------------------|
 | Amazon S3                                                   | `s3`        | Bucket name                                      | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`                               |
-| Azure                                                       | `azure`     | Container name                                   | `AZURE_ACCOUNT_KEY`, `AZURE_ACCOUNT_NAME`                                  |
+| Azure                                                       | `azure`     | N/A (see [Example file URLs](#example-file-urls) | `AZURE_ACCOUNT_KEY`, `AZURE_ACCOUNT_NAME`                                  |
 | Google Cloud&nbsp;[<sup>1</sup>](#considerations)           | `gs`        | Bucket name                                      | `AUTH` (optional): can be `default` or `implicit`                          |
 | HTTP&nbsp;[<sup>2</sup>](#considerations)                   | `http`      | Remote host                                      | N/A                                                                        |
 | NFS/Local&nbsp;[<sup>3</sup>](#considerations)              | `nodelocal` | N/A (see [Example file URLs](#example-file-urls) | N/A                                                                        |
@@ -32,7 +32,7 @@ The location parameters often contain special characters that need to be URI-enc
 | Location     | Example                                                                          |
 |--------------+----------------------------------------------------------------------------------|
 | Amazon S3    | `s3://acme-co/employees.sql?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`     |
-| Azure        | `azure://acme-co/employees.sql?AZURE_ACCOUNT_KEY=123&AZURE_ACCOUNT_NAME=acme-co` |
+| Azure        | `azure://employees.sql?AZURE_ACCOUNT_KEY=123&AZURE_ACCOUNT_NAME=acme-co`         |
 | Google Cloud | `gs://acme-co/employees.sql`                                                     |
 | HTTP         | `http://localhost:8080/employees.sql`                                            |
 | NFS/Local    | `nodelocal:///employees.sql`                                                     |


### PR DESCRIPTION
Currently the doc specifies that the Host should be the container name - this isn't correct. This URL:
`'azure://foo.blob.core.windows.net/employees.sql?AZURE_ACCOUNT_KEY=12345&AZURE_ACCOUNT_NAME=foo';` will throw an error from Azure since we attempt to conect to `foo.blob.core.windows.net/foo.blob.core.windows.net`. There should not be a host at all in the `azure://` string.