### PR TITLE
Document customizable savepoint names

### DIFF
--- a/_includes/v2.2/misc/customizing-the-savepoint-name.md
+++ b/_includes/v2.2/misc/customizing-the-savepoint-name.md
@@ -1,0 +1,7 @@
+<span class="version-tag">New in v2.2:</span> Set the `force_savepoint_restart` [session variable](set-vars.html#supported-variables) to `true` to enable using a custom name for the restart savepoint (for example, because you are using an ORM that wants to use its own names for savepoints).
+
+Once this variable is set, the [`SAVEPOINT`](savepoint.html) statement will accept any name for the savepoint, not just `cockroach_restart`. This allows compatibility with existing code that uses a single savepoint per transaction as long as that savepoint occurs before any statements that access data stored in non-virtual tables.
+
+{{site.data.alerts.callout_danger}}
+The `force_savepoint_restart` variable changes the semantics of CockroachDB savepoints so that `RELEASE SAVEPOINT <your-custom-name>` functions as a real commit. Note that the existence of this variable and its behavior does not change the fact that CockroachDB savepoints can only be used as a part of the transaction retry protocol.
+{{site.data.alerts.end}}

--- a/_includes/v2.2/misc/savepoint-limitations.md
+++ b/_includes/v2.2/misc/savepoint-limitations.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_danger}}
+CockroachDB's [`SAVEPOINT`](savepoint.html) implementation does not support nested transactions (i.e., subtransactions).  It is only used to handle [transaction retries](transactions.html#transaction-retries).
+{{site.data.alerts.end}}

--- a/_includes/v2.2/misc/session-vars.html
+++ b/_includes/v2.2/misc/session-vars.html
@@ -1,0 +1,361 @@
+<table>
+ <thead>
+
+  <tr>
+   <td>Variable name</td>
+   <td>Description</td>
+   <td>Initial value</td>
+   <td>Modify with <a href="set-vars.html">
+     <code>SET</code>
+    </a>?</td>
+   <td>View with <a href="show-vars.html">
+     <code>SHOW</code>
+    </a>?</td>
+  </tr>
+
+ </thead>
+ <tbody>
+
+  <tr>
+   <td>
+    <code>application_name</code>
+   </td>
+   <td>The current application name for statistics collection.</td>
+   <td>Empty string, or <code>cockroach</code> for sessions from the <a href="use-the-built-in-sql-client.html">built-in SQL client</a>.</td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>database</code>
+   </td>
+   <td>The <a href="sql-name-resolution.html#current-database">current database</a>.</td>
+   <td>Database in connection string, or empty if not specified.</td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>default_transaction_isolation</code>
+   </td>
+   <td>All transactions execute with <code>SERIALIZABLE</code> isolation. See <a href="transactions.html#isolation-levels">Transactions: Isolation levels</a>.</td>
+   <td>
+    <code>SERIALIZABLE</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>default_transaction_read_only</code>
+   </td>
+   <td>The default transaction access mode for the current session. If set to <code>on</code>, only read operations are allowed in transactions in the current session; if set to <code>off</code>, both read and write operations are allowed. See <a href="set-transaction.html"><code>SET TRANSACTION</code></a>
+ for more details.</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>distsql</code>
+   </td>
+   <td>The query distribution mode for the session. By default, CockroachDB determines which queries are faster to execute if distributed across multiple nodes, and all other queries are run through the gateway node.</td>
+   <td>
+    <code>auto</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>extra_float_digits</code>
+   </td>
+   <td>The number of digits displayed for floating-point values. Only values between <code>-15</code> and <code>3</code> are supported.</td>
+   <td>
+    <code>0</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td><code>force_savepoint_restart</code></td>
+   <td>When set to <code>true</code>, allows the <a href="savepoint.html"><code>SAVEPOINT</code></a> statement to accept any name for a savepoint.</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>node_id</code>
+   </td>
+   <td>The ID of the node currently connected to.<br />
+    <br />This variable is particularly useful for verifying load balanced connections.</td>
+   <td>Node-dependent</td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>optimizer</code>
+   </td>
+   <td>The mode in which a query execution plan is generated. If set to <code>on</code>, the <a href="cost-based-optimizer.html">cost-based optimizer</a> is enabled by default and the heuristic planner will only be used if the query is not supported by the cost-based optimizer; if set to <code>off</code>, all queries are run through the legacy heuristic planner.</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>search_path</code>
+   </td>
+   <td>A list of schemas that will be searched to resolve unqualified table or function names. For more details, see <a href="sql-name-resolution.html">SQL name resolution</a>.</td>
+   <td>
+    <code>public</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>server_version</code>
+   </td>
+   <td>The version of PostgreSQL that CockroachDB emulates.</td>
+   <td>Version-dependent</td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>server_version_num</code>
+   </td>
+   <td>The version of PostgreSQL that CockroachDB emulates.</td>
+   <td>Version-dependent</td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>session_user</code>
+   </td>
+   <td>The user connected for the current session.</td>
+   <td>User in connection string</td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>sql_safe_updates</code>
+   </td>
+   <td>If <code>false</code>, potentially unsafe SQL statements are allowed, including <code>DROP</code> of a non-empty database and all dependent objects, <code>DELETE</code> without a <code>WHERE</code> clause, <code>UPDATE</code> without a <code>WHERE</code> clause, and <code>ALTER TABLE .. DROP COLUMN</code>. See <a href="use-the-built-in-sql-client.html#allow-potentially-unsafe-sql-statements">Allow Potentially Unsafe SQL Statements</a> for more details.</td>
+   <td>
+    <code>true</code> for interactive sessions from the <a href="use-the-built-in-sql-client.html">built-in SQL client</a>,<br /><code>false</code> for sessions from other clients</td>
+    <td>Yes</td>
+    <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>statement_timeout</code>
+   </td>
+   <td>The amount of time a statement can run before being stopped.<br />
+    <br />This value can be an <code>int</code> (e.g., <code>10</code>) and will be interpreted as milliseconds. It can also be an interval or string argument, where the string can be parsed as a valid interval (e.g., <code>'4s'</code>). A value of <code>0</code> turns it off.</td>
+   <td>
+    <code>0s</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>timezone</code>
+   </td>
+   <td>The default time zone for the current session. <br />
+    <br />This session variable was named <code>"time zone"</code> (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL.</td>
+   <td>
+    <code>UTC</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>tracing</code>
+   </td>
+   <td>The trace recording state.</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>
+   </td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>transaction_isolation</code>
+   </td>
+   <td>All transactions execute with <code>SERIALIZABLE</code> isolation. See <a href="transactions.html#isolation-levels">Transactions: Isolation levels</a>. <br />
+    <br />This session variable was called <code>transaction isolation level</code> (with spaces) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL.</td>
+   <td>
+    <code>SERIALIZABLE</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>transaction_priority</code>
+   </td>
+   <td>The priority of the current transaction. See <a href="transactions.html#isolation-levels">Transactions: Isolation levels</a> for more details.<br />
+    <br />This session variable was called <code>transaction priority</code> (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL.</td>
+   <td>
+    <code>NORMAL</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>transaction_read_only</code>
+   </td>
+   <td>The access mode of the current transaction. See <a href="set-transaction.html">Set Transaction</a> for more details.</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>transaction_status</code>
+   </td>
+   <td>The state of the current transaction. See <a href="transactions.html">Transactions</a> for more details.<br />
+    <br />This session variable was called <code>transaction status</code> (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL.</td>
+   <td>
+    <code>NoTxn</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>client_encoding</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>UTF8</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>client_min_messages</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>notice</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>datestyle</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>ISO</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>integer_datetimes</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>intervalstyle</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>postgres</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>max_index_keys</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>32</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>standard_conforming_strings</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>server_encoding</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>UTF8</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+ </tbody>
+</table>

--- a/v2.2/commit-transaction.md
+++ b/v2.2/commit-transaction.md
@@ -6,7 +6,7 @@ toc: true
 
 The `COMMIT` [statement](sql-statements.html) commits the current [transaction](transactions.html) or, when using [client-side transaction retries](transactions.html#client-side-transaction-retries), clears the connection to allow new transactions to begin.
 
-When using [client-side transaction retries](transactions.html#client-side-transaction-retries), statements issued after [`SAVEPOINT cockroach_restart`](savepoint.html) are committed when [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html) is issued instead of `COMMIT`. However, you must still issue a `COMMIT` statement to clear the connection for the next transaction.
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), statements issued after [`SAVEPOINT`](savepoint.html) are committed when [`RELEASE SAVEPOINT`](release-savepoint.html) is issued instead of `COMMIT`. However, you must still issue a `COMMIT` statement to clear the connection for the next transaction.
 
 For non-retryable transactions, if statements in the transaction [generated any errors](transactions.html#error-handling), `COMMIT` is equivalent to `ROLLBACK`, which aborts the transaction and discards *all* updates made by its statements.
 
@@ -31,7 +31,7 @@ How you commit transactions depends on how your application handles [transaction
 
 #### Client-side retryable transactions
 
-When using [client-side transaction retries](transactions.html#client-side-transaction-retries), statements are committed by [`RELEASE SAVEPOINT cockroach_restart`](release-savepoint.html). `COMMIT` itself only clears the connection for the next transaction.
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), statements are committed by [`RELEASE SAVEPOINT`](release-savepoint.html). `COMMIT` itself only clears the connection for the next transaction.
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v2.2/release-savepoint.md
+++ b/v2.2/release-savepoint.md
@@ -1,17 +1,16 @@
 ---
-title: RELEASE SAVEPOINT cockroach_restart
-summary: Commit a transaction's changes once there are no retryable errors with the RELEASE SAVEPOINT cockroach_restart statement in CockroachDB.
+title: RELEASE SAVEPOINT
+summary: Commit a transaction's changes once there are no retryable errors with the RELEASE SAVEPOINT statement in CockroachDB.
 toc: true
 ---
 
-When using [client-side transaction retries](transactions.html#client-side-transaction-retries), the `RELEASE SAVEPOINT cockroach_restart` statement commits the transaction.
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), the `RELEASE SAVEPOINT` statement commits the transaction.
 
-If statements in the transaction [generated any non-retryable errors](transactions.html#error-handling), `RELEASE SAVEPOINT cockroach_restart` is equivalent to [`ROLLBACK`](rollback-transaction.html), which aborts the transaction and discards *all* updates made by its statements.
+If statements in the transaction [generated any non-retryable errors](transactions.html#error-handling), `RELEASE SAVEPOINT` is equivalent to [`ROLLBACK`](rollback-transaction.html), which aborts the transaction and discards all updates made by its statements.
 
-Despite committing the transaction, you must still issue a [`COMMIT`](commit-transaction.html) statement to prepare the connection for the next transaction.
+Note that although issuing this statement commits the transaction, you must also issue a subsequent [`COMMIT`](commit-transaction.html) statement to prepare the connection for the next transaction.
 
-{{site.data.alerts.callout_danger}}CockroachDB’s <code>SAVEPOINT</code> implementation only supports the <code>cockroach_restart</code> savepoint and does not support all savepoint functionality, such as nested transactions.{{site.data.alerts.end}}
-
+{% include {{ page.version.version }}/misc/savepoint-limitations.md %}
 
 ## Synopsis
 
@@ -23,11 +22,21 @@ Despite committing the transaction, you must still issue a [`COMMIT`](commit-tra
 
 No [privileges](privileges.html) are required to release a savepoint. However, privileges are required for each statement within a transaction.
 
+## Parameters
+
+Parameter | Description
+--------- | -----------
+name      | The name of the savepoint.  Defaults to `cockroach_restart`, but may be customized.  For more information, see [Customizing the savepoint name](#customizing-the-savepoint-name).
+
+## Customizing the savepoint name
+
+{% include {{ page.version.version }}/misc/customizing-the-savepoint-name.md %}
+
 ## Examples
 
 ### Commit a Transaction
 
-After declaring `SAVEPOINT cockroach_restart`, commit the transaction with `RELEASE SAVEPOINT cockroach_restart` and then prepare the connection for the next transaction with `COMMIT`.
+After declaring a [`SAVEPOINT`](savepoint.html), commit the transaction with `RELEASE SAVEPOINT` and then prepare the connection for the next transaction with [`COMMIT`](commit-transaction.html):
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v2.2/rollback-transaction.md
+++ b/v2.2/rollback-transaction.md
@@ -6,8 +6,7 @@ toc: true
 
 The `ROLLBACK` [statement](sql-statements.html) aborts the current [transaction](transactions.html), discarding all updates made by statements included in the transaction.
 
-When using [client-side transaction retries](transactions.html#client-side-transaction-retries), use `ROLLBACK TO SAVEPOINT cockroach_restart` to handle a transaction that needs to be retried (identified via the `40001` error code or `retry transaction` string in the error message), and then re-execute the statements you want the transaction to contain.
-
+When using [client-side transaction retries](transactions.html#client-side-transaction-retries), use `ROLLBACK TO SAVEPOINT` to handle a transaction that needs to be retried (identified via the `40001` error code or `retry transaction` string in the error message), and then re-execute the statements you want the transaction to contain.
 
 ## Synopsis
 
@@ -74,7 +73,7 @@ Typically, an application conditionally executes rollbacks, but we can see their
 
 ### Retry a transaction
 
-To use [client-side transaction retries](transactions.html#client-side-transaction-retries), an application must execute `ROLLBACK TO SAVEPOINT cockroach_restart` after detecting a `40001` / `retry transaction` error:
+To use [client-side transaction retries](transactions.html#client-side-transaction-retries), an application must execute `ROLLBACK TO SAVEPOINT` after detecting a `40001` / `retry transaction` error:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v2.2/savepoint.md
+++ b/v2.2/savepoint.md
@@ -1,13 +1,12 @@
 ---
 title: SAVEPOINT
-summary: Identify your intent to retry aborted transactions with the SAVEPOINT cockroach_restart statement in CockroachDB.
+summary: Identify your intent to retry aborted transactions with the SAVEPOINT statement in CockroachDB.
 toc: true
 ---
 
-The `SAVEPOINT cockroach_restart` statement defines the intent to retry [transactions](transactions.html) using the CockroachDB-provided function for client-side transaction retries. For more information, see [Transaction Retries](transactions.html#transaction-retries).
+The `SAVEPOINT` statement defines the intent to retry [transactions](transactions.html) using the CockroachDB-provided function for client-side transaction retries. For more information, see [Transaction Retries](transactions.html#transaction-retries).
 
-{{site.data.alerts.callout_danger}}CockroachDB’s <code>SAVEPOINT</code> implementation only supports the <code>cockroach_restart</code> savepoint and does not support all savepoint functionality, such as nested transactions.{{site.data.alerts.end}}
-
+{% include {{ page.version.version }}/misc/savepoint-limitations.md %}
 
 ## Synopsis
 
@@ -19,9 +18,21 @@ The `SAVEPOINT cockroach_restart` statement defines the intent to retry [transac
 
 No [privileges](privileges.html) are required to create a savepoint. However, privileges are required for each statement within a transaction.
 
+## Parameters
+
+Parameter | Description
+--------- | -----------
+name      | The name of the savepoint.  Defaults to `cockroach_restart`, but may be customized.  For more information, see [Customizing the savepoint name](#customizing-the-savepoint-name).
+
+## Customizing the savepoint name
+
+{% include {{ page.version.version }}/misc/customizing-the-savepoint-name.md %}
+
 ## Example
 
-After you `BEGIN` the transaction, you must create the savepoint to identify that if the transaction contends with another transaction for resources and "loses", you intend to use [the function for client-side transaction retries](transactions.html#transaction-retries):
+After you `BEGIN` the transaction, you must create the savepoint to identify that if the transaction contends with another transaction for resources and "loses", you intend to use [client-side transaction retries](transactions.html#transaction-retries).
+
+Applications using `SAVEPOINT` must also include functions to execute retries with [`ROLLBACK TO SAVEPOINT `](rollback-transaction.html#retry-a-transaction).
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -53,8 +64,6 @@ After you `BEGIN` the transaction, you must create the savepoint to identify tha
 > COMMIT;
 ~~~
 
-When using `SAVEPOINT`, an application must also include functions to execute retries with [`ROLLBACK TO SAVEPOINT cockroach_restart`](rollback-transaction.html#retry-a-transaction).
-
 ## See also
 
 - [Transactions](transactions.html)
@@ -62,3 +71,5 @@ When using `SAVEPOINT`, an application must also include functions to execute re
 - [`ROLLBACK`](rollback-transaction.html)
 - [`BEGIN`](begin-transaction.html)
 - [`COMMIT`](commit-transaction.html)
+- [Retryable transaction example code in Java using JDBC](build-a-java-app-with-cockroachdb.html#transaction-example-with-retry-logic)
+- [CockroachDB Architecture: Transaction Layer](architecture/transaction-layer.html)

--- a/v2.2/set-vars.md
+++ b/v2.2/set-vars.md
@@ -34,30 +34,7 @@ The variable name is case insensitive. The value can be a list of one or more it
 
 ### Supported variables
 
- Variable name | Description  | Initial value | Can be viewed with [`SHOW`](show-vars.html)? |
----------------|--------------|---------------|-----------------------------------------
- `application_name` | The current application name for statistics collection. | Empty string | Yes
- `database` | The [current database](sql-name-resolution.html#current-database).  Database in connection string, or empty if not specified | Yes
- `default_transaction_isolation` | _Read only:_ All transactions execute with [`SERIALIZABLE` isolation](transactions.html#isolation-levels), meaning you cannot `SET default_transaction_isolation...` to any value. However, this setting remains available for ORM compatibility. | `SERIALIZABLE` | Yes
- `default_transaction_read_only` | The default transaction access mode for the current session. If set to `on`, only read operations are allowed in transactions in the current session; if set to `off`, both read and write operations are allowed. See [`SET TRANSACTION`](set-transaction.html) for more details. | `off` | Yes
- `distsql` | The query distribution mode for the current session.<br><br>If `auto`, CockroachDB determines which queries are faster to execute if distributed across multiple nodes, and all other queries are run through the gateway node. **`auto` is recommended.** <br><br>If `on`, any queries that can be distributed are distributed, and all other queries are run through the gateway node.<br><br>If `off`, all queries are run through the local SQL engine. <br><br>If `always`, all queries are distributed, even those that cannot be distributed (returns an error). This setting is used for internal testing and is not recommended. | `auto` | Yes
- `extra_float_digits` | The number of digits displayed for floating-point values. Only values between `-15` and `3` are supported. | `0` | Yes
- `optimizer` | The mode in which a query execution plan is generated. If set to `on`, the [cost-based optimizer](cost-based-optimizer.html) is enabled by default and the heuristic planner will only be used if the query is not supported by the cost-based optimizer; if set to `off`, all queries are run through the legacy heuristic planner. | `on` | Yes
- `sql_safe_updates` | If `true`, disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`. See [Allow Potentially Unsafe SQL Statements](use-the-built-in-sql-client.html#allow-potentially-unsafe-sql-statements) for more details. | `true` for interactive sessions from the [built-in SQL client](use-the-built-in-sql-client.html) unless `--safe-updates=false` is specified,<br>`false` for sessions from other clients | Yes
- `search_path` | A list of schemas that will be searched to resolve unqualified table or function names. For more details, see [Name Resolution](sql-name-resolution.html). | "`{public}`" | Yes
- `server_version_num` | The version of PostgreSQL that CockroachDB emulates. | Version-dependent | Yes
- `statement_timeout` | The amount of time a statement can run before being stopped.<br><br>This value can be an `int` (e.g., `10`) and will be interpreted as milliseconds. It can also be an interval or string argument, where the string can be parsed as a valid interval (e.g., `'4s'`). A value of `0` turns it off. | `0s` | Yes
- `timezone` | The default time zone for the current session.<br><br>This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`). Also, `DEFAULT`, `LOCAL`, or `0` sets the session time zone to `UTC`.</br><br>See [Setting the Time Zone](#set-time-zone) for more details. <br><br>This session variable was named `"time zone"` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `UTC` | Yes
- `tracing` | The trace recording state.<br><br>See [`SET TRACING`](#set-tracing) for more details. | `off` | Yes
- `transaction_isolation` | _Read only:_ All transactions execute with [`SERIALIZABLE` isolation](transactions.html#isolation-levels), meaning you cannot `SET transaction_isolation...` to any value. However, this  available for ORM compatibility.<br><br>This session variable was called `transaction isolation level` (with spaces) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `SERIALIZABLE` | Yes
- `transaction_priority` | The priority of the current transaction. See [Transactions: Priority levels](transactions.html#transaction-priorities) for more details.<br><br>This session variable was called `transaction priority` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `NORMAL` | Yes
- `transaction_read_only` | The access mode of the current transaction. See [Set Transaction](set-transaction.html) for more details. | `off` | Yes
- `transaction_status` | The state of the current transaction. See [Transactions](transactions.html) for more details.<br><br>This session variable was called `transaction status` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `NoTxn` | Yes
- `client_encoding` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is "`UTF8`". | N/A | No
- `client_min_messages` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is `notice`. | N/A | Yes
- `standard_conforming_strings` | Ignored; recognized for compatibility with PostgreSQL clients. | N/A | Yes
-`integer_datetimes` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is `on`. | N/A | Yes
-`server_encoding` | Ignored; recognized for compatibility with PostgreSQL clients. Only possible value is `UTF8`. | N/A | Yes
+{% include {{ page.version.version }}/misc/session-vars.html %}
 
 Special syntax cases:
 

--- a/v2.2/show-vars.md
+++ b/v2.2/show-vars.md
@@ -31,37 +31,7 @@ The variable name is case insensitive. It may be enclosed in double quotes; this
 
 ### Supported variables
 
- Variable name | Description | Initial value |  Can be modified with [`SET`](set-vars.html)?
----------------|-------------|---------------|-----------------------------------------------
- `application_name` | The current application name for statistics collection. | Empty string, or `cockroach` for sessions from the [built-in SQL client](use-the-built-in-sql-client.html)  | Yes
- `database` | The [current database](sql-name-resolution.html#current-database). Database in connection string, or empty if not specified | Yes |
- `default_transaction_isolation` | All transactions execute with `SERIALIZABLE` isolation. See [Transactions: Isolation levels](transactions.html#isolation-levels). | `SERIALIZABLE`  | No
- `default_transaction_read_only` | The default transaction access mode for the current session. If set to `on`, only read operations are allowed in transactions in the current session; if set to `off`, both read and write operations are allowed. See [`SET TRANSACTION`](set-transaction.html) for more details. | `off` | Yes
- `distsql` | The query distribution mode for the session. By default, CockroachDB determines which queries are faster to execute if distributed across multiple nodes, and all other queries are run through the gateway node. | `auto` | Yes
- `extra_float_digits` | The number of digits displayed for floating-point values. Only values between `-15` and `3` are supported. | `0` | Yes
- `node_id` | The ID of the node currently connected to.<br><br>This variable is particularly useful for verifying load balanced connections. | Node-dependent | No
- `optimizer` | The mode in which a query execution plan is generated. If set to `on`, the [cost-based optimizer](cost-based-optimizer.html) is enabled by default and the heuristic planner will only be used if the query is not supported by the cost-based optimizer; if set to `off`, all queries are run through the legacy heuristic planner. | `on` | Yes
- `search_path` | A list of schemas that will be searched to resolve unqualified table or function names. For more details, see [Name Resolution](sql-name-resolution.html). | `{public}` | Yes
- `server_version` | The version of PostgreSQL that CockroachDB emulates. | Version-dependent | No |
- `server_version_num` | The version of PostgreSQL that CockroachDB emulates. | Version-dependent | Yes
- `session_user` | The user connected for the current session. | User in connection string | No
- `sql_safe_updates` | If `false`, potentially unsafe SQL statements are allowed, including `DROP` of a non-empty database and all dependent objects, `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE .. DROP COLUMN`. See [Allow Potentially Unsafe SQL Statements](use-the-built-in-sql-client.html#allow-potentially-unsafe-sql-statements) for more details. | `true` for interactive sessions from the [built-in SQL client](use-the-built-in-sql-client.html),<br>`false` for sessions from other clients | Yes
- `statement_timeout` | The amount of time a statement can run before being stopped.<br><br>This value can be an `int` (e.g., `10`) and will be interpreted as milliseconds. It can also be an interval or string argument, where the string can be parsed as a valid interval (e.g., `'4s'`). A value of `0` turns it off. | `0s` | Yes
- `timezone` | The default time zone for the current session. <br><br>This session variable was named `"time zone"` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `UTC` | Yes
- `tracing` | | `off` |
- `transaction_isolation` | All transactions execute with `SERIALIZABLE` isolation. See [Transactions: Isolation levels](transactions.html#isolation-levels). <br><br>This session variable was called `transaction isolation level` (with spaces) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `SERIALIZABLE` | No
- `transaction_priority` | The priority of the current transaction. See [Transactions: Isolation levels](transactions.html#isolation-levels) for more details.<br><br>This session variable was called `transaction priority` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `NORMAL` | Yes
- `transaction_read_only` | The access mode of the current transaction. See [Set Transaction](set-transaction.html) for more details. | `off` | Yes
- `transaction_status` | The state of the current transaction. See [Transactions](transactions.html) for more details.<br><br>This session variable was called `transaction status` (with a space) in CockroachDB 1.x. It has been renamed for compatibility with PostgreSQL. | `NoTxn` | No
- `client_encoding` | (Reserved; exposed only for ORM compatibility.) | `UTF8` | No
- `client_min_messages` | (Reserved; exposed only for ORM compatibility.) | `notice` | No
- `datestyle` | (Reserved; exposed only for ORM compatibility.) | `ISO` | No
- `integer_datetimes` | (Reserved; exposed only for ORM compatibility.) | `on` | No
- `intervalstyle` | (Reserved; exposed only for ORM compatibility.) | `postgres` | No
- `max_index_keys` | (Reserved; exposed only for ORM compatibility.) | `32` | No
- `standard_conforming_strings` | (Reserved; exposed only for ORM compatibility.)  
- `on` | No
- `server_encoding` | (Reserved; exposed only for ORM compatibility.) | `UTF8` | Yes
+{% include {{ page.version.version }}/misc/session-vars.html %}
 
 Special syntax cases supported for compatibility:
 

--- a/v2.2/sql-statements.md
+++ b/v2.2/sql-statements.md
@@ -81,7 +81,7 @@ Statement | Usage
 [`BEGIN`](begin-transaction.html)| Initiate a [transaction](transactions.html).
 [`COMMIT`](commit-transaction.html) | Commit the current [transaction](transactions.html).
 [`RELEASE SAVEPOINT`](release-savepoint.html) | When using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), commit the transaction's changes once there are no retryable errors.
-[`ROLLBACK`](rollback-transaction.html) | Discard all updates made by the current [transaction](transactions.html) or, when using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), rollback to the `cockroach_restart` savepoint and retry the transaction.
+[`ROLLBACK`](rollback-transaction.html) | Discard all updates made by the current [transaction](transactions.html) or, when using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), rollback to the savepoint and retry the transaction.
 [`SAVEPOINT`](savepoint.html) | When using the CockroachDB-provided function for client-side [transaction retries](transactions.html#transaction-retries), start a retryable transaction.
 [`SET TRANSACTION`](set-transaction.html) | Set the priority for the session or for an individual [transaction](transactions.html).
 [`SHOW`](show-vars.html) | View the current [transaction settings](transactions.html).


### PR DESCRIPTION
Fixes #4008.

Summary of changes:

- Added a new section *Customizing the savepoint name* to several
  pages (via include), which describes the new `force_savepoint_restart`
  session variable and makes clear that SAVEPOINT is still only used for
  transaction retries, and that we don't support nested
  transactions (yet!).

- Made the "this is not a generalized SAVEPOINT, it's only for retries"
  warning that lives on several pages an include.

- Removed all inline mentions of `cockroach_restart` *except* in actual
  code samples, since it's not part of the statement name.  E.g.,
  everywhere `SAVEPOINT cockroach_restart` is used in prose, it's been
  changed to just `SAVEPOINT`.

- Added the `force_savepoint_restart` session variable to the list of
  session vars.  While there, I discovered some broken table cells (and
  that we had two duplicate lists in different files) so I broke the
  list of session vars out into a single (HTML) include.  This had the
  following benefits:

  - HTML can be validated, allowing me to see and fix existing
    errors (due to error-prone Markdown table pipe syntax on big tables)

  - List of session vars can now be maintained in one place (the table
    has an addition column so that "See with SHOW?" and "Update with
    SET?" are both listed, to facilitate re-use).