### PR TITLE
Correct avro format in 2.1 cdc docs

### DIFF
--- a/v2.1/change-data-capture.md
+++ b/v2.1/change-data-capture.md
@@ -439,7 +439,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > CREATE CHANGEFEED FOR TABLE office_dogs INTO 'kafka://localhost:9092' WITH format = experimental_avro, confluent_schema_registry = 'http://localhost:8081';
+    > CREATE CHANGEFEED FOR TABLE office_dogs INTO 'kafka://localhost:9092' WITH format = 'experimental-avro', confluent_schema_registry = 'http://localhost:8081';
     ~~~
 
     ~~~

--- a/v2.1/create-changefeed.md
+++ b/v2.1/create-changefeed.md
@@ -48,8 +48,8 @@ Option | Value | Description
 `resolved` | [`INTERVAL`](interval.html) | Periodically emit resolved timestamps to the changefeed. Optionally, set a minimum duration between emitting resolved timestamps. If unspecified, all resolved timestamps are emitted.<br><br>Example: `resolved='10s'`
 `envelope` | `key_only` / `row` | Use `key_only` to emit only the key and no value, which is faster if you only want to know when the key changes.<br><br>Default: `envelope=row`
 `cursor` | [Timestamp](as-of-system-time.html#parameters)  | Emits any changes after the given timestamp, but does not output the current state of the table first. If `cursor` is not specified, the changefeed starts by doing a consistent scan of all the watched rows and emits the current value, then moves to emitting any changes that happen after the scan.<br><br>`cursor` can be used to [start a new changefeed where a previous changefeed ended.](#start-a-new-changefeed-where-another-ended)<br><br>Example: `CURSOR=1536242855577149065.0000000000`
-`format` | `json` / `experimental_avro` | Format of the emitted record. Currently, support for Avro is limited and experimental. <br><br>Default: `format=json`.
-`confluent_schema_registry` | Schema Registry address | The [Schema Registry](https://docs.confluent.io/current/schema-registry/docs/index.html#sr) address is required to use `experimental_avro`.
+`format` | `json` / `'experimental-avro'` | Format of the emitted record. Currently, support for Avro is limited and experimental. <br><br>Default: `format=json`.
+`confluent_schema_registry` | Schema Registry address | The [Schema Registry](https://docs.confluent.io/current/schema-registry/docs/index.html#sr) address is required to use `'experimental-avro'`.
 
 ## Examples
 
@@ -74,7 +74,7 @@ For more information on how to create a changefeed connected to Kafka, see [Chan
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> CREATE CHANGEFEED FOR TABLE name INTO 'kafka://host:port' WITH format = experimental_avro, confluent_schema_registry = <schema_registry_address>;
+> CREATE CHANGEFEED FOR TABLE name INTO 'kafka://host:port' WITH format = 'experimental-avro', confluent_schema_registry = '<schema_registry_address>';
 ~~~
 ~~~
 +--------------------+


### PR DESCRIPTION
In 2.1, the avro format option is `'experimental-avro'`, whereas in 2.2, it's `experimental_avro` without quotes. 

Fixes #4115.