### PR TITLE
fix bug that caused strange formatting with on-page jumps

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -3397,7 +3397,7 @@ h6:target:before {
   content: '';
   display: block;
   height: 155px;
-  margin-top: -100px; }
+  margin-top: -155px; }
 
 .post-content img {
   margin: 12px 0px 3px 0px; }

--- a/css/customstyles.scss
+++ b/css/customstyles.scss
@@ -149,7 +149,7 @@ h6:target:before {
   content: '';
   display: block;
   height: 155px;
-  margin-top: -100px; }
+  margin-top: -155px; }
 
 .post-content {
   img {


### PR DESCRIPTION
#4084 left a bug that caused a large amount of spacing above a header if you jumped to it using the right-hand nav. This PR fixes it.