### PR TITLE
Remove duplicate paras from GORM insecure example

### DIFF
--- a/v2.1/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v2.1/build-a-go-app-with-cockroachdb-gorm.md
@@ -103,14 +103,6 @@ $ cockroach sql --certs-dir=certs -e 'SELECT id, balance FROM accounts' --databa
 
 {% include {{page.version.version}}/app/insecure/create-maxroach-user-and-bank-database.md %}
 
-</section>
-
-<section class="filter-content" markdown="1" data-scope="insecure">
-
-## Step 2. Create the `maxroach` user and `bank` database
-
-{% include {{page.version.version}}/app/insecure/create-maxroach-user-and-bank-database.md %}
-
 ## Step 3. Run the Go code
 
 The following code uses the [GORM](http://gorm.io) ORM to map Go-specific objects to SQL operations. Specifically, `db.AutoMigrate(&Account{})` creates an `accounts` table based on the Account model, `db.Create(&Account{})` inserts rows into the table, and `db.Find(&accounts)` selects from the table so that balances can be printed.

--- a/v2.2/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v2.2/build-a-go-app-with-cockroachdb-gorm.md
@@ -103,14 +103,6 @@ $ cockroach sql --certs-dir=certs -e 'SELECT id, balance FROM accounts' --databa
 
 {% include {{page.version.version}}/app/insecure/create-maxroach-user-and-bank-database.md %}
 
-</section>
-
-<section class="filter-content" markdown="1" data-scope="insecure">
-
-## Step 2. Create the `maxroach` user and `bank` database
-
-{% include {{page.version.version}}/app/insecure/create-maxroach-user-and-bank-database.md %}
-
 ## Step 3. Run the Go code
 
 The following code uses the [GORM](http://gorm.io) ORM to map Go-specific objects to SQL operations. Specifically, `db.AutoMigrate(&Account{})` creates an `accounts` table based on the Account model, `db.Create(&Account{})` inserts rows into the table, and `db.Find(&accounts)` selects from the table so that balances can be printed.


### PR DESCRIPTION
Fixes #4140.

Summary of changes:

- Delete an extra header and include that had snuck into the "insecure"
  example section.  Looks like good old-fashioned human error.