### PR TITLE
Computed columns: not just at table creation

### DIFF
--- a/v2.1/computed-columns.md
+++ b/v2.1/computed-columns.md
@@ -28,7 +28,7 @@ Computed columns:
 
 ## Creation
 
-Computed columns can only be added at the time of [table creation](create-table.html). Use the following syntax:
+To define a computed column, use the following syntax:
 
 ~~~
 column_name <type> AS (<expr>) STORED

--- a/v2.2/computed-columns.md
+++ b/v2.2/computed-columns.md
@@ -28,7 +28,7 @@ Computed columns:
 
 ## Creation
 
-Computed columns can only be added at the time of [table creation](create-table.html). Use the following syntax:
+To define a computed column, use the following syntax:
 
 ~~~
 column_name <type> AS (<expr>) STORED


### PR DESCRIPTION
Fixes #4137.

Related to #3501.

Summary of changes:

- Remove erroneous claim that computed columns can only be added at
  table creation time.