### PR TITLE
Remove now-irrelevant mention of splitting

### DIFF
--- a/v2.1/demo-automatic-rebalancing.md
+++ b/v2.1/demo-automatic-rebalancing.md
@@ -4,7 +4,7 @@ summary: Use a local cluster to explore how CockroachDB automatically rebalances
 toc: true
 ---
 
-This page walks you through a simple demonstration of how CockroachDB automatically rebalances data as you scale. Starting with a 3-node local cluster, you'll run a sample workload and watch the replica count quickly increase as ranges split. You'll then add 2 more nodes and watch how CockroachDB automatically rebalances replicas to efficiently use all available capacity.
+This page walks you through a simple demonstration of how CockroachDB automatically rebalances data as you scale. Starting with a 3-node local cluster, you'll run a sample workload and watch the replica count increase. You'll then add 2 more nodes and watch how CockroachDB automatically rebalances replicas to efficiently use all available capacity.
 
 ## Before you begin
 

--- a/v2.2/demo-automatic-rebalancing.md
+++ b/v2.2/demo-automatic-rebalancing.md
@@ -4,7 +4,7 @@ summary: Use a local cluster to explore how CockroachDB automatically rebalances
 toc: true
 ---
 
-This page walks you through a simple demonstration of how CockroachDB automatically rebalances data as you scale. Starting with a 3-node local cluster, you'll run a sample workload and watch the replica count quickly increase as ranges split. You'll then add 2 more nodes and watch how CockroachDB automatically rebalances replicas to efficiently use all available capacity.
+This page walks you through a simple demonstration of how CockroachDB automatically rebalances data as you scale. Starting with a 3-node local cluster, you'll run a sample workload and watch the replica count increase. You'll then add 2 more nodes and watch how CockroachDB automatically rebalances replicas to efficiently use all available capacity.
 
 ## Before you begin
 


### PR DESCRIPTION
Follow-up fix to https://github.com/cockroachdb/docs/pull/4111/files.