### PR TITLE
Tell search engines to start indexing managed docs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{% if page.tags %}{{ page.tags | join: ', ' | escape }}{% endif %}">
-{% if page.block_search or site.managed %}
+{% if page.block_search %}
 <meta name="robots" content="noindex">
 <meta name="robots" content="nofollow">
 <meta name="robots" content="noarchive">


### PR DESCRIPTION
For the initial release, we didn't want search engines indexing our managed docs. Now that we're up and running, it makes sense to have them indexed.