### PR TITLE
Update INT docs re: INT8, default_int_size setting

### DIFF
--- a/_includes/v2.2/misc/session-vars.html
+++ b/_includes/v2.2/misc/session-vars.html
@@ -38,6 +38,18 @@
 
   <tr>
    <td>
+    <code>default_int_size</code>
+   </td>
+   <td>The size, in bytes, of an <a href="int.html"><code>INT</code></a> type.</td>
+   <td>
+    <code>8</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>default_transaction_isolation</code>
    </td>
    <td>All transactions execute with <code>SERIALIZABLE</code> isolation. See <a href="transactions.html#isolation-levels">Transactions: Isolation levels</a>.</td>

--- a/v2.2/int.md
+++ b/v2.2/int.md
@@ -10,14 +10,14 @@ CockroachDB supports various signed integer [data types](data-types.html).
 For instructions showing how to auto-generate integer values (e.g., to auto-number rows in a table), see [this FAQ entry](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb).
 {{site.data.alerts.end}}
 
-
 ## Names and Aliases
 
-Name | Allowed Width | Aliases
------|-------|--------
-`INT` | 64-bit | `INTEGER`<br>`INT8`<br>`INT64`<br>`BIGINT`
-`INT4` | 32-bit | None
-`INT2` | 16-bit | `SMALLINT`
+| Name   | Allowed Width | Aliases                                          | Range                                        |
+|--------+---------------+--------------------------------------------------+----------------------------------------------|
+| `INT`  | 64-bit        | `INTEGER`<br />`INT8`<br />`INT64`<br />`BIGINT` | -9223372036854775807 to +9223372036854775807 |
+| `INT2` | 16-bit        | `SMALLINT`                                       | -32768 to +32767                             |
+| `INT4` | 32-bit        | None                                             | -2147483648 to +2147483647                   |
+| `INT8` | 64-bit        | `INT`                                            | -9223372036854775807 to +9223372036854775807 |
 
 ## Syntax
 
@@ -27,6 +27,28 @@ For example: `42`, `-1234`, or `0xCAFE`.
 ## Size
 
 The different integer types place different constraints on the range of allowable values, but all integers are stored in the same way regardless of type. Smaller values take up less space than larger ones (based on the numeric value, not the data type).
+
+### Considerations for 64-bit signed integers
+
+By default, `INT` is an alias for `INT8`, which creates 64-bit signed integers. This differs from the Postgres default for `INT`, [which is 32 bits](https://www.postgresql.org/docs/9.6/datatype-numeric.html), and may cause issues for your application if it is not written to handle 64-bit integers, whether due to the language your application is written in, or the ORM/framework it uses to generate SQL (if any).
+
+For example, JavaScript language runtimes represent numbers as 64-bit floats, which means that the JS runtime [can only represent 53 bits of numeric accuracy](http://2ality.com/2012/04/number-encoding.html) and thus has a max safe value of 2<sup>53</sup>, or 9007199254740992.  This means that the maximum size of a default `INT` in CockroachDB is much larger than JavaScript can represent as an integer. Visually, the size difference is as follows:
+
+```
+9223372036854775807 # INT default max value
+   9007199254740991 # JS integer max value
+```
+
+Given the above, if a table contains a column with a default-sized `INT` value, and you are reading from it or writing to it via JavaScript, you will not be able to read and write values to that column correctly. This issue can pop up in a surprising way if you are using a framework that autogenerates both frontend and backend code (such as [twirp](https://github.com/twitchtv/twirp)). In such cases, you may find that your backend code can handle 64-bit signed integers, but the generated client/frontend code cannot.
+
+If your application needs to use an integer size that is different than the CockroachDB default (for these or other reasons), you can change one or both of the settings below. For example, you can set either of the below to `4` to cause `INT` and `SERIAL` to become aliases for `INT4` and `SERIAL4`, which use 32-bit integers.
+
+1. The `default_int_size` [session variable](set-vars.html).
+2. The `sql.defaults.default_int_size` [cluster setting](cluster-settings.html).
+
+{{site.data.alerts.callout_success}}
+If your application requires arbitrary precision numbers, use the [`DECIMAL`](decimal.html) data type.
+{{site.data.alerts.end}}
 
 ## Examples
 
@@ -89,4 +111,6 @@ Type | Details
 
 ## See also
 
-[Data Types](data-types.html)
+- [Data Types](data-types.html)
+- [`FLOAT`](float.html)
+- [`DECIMAL`](decimal.html)


### PR DESCRIPTION
Fixes #4183, #4254.

Lays some groundwork for future work on #4298.

Summary of changes:

- Update `INT` page to include examples of actual min/max integers
  supported by each type for easier reference.

- Update `INT` data type page with additions to the **Size**
  section, specifically:

  - A description of possible compatibility issues caused by 64-bit
    integers vs. e.g. JavaScript runtimes, including when using
    frameworks that autogenerate frontend code.

  - Mention and link to `default_int_size` session var and cluster
    setting.

- Add `default_int_size` to session vars page