### PR TITLE
Add missing bullet to 2.2.0-alpha.20181119 release notes

### DIFF
--- a/releases/v2.2.0-alpha.20181119.md
+++ b/releases/v2.2.0-alpha.20181119.md
@@ -68,6 +68,7 @@ $ docker pull cockroachdb/cockroach:v2.2.0-alpha.20181118
 - The new `experimental_vectorize` [session setting](../v2.2/set-vars.html), when enabled, causes columnar operators to be planned instead of row-by-row processors, when possible. [#31354][#31354] {% comment %}doc{% endcomment %}
 - CockroachDB now supports the `BIT` and `VARBIT (BIT VARYING)` bit array data types like PostgreSQL. Currently, only the bit array literal notation with a capital B (e.g., `B'10001'`) is supported; the notation with a small `b` (e.g., `b'abcd'`) continues to denote **byte** arrays as in previous versions of CockroachDB. [#28807][#28807] {% comment %}doc{% endcomment %}
 - Added the `array_to_json` [built-in function](../v2.2/functions-and-operators.html). [#29818][#29818]
+- Statements involving the dropping or truncating of tables, such as [`DROP DATABASE`](../v2.2/drop-database.html), [`DROP TABLE`](../v2.2/drop-table.html), and [`TRUNCATE`](../v2.2/truncate.html), are now considered jobs and, as such, can be tracked via [`SHOW JOBS`](../v2.2/show-jobs.html) and the [**Jobs** page](../v2.2/admin-ui-jobs-page.html) of the Admin UI. [#29993][#29993]
 
 ### Command-line changes
 
@@ -146,6 +147,7 @@ This release includes 998 merged PRs by 50 authors. We would like to thank the f
 [#29684]: https://github.com/cockroachdb/cockroach/pull/29684
 [#29818]: https://github.com/cockroachdb/cockroach/pull/29818
 [#29822]: https://github.com/cockroachdb/cockroach/pull/29822
+[#29993]: https://github.com/cockroachdb/cockroach/pull/29993
 [#30019]: https://github.com/cockroachdb/cockroach/pull/30019
 [#30143]: https://github.com/cockroachdb/cockroach/pull/30143
 [#30339]: https://github.com/cockroachdb/cockroach/pull/30339


### PR DESCRIPTION
For https://github.com/cockroachdb/cockroach/pull/29993/.

The commits in this PR incorrectly used `Release note: none`. 