### PR TITLE
Clarify when to use DELETE vs. TRUNCATE

### DIFF
--- a/v2.1/delete.md
+++ b/v2.1/delete.md
@@ -10,7 +10,6 @@ The `DELETE` [statement](sql-statements.html) deletes rows from a table.
 
 {{site.data.alerts.callout_info}}To delete columns, see <a href="drop-column.html"><code>DROP COLUMN</code></a>.{{site.data.alerts.end}}
 
-
 ## Required privileges
 
 The user must have the `DELETE` and `SELECT` [privileges](privileges.html) on the table.
@@ -54,12 +53,11 @@ Deleting a row does not immediately free up the disk space. This is
 due to the fact that CockroachDB retains [the ability to query tables
 historically](https://www.cockroachlabs.com/blog/time-travel-queries-select-witty_subtitle-the_future/).
 
-If disk usage is a concern, there are two potential solutions. The
-first is to [reduce the time-to-live](configure-replication-zones.html)
-(TTL) for the zone, which will cause garbage collection to clean up
-deleted rows more frequently. Second, unlike `DELETE`,
-[truncate](truncate.html) immediately deletes the entire table, so
-consider if you can use `TRUNCATE` instead.
+If disk usage is a concern, the solution is to
+[reduce the time-to-live](configure-replication-zones.html) (TTL) for
+the zone by setting `gc.ttlseconds` to a lower value, which will cause
+garbage collection to clean up deleted objects (rows, tables) more
+frequently.
 
 ## Select performance on deleted rows
 
@@ -84,19 +82,9 @@ You can delete all rows from a table by not including a `WHERE` clause in your `
 DELETE 7
 ~~~
 
-This is roughly equivalent to [`TRUNCATE`](truncate.html).
-
-{% include copy-clipboard.html %}
-~~~ sql
-> TRUNCATE account_details;
-~~~
-~~~
-TRUNCATE
-~~~
-
-As you can see, one difference is that `TRUNCATE` does not return the number of rows it deleted.
-
-{{site.data.alerts.callout_info}}The <code>TRUNCATE</code> statement removes all rows from a table by dropping the table and recreating a new table with the same name. This is much more performant than deleting each of the rows. {{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}
+Unless your table is small (less than 1000 rows), using [`TRUNCATE`][truncate] to delete the contents of a table will be more performant than using `DELETE`.
+{{site.data.alerts.end}}
 
 ### Delete specific rows
 
@@ -120,7 +108,7 @@ In this example, `account_id` is our primary key and we want to delete the row w
 +------------+---------+--------------+
 ~~~
 
-#### Delete rows Using non-unique columns
+#### Delete rows using non-unique columns
 
 Deleting rows using non-unique columns removes _every_ row that returns `TRUE` for the `WHERE` clause's `a_expr`. This can easily result in deleting data you didn't intend to.
 
@@ -144,6 +132,7 @@ The example statement deleted two rows, which might be unexpected.
 To see which rows your statement deleted, include the `RETURNING` clause to retrieve them using the columns you specify.
 
 #### Use all columns
+
 By specifying `*`, you retrieve all columns of the delete rows.
 
 {% include copy-clipboard.html %}
@@ -195,9 +184,13 @@ When `RETURNING` specific columns, you can change their labels using `AS`.
 - [`INSERT`](insert.html)
 - [`UPDATE`](update.html)
 - [`UPSERT`](upsert.html)
-- [`TRUNCATE`](truncate.html)
+- [`TRUNCATE`][truncate]
 - [`ALTER TABLE`](alter-table.html)
 - [`DROP TABLE`](drop-table.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
 - [Limiting Query Results](limit-offset.html)
+
+<!-- Reference Links -->
+
+[truncate]: truncate.html

--- a/v2.1/truncate.md
+++ b/v2.1/truncate.md
@@ -4,10 +4,10 @@ summary: The TRUNCATE statement deletes all rows from specified tables.
 toc: true
 ---
 
-The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
+The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. At a high level, it works by dropping the table and recreating a new table with the same name.
 
 {{site.data.alerts.callout_info}}
-`TRUNCATE` removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows).
+For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
 {{site.data.alerts.end}}
 
 ## Synopsis
@@ -152,5 +152,5 @@ pq: "customers" is referenced by foreign key from table "orders"
 
 ## See also
 
-- [`DELETE](delete.html)
+- [`DELETE`](delete.html)
 - [Foreign Key constraint](foreign-key.html)

--- a/v2.2/delete.md
+++ b/v2.2/delete.md
@@ -10,7 +10,6 @@ The `DELETE` [statement](sql-statements.html) deletes rows from a table.
 
 {{site.data.alerts.callout_info}}To delete columns, see <a href="drop-column.html"><code>DROP COLUMN</code></a>.{{site.data.alerts.end}}
 
-
 ## Required privileges
 
 The user must have the `DELETE` and `SELECT` [privileges](privileges.html) on the table.
@@ -54,12 +53,11 @@ Deleting a row does not immediately free up the disk space. This is
 due to the fact that CockroachDB retains [the ability to query tables
 historically](https://www.cockroachlabs.com/blog/time-travel-queries-select-witty_subtitle-the_future/).
 
-If disk usage is a concern, there are two potential solutions. The
-first is to [reduce the time-to-live](configure-replication-zones.html)
-(TTL) for the zone, which will cause garbage collection to clean up
-deleted rows more frequently. Second, unlike `DELETE`,
-[truncate](truncate.html) immediately deletes the entire table, so
-consider if you can use `TRUNCATE` instead.
+If disk usage is a concern, the solution is to
+[reduce the time-to-live](configure-replication-zones.html) (TTL) for
+the zone by setting `gc.ttlseconds` to a lower value, which will cause
+garbage collection to clean up deleted objects (rows, tables) more
+frequently.
 
 ## Select performance on deleted rows
 
@@ -84,19 +82,9 @@ You can delete all rows from a table by not including a `WHERE` clause in your `
 DELETE 7
 ~~~
 
-This is roughly equivalent to [`TRUNCATE`](truncate.html).
-
-{% include copy-clipboard.html %}
-~~~ sql
-> TRUNCATE account_details;
-~~~
-~~~
-TRUNCATE
-~~~
-
-As you can see, one difference is that `TRUNCATE` does not return the number of rows it deleted.
-
-{{site.data.alerts.callout_info}}The <code>TRUNCATE</code> statement removes all rows from a table by dropping the table and recreating a new table with the same name. This is much more performant than deleting each of the rows. {{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}
+Unless your table is small (less than 1000 rows), using [`TRUNCATE`][truncate] to delete the contents of a table will be more performant than using `DELETE`.
+{{site.data.alerts.end}}
 
 ### Delete specific rows
 
@@ -120,7 +108,7 @@ In this example, `account_id` is our primary key and we want to delete the row w
 +------------+---------+--------------+
 ~~~
 
-#### Delete rows Using non-unique columns
+#### Delete rows using non-unique columns
 
 Deleting rows using non-unique columns removes _every_ row that returns `TRUE` for the `WHERE` clause's `a_expr`. This can easily result in deleting data you didn't intend to.
 
@@ -144,6 +132,7 @@ The example statement deleted two rows, which might be unexpected.
 To see which rows your statement deleted, include the `RETURNING` clause to retrieve them using the columns you specify.
 
 #### Use all columns
+
 By specifying `*`, you retrieve all columns of the delete rows.
 
 {% include copy-clipboard.html %}
@@ -195,9 +184,13 @@ When `RETURNING` specific columns, you can change their labels using `AS`.
 - [`INSERT`](insert.html)
 - [`UPDATE`](update.html)
 - [`UPSERT`](upsert.html)
-- [`TRUNCATE`](truncate.html)
+- [`TRUNCATE`][truncate]
 - [`ALTER TABLE`](alter-table.html)
 - [`DROP TABLE`](drop-table.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
 - [Limiting Query Results](limit-offset.html)
+
+<!-- Reference Links -->
+
+[truncate]: truncate.html

--- a/v2.2/truncate.md
+++ b/v2.2/truncate.md
@@ -4,10 +4,10 @@ summary: The TRUNCATE statement deletes all rows from specified tables.
 toc: true
 ---
 
-The `TRUNCATE` [statement](sql-statements.html) deletes all rows from specified tables.
+The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. At a high level, it works by dropping the table and recreating a new table with the same name.
 
 {{site.data.alerts.callout_info}}
-`TRUNCATE` removes all rows from a table by dropping the table and recreating a new table with the same name. For large tables, this is much more performant than deleting each of the rows. However, for smaller tables, it's more performant to use a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows).
+For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
 {{site.data.alerts.end}}
 
 ## Synopsis
@@ -152,5 +152,5 @@ pq: "customers" is referenced by foreign key from table "orders"
 
 ## See also
 
-- [`DELETE](delete.html)
+- [`DELETE`](delete.html)
 - [Foreign Key constraint](foreign-key.html)


### PR DESCRIPTION
Fixes #4088.

Summary of changes:

- Update `DELETE` page to remove unnecessary `TRUNCATE` example, and add
  a note saying to prefer `TRUNCATE` for tables >= 1000 rows.

- Update `TRUNCATE` page to expand the initial description of its
  behavior slightly, and to add a note saying to prefer `DELETE` for
  tables with < 1000 rows.

- Various small copy edits: typo fix; link update; whitespace.