### PR TITLE
Update CREATE STATISTICS doc with missing variants

### DIFF
--- a/_includes/sidebar-data-v2.2.json
+++ b/_includes/sidebar-data-v2.2.json
@@ -733,7 +733,7 @@
                 ]
               },
               {
-                "title": "<code>CREATE STATISTICS</code> (Experimental)",
+                "title": "<code>CREATE STATISTICS</code>",
                 "urls": [
                   "/${VERSION}/create-statistics.html"
                 ]
@@ -1075,7 +1075,7 @@
                 ]
               },
               {
-                "title": "<code>SHOW STATISTICS</code> (Experimental)",
+                "title": "<code>SHOW STATISTICS</code>",
                 "urls": [
                   "/${VERSION}/show-statistics.html"
                 ]

--- a/_includes/v2.2/misc/automatic-statistics.md
+++ b/_includes/v2.2/misc/automatic-statistics.md
@@ -1,0 +1,27 @@
+<span class="version-tag">New in v2.2</span>: CockroachDB can generate table statistics automatically as tables are updated.
+
+To turn on automatic statistics collection:
+
+1. Run the following statement to enable the automatic statistics [cluster setting](cluster-settings.html):
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true
+    ~~~
+
+2. Restart the nodes in your cluster so it can generate statistics for all tables at startup (including read-only tables).
+
+To turn off automatic statistics collection:
+
+1. Run the following statement to disable the automatic statistics [cluster setting](cluster-settings.html):
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=false
+    ~~~
+
+2. Look up what statistics were created by the automatic statistics generator using the [`SHOW STATISTICS`](show-statistics.html) statement.
+
+3. Delete the automatically generated statistics using the instructions in [delete statistics](create-statistics.html#delete-statistics).
+
+4. Restart the nodes in your cluster to clear the statistics caches.

--- a/_includes/v2.2/misc/delete-statistics.md
+++ b/_includes/v2.2/misc/delete-statistics.md
@@ -1,0 +1,15 @@
+To delete statistics for all tables in all databases:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DELETE FROM system.table_statistics WHERE true;
+~~~
+
+To delete a named set of statistics (e.g, one named "my_stats"), run a query like the following:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DELETE FROM system.table_statistics WHERE name = 'my_stats';
+~~~
+
+For more information about the `DELETE` statement, see [`DELETE`](delete.html).

--- a/_includes/v2.2/sql/diagrams/create_stats.html
+++ b/_includes/v2.2/sql/diagrams/create_stats.html
@@ -1,4 +1,4 @@
-<div><svg width="655" height="103">
+<div><svg width="627" height="103">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="72" height="32" rx="10"></rect>
@@ -9,16 +9,17 @@
 <text class="terminal" x="131" y="21">STATISTICS</text>
 <rect x="245" y="3" width="120" height="32"></rect>
 <rect x="243" y="1" width="120" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="253" y="21">statistics_name</text><rect x="385" y="3" width="40" height="32" rx="10"></rect>
-<rect x="383" y="1" width="40" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="393" y="21">ON</text>
-<rect x="445" y="3" width="108" height="32"></rect>
-<rect x="443" y="1" width="108" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="453" y="21">column_name</text><rect x="573" y="3" width="60" height="32" rx="10"></rect>
-<rect x="571" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="581" y="21">FROM</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="531" y="69" width="96" height="32"></rect>
-<rect x="529" y="67" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="539" y="87">table_name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-146 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m3 0 h-3"></path>
-<polygon points="645 83 653 79 653 87"></polygon>
-<polygon points="645 83 637 79 637 87"></polygon></svg></div>
+<text class="nonterminal" x="253" y="21">statistics_name</text>
+<rect x="385" y="3" width="140" height="32"></rect>
+<rect x="383" y="1" width="140" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="393" y="21">opt_stats_columns</text><rect x="545" y="3" width="60" height="32" rx="10"></rect>
+<rect x="543" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="553" y="21">FROM</text>
+<rect x="301" y="69" width="146" height="32"></rect>
+<rect x="299" y="67" width="146" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="309" y="87">create_stats_target</text>
+<rect x="467" y="69" width="132" height="32"></rect>
+<rect x="465" y="67" width="132" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="475" y="87">opt_as_of_clause</text><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-348 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m146 0 h10 m0 0 h10 m132 0 h10 m3 0 h-3"></path>
+<polygon points="617 83 625 79 625 87"></polygon>
+<polygon points="617 83 609 79 609 87"></polygon></svg></div>

--- a/_includes/v2.2/sql/settings/settings.md
+++ b/_includes/v2.2/sql/settings/settings.md
@@ -61,7 +61,7 @@
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.defaults.default_int_size</code></td><td>integer</td><td><code>8</code></td><td>the size, in bytes, of an INT type</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>default distributed SQL execution mode [off = 0, auto = 1, on = 2, 2.0-off = 3, 2.0-auto = 4]</td></tr>
-<tr><td><code>sql.defaults.experimental_automatic_statistics</code></td><td>boolean</td><td><code>false</code></td><td>default experimental automatic statistics mode</td></tr>
+<tr><td><code>sql.stats.experimental_automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>If <code>true</code>, turn on the experimental <a href="create-statistics.html#automatic-table-statistics">automatic statistics collection</a>.</td></tr>
 <tr><td><code>sql.defaults.experimental_optimizer_mutations</code></td><td>boolean</td><td><code>false</code></td><td>default experimental_optimizer_mutations mode</td></tr>
 <tr><td><code>sql.defaults.experimental_vectorize</code></td><td>enumeration</td><td><code>0</code></td><td>default experimental_vectorize mode [off = 0, on = 1, always = 2]</td></tr>
 <tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>1</code></td><td>default cost-based optimizer mode [off = 0, on = 1, local = 2]</td></tr>

--- a/v2.2/cost-based-optimizer.md
+++ b/v2.2/cost-based-optimizer.md
@@ -96,34 +96,18 @@ There are several ways to generate table statistics:
 
 Each method is described below.
 
+### Automatic table statistics
+
+{% include {{ page.version.version }}/misc/automatic-statistics.md %}
+
 ### Manually generating table statistics
 
-To manually generate statistics for a table, run a [`CREATE STATISTICS`](create-statistics.html) statement like the one shown below. It automatically figures out which columns to get statistics on -- specifically, it chooses columns which are part of the primary key or an index.
+To manually generate statistics for a table, run a [`CREATE STATISTICS`](create-statistics.html) statement like the one shown below. It automatically figures out which columns to get statistics on &mdash; specifically, it chooses columns which are part of the primary key or an index.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> CREATE STATISTICS __auto__ FROM employees;
+> CREATE STATISTICS employees_stats FROM employees;
 ~~~
-
-### Automatic table statistics
-
-<span class="version-tag">New in v2.2</span>: CockroachDB can generate table statistics automatically as tables are updated.
-
-To turn on this feature:
-
-1. For each table in the database, run [`CREATE STATISTICS`](create-statistics.html) manually **before** enabling the automatic statistics flag. This is necessary to prevent the system from getting too overloaded right after the feature is enabled.
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > CREATE STATISTICS __auto__ FROM table1;  -- Repeat for table2, table3, ..., tableN.
-    ~~~
-
-2. Run the following statement to turn on the automatic statistics system:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SET sql.defaults.experimental_automatic_statistics=true
-    ~~~
 
 ## Query plan cache
 

--- a/v2.2/create-statistics.md
+++ b/v2.2/create-statistics.md
@@ -1,17 +1,11 @@
 ---
-title: CREATE STATISTICS (Experimental)
+title: CREATE STATISTICS
 summary: Use the CREATE STATISTICS statement to generate table statistics for the cost-based optimizer to use.
 toc: true
 ---
 Use the `CREATE STATISTICS` [statement](sql-statements.html) to generate table statistics for the [cost-based optimizer](cost-based-optimizer.html) to use.
 
 Once you [create a table](create-table.html) and load data into it (e.g., [`INSERT`](insert.html), [`IMPORT`](import.html)), table statistics can be generated. Table statistics help the cost-based optimizer determine the cardinality of the rows used in each query, which helps to predict more accurate costs.
-
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
-
-## Considerations
-
-Each time `CREATE STATISTICS` is used, a new statistic is created without removing any old statistics. To delete statistics for all tables in all databases, use [`DELETE`](#delete-all-statistics).
 
 ## Synopsis
 
@@ -25,43 +19,53 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
 ## Parameters
 
-Parameter            | Description
----------------------+--------------------------------------------------------------
-`statistics_name`    | The name of the statistic you are creating.
-`column_name`        | The name of the column you want to create the statistic for.
-`table_name`         | The name of the table you want to create the statistic for.
+| Parameter             | Description                                                                                                                                                                                           |
+|-----------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `statistics_name`     | The name of the set of statistics you are creating.                                                                                                                                                   |
+| `opt_stats_columns`   | The name of the column(s) you want to create statistics for.                                                                                                                                          |
+| `create_stats_target` | The name of the table you want to create statistics for.                                                                                                                                              |
+| `opt_as_of_clause`    | Used to create historical stats using the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause.  For instructions, see [Create statistics as of a given time](#create-statistics-as-of-a-given-time). |
 
 ## Examples
 
-### Create statistics
+### Automatic table statistics
+
+{% include {{ page.version.version }}/misc/automatic-statistics.md %}
+
+### Create statistics on a specific column
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE STATISTICS students ON id FROM students_by_list;
 ~~~
 
-~~~
-CREATE STATISTICS
-~~~
-
 {{site.data.alerts.callout_info}}
 Multi-column statistics are not supported yet.
 {{site.data.alerts.end}}
 
-### Delete all statistics
+### Create statistics on a default set of columns
 
-To delete statistics for all tables in all databases:
+The `CREATE STATISTICS` statement shown below automatically figures out which columns to get statistics on &mdash; specifically, it chooses columns which are part of the primary key and/or an index.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> DELETE FROM system.table_statistics WHERE true;
+> CREATE STATISTICS students FROM students_by_list;
 ~~~
 
-~~~
-DELETE 1
+### Create statistics as of a given time
+
+To create statistics as of a given time (in this example, 1 minute ago to avoid interfering with the production workload), run a statement like the following:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE STATISTICS employee_stats FROM employees AS OF SYSTEM TIME '-1m';
 ~~~
 
-For more information, see [`DELETE`](delete.html).
+For more information about how the `AS OF SYSTEM TIME` clause works, including supported time formats, see [`AS OF SYSTEM TIME`](as-of-system-time.html).
+
+### Delete statistics
+
+{% include {{ page.version.version }}/misc/delete-statistics.md %}
 
 ## See Also
 

--- a/v2.2/show-statistics.md
+++ b/v2.2/show-statistics.md
@@ -1,11 +1,9 @@
 ---
-title: SHOW STATISTICS (Experimental)
+title: SHOW STATISTICS
 summary: The SHOW STATISTICS statement lists table statistics.
 toc: true
 ---
 The `SHOW STATISTICS` [statement](sql-statements.html) lists [table statistics](create-statistics.html) used by the [cost-based optimizer](cost-based-optimizer.html).
-
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
 
 ## Synopsis
 
@@ -47,6 +45,10 @@ CREATE STATISTICS
   students        | {"id"}       | 2018-10-26 15:06:34.320165+00:00 |         0 |              0 |          0 |         NULL
 (1 row)
 ~~~
+
+### Delete statistics
+
+{% include {{ page.version.version }}/misc/delete-statistics.md %}
 
 ## See Also
 


### PR DESCRIPTION
Fixes #4241, #4253, #4180.

Summary of changes:

- Update CREATE STATISTICS doc with the following variants:

  - CREATE STATISTICS foo FROM bar
  - CREATE STATISTICS __auto__ FROM bar
  - CREATE STATISTICS foo FROM bar AS OF SYSTEM TIME '-4h'

- Added information about automatic stats collection to the CREATE
  STATISTICS page (via an include)

- Updated instructions for deleting statistics, added to both CREATE
  STATISTICS and SHOW STATISTICS pages (via include)

- Updated railroad diagram and parameter descriptions for CREATE
  STATISTICS v2.2

- Updated sidebar and page titles to remove extraneous "experimental"
  text, since it's already clearly marked in the various documents via
  an include.

- Used a proper emdash (!) in a few places.