### PR TITLE
Add more links between various schema change docs

### DIFF
--- a/_includes/v2.1/misc/schema-change-stmt-note.md
+++ b/_includes/v2.1/misc/schema-change-stmt-note.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+This statement performs a schema change. For more information about how online schema changes work in CockroachDB, see [Online Schema Changes](online-schema-changes.html).
+{{site.data.alerts.end}}

--- a/_includes/v2.2/misc/schema-change-stmt-note.md
+++ b/_includes/v2.2/misc/schema-change-stmt-note.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+This statement performs a schema change. For more information about how online schema changes work in CockroachDB, see [Online Schema Changes](online-schema-changes.html).
+{{site.data.alerts.end}}

--- a/v2.1/alter-database.md
+++ b/v2.1/alter-database.md
@@ -6,9 +6,7 @@ toc: false
 
 The `ALTER DATABASE` [statement](sql-statements.html) applies a schema change to a database.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 For information on using `ALTER DATABASE`, see the documents for its relevant subcommands.
 

--- a/v2.1/alter-index.md
+++ b/v2.1/alter-index.md
@@ -6,9 +6,7 @@ toc: false
 
 The `ALTER INDEX` [statement](sql-statements.html) applies a schema change to an index.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 For information on using `ALTER INDEX`, see the documents for its relevant subcommands.
 

--- a/v2.1/alter-range.md
+++ b/v2.1/alter-range.md
@@ -6,9 +6,7 @@ toc: false
 
 <span class="version-tag">New in v2.1:</span> The `ALTER RANGE` [statement](sql-statements.html) applies a schema change to a system range.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 For information on using `ALTER RANGE`, see the documents for its relevant subcommands.
 

--- a/v2.1/alter-sequence.md
+++ b/v2.1/alter-sequence.md
@@ -6,10 +6,7 @@ toc: true
 
 The `ALTER SEQUENCE` [statement](sql-statements.html) [changes the name](rename-sequence.html), increment values, and other settings of a sequence.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
-
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -117,3 +114,4 @@ Let's add another record to the table to check that the new record adheres to th
 - [`DROP SEQUENCE`](drop-sequence.html)
 - [Functions and Operators](functions-and-operators.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/alter-table.md
+++ b/v2.1/alter-table.md
@@ -6,9 +6,7 @@ toc: true
 
 The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes](online-schema-changes.html).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Subcommands
 

--- a/v2.1/alter-view.md
+++ b/v2.1/alter-view.md
@@ -6,10 +6,11 @@ toc: true
 
 The `ALTER VIEW` [statement](sql-statements.html) changes the name of a [view](views.html).
 
-{{site.data.alerts.callout_info}}
-It is not currently possible to change the `SELECT` statement executed by a view. Instead, you must drop the existing view and create a new view. Also, it is not currently possible to rename a view that other views depend on, but this ability may be added in the future (see [this issue](https://github.com/cockroachdb/cockroach/issues/10083)).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
+{{site.data.alerts.callout_info}}
+It is not currently possible to change the `SELECT` statement executed by a view.  Instead, you must drop the existing view and create a new view.  Also, it is not currently possible to rename a view that other views depend on, but this ability may be added in the future (see [this issue](https://github.com/cockroachdb/cockroach/issues/10083)).
+{{site.data.alerts.end}}
 
 ## Required privileges
 
@@ -77,3 +78,4 @@ Parameter | Description
 - [`CREATE VIEW`](create-view.html)
 - [`SHOW CREATE`](show-create.html)
 - [`DROP VIEW`](drop-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/create-database.md
+++ b/v2.1/create-database.md
@@ -6,6 +6,7 @@ toc: true
 
 The `CREATE DATABASE` [statement](sql-statements.html) creates a new CockroachDB database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -93,3 +94,4 @@ SQL does not generate an error, but instead responds `CREATE DATABASE` even thou
 - [`SET DATABASE`](set-vars.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/create-index.md
+++ b/v2.1/create-index.md
@@ -14,6 +14,7 @@ Indexes are automatically created for a table's [`PRIMARY KEY`](primary-key.html
 When querying a table, CockroachDB uses the fastest index. For more information about that process, see [Index Selection in CockroachDB](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/).
 {{site.data.alerts.end}}
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -161,3 +162,4 @@ Normally, CockroachDB selects the index that it calculates will scan the fewest 
 - [`DROP INDEX`](drop-index.html)
 - [`RENAME INDEX`](rename-index.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/create-sequence.md
+++ b/v2.1/create-sequence.md
@@ -6,6 +6,8 @@ toc: true
 
 The `CREATE SEQUENCE` [statement](sql-statements.html) creates a new sequence in a database. Use a sequence to auto-increment integers in a table.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
+
 ## Considerations
 
 - Using a sequence is slower than [auto-generating unique IDs with the `gen_random_uuid()`, `uuid_v4()` or `unique_rowid()` built-in functions](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb). Incrementing a sequence requires a write to persistent storage, whereas auto-generating a unique ID does not. Therefore, use auto-generated unique IDs unless an incremental sequence is preferred or required.
@@ -196,3 +198,4 @@ If a value has been obtained from the sequence in the current session, you can a
 - [`SHOW CREATE`](show-create.html)
 - [Functions and Operators](functions-and-operators.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/create-table.md
+++ b/v2.1/create-table.md
@@ -6,6 +6,7 @@ toc: true
 
 The `CREATE TABLE` [statement](sql-statements.html) creates a new table in a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -465,3 +466,4 @@ To show the definition of a table, use the [`SHOW CREATE`](show-create.html) sta
 - [Column Families](column-families.html)
 - [Table-Level Replication Zones](configure-replication-zones.html#create-a-replication-zone-for-a-table)
 - [Define Table Partitions](partitioning.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/create-view.md
+++ b/v2.1/create-view.md
@@ -6,6 +6,7 @@ toc: true
 
 The `CREATE VIEW` statement creates a new [view](views.html), which is a stored query represented as a virtual table.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -108,3 +109,4 @@ Executing the query is as easy as `SELECT`ing from the view, as you would from a
 - [`SHOW CREATE`](show-create.html)
 - [`ALTER VIEW`](alter-view.html)
 - [`DROP VIEW`](drop-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/drop-database.md
+++ b/v2.1/drop-database.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP DATABASE` [statement](sql-statements.html) removes a database and all its objects from a CockroachDB cluster.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -96,3 +97,4 @@ pq: database "db2" is not empty and CASCADE was not specified
 - [`RENAME DATABASE`](rename-database.html)
 - [`SET DATABASE`](set-vars.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/drop-index.md
+++ b/v2.1/drop-index.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP INDEX` [statement](sql-statements.html) removes indexes from tables.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Synopsis
 
@@ -126,3 +127,8 @@ pq: index "orders_auto_index_fk_customer_ref_customers" is in use as a foreign k
 +------------+-----------------+-----------------+----------------------+-----------+
 (1 row)
 ~~~
+
+## See Also
+
+- [Indexes](indexes.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/drop-sequence.md
+++ b/v2.1/drop-sequence.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP SEQUENCE` [statement](sql-statements.html) removes a sequence from a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -97,3 +98,4 @@ DROP SEQUENCE
 - [`RENAME SEQUENCE`](rename-sequence.html)
 - [Functions and Operators](functions-and-operators.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/drop-table.md
+++ b/v2.1/drop-table.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP TABLE` [statement](sql-statements.html) removes a table and all its indexes from a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -134,3 +135,4 @@ DROP TABLE
 - [`DELETE`](delete.html)
 - [`DROP INDEX`](drop-index.html)
 - [`DROP VIEW`](drop-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/drop-view.md
+++ b/v2.1/drop-view.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP VIEW` [statement](sql-statements.html) removes a [view](views.html) from a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -127,3 +128,4 @@ DROP VIEW
 - [`CREATE VIEW`](create-view.html)
 - [`SHOW CREATE`](show-create.html)
 - [`ALTER VIEW`](alter-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.1/online-schema-changes.md
+++ b/v2.1/online-schema-changes.md
@@ -197,10 +197,25 @@ ROLLBACK
 ## See also
 
 + [How online schema changes are possible in CockroachDB][blog]: Blog post with more technical details about how our schema change engine works.
++ [`ALTER DATABASE`](alter-database.html)
++ [`ALTER INDEX`](alter-index.html)
++ [`ALTER RANGE`](alter-range.html)
++ [`ALTER SEQUENCE`](alter-sequence.html)
 + [`ALTER TABLE`][alter-table]
++ [`ALTER VIEW`](alter-view.html)
++ [`CREATE DATABASE`](create-database.html)
 + [`CREATE INDEX`][create-index]
++ [`CREATE SEQUENCE`](create-sequence.html)
++ [`CREATE TABLE`](create-table.html)
++ [`CREATE VIEW`](create-view.html)
++ [`DROP DATABASE`](drop-database.html)
 + [`DROP INDEX`][drop-index]
++ [`DROP SEQUENCE`](drop-sequence.html)
++ [`DROP TABLE`](drop-table.html)
++ [`DROP VIEW`](drop-view.html)
 + [`TRUNCATE`][truncate]
+
+
 
 <!-- Reference Links -->
 

--- a/v2.1/truncate.md
+++ b/v2.1/truncate.md
@@ -10,6 +10,8 @@ The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. A
 For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
 {{site.data.alerts.end}}
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
+
 ## Synopsis
 
 <div>
@@ -154,3 +156,4 @@ pq: "customers" is referenced by foreign key from table "orders"
 
 - [`DELETE`](delete.html)
 - [Foreign Key constraint](foreign-key.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/alter-database.md
+++ b/v2.2/alter-database.md
@@ -6,9 +6,7 @@ toc: false
 
 The `ALTER DATABASE` [statement](sql-statements.html) applies a schema change to a database.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 For information on using `ALTER DATABASE`, see the documents for its relevant subcommands.
 

--- a/v2.2/alter-index.md
+++ b/v2.2/alter-index.md
@@ -6,9 +6,7 @@ toc: false
 
 The `ALTER INDEX` [statement](sql-statements.html) applies a schema change to an index.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 For information on using `ALTER INDEX`, see the documents for its relevant subcommands.
 

--- a/v2.2/alter-range.md
+++ b/v2.2/alter-range.md
@@ -6,9 +6,7 @@ toc: false
 
 The `ALTER RANGE` [statement](sql-statements.html) applies a schema change to a system range.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 For information on using `ALTER RANGE`, see the documents for its relevant subcommands.
 

--- a/v2.2/alter-sequence.md
+++ b/v2.2/alter-sequence.md
@@ -6,10 +6,7 @@ toc: true
 
 The `ALTER SEQUENCE` [statement](sql-statements.html) [changes the name](rename-sequence.html), increment values, and other settings of a sequence.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes in CockroachDB](https://www.cockroachlabs.com/blog/how-online-schema-changes-are-possible-in-cockroachdb/).
-{{site.data.alerts.end}}
-
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -117,3 +114,4 @@ Let's add another record to the table to check that the new record adheres to th
 - [`DROP SEQUENCE`](drop-sequence.html)
 - [Functions and Operators](functions-and-operators.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/alter-table.md
+++ b/v2.2/alter-table.md
@@ -6,9 +6,7 @@ toc: true
 
 The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table.
 
-{{site.data.alerts.callout_info}}
-To understand how CockroachDB changes schema elements without requiring table locking or other user-visible downtime, see [Online Schema Changes](online-schema-changes.html).
-{{site.data.alerts.end}}
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Subcommands
 

--- a/v2.2/alter-view.md
+++ b/v2.2/alter-view.md
@@ -6,10 +6,11 @@ toc: true
 
 The `ALTER VIEW` [statement](sql-statements.html) changes the name of a [view](views.html).
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
+
 {{site.data.alerts.callout_info}}
 It is not currently possible to change the `SELECT` statement executed by a view. Instead, you must drop the existing view and create a new view. Also, it is not currently possible to rename a view that other views depend on, but this ability may be added in the future (see [this issue](https://github.com/cockroachdb/cockroach/issues/10083)).
 {{site.data.alerts.end}}
-
 
 ## Required privileges
 
@@ -77,3 +78,4 @@ Parameter | Description
 - [`CREATE VIEW`](create-view.html)
 - [`SHOW CREATE`](show-create.html)
 - [`DROP VIEW`](drop-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/create-database.md
+++ b/v2.2/create-database.md
@@ -6,6 +6,7 @@ toc: true
 
 The `CREATE DATABASE` [statement](sql-statements.html) creates a new CockroachDB database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -93,3 +94,4 @@ SQL does not generate an error, but instead responds `CREATE DATABASE` even thou
 - [`SET DATABASE`](set-vars.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/create-index.md
+++ b/v2.2/create-index.md
@@ -14,6 +14,7 @@ Indexes are automatically created for a table's [`PRIMARY KEY`](primary-key.html
 When querying a table, CockroachDB uses the fastest index. For more information about that process, see [Index Selection in CockroachDB](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/).
 {{site.data.alerts.end}}
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -161,3 +162,4 @@ Normally, CockroachDB selects the index that it calculates will scan the fewest 
 - [`DROP INDEX`](drop-index.html)
 - [`RENAME INDEX`](rename-index.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/create-sequence.md
+++ b/v2.2/create-sequence.md
@@ -6,6 +6,8 @@ toc: true
 
 The `CREATE SEQUENCE` [statement](sql-statements.html) creates a new sequence in a database. Use a sequence to auto-increment integers in a table.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
+
 ## Considerations
 
 - Using a sequence is slower than [auto-generating unique IDs with the `gen_random_uuid()`, `uuid_v4()` or `unique_rowid()` built-in functions](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb). Incrementing a sequence requires a write to persistent storage, whereas auto-generating a unique ID does not. Therefore, use auto-generated unique IDs unless an incremental sequence is preferred or required.
@@ -196,3 +198,4 @@ If a value has been obtained from the sequence in the current session, you can a
 - [`SHOW CREATE`](show-create.html)
 - [Functions and Operators](functions-and-operators.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/create-table.md
+++ b/v2.2/create-table.md
@@ -6,6 +6,7 @@ toc: true
 
 The `CREATE TABLE` [statement](sql-statements.html) creates a new table in a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -465,3 +466,4 @@ To show the definition of a table, use the [`SHOW CREATE`](show-create.html) sta
 - [Column Families](column-families.html)
 - [Table-Level Replication Zones](configure-replication-zones.html#create-a-replication-zone-for-a-table)
 - [Define Table Partitions](partitioning.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/create-view.md
+++ b/v2.2/create-view.md
@@ -6,6 +6,7 @@ toc: true
 
 The `CREATE VIEW` statement creates a new [view](views.html), which is a stored query represented as a virtual table.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -108,3 +109,4 @@ Executing the query is as easy as `SELECT`ing from the view, as you would from a
 - [`SHOW CREATE`](show-create.html)
 - [`ALTER VIEW`](alter-view.html)
 - [`DROP VIEW`](drop-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/drop-database.md
+++ b/v2.2/drop-database.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP DATABASE` [statement](sql-statements.html) removes a database and all its objects from a CockroachDB cluster.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -96,3 +97,4 @@ pq: database "db2" is not empty and CASCADE was not specified
 - [`RENAME DATABASE`](rename-database.html)
 - [`SET DATABASE`](set-vars.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/drop-index.md
+++ b/v2.2/drop-index.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP INDEX` [statement](sql-statements.html) removes indexes from tables.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Synopsis
 
@@ -126,3 +127,8 @@ pq: index "orders_auto_index_fk_customer_ref_customers" is in use as a foreign k
 +------------+-----------------+-----------------+----------------------+-----------+
 (1 row)
 ~~~
+
+## See Also
+
+- [Indexes](indexes.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/drop-sequence.md
+++ b/v2.2/drop-sequence.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP SEQUENCE` [statement](sql-statements.html) removes a sequence from a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -97,3 +98,4 @@ DROP SEQUENCE
 - [`RENAME SEQUENCE`](rename-sequence.html)
 - [Functions and Operators](functions-and-operators.html)
 - [Other SQL Statements](sql-statements.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/drop-table.md
+++ b/v2.2/drop-table.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP TABLE` [statement](sql-statements.html) removes a table and all its indexes from a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -134,3 +135,4 @@ DROP TABLE
 - [`DELETE`](delete.html)
 - [`DROP INDEX`](drop-index.html)
 - [`DROP VIEW`](drop-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/drop-view.md
+++ b/v2.2/drop-view.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DROP VIEW` [statement](sql-statements.html) removes a [view](views.html) from a database.
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges
 
@@ -127,3 +128,4 @@ DROP VIEW
 - [`CREATE VIEW`](create-view.html)
 - [`SHOW CREATE`](show-create.html)
 - [`ALTER VIEW`](alter-view.html)
+- [Online Schema Changes](online-schema-changes.html)

--- a/v2.2/online-schema-changes.md
+++ b/v2.2/online-schema-changes.md
@@ -197,10 +197,25 @@ ROLLBACK
 ## See also
 
 + [How online schema changes are possible in CockroachDB][blog]: Blog post with more technical details about how our schema change engine works.
++ [`ALTER DATABASE`](alter-database.html)
++ [`ALTER INDEX`](alter-index.html)
++ [`ALTER RANGE`](alter-range.html)
++ [`ALTER SEQUENCE`](alter-sequence.html)
 + [`ALTER TABLE`][alter-table]
++ [`ALTER VIEW`](alter-view.html)
++ [`CREATE DATABASE`](create-database.html)
 + [`CREATE INDEX`][create-index]
++ [`CREATE SEQUENCE`](create-sequence.html)
++ [`CREATE TABLE`](create-table.html)
++ [`CREATE VIEW`](create-view.html)
++ [`DROP DATABASE`](drop-database.html)
 + [`DROP INDEX`][drop-index]
++ [`DROP SEQUENCE`](drop-sequence.html)
++ [`DROP TABLE`](drop-table.html)
++ [`DROP VIEW`](drop-view.html)
 + [`TRUNCATE`][truncate]
+
+
 
 <!-- Reference Links -->
 

--- a/v2.2/truncate.md
+++ b/v2.2/truncate.md
@@ -10,6 +10,8 @@ The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. A
 For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
 {{site.data.alerts.end}}
 
+{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
+
 ## Synopsis
 
 <div>
@@ -154,3 +156,4 @@ pq: "customers" is referenced by foreign key from table "orders"
 
 - [`DELETE`](delete.html)
 - [Foreign Key constraint](foreign-key.html)
+- [Online Schema Changes](online-schema-changes.html)


### PR DESCRIPTION
Fixes #3846.

Summary of changes:

- Update the following statement docs to note that the statement
  performs a schema change, and add a link to the 'Online Schema
  Changes' page:

  - ALTER DATABASE
  - ALTER INDEX
  - ALTER RANGE
  - ALTER SEQUENCE
  - ALTER TABLE
  - ALTER VIEW
  - CREATE DATABASE
  - CREATE INDEX
  - CREATE SEQUENCE
  - CREATE TABLE
  - CREATE VIEW
  - DROP DATABASE
  - DROP INDEX
  - DROP SEQUENCE
  - DROP TABLE
  - DROP VIEW
  - TRUNCATE

- Edit the 'Online Schema Changes' page to link back to the various
  schema-change-effecting statements