### PR TITLE
Update C# code samples to use secure connections

### DIFF
--- a/_includes/v2.1/app/basic-sample.cs
+++ b/_includes/v2.1/app/basic-sample.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
 using Npgsql;
 
 namespace Cockroach
@@ -11,6 +13,7 @@ namespace Cockroach
       var connStringBuilder = new NpgsqlConnectionStringBuilder();
       connStringBuilder.Host = "localhost";
       connStringBuilder.Port = 26257;
+      connStringBuilder.SslMode = SslMode.Require;
       connStringBuilder.Username = "maxroach";
       connStringBuilder.Database = "bank";
       Simple(connStringBuilder.ConnectionString);
@@ -18,15 +21,17 @@ namespace Cockroach
 
     static void Simple(string connString)
     {
-      using(var conn = new NpgsqlConnection(connString))
+      using (var conn = new NpgsqlConnection(connString))
       {
+        conn.ProvideClientCertificatesCallback += ProvideClientCertificatesCallback;
+        conn.UserCertificateValidationCallback += UserCertificateValidationCallback;
         conn.Open();
 
         // Create the "accounts" table.
         new NpgsqlCommand("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)", conn).ExecuteNonQuery();
 
         // Insert two rows into the "accounts" table.
-        using(var cmd = new NpgsqlCommand())
+        using (var cmd = new NpgsqlCommand())
         {
           cmd.Connection = conn;
           cmd.CommandText = "UPSERT INTO accounts(id, balance) VALUES(@id1, @val1), (@id2, @val2)";
@@ -39,11 +44,58 @@ namespace Cockroach
 
         // Print out the balances.
         System.Console.WriteLine("Initial balances:");
-        using(var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
-        using(var reader = cmd.ExecuteReader())
-        while (reader.Read())
-          Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
+        using (var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
+        using (var reader = cmd.ExecuteReader())
+          while (reader.Read())
+            Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
       }
     }
+
+    static void ProvideClientCertificatesCallback(X509CertificateCollection clientCerts)
+    {
+      // To be able to add a certificate with a private key included, we must convert it to
+      // a PKCS #12 format. The following openssl command does this:
+      // openssl pkcs12 -password pass: -inkey client.maxroach.key -in client.maxroach.crt -export -out client.maxroach.pfx
+      // As of 2018-12-10, you need to provide a password for this to work on macOS.
+      // See https://github.com/dotnet/corefx/issues/24225
+
+      // Note that the password used during X509 cert creation below
+      // must match the password used in the openssl command above.
+      clientCerts.Add(new X509Certificate2("certs/client.maxroach.pfx", "pass"));
+    }
+
+    // By default, .Net does all of its certificate verification using the system certificate store.
+    // This callback is necessary to validate the server certificate against a CA certificate file.
+    static bool UserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain defaultChain, SslPolicyErrors defaultErrors)
+    {
+      X509Certificate2 caCert = new X509Certificate2("certs/ca.crt");
+      X509Chain caCertChain = new X509Chain();
+      caCertChain.ChainPolicy = new X509ChainPolicy()
+      {
+        RevocationMode = X509RevocationMode.NoCheck,
+        RevocationFlag = X509RevocationFlag.EntireChain
+      };
+      caCertChain.ChainPolicy.ExtraStore.Add(caCert);
+
+      X509Certificate2 serverCert = new X509Certificate2(certificate);
+
+      caCertChain.Build(serverCert);
+      if (caCertChain.ChainStatus.Length == 0)
+      {
+        // No errors
+        return true;
+      }
+
+      foreach (X509ChainStatus status in caCertChain.ChainStatus)
+      {
+        // Check if we got any errors other than UntrustedRoot (which we will always get if we don't install the CA cert to the system store)
+        if (status.Status != X509ChainStatusFlags.UntrustedRoot)
+        {
+          return false;
+        }
+      }
+      return true;
+    }
+
   }
 }

--- a/_includes/v2.1/app/insecure/basic-sample.cs
+++ b/_includes/v2.1/app/insecure/basic-sample.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Data;
+using Npgsql;
+
+namespace Cockroach
+{
+  class MainClass
+  {
+    static void Main(string[] args)
+    {
+      var connStringBuilder = new NpgsqlConnectionStringBuilder();
+      connStringBuilder.Host = "localhost";
+      connStringBuilder.Port = 26257;
+      connStringBuilder.SslMode = SslMode.Disable;
+      connStringBuilder.Username = "maxroach";
+      connStringBuilder.Database = "bank";
+      Simple(connStringBuilder.ConnectionString);
+    }
+
+    static void Simple(string connString)
+    {
+      using (var conn = new NpgsqlConnection(connString))
+      {
+        conn.Open();
+
+        // Create the "accounts" table.
+        new NpgsqlCommand("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)", conn).ExecuteNonQuery();
+
+        // Insert two rows into the "accounts" table.
+        using (var cmd = new NpgsqlCommand())
+        {
+          cmd.Connection = conn;
+          cmd.CommandText = "UPSERT INTO accounts(id, balance) VALUES(@id1, @val1), (@id2, @val2)";
+          cmd.Parameters.AddWithValue("id1", 1);
+          cmd.Parameters.AddWithValue("val1", 1000);
+          cmd.Parameters.AddWithValue("id2", 2);
+          cmd.Parameters.AddWithValue("val2", 250);
+          cmd.ExecuteNonQuery();
+        }
+
+        // Print out the balances.
+        System.Console.WriteLine("Initial balances:");
+        using (var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
+        using (var reader = cmd.ExecuteReader())
+          while (reader.Read())
+            Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
+      }
+    }
+  }
+}

--- a/_includes/v2.1/app/insecure/txn-sample.cs
+++ b/_includes/v2.1/app/insecure/txn-sample.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Data;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Security;
 using Npgsql;
 
 namespace Cockroach
@@ -13,7 +11,7 @@ namespace Cockroach
       var connStringBuilder = new NpgsqlConnectionStringBuilder();
       connStringBuilder.Host = "localhost";
       connStringBuilder.Port = 26257;
-      connStringBuilder.SslMode = SslMode.Require;
+      connStringBuilder.SslMode = SslMode.Disable;
       connStringBuilder.Username = "maxroach";
       connStringBuilder.Database = "bank";
       TxnSample(connStringBuilder.ConnectionString);
@@ -52,9 +50,6 @@ namespace Cockroach
     {
       using (var conn = new NpgsqlConnection(connString))
       {
-        conn.ProvideClientCertificatesCallback += ProvideClientCertificatesCallback;
-        conn.UserCertificateValidationCallback += UserCertificateValidationCallback;
-
         conn.Open();
 
         // Create the "accounts" table.
@@ -120,49 +115,6 @@ namespace Cockroach
         while (reader.Read())
           Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
       }
-    }
-
-    static void ProvideClientCertificatesCallback(X509CertificateCollection clientCerts)
-    {
-      // To be able to add a certificate with a private key included, we must convert it to
-      // a PKCS #12 format. The following openssl command does this:
-      // openssl pkcs12 -inkey client.maxroach.key -in client.maxroach.crt -export -out client.maxroach.pfx
-      // As of 2018-12-10, you need to provide a password for this to work on macOS.
-      // See https://github.com/dotnet/corefx/issues/24225
-      clientCerts.Add(new X509Certificate2("certs/client.maxroach.pfx", "pass"));
-    }
-
-    // By default, .Net does all of its certificate verification using the system certificate store.
-    // This callback is necessary to validate the server certificate against a CA certificate file.
-    static bool UserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain defaultChain, SslPolicyErrors defaultErrors)
-    {
-      X509Certificate2 caCert = new X509Certificate2("certs/ca.crt");
-      X509Chain caCertChain = new X509Chain();
-      caCertChain.ChainPolicy = new X509ChainPolicy()
-      {
-        RevocationMode = X509RevocationMode.NoCheck,
-        RevocationFlag = X509RevocationFlag.EntireChain
-      };
-      caCertChain.ChainPolicy.ExtraStore.Add(caCert);
-
-      X509Certificate2 serverCert = new X509Certificate2(certificate);
-
-      caCertChain.Build(serverCert);
-      if (caCertChain.ChainStatus.Length == 0)
-      {
-        // No errors
-        return true;
-      }
-
-      foreach (X509ChainStatus status in caCertChain.ChainStatus)
-      {
-        // Check if we got any errors other than UntrustedRoot (which we will always get if we don't install the CA cert to the system store)
-        if (status.Status != X509ChainStatusFlags.UntrustedRoot)
-        {
-          return false;
-        }
-      }
-      return true;      
     }
   }
 }

--- a/_includes/v2.2/app/basic-sample.cs
+++ b/_includes/v2.2/app/basic-sample.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
 using Npgsql;
 
 namespace Cockroach
@@ -11,6 +13,7 @@ namespace Cockroach
       var connStringBuilder = new NpgsqlConnectionStringBuilder();
       connStringBuilder.Host = "localhost";
       connStringBuilder.Port = 26257;
+      connStringBuilder.SslMode = SslMode.Require;
       connStringBuilder.Username = "maxroach";
       connStringBuilder.Database = "bank";
       Simple(connStringBuilder.ConnectionString);
@@ -18,15 +21,17 @@ namespace Cockroach
 
     static void Simple(string connString)
     {
-      using(var conn = new NpgsqlConnection(connString))
+      using (var conn = new NpgsqlConnection(connString))
       {
+        conn.ProvideClientCertificatesCallback += ProvideClientCertificatesCallback;
+        conn.UserCertificateValidationCallback += UserCertificateValidationCallback;
         conn.Open();
 
         // Create the "accounts" table.
         new NpgsqlCommand("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)", conn).ExecuteNonQuery();
 
         // Insert two rows into the "accounts" table.
-        using(var cmd = new NpgsqlCommand())
+        using (var cmd = new NpgsqlCommand())
         {
           cmd.Connection = conn;
           cmd.CommandText = "UPSERT INTO accounts(id, balance) VALUES(@id1, @val1), (@id2, @val2)";
@@ -39,11 +44,58 @@ namespace Cockroach
 
         // Print out the balances.
         System.Console.WriteLine("Initial balances:");
-        using(var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
-        using(var reader = cmd.ExecuteReader())
-        while (reader.Read())
-          Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
+        using (var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
+        using (var reader = cmd.ExecuteReader())
+          while (reader.Read())
+            Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
       }
     }
+
+    static void ProvideClientCertificatesCallback(X509CertificateCollection clientCerts)
+    {
+      // To be able to add a certificate with a private key included, we must convert it to
+      // a PKCS #12 format. The following openssl command does this:
+      // openssl pkcs12 -password pass: -inkey client.maxroach.key -in client.maxroach.crt -export -out client.maxroach.pfx
+      // As of 2018-12-10, you need to provide a password for this to work on macOS.
+      // See https://github.com/dotnet/corefx/issues/24225
+
+      // Note that the password used during X509 cert creation below
+      // must match the password used in the openssl command above.
+      clientCerts.Add(new X509Certificate2("client.maxroach.pfx", "pass"));
+    }
+
+    // By default, .Net does all of its certificate verification using the system certificate store.
+    // This callback is necessary to validate the server certificate against a CA certificate file.
+    static bool UserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain defaultChain, SslPolicyErrors defaultErrors)
+    {
+      X509Certificate2 caCert = new X509Certificate2("ca.crt");
+      X509Chain caCertChain = new X509Chain();
+      caCertChain.ChainPolicy = new X509ChainPolicy()
+      {
+        RevocationMode = X509RevocationMode.NoCheck,
+        RevocationFlag = X509RevocationFlag.EntireChain
+      };
+      caCertChain.ChainPolicy.ExtraStore.Add(caCert);
+
+      X509Certificate2 serverCert = new X509Certificate2(certificate);
+
+      caCertChain.Build(serverCert);
+      if (caCertChain.ChainStatus.Length == 0)
+      {
+        // No errors
+        return true;
+      }
+
+      foreach (X509ChainStatus status in caCertChain.ChainStatus)
+      {
+        // Check if we got any errors other than UntrustedRoot (which we will always get if we don't install the CA cert to the system store)
+        if (status.Status != X509ChainStatusFlags.UntrustedRoot)
+        {
+          return false;
+        }
+      }
+      return true;
+    }
+
   }
 }

--- a/_includes/v2.2/app/insecure/basic-sample.cs
+++ b/_includes/v2.2/app/insecure/basic-sample.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Data;
+using Npgsql;
+
+namespace Cockroach
+{
+  class MainClass
+  {
+    static void Main(string[] args)
+    {
+      var connStringBuilder = new NpgsqlConnectionStringBuilder();
+      connStringBuilder.Host = "localhost";
+      connStringBuilder.Port = 26257;
+      connStringBuilder.SslMode = SslMode.Disable;
+      connStringBuilder.Username = "maxroach";
+      connStringBuilder.Database = "bank";
+      Simple(connStringBuilder.ConnectionString);
+    }
+
+    static void Simple(string connString)
+    {
+      using (var conn = new NpgsqlConnection(connString))
+      {
+        conn.Open();
+
+        // Create the "accounts" table.
+        new NpgsqlCommand("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)", conn).ExecuteNonQuery();
+
+        // Insert two rows into the "accounts" table.
+        using (var cmd = new NpgsqlCommand())
+        {
+          cmd.Connection = conn;
+          cmd.CommandText = "UPSERT INTO accounts(id, balance) VALUES(@id1, @val1), (@id2, @val2)";
+          cmd.Parameters.AddWithValue("id1", 1);
+          cmd.Parameters.AddWithValue("val1", 1000);
+          cmd.Parameters.AddWithValue("id2", 2);
+          cmd.Parameters.AddWithValue("val2", 250);
+          cmd.ExecuteNonQuery();
+        }
+
+        // Print out the balances.
+        System.Console.WriteLine("Initial balances:");
+        using (var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
+        using (var reader = cmd.ExecuteReader())
+          while (reader.Read())
+            Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
+      }
+    }
+  }
+}

--- a/_includes/v2.2/app/insecure/txn-sample.cs
+++ b/_includes/v2.2/app/insecure/txn-sample.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Data;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Security;
 using Npgsql;
 
 namespace Cockroach
@@ -13,7 +11,7 @@ namespace Cockroach
       var connStringBuilder = new NpgsqlConnectionStringBuilder();
       connStringBuilder.Host = "localhost";
       connStringBuilder.Port = 26257;
-      connStringBuilder.SslMode = SslMode.Require;
+      connStringBuilder.SslMode = SslMode.Disable;
       connStringBuilder.Username = "maxroach";
       connStringBuilder.Database = "bank";
       TxnSample(connStringBuilder.ConnectionString);
@@ -52,9 +50,6 @@ namespace Cockroach
     {
       using (var conn = new NpgsqlConnection(connString))
       {
-        conn.ProvideClientCertificatesCallback += ProvideClientCertificatesCallback;
-        conn.UserCertificateValidationCallback += UserCertificateValidationCallback;
-
         conn.Open();
 
         // Create the "accounts" table.
@@ -120,49 +115,6 @@ namespace Cockroach
         while (reader.Read())
           Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
       }
-    }
-
-    static void ProvideClientCertificatesCallback(X509CertificateCollection clientCerts)
-    {
-      // To be able to add a certificate with a private key included, we must convert it to
-      // a PKCS #12 format. The following openssl command does this:
-      // openssl pkcs12 -inkey client.maxroach.key -in client.maxroach.crt -export -out client.maxroach.pfx
-      // As of 2018-12-10, you need to provide a password for this to work on macOS.
-      // See https://github.com/dotnet/corefx/issues/24225
-      clientCerts.Add(new X509Certificate2("certs/client.maxroach.pfx", "pass"));
-    }
-
-    // By default, .Net does all of its certificate verification using the system certificate store.
-    // This callback is necessary to validate the server certificate against a CA certificate file.
-    static bool UserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain defaultChain, SslPolicyErrors defaultErrors)
-    {
-      X509Certificate2 caCert = new X509Certificate2("certs/ca.crt");
-      X509Chain caCertChain = new X509Chain();
-      caCertChain.ChainPolicy = new X509ChainPolicy()
-      {
-        RevocationMode = X509RevocationMode.NoCheck,
-        RevocationFlag = X509RevocationFlag.EntireChain
-      };
-      caCertChain.ChainPolicy.ExtraStore.Add(caCert);
-
-      X509Certificate2 serverCert = new X509Certificate2(certificate);
-
-      caCertChain.Build(serverCert);
-      if (caCertChain.ChainStatus.Length == 0)
-      {
-        // No errors
-        return true;
-      }
-
-      foreach (X509ChainStatus status in caCertChain.ChainStatus)
-      {
-        // Check if we got any errors other than UntrustedRoot (which we will always get if we don't install the CA cert to the system store)
-        if (status.Status != X509ChainStatusFlags.UntrustedRoot)
-        {
-          return false;
-        }
-      }
-      return true;      
     }
   }
 }

--- a/_includes/v2.2/app/txn-sample.cs
+++ b/_includes/v2.2/app/txn-sample.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Data;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
 using Npgsql;
 
 namespace Cockroach
@@ -11,6 +13,7 @@ namespace Cockroach
       var connStringBuilder = new NpgsqlConnectionStringBuilder();
       connStringBuilder.Host = "localhost";
       connStringBuilder.Port = 26257;
+      connStringBuilder.SslMode = SslMode.Require;
       connStringBuilder.Username = "maxroach";
       connStringBuilder.Database = "bank";
       TxnSample(connStringBuilder.ConnectionString);
@@ -19,8 +22,8 @@ namespace Cockroach
     static void TransferFunds(NpgsqlConnection conn, NpgsqlTransaction tran, int from, int to, int amount)
     {
       int balance = 0;
-      using(var cmd = new NpgsqlCommand(String.Format("SELECT balance FROM accounts WHERE id = {0}", from), conn, tran))
-      using(var reader = cmd.ExecuteReader())
+      using (var cmd = new NpgsqlCommand(String.Format("SELECT balance FROM accounts WHERE id = {0}", from), conn, tran))
+      using (var reader = cmd.ExecuteReader())
       {
         if (reader.Read())
         {
@@ -35,11 +38,11 @@ namespace Cockroach
       {
         throw new DataException(String.Format("Insufficient balance in account id={0}", from));
       }
-      using(var cmd = new NpgsqlCommand(String.Format("UPDATE accounts SET balance = balance - {0} where id = {1}", amount, from), conn, tran))
+      using (var cmd = new NpgsqlCommand(String.Format("UPDATE accounts SET balance = balance - {0} where id = {1}", amount, from), conn, tran))
       {
         cmd.ExecuteNonQuery();
       }
-      using(var cmd = new NpgsqlCommand(String.Format("UPDATE accounts SET balance = balance + {0} where id = {1}", amount, to), conn, tran))
+      using (var cmd = new NpgsqlCommand(String.Format("UPDATE accounts SET balance = balance + {0} where id = {1}", amount, to), conn, tran))
       {
         cmd.ExecuteNonQuery();
       }
@@ -47,15 +50,18 @@ namespace Cockroach
 
     static void TxnSample(string connString)
     {
-      using(var conn = new NpgsqlConnection(connString))
+      using (var conn = new NpgsqlConnection(connString))
       {
+        conn.ProvideClientCertificatesCallback += ProvideClientCertificatesCallback;
+        conn.UserCertificateValidationCallback += UserCertificateValidationCallback;
+
         conn.Open();
 
         // Create the "accounts" table.
         new NpgsqlCommand("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)", conn).ExecuteNonQuery();
 
         // Insert two rows into the "accounts" table.
-        using(var cmd = new NpgsqlCommand())
+        using (var cmd = new NpgsqlCommand())
         {
           cmd.Connection = conn;
           cmd.CommandText = "UPSERT INTO accounts(id, balance) VALUES(@id1, @val1), (@id2, @val2)";
@@ -68,14 +74,14 @@ namespace Cockroach
 
         // Print out the balances.
         System.Console.WriteLine("Initial balances:");
-        using(var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
-        using(var reader = cmd.ExecuteReader())
+        using (var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
+        using (var reader = cmd.ExecuteReader())
         while (reader.Read())
           Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
 
         try
         {
-          using(var tran = conn.BeginTransaction())
+          using (var tran = conn.BeginTransaction())
           {
             tran.Save("cockroach_restart");
             while (true)
@@ -109,11 +115,54 @@ namespace Cockroach
 
         // Now printout the results.
         Console.WriteLine("Final balances:");
-        using(var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
-        using(var reader = cmd.ExecuteReader())
+        using (var cmd = new NpgsqlCommand("SELECT id, balance FROM accounts", conn))
+        using (var reader = cmd.ExecuteReader())
         while (reader.Read())
           Console.Write("\taccount {0}: {1}\n", reader.GetValue(0), reader.GetValue(1));
       }
+    }
+
+    static void ProvideClientCertificatesCallback(X509CertificateCollection clientCerts)
+    {
+      // To be able to add a certificate with a private key included, we must convert it to
+      // a PKCS #12 format. The following openssl command does this:
+      // openssl pkcs12 -inkey client.maxroach.key -in client.maxroach.crt -export -out client.maxroach.pfx
+      // As of 2018-12-10, you need to provide a password for this to work on macOS.
+      // See https://github.com/dotnet/corefx/issues/24225
+      clientCerts.Add(new X509Certificate2("client.maxroach.pfx", "pass"));
+    }
+
+    // By default, .Net does all of its certificate verification using the system certificate store.
+    // This callback is necessary to validate the server certificate against a CA certificate file.
+    static bool UserCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain defaultChain, SslPolicyErrors defaultErrors)
+    {
+      X509Certificate2 caCert = new X509Certificate2("ca.crt");
+      X509Chain caCertChain = new X509Chain();
+      caCertChain.ChainPolicy = new X509ChainPolicy()
+      {
+        RevocationMode = X509RevocationMode.NoCheck,
+        RevocationFlag = X509RevocationFlag.EntireChain
+      };
+      caCertChain.ChainPolicy.ExtraStore.Add(caCert);
+
+      X509Certificate2 serverCert = new X509Certificate2(certificate);
+
+      caCertChain.Build(serverCert);
+      if (caCertChain.ChainStatus.Length == 0)
+      {
+        // No errors
+        return true;
+      }
+
+      foreach (X509ChainStatus status in caCertChain.ChainStatus)
+      {
+        // Check if we got any errors other than UntrustedRoot (which we will always get if we don't install the CA cert to the system store)
+        if (status.Status != X509ChainStatusFlags.UntrustedRoot)
+        {
+          return false;
+        }
+      }
+      return true;      
     }
   }
 }

--- a/v2.1/build-a-csharp-app-with-cockroachdb.md
+++ b/v2.1/build-a-csharp-app-with-cockroachdb.md
@@ -9,10 +9,9 @@ This tutorial shows you how build a simple C# (.NET) application with CockroachD
 
 We have tested the [.NET Npgsql driver](http://www.npgsql.org/) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
-
 ## Before you begin
 
-Make sure you have already [installed CockroachDB](install-cockroachdb.html) and the <a href="https://www.microsoft.com/net/download/" data-proofer-ignore>.NET SDK</a> for your OS.
+{% include {{page.version.version}}/app/before-you-begin.md %}
 
 ## Step 1. Create a .NET project
 
@@ -37,57 +36,51 @@ Install the latest version of the [Npgsql driver](https://www.nuget.org/packages
 $ dotnet add package Npgsql
 ~~~
 
-## Step 3. Start a single-node cluster
+<section class="filter-content" markdown="1" data-scope="secure">
 
-For the purpose of this tutorial, you need only one CockroachDB node running in insecure mode:
+## Step 3. Create the `maxroach` user and `bank` database
 
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach start \
---insecure \
---store=hello-1 \
---listen-addr=localhost
-~~~
+{% include {{page.version.version}}/app/create-maxroach-user-and-bank-database.md %}
 
-## Step 4. Create a user
+## Step 4. Generate a certificate for the `maxroach` user
 
-In a new terminal, as the `root` user, use the [`cockroach user`](create-and-manage-users.html) command to create a new user, `maxroach`.
+Create a certificate and key for the `maxroach` user by running the following command.  The code samples will run as this user.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach user set maxroach --insecure
+$ cockroach cert create-client maxroach --certs-dir=certs --ca-key=my-safe-directory/ca.key
 ~~~
 
-## Step 5. Create a database and grant privileges
+## Step 5. Convert the key file for use by C# programs
 
-As the `root` user, use the [built-in SQL client](use-the-built-in-sql-client.html) to create a `bank` database.
+The private key generated for user `maxroach` by CockroachDB is [PEM encoded](https://tools.ietf.org/html/rfc1421).  To read the key in a C# application, you will need to convert it into PKCS#12 format.
+
+To convert the key to PKCS#12 format, run the following OpenSSL command on the `maxroach` user's key file in the directory where you stored your certificates:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach sql --insecure -e 'CREATE DATABASE bank'
+$ openssl pkcs12 -inkey client.maxroach.key -password pass: -in client.maxroach.crt -export -out client.maxroach.pfx
 ~~~
 
-Then [grant privileges](grant.html) to the `maxroach` user.
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach sql --insecure -e 'GRANT ALL ON DATABASE bank TO maxroach'
-~~~
+As of December 2018, you need to provide a password for this to work on macOS. See <https://github.com/dotnet/corefx/issues/24225>.
 
 ## Step 6. Run the C# code
 
-Now that you have a database and a user, you'll run code to create a table and insert some rows, and then you'll run code to read and update values as an atomic [transaction](transactions.html).
+Now that you have created a database and set up encryption keys, in this section you will:
 
-### Basic statements
+- [Create a table and insert some rows](#basic-example)
+- [Execute a batch of statements as a transaction](#transaction-example-with-retry-logic)
 
-Replace the contents of `cockraochdb-test-app/Program.cs` with the following code:
+### Basic example
+
+Replace the contents of `cockroachdb-test-app/Program.cs` with the following code:
 
 {% include copy-clipboard.html %}
 ~~~ csharp
 {% include {{ page.version.version }}/app/basic-sample.cs %}
 ~~~
 
-Then run the code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows:
+Then, run the code to again connect as the `maxroach` user.  This time, execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -102,25 +95,23 @@ Initial balances:
 	account 2: 250
 ~~~
 
-### Transaction (with retry logic)
+### Transaction example (with retry logic)
 
-Open `cockraochdb-test-app/Program.cs` again and replace the contents with the following code:
+Open `cockroachdb-test-app/Program.cs` again and replace the contents with the code shown below.
+
+{% include {{page.version.version}}/client-transaction-retry.md %}
 
 {% include copy-clipboard.html %}
 ~~~ csharp
 {% include {{ page.version.version }}/app/txn-sample.cs %}
 ~~~
 
-Then run the code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
+Then, run the code to connect as the `maxroach` user.  This time, execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ dotnet run
 ~~~
-
-{{site.data.alerts.callout_info}}
-CockroachDB may require the [client to retry a transaction](transactions.html#transaction-retries) in case of read/write contention. CockroachDB provides a generic **retry function** that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.
-{{site.data.alerts.end}}
 
 The output should be:
 
@@ -137,18 +128,105 @@ However, if you want to verify that funds were transferred from one account to a
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
+$ cockroach sql --certs-dir=certs --database=bank -e 'SELECT id, balance FROM accounts'
 ~~~
 
 ~~~
+  id | balance
 +----+---------+
-| id | balance |
-+----+---------+
-|  1 |     900 |
-|  2 |     350 |
-+----+---------+
+   1 |     900
+   2 |     350
 (2 rows)
 ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="insecure">
+
+## Step 3. Create the `maxroach` user and `bank` database
+
+{% include {{page.version.version}}/app/insecure/create-maxroach-user-and-bank-database.md %}
+
+## Step 4. Run the C# code
+
+Now that you have created a database and set up encryption keys, in this section you will:
+
+- [Create a table and insert some rows](#basic2)
+- [Execute a batch of statements as a transaction](#transaction2)
+
+<a name="basic2"></a>
+
+### Basic example
+
+Replace the contents of `cockroachdb-test-app/Program.cs` with the following code:
+
+{% include copy-clipboard.html %}
+~~~ csharp
+{% include {{ page.version.version }}/app/insecure/basic-sample.cs %}
+~~~
+
+Then, run the code to connect as the `maxroach` user and execute some basic SQL statements: creating a table, inserting rows, and reading and printing the rows.
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ dotnet run
+~~~
+
+The output should be:
+
+~~~
+Initial balances:
+	account 1: 1000
+	account 2: 250
+~~~
+
+<a name="transaction2"></a>
+
+### Transaction example (with retry logic)
+
+Open `cockroachdb-test-app/Program.cs` again and replace the contents with the code shown below.
+
+{% include {{page.version.version}}/client-transaction-retry.md %}
+
+{% include copy-clipboard.html %}
+~~~ csharp
+{% include {{ page.version.version }}/app/insecure/txn-sample.cs %}
+~~~
+
+Then, run the code to connect as the `maxroach` user.  This time, execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ dotnet run
+~~~
+
+The output should be:
+
+~~~
+Initial balances:
+	account 1: 1000
+	account 2: 250
+Final balances:
+	account 1: 900
+	account 2: 350
+~~~
+
+However, if you want to verify that funds were transferred from one account to another, use the [built-in SQL client](use-the-built-in-sql-client.html):
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --insecure  --database=bank -e 'SELECT id, balance FROM accounts'
+~~~
+
+~~~
+  id | balance
++----+---------+
+   1 |     900
+   2 |     350
+(2 rows)
+~~~
+
+</section>
 
 ## What's next?
 

--- a/v2.2/build-a-csharp-app-with-cockroachdb.md
+++ b/v2.2/build-a-csharp-app-with-cockroachdb.md
@@ -9,10 +9,9 @@ This tutorial shows you how build a simple C# (.NET) application with CockroachD
 
 We have tested the [.NET Npgsql driver](http://www.npgsql.org/) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
-
 ## Before you begin
 
-Make sure you have already [installed CockroachDB](install-cockroachdb.html) and the <a href="https://www.microsoft.com/net/download/" data-proofer-ignore>.NET SDK</a> for your OS.
+{% include {{page.version.version}}/app/before-you-begin.md %}
 
 ## Step 1. Create a .NET project
 
@@ -37,57 +36,51 @@ Install the latest version of the [Npgsql driver](https://www.nuget.org/packages
 $ dotnet add package Npgsql
 ~~~
 
-## Step 3. Start a single-node cluster
+<section class="filter-content" markdown="1" data-scope="secure">
 
-For the purpose of this tutorial, you need only one CockroachDB node running in insecure mode:
+## Step 3. Create the `maxroach` user and `bank` database
 
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach start \
---insecure \
---store=hello-1 \
---listen-addr=localhost
-~~~
+{% include {{page.version.version}}/app/create-maxroach-user-and-bank-database.md %}
 
-## Step 4. Create a user
+## Step 4. Generate a certificate for the `maxroach` user
 
-In a new terminal, as the `root` user, use the [`cockroach user`](create-and-manage-users.html) command to create a new user, `maxroach`.
+Create a certificate and key for the `maxroach` user by running the following command.  The code samples will run as this user.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach user set maxroach --insecure
+$ cockroach cert create-client maxroach --certs-dir=certs --ca-key=my-safe-directory/ca.key
 ~~~
 
-## Step 5. Create a database and grant privileges
+## Step 5. Convert the key file for use by C# programs
 
-As the `root` user, use the [built-in SQL client](use-the-built-in-sql-client.html) to create a `bank` database.
+The private key generated for user `maxroach` by CockroachDB is [PEM encoded](https://tools.ietf.org/html/rfc1421).  To read the key in a C# application, you will need to convert it into PKCS#12 format.
+
+To convert the key to PKCS#12 format, run the following OpenSSL command on the `maxroach` user's key file in the directory where you stored your certificates:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach sql --insecure -e 'CREATE DATABASE bank'
+$ openssl pkcs12 -inkey client.maxroach.key -password pass: -in client.maxroach.crt -export -out client.maxroach.pfx
 ~~~
 
-Then [grant privileges](grant.html) to the `maxroach` user.
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach sql --insecure -e 'GRANT ALL ON DATABASE bank TO maxroach'
-~~~
+As of December 2018, you need to provide a password for this to work on macOS. See <https://github.com/dotnet/corefx/issues/24225>.
 
 ## Step 6. Run the C# code
 
-Now that you have a database and a user, you'll run code to create a table and insert some rows, and then you'll run code to read and update values as an atomic [transaction](transactions.html).
+Now that you have created a database and set up encryption keys, in this section you will:
 
-### Basic statements
+- [Create a table and insert some rows](#basic-example)
+- [Execute a batch of statements as a transaction](#transaction-example-with-retry-logic)
 
-Replace the contents of `cockraochdb-test-app/Program.cs` with the following code:
+### Basic example
+
+Replace the contents of `cockroachdb-test-app/Program.cs` with the following code:
 
 {% include copy-clipboard.html %}
 ~~~ csharp
 {% include {{ page.version.version }}/app/basic-sample.cs %}
 ~~~
 
-Then run the code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows:
+Then, run the code to connect as the `maxroach` user.  This time, execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -102,25 +95,23 @@ Initial balances:
 	account 2: 250
 ~~~
 
-### Transaction (with retry logic)
+### Transaction example (with retry logic)
 
-Open `cockraochdb-test-app/Program.cs` again and replace the contents with the following code:
+Open `cockroachdb-test-app/Program.cs` again and replace the contents with the code shown below.
+
+{% include {{page.version.version}}/client-transaction-retry.md %}
 
 {% include copy-clipboard.html %}
 ~~~ csharp
 {% include {{ page.version.version }}/app/txn-sample.cs %}
 ~~~
 
-Then run the code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
+Then, run the code to connect as the `maxroach` user.  This time, execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ dotnet run
 ~~~
-
-{{site.data.alerts.callout_info}}
-CockroachDB may require the [client to retry a transaction](transactions.html#transaction-retries) in case of read/write contention. CockroachDB provides a generic **retry function** that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.
-{{site.data.alerts.end}}
 
 The output should be:
 
@@ -137,18 +128,105 @@ However, if you want to verify that funds were transferred from one account to a
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
+$ cockroach sql --certs-dir=certs --database=bank -e 'SELECT id, balance FROM accounts'
 ~~~
 
 ~~~
+  id | balance
 +----+---------+
-| id | balance |
-+----+---------+
-|  1 |     900 |
-|  2 |     350 |
-+----+---------+
+   1 |     900
+   2 |     350
 (2 rows)
 ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="insecure">
+
+## Step 3. Create the `maxroach` user and `bank` database
+
+{% include {{page.version.version}}/app/insecure/create-maxroach-user-and-bank-database.md %}
+
+## Step 4. Run the C# code
+
+Now that you have created a database and set up encryption keys, in this section you will:
+
+- [Create a table and insert some rows](#basic2)
+- [Execute a batch of statements as a transaction](#transaction2)
+
+<a name="basic2"></a>
+
+### Basic example
+
+Replace the contents of `cockroachdb-test-app/Program.cs` with the following code:
+
+{% include copy-clipboard.html %}
+~~~ csharp
+{% include {{ page.version.version }}/app/insecure/basic-sample.cs %}
+~~~
+
+Then, run the code to connect as the `maxroach` user and execute some basic SQL statements: creating a table, inserting rows, and reading and printing the rows:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ dotnet run
+~~~
+
+The output should be:
+
+~~~
+Initial balances:
+	account 1: 1000
+	account 2: 250
+~~~
+
+<a name="transaction2"></a>
+
+### Transaction example (with retry logic)
+
+Open `cockroachdb-test-app/Program.cs` again and replace the contents with the code shown below.
+
+{% include {{page.version.version}}/client-transaction-retry.md %}
+
+{% include copy-clipboard.html %}
+~~~ csharp
+{% include {{ page.version.version }}/app/insecure/txn-sample.cs %}
+~~~
+
+Then, run the code to connect as the `maxroach` user.  This time, execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ dotnet run
+~~~
+
+The output should be:
+
+~~~
+Initial balances:
+	account 1: 1000
+	account 2: 250
+Final balances:
+	account 1: 900
+	account 2: 350
+~~~
+
+However, if you want to verify that funds were transferred from one account to another, use the [built-in SQL client](use-the-built-in-sql-client.html):
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --insecure  --database=bank -e 'SELECT id, balance FROM accounts'
+~~~
+
+~~~
+  id | balance
++----+---------+
+   1 |     900
+   2 |     350
+(2 rows)
+~~~
+
+</section>
 
 ## What's next?
 


### PR DESCRIPTION
Addresses part of #3700.

Summary of changes:

- Update C# code samples to show how to connect to secure clusters (this
  is using code from @BramGruneir and @rolandcrosby - thanks guys!).

- Update the instructions in the docs to show how to create the
  PKCS#12-formatted certificates which are required by C# (thanks for
  the magic openssl incantation @mberhault).

- Various updates and copy edits to make the page work like our other
  updated "Build an app" examples, i.e., using the new includes,
  providing secure and insecure examples, etc.

- Note: all of the changes to both docs and code were replicated across
  both v2.1 and v2.2.