### PR TITLE
Add doc on API stability

### DIFF
--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -2051,6 +2051,82 @@
             ]
           }
         ]
+      },
+      {
+          "title": "APIs and forward compatibility",
+          "items": [
+			  {
+				  "title": "Interface types",
+				  "urls": [
+					  "/${VERSION}/interface-types.html"
+				  ]
+			  },
+			  {
+				  "title": "Compatibility and programmability guarantees",
+				  "urls": [
+					  "/${VERSION}/compatibility-and-programmability-guarantees.html"
+				  ]
+			  },
+			  {
+			  	  "title": "Experimental feature lifecycle",
+			  	  "urls": [
+			  		  "/${VERSION}/experimental-feature-lifecycle.html"
+			  	  ]
+			  },
+			  {
+				  "title": "Overview of APIs and interfaces",
+				  "urls": [
+					  "/${VERSION}/overview-of-apis-and-interfaces.html"
+				  ]
+			  },
+			  {
+				  "title": "Programmability of command-line interfaces",
+				  "urls": [
+					  "/${VERSION}/programmability-of-command-line-interfaces.html"
+				  ]
+			  },
+			  {
+				  "title": "SQL APIs and compatibility",
+				  "items": [
+					  {
+						  "title": "Client-server protocol",
+						  "urls": [
+							  "/${VERSION}/client-server-protocol.html"
+						  ]
+					  },
+					  {
+						  "title": "SQL functional behavior guarantees",
+						  "urls": [
+							  "/${VERSION}/sql-functional-behavior-guarantees.html"
+						  ]
+					  },
+					  {
+						  "title": "Programmability of session variables",
+						  "urls": [
+							  "/${VERSION}/programmability-of-session-variables.html"
+						  ]
+					  },
+					  {
+						  "title": "Time and memory cost model",
+						  "urls": [
+							  "/${VERSION}/time-and-memory-cost-model.html"
+						  ]
+					  },
+					  {
+						  "title": "Introspection interfaces",
+						  "urls": [
+							  "/${VERSION}/introspection-interfaces.html"
+						  ]
+					  }
+				  ]
+			  },
+			  {
+				  "title": "Programmability of other interfaces",
+				  "urls": [
+					  "/${VERSION}/programmability-of-other-interfaces.html"
+				  ]
+			  }
+		   ]
       }
     ]
   },

--- a/_includes/v19.2/misc/experimental-warning.md
+++ b/_includes/v19.2/misc/experimental-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-**This is an experimental feature**. The interface and output are subject to change.
+**This is an [experimental](experimental-feature-lifecycle.html) feature**. The interface and output are subject to change.
 {{site.data.alerts.end}}

--- a/v19.2/as-of-system-time.md
+++ b/v19.2/as-of-system-time.md
@@ -36,7 +36,7 @@ Format | Notes
 [`INT`](int.html) | Nanoseconds since the Unix epoch.
 negative [`INTERVAL`](interval.html) | Added to `statement_timestamp()`, and thus must be negative.
 [`STRING`](string.html) | A [`TIMESTAMP`](timestamp.html), [`INT`](int.html) of nanoseconds, or negative [`INTERVAL`](interval.html).
-`experimental_follower_read_timestamp()`| A [function](functions-and-operators.html) that runs your queries at a time as close as possible to the present time while remaining safe for [follower reads](follower-reads.html).
+`experimental_follower_read_timestamp()`| An [experimental](experimental-feature-lifecycle.html)  [function](functions-and-operators.html) that runs your queries at a time as close as possible to the present time while remaining safe for [follower reads](follower-reads.html).
 
 ## Examples
 

--- a/v19.2/change-data-capture.md
+++ b/v19.2/change-data-capture.md
@@ -796,3 +796,4 @@ The following are limitations in the current release and will be addressed in th
 - [`CANCEL JOB`](cancel-job.html)
 - [Other SQL Statements](sql-statements.html)
 - [Changefeed Dashboard](admin-ui-cdc-dashboard.html)
+

--- a/v19.2/client-server-protocol.md
+++ b/v19.2/client-server-protocol.md
@@ -1,0 +1,36 @@
+---
+title: Client-server protocol
+summary: Compatibility and stability guarantees for the low-level SQL wire protocol
+toc: true
+---
+
+CockroachDB uses a subset of the low level client-server byte protocol
+as PostgreSQL, called "pgwire" inside CockroachDB's source code and
+"Frontend/Backend protocol" inside PostgreSQL.
+
+For those wire protocol features that are common between PostgreSQL
+and CockroachDB, the [forward compatibility
+guarantees](compatibility-and-programmability-guarantees.html) are
+spelled out in this table:
+
+| Component                                                       | Status                        |
+|-----------------------------------------------------------------|-------------------------------|
+| Client status parameters passed during connection set-up        | [public and programmable]     |
+| Server status parameters passed during connection set-up        | [public and programmable]     |
+| Text data encoding for values                                   | [public and programmable]     |
+| Binary data encoding for values                                 | [public and programmable]     |
+| Error code 40001 for [retry errors](transactions.html)          | [public and programmable]     |
+| Error codes for other errors, error message text for all errors | [public and non-programmable] |
+
+## See also
+
+- [PostgreSQL Frontend/Backend Protocol](https://www.postgresql.org/docs/11/protocol.html)
+- [Client drivers](install-client-drivers.html)
+- [Client connection parameters](connection-parameters.html)
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces

--- a/v19.2/cluster-settings.md
+++ b/v19.2/cluster-settings.md
@@ -38,6 +38,7 @@ Before changing a cluster setting, please note the following:
 
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
+- [Programmability and forward compatibility for cluster settings](programmability-of-other-interfaces.html#cluster-settings)
 - [Diagnostics Reporting](diagnostics-reporting.html)
 - [Start a Node](cockroach-start.html)
 - [Use the Built-in SQL Client](cockroach-sql.html)

--- a/v19.2/cockroach-commands.md
+++ b/v19.2/cockroach-commands.md
@@ -48,3 +48,7 @@ CockroachDB prioritizes command flags, environment variables, and defaults as fo
 4. If there's no flag default, CockroachDB gives an error.
 
 For more details, see [Client Connection Parameters](connection-parameters.html).
+
+## See also
+
+- [Programmability and forward compatibility guarantees of command-line interfaces](programmability-of-command-line-interfaces.html)

--- a/v19.2/cockroach-demo.md
+++ b/v19.2/cockroach-demo.md
@@ -245,6 +245,7 @@ In addition to using one of the [pre-loaded dataset](#datasets), you can create 
 
 ## See also
 
+- [Programmability and forward compatibility guarantees for the `demo` shell](programmability-of-command-line-interfaces.html#guarantees-per-command)
 - [`cockroach sql`](cockroach-sql.html)
 - [`cockroach workload`](cockroach-workload.html)
 - [Other Cockroach Commands](cockroach-commands.html)

--- a/v19.2/cockroach-sql.md
+++ b/v19.2/cockroach-sql.md
@@ -772,6 +772,7 @@ In this example, the statement is executed every minute. We let the process run 
 
 ## See also
 
+- [Programmability and forward compatibility guarantees for the SQL shell](programmability-of-command-line-interfaces.html#guarantees-per-command)
 - [Client Connection Parameters](connection-parameters.html)
 - [`cockroach demo`](cockroach-demo.html)
 - [Other Cockroach Commands](cockroach-commands.html)

--- a/v19.2/cockroach-sqlfmt.md
+++ b/v19.2/cockroach-sqlfmt.md
@@ -153,6 +153,7 @@ SELECT (1 * 2) + 3, (1 + 2) * 3
 
 ## See also
 
+- [Programmability and forward compatibility guarantees for the `sqlfmt` command](programmability-of-command-line-interfaces.html#guarantees-per-command)
 - [Sequel Fumpt](https://sqlfum.pt/)
 - [`cockroach demo`](cockroach-demo.html)
 - [`cockroach sql`](cockroach-sql.html)

--- a/v19.2/cockroach-workload.md
+++ b/v19.2/cockroach-workload.md
@@ -7,7 +7,7 @@ toc: true
 CockroachDB comes with built-in load generators for simulating different types of client workloads, printing per-operation statistics and totals after a specific duration or max number of operations. To run one of these load generators, use the `cockroach workload` [command](cockroach-commands.html) as described below.
 
 {{site.data.alerts.callout_danger}}
-The `cockroach workload` command is experimental. The interface and output are subject to change.
+The `cockroach workload` command is [experimental](experimental-feature-lifecycle.html). The interface and output are subject to change.
 {{site.data.alerts.end}}
 
 ## Synopsis
@@ -653,6 +653,7 @@ To customize the frequency of per-operation statistics, use the `--display-every
 
 ## See also
 
+- [Programmability and forward compatibility guarantees for the `workload` command](programmability-of-command-line-interfaces.html#guarantees-per-command)
 - [`cockroach demo`](cockroach-demo.html)
 - [Other Cockroach Commands](cockroach-commands.html)
 - [Performance Benchmarking with TPC-C](performance-benchmarking-with-tpc-c-1k-warehouses.html)

--- a/v19.2/compatibility-and-programmability-guarantees.md
+++ b/v19.2/compatibility-and-programmability-guarantees.md
@@ -1,0 +1,166 @@
+---
+title: Compatibility and programmability guarantees
+summary: Stability commitment of various APIs throughout the lifecycle of CockroachDB.
+toc: true
+---
+
+This page outlines the stability guarantees offered with CockroachDB's
+[external interfaces](overview-of-apis-and-interfaces.html).
+
+## Overview
+
+### API stability in relation to CockroachDB's lifecycle
+
+Cockroach Labs uses patch revisions as a way to push corrections of
+implementation mistakes towards users (bug fixes and other
+adjustments). We expect users to be able to adopt patch revisions
+frequently, without fearing their applications will break in this
+process. The counterpoint is a **guarantee of API stability across
+patch revisions**.
+
+To reduce the internal complexity of CockroachDB around live
+upgrades, users are required to step through intermediate
+versions. We acknowledge this process is somewhat inconvenient.  To
+reduce this inconvenience, we choose to limit this requirement to
+intermediate major versions.  This in turn implies that **major
+changes will only be introduced in major versions**.
+
+### Scope of API stability
+
+Stability mainly matters when an interface is exploited by
+automation: stability ensures that this automation is preserved.
+However, a commitment to stability also comes with an engineering
+burden.
+
+To reduce this burden and preserve Cockroach Labs's ability to move
+CockroachDB forward, Cockroach Labs designs separate [programmable and
+non-programmable interfaces](interface-types.html) and restricts the
+stronger API stability guarantees to just those interfaces marked as
+programmable.
+
+### Introduction of new APIs
+
+When introducing new features or performing changes in CockroachDB,
+Cockroach Labs wishes to preserve a period of time to gather feedback
+from users and potentially make API changes accordingly. We thereby
+introduce [intermediate **experimental** and **beta**
+stages](experimental-feature-lifecycle.html)
+during which new APIs may change more frequently or more radically.
+
+### API evolution
+
+In rare cases, we may find overwhelming evidence that the current
+behavior of a public API is inadequate for most users. This includes
+security vulnerabilities, or cases where CockroachDB's behavior is
+incompatible with the expectation of 3rd-party PostgreSQL client
+applications or frameworks. In those cases, we may choose to
+introduce an API change in a patch revision to facilitate adoption
+of CockroachDB, with extra care to preserve compatibility with
+existing CockroachDB client apps. We enumerate these [**exceptions
+to the stability guarantees**](#exceptions-to-stability-guarantees)
+below.
+
+## Definitions
+
+Major versions are identified by the first two numbers in the full
+version string, and patch revisions are identified by the last number
+in the string.
+
+For example:
+
+| Version string | Major version | Patch revision |
+|----------------|---------------|----------------|
+| 2.1            | 2.1           | 0              |
+| 2.1.4          | 2.1           | 4              |
+| 19.1           | 19.1          | 0              |
+| 19.1.2         | 19.1          | 2              |
+
+## Exceptions to stability guarantees
+
+Generally, the CockroachDB team will attempt to preserve compatibility
+with existing CockroachDB apps built on major version N with versions N+1,
+N+2 and further. There are four main exceptions to this rule however:
+
+| Situation in “stable” phase of major version N                  | Earliest version where change can occur, if backward-compatible with existing apps | Earliest version where change can occur, when backward-incompatible |
+|-----------------------------------------------------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| [Implementation errors](#implementation-errors) (bugs)          | N.(X+1)  (patch revision)                                                          | N.(X+1) or N+1 depending on severity                                |
+| [Compatibility with PostgreSQL](#compatibility-with-postgresql) | N.(X+1)  (patch revision)                                                          | N.(X+1) opt-in<br>N+1 opt-out<br>N+2  definitive                    |
+| [Architectural changes](#architectural-changes)                 | N+1                                                                                | N+2                                                                 |
+| [Product evolution](#product-evolution)                         | N+1                                                                                | N+2                                                                 |
+
+Examples:
+
+- a bug is found in version 19.1.2. A bug fix is available, which does
+  not require changes to client apps. This fix may be implemented in
+  version 19.1.3.
+- a minor bug is found in version 19.1.3. A bug fix is available, but
+  requires minor changes to client apps or a cluster configuration
+  variable. This fix may be implemented no earlier than version 19.2.
+
+### Implementation errors
+
+If a public interface misbehaves in a way
+that is blatantly against expectations, this may be fixed
+in a subsequent patch revision.
+
+For example, the check for SQL access privileges (security), or the
+output of a SQL built-in function on edge case inputs, can be
+corrected across patch revisions.
+
+The CockroachDB team will work (via testing) to ensure that existing
+clients/tools are not negatively impacted by bug fixes; however
+there will be no consideration for tooling built expressely to rely
+on blatantly mis-behaving interfaces.
+
+### Compatibility with PostgreSQL
+
+If a feature combines the following properties:
+
+- It is supported both by CockroachDB and PostgreSQL.
+- Its interface is programmable.
+- Its behavior differs between CockroachDB and PostgreSQL.
+- There are well-known or sufficiently-widely used 3rd party apps built for PostgreSQL which do not react well to the CockroachDB behavior.
+- Changing CockroachDB to become more alike to PostgreSQL will not be overly disruptive to existing CockroachDB-specific apps.
+
+Then, CockroachDB will evolve to adopt the PostgreSQL behavior. This
+may occur in the next patch revision if there is a way to make the
+change invisible to existing CockroachDB apps. Once the change is
+prepared by Cockroach Labs, it will be finalized and published at the
+latest in major version N+2 if the change also requires changing
+existing CockroachDB apps. In-between, the compatibility may be
+adjustable with session variables or cluster settings.
+
+For example, the rules to derive data types for intermediate results
+in complex [SQL scalar expressions](scalar-expressions.html) may
+evolve in this way.
+
+### Architectural changes
+
+If a feature is based off an architectural choice inside CockroachDB,
+and the architecture of CockroachDB evolves in such a way that the
+feature becomes non-sensical or overly costly to maintain, it may be
+changed or removed in the next major release.
+
+For example, the structure and meaning of the output of the [`EXPLAIN`
+statement](explain.html) changes radically across major versions of
+CockroachDB due to the evolution of its query optimizer.
+
+### Product evolution
+
+When Cockroach Labs decides to evolve
+CockroachDB to better match demand by users, some existing public
+interfaces may change.
+
+In that case, existing clients will continue to work for patch
+revisions in the current major version and next, but may need to
+evolve in version N+2.
+
+For example, the features and particular data output of [`cockroach`
+sub-commands](cockroach-commands.html) is
+likely to evolve in this way.
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/date.md
+++ b/v19.2/date.md
@@ -84,12 +84,14 @@ String literal implicitly typed as `DATE`:
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
+`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
 `TIMESTAMP` | Sets the time to 00:00 (midnight) in the resulting timestamp.
-`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
 `STRING` | ––
 
 ## See also
 
 [Data Types](data-types.html)
+
+[experimental]: experimental-feature-lifecycle.html

--- a/v19.2/experimental-feature-lifecycle.md
+++ b/v19.2/experimental-feature-lifecycle.md
@@ -1,0 +1,53 @@
+---
+title: Experimental, beta and stable features
+summary: The expected lifecycle of features initially marked as "experimental".
+toc: true
+---
+
+New features are usually designed and prototyped in collaboration with
+users and customers, so that their initial release in a new major
+version of CockroachDB can be considered stable and ready for use
+immediately.
+
+Some features, however, require a longer period of time to explore uses
+in real-world scenarios, gather feedback and potentially make API
+changes accordingly.
+
+For this purpose, features may be released first with an “experimental” marker.
+At a later stage, they may be also marked as “beta”.
+Finally, when user feedback and design iterations have stabilized the
+result, the feature can be considered “stable”.
+
+## Support levels for experimental and beta features
+
+These three stages correspond to different levels of commitment from
+Cockroach Labs to provide support and preserve API forward
+compatibility, as follows:
+
+| Guarantee                                                                               | Experimental | Beta              | Stable          |
+|-----------------------------------------------------------------------------------------|--------------|-------------------|-----------------|
+| Client/app built on patch revision N.X works on revision N.X+1                          | No guarantee | Yes (best effort) | Yes             |
+| Client/app built on major version N works on version N+1 with only configuration change | No guarantee | Yes (best effort) | Yes             |
+| Client/app built on major version N works on version N+1 without any changes            | No guarantee | No guarantee      | Yes (see below) |
+| Client/app built on major version N works on version N+2 with only configuration change | No guarantee | No guarantee      | Yes (see below) |
+| Client/app built on major version N works on version N+2 without any changes            | No guarantee | No guarantee      | Yes (see below) |
+
+Stable features are linked to [stronger API stability and forward compatibility guarantees](compatibility-and-programmability-guarantees.html).
+
+## Experimental markers in the SQL syntax
+
+In addition to mentioning the “experimental” or “beta” status in the documentation,
+a feature may be marked in its API directly:
+
+- By including the prefix `experimental_` in the name of an
+  identifier, for example in [session variables](show-vars.html) or
+  [built-in functions](functions-and-operators.html).
+- By including the keyword `EXPERIMENTAL` in the SQL syntax,
+  for example in [SQL statements](sql-statements.html).
+
+## See also
+
+- [List of experimental features](experimental-features.html)
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/experimental-features.md
+++ b/v19.2/experimental-features.md
@@ -7,7 +7,7 @@ toc: true
 This page lists the experimental features that are available in CockroachDB {{ page.version.version }}.
 
 {{site.data.alerts.callout_danger}}
-**This page describes experimental features.**  Their interfaces and outputs are subject to change, and there may be bugs.
+**This page describes experimental features.**  Their interfaces and outputs are [subject to change](experimental-feature-lifecycle.html), and there may be bugs.
 <br />
 <br />
 If you encounter a bug, please [file an issue](file-an-issue.html).
@@ -144,6 +144,7 @@ To turn vectorized execution on for all operations, set the `vectorize` [session
 
 ## See Also
 
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
 - [`SHOW` (session)](show-vars.html)
 - [Functions and Operators](functions-and-operators.html)
 - [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html)

--- a/v19.2/information-schema.md
+++ b/v19.2/information-schema.md
@@ -298,7 +298,7 @@ Column | Description
 `table_schema` | Name of the schema that contains the table.
 `table_name` | Name of the table.
 `table_type` | Type of the table: `BASE TABLE` for a normal table, `VIEW` for a view, or `SYSTEM VIEW` for a view created by CockroachDB.
-`version` | Version number of the table; versions begin at 1 and are incremented each time an `ALTER TABLE` statement is issued on the table. Note that this column is an experimental feature used for internal purposes inside CockroachDB and its definition is subject to change without notice.
+`version` | Version number of the table; versions begin at 1 and are incremented each time an `ALTER TABLE` statement is issued on the table. Note that this column is a [reserved](interface-types.html) [experimental feature](experimental-feature-lifecycle.html) used for internal purposes inside CockroachDB and its definition is subject to change without notice.
 
 ### user_privileges
 
@@ -385,6 +385,7 @@ Column | Description
 
 ## See also
 
+- [SQL introspection interfaces](introspection-interfaces.html)
 - [`SHOW`](show-vars.html)
 - [`SHOW COLUMNS`](show-columns.html)
 - [`SHOW CONSTRAINTS`](show-constraints.html)

--- a/v19.2/int.md
+++ b/v19.2/int.md
@@ -105,8 +105,8 @@ Type | Details
 `FLOAT` | Loses precision if the `INT` value is larger than 2^53 in magnitude.
 `BIT` | Converts to the binary representation of the integer value. If the value is negative, the sign bit is replicated on the left to fill the entire bit array.
 `BOOL` | **0** converts to `false`; all other values convert to `true`.
-`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
+`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
 `INTERVAL` | Converts to microseconds.
 `STRING` | ––
 
@@ -115,3 +115,5 @@ Type | Details
 - [Data Types](data-types.html)
 - [`FLOAT`](float.html)
 - [`DECIMAL`](decimal.html)
+
+[experimental]: experimental-feature-lifecycle.html

--- a/v19.2/interface-types.md
+++ b/v19.2/interface-types.md
@@ -1,0 +1,97 @@
+---
+title: Interface types
+summary: Programmable, non-programmable and reserved interfaces in CockroachDB.
+toc: true
+---
+
+Cockroach Labs understands the need of users to rely on stable product
+interfaces that they can use to build further tooling and automation.
+Meanwhile, we have found from observing users that certain interfaces
+are mostly used interactively.
+
+We capture this difference by separating
+[**programmable**](#public-and-programmable-interfaces) interfaces,
+suitable for automation, from
+[**non-programmable**](#public-and-non-programmable-interfaces)
+interfaces which are meant for human consumption.
+
+Our [strong API stability and forward compatibility
+guarantees](compatibility-and-programmability-guarantees.html) are
+limited to those interfaces marked as programmable. The motivation is
+to limit the engineering burden incurred by a strong commitment to
+stability and forward compatibility, and enable faster and nimble
+evolutions of features intended for interactive use.
+
+Additionally, certain features exist only as a mean to aid
+development of CockroachDB itself and not meant to be consumed by
+end-users. However, because CockroachDB is an open source project, users
+often stumble upon these interfaces. To prevent users from accidentally
+starting to rely on an internal interface without any stability
+guarantee, we aim to call them out explicitly as [**reserved**](#reserved-interfaces).
+
+## Public and programmable interfaces
+
+These interfaces are meant for interfacing with third party automated
+tools. For example, the output of a `SELECT` query is public and
+programmable.
+
+The full list of public and programmable interfaces is given in the
+[Overview of APIs and
+interfaces](overview-of-apis-and-interfaces.html) and its linked sub-pages.
+
+For these interfaces, an app/client that works with major version N is
+expected to work with all patch revisions. Compatibility with version
+N+1 and later depends on the stability phase, as detailed in
+[Experimental feature lifecycle](experimental-feature-lifecycle.html).
+
+Additionally, the CockroachDB team commits to documenting remaining
+programmable interfaces over time, and/or upon request.
+
+## Public and non-programmable interfaces
+
+These interfaces are meant to be consumed by humans and are not
+suitable for automation. For example, the output of SQL `SHOW`
+statements is public but non-programmable.
+
+A partial list of public and non-programmable interfaces is given in the
+[Overview of APIs and
+interfaces](overview-of-apis-and-interfaces.html) and its linked sub-pages.
+
+For these interfaces, the stability guarantees are as follows:
+
+- the particular data format of the inputs and outputs may change across patch
+  revisions, although the CockroachDB team will make some effort to avoid this;
+- the particular data format of the inputs and outputs are likely to change
+  across major versions.
+
+These interfaces may not be documented, but can be incidentally
+explained on-demand by the CockroachDB team during discussions on
+public forums or during troubleshooting sessions. **Users are invited
+to reuse this knowledge.**
+
+## Reserved interfaces
+
+These interfaces are meant for use by CockroachDB developers and are
+not suitable for use, neither in automation by 3rd parties, nor by
+external documentation that aims to remain relevant across CockroachDB
+revisions.
+
+For example, the contents of certain tables in the
+`crdb_internal` SQL virtual schema is a reserved interface.
+
+**As a general rule, an interface should be considered reserved if it is
+not explicitly documented as public.** A partial list of reserved
+interfaces is given in the [Overview of APIs and
+interfaces](overview-of-apis-and-interfaces.html) and its linked
+sub-pages.
+
+For these, the stability guarantees are as follows:
+
+- the particular data format of inputs or outputs may change between
+  patch revisions.
+- there is no expectation of accurate nor up-to-date documentation.
+
+## See also
+
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/introspection-interfaces.md
+++ b/v19.2/introspection-interfaces.md
@@ -1,0 +1,131 @@
+---
+title: SQL introspection interfaces
+summary: Which interfaces can be queried to inspect CockroachDB from SQL and forward compatibility guarantees.
+toc: true
+---
+
+The SQL introspection interfaces are pre-defined tables and system
+views that provide access to the current state of a CockroachDB
+clusters, including the SQL metaschema and other configuration
+settings.
+
+CockroachDB provides the following introspection interfaces:
+
+- The virtual [`information_schema`](information-schema.html) in each
+  database. This is the **recommended** primary introspection facility
+  provided by CockroachDB. This is modeled after [PostgreSQL's own
+  `information_schema`](https://www.postgresql.org/docs/11/information-schema.html),
+  with some CockroachDB-specific extensions.
+
+- The virtual `crdb_internal` schema shared by all databases.  This is
+  an advanced introspection facility that is partially public and
+  programmable but also still contains reserved components. Users are
+  advised to use the [section
+  below](#programmability-and-forward-compatibility-for-crdb_internal)
+  for details.
+
+- The virtual `pg_catalog` schema in each database. This is provided
+  primarily for compatibility with extant PostgreSQL clients and may
+  contain less information than `information_schema`, or information
+  that is more difficult to consume. Only partial compatibility with
+  [PostgreSQL's own
+  `pg_catalog`](https://www.postgresql.org/docs/11/catalogs.html) is
+  provided.
+
+- The [`SHOW` statements](sql-statements.html). These produce output
+  derived from other sources and optimized for human consumption, may
+  change between versions without notice, and should thus always be
+  considered a [public and non-programmable] interface.
+
+Meanwhile the pre-defined `system` database should be considered a
+[reserved] interface and should not be used directly by clients.
+
+Summary:
+
+| Component                                                                                                | Status if feature documented on this site                                                    | Status if not documented on this site |
+|----------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
+| Table and column schema of `information_schema`, when also present in PostgreSQL                         | [public and programmable]                                                                    | [public and programmable]             |
+| Table and column schema of `information_schema`, when CockroachDB-specific                               | [public and programmable]                                                                    | [reserved]                            |
+| Table and column schema of `pg_catalog`, when same as PostgreSQL                                         | [public and programmable]                                                                    | [public and programmable]             |
+| Table and column schema of `pg_catalog`, when incomplete/missing compared to PostgreSQL                  | [public and programmable]                                                                    | [reserved]                            |
+| Table and column schema of `crdb_internal`                                                               | [See section below](#programmability-and-forward-compatibility-for-crdb_internal)            | [reserved]                            |
+| Cell contents of `pg_catalog` and `information_schema`, when populated similarly as PostgreSQL           | [public and programmable]                                                                    | [public and programmable]             |
+| Cell contents of `pg_catalog` and `information_schema`, when absent or incomplete compared to PostgreSQL | [public and programmable] with  [“experimental” status](experimental-feature-lifecycle.html) | [reserved]                            |
+| Cell contents of `crdb_internal`                                                                         | [See section below](#programmability-and-forward-compatibility-for-crdb_internal)            | [reserved]                            |
+| Tables and cell contents in the `system` database/catalog                                                | [reserved]                                                                                   | [reserved]                            |
+
+## Programmability and forward compatibility for `crdb_internal`
+
+Note: for the following system tables, the reader is invited to refer
+to the output of `SHOW TABLES FROM crdb_internal WITH COMMENT`. The
+comments describe the purpose of each table and also provide an
+indication of the expected cost of access. Some of these tables incur
+a non-negligible load on the entire cluster upon access.
+
+Note: any `crdb_internal` table not listed below should be considered
+[reserved].
+
+| Table                                     | Columns                                                                                                                                              | Status                                    |
+|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| `crdb_internal.backward_dependencies`     | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.builtin_functions`         | all                                                                                                                                                  | [reserved], use `pg_catalog.pg_proc`      |
+| `crdb_internal.cluster_queries`           | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.cluster_sessions`          | -                                                                                                                                                    | same as `crdb_internal.node_sessions`     |
+| `crdb_internal.cluster_settings`          | all                                                                                                                                                  | [public and programmable], see note below |
+| `crdb_internal.create_statements`         | `database_name`, `schema_name`, `descriptor_id`, `descriptor_type`, `descriptor_name`, `create_statement`, `alter_statements`, `validate_statements` | [public and programmable]                 |
+| `crdb_internal.create_statements`         | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.feature_usage`             | all                                                                                                                                                  | [public and non-programmable]             |
+| `crdb_internal.forward_dependencies`      | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.gossip_alerts`             | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.gossip_liveness`           | `node_id`, `draining`, `decommissioning`, `updated_at`                                                                                               | [public and programmable]                 |
+| `crdb_internal.gossip_liveness`           | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.gossip_network`            | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.gossip_nodes`              | `node_id`, `is_live`, `ranges`, `leases`                                                                                                             | [public and programmable]                 |
+| `crdb_internal.gossip_nodes`              | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.index_columns`             | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.jobs`                      | `job_id`, `job_type`, `description`, `statement`, `user_name`, `status`, `created`, `started`, `finished`, `fraction_completed`, `error`             | [public and programmable]                 |
+| `crdb_internal.jobs`                      | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.kv_node_status`            | `node_id`, `network`, `address`, `attrs`, `locality`, `server_version`, `tag`, `platform`, `distribution`, `type`, `started_at`                      | [public and programmable]                 |
+| `crdb_internal.kv_node_status`            | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.kv_store_status`           | `node_id`, `store_id`, `attrs`, `capacity`, `available`, `used`, `logical_bytes`, `range_count`, `lease_count`                                       | [public and programmable]                 |
+| `crdb_internal.kv_store_status`           | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.leases`                    | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.node_build_info`           | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.node_metrics`              | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.node_queries`              | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.node_runtime_info`         | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.node_sessions`             | `node_id`, `session_id`, `user_name`, `client_address`, `application_name`, `active_queries`,`last_active_query`, `session_start`                    | [public and programmable]                 |
+| `crdb_internal.node_sessions`             | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.node_statement_statistics` | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.node_txn_stats`            | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.partitions`                | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.predefined_comments`       | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.ranges_no_leases`          | -                                                                                                                                                    | same as `crdb_internal.ranges`            |
+| `crdb_internal.ranges`                    | `range_id`, `start_key`, `end_key`, `database_name`, `table_name`, `index_name`, `replicas`, `lease_holder`                                          | [public and programmable]                 |
+| `crdb_internal.ranges`                    | `start_pretty`, `end_pretty`                                                                                                                         | [public and non-programmable]             |
+| `crdb_internal.ranges`                    | other columnns                                                                                                                                       | [reserved]                                |
+| `crdb_internal.schema_changes`            | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.session_trace`             | all                                                                                                                                                  | [reserved]                                |
+| `crdb_internal.session_variables`         | all                                                                                                                                                  | [public and programmable], see note below |
+| `crdb_internal.table_columns`             | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.table_indexes`             | all                                                                                                                                                  | [public and programmable]                 |
+| `crdb_internal.tables`                    | `table_id`, `name`, `database_name`, `schema_name`                                                                                                   | [public and programmable]                 |
+| `crdb_internal.tables`                    | other columns                                                                                                                                        | [reserved]                                |
+| `crdb_internal.zones`                     | `zone_id`, `zone_name`, `config_sql`                                                                                                                 | [public and programmable]                 |
+| `crdb_internal.zones`                     | other columns                                                                                                                                        | [reserved]                                |
+
+Note on `crdb_internal.cluster_settings`: See also [Programmability and forward compatibility guarantees for cluster settings](programmability-of-other-interfaces.html#cluster-settings).
+
+Note on `crdb_itnernal.session_variables`: See also [Programmability and forward compatibility guarantees for SQL session variables](programmability-of-session-variables.html).
+
+## See also
+
+- [`information_schema`](information-schema.html)
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces

--- a/v19.2/monitor-cockroachdb-with-prometheus.md
+++ b/v19.2/monitor-cockroachdb-with-prometheus.md
@@ -185,4 +185,5 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
 ## See also
 
+- [Programmability and forward compatibility of HTTP status endpoints](programmability-of-other-interfaces.html#http-status-endpoints)
 - [Monitoring and Alerting](monitoring-and-alerting.html)

--- a/v19.2/monitoring-and-alerting.md
+++ b/v19.2/monitoring-and-alerting.md
@@ -183,6 +183,7 @@ Active monitoring helps you spot problems early, but it is also essential to cre
 
 ## See also
 
+- [Programmability and forward compatibility of HTTP status endpoints](programmability-of-other-interfaces.html#http-status-endpoints)
 - [Production Checklist](recommended-production-settings.html)
 - [Manual Deployment](manual-deployment.html)
 - [Orchestrated Deployment](orchestration.html)

--- a/v19.2/overview-of-apis-and-interfaces.md
+++ b/v19.2/overview-of-apis-and-interfaces.md
@@ -1,0 +1,33 @@
+---
+title: Overview of APIs and interfaces
+summary: High-level list of programmable and other interfaces in CockroachDB.
+toc: true
+---
+
+The external interfaces of CockroachDB are:
+
+- The [command line
+  interfaces](programmability-of-command-line-interfaces.html): the inputs
+  and outputs of the [`cockroach` sub-commands](cockroach-commands.html).
+
+- The SQL interfaces:
+  - The [Client-server protocol](client-server-protocol.html) for SQL clients (pgwire): the byte structure of the flow of data between CockroachDB clients and nodes.
+  - The [SQL functional behavior](sql-functional-behavior-guarantees.html): which row sets / result counts are produced for a given input query.
+  - The [SQL session variables](programmability-of-session-variables.html): the list and effects of session variables (`SHOW all` / `SET`).
+  - The [SQL introspection interfaces](introspection-interfaces.html): the contents of `information_schema`, `pg_catalog` and `crdb_internal` tables.
+  - The [SQL operational complexity](time-and-memory-cost-model.html): max time and space complexity of individual SQL operators as a function of the input and operational parameters.
+
+- [The remaining interfaces](programmability-of-other-interfaces.html):
+  - The [Web UI components](programmability-of-other-interfaces.html#web-ui-components): the in-browser cluster visualization and management panel.
+  - The [HTTP status endpoints](programmability-of-other-interfaces.html#http-status-endpoints): the direct URLs that provide access to CockroachDB status variables.
+  - The [RPC endpoints](programmability-of-other-interfaces.html#rpc-endpoints): the HTTP and RPC endpoints tht provide access to CockroachDB internal status and APIs.
+  - The [Cluster Settings](programmability-of-other-interfaces.html#cluster-settings): the list and effects of [cluster-wide settings](cluster-settings.html).
+
+Each of these interfaces have separate public/programmable,
+public/non-programmable and reserved parts. These are detailed in the
+respective pages.
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)

--- a/v19.2/programmability-of-command-line-interfaces.md
+++ b/v19.2/programmability-of-command-line-interfaces.md
@@ -1,0 +1,81 @@
+---
+title: Programmability of command-line interfaces
+summary: Which command-line utilities are programmable and forward compatibility guarantees.
+toc: true
+---
+
+The `cockroach` executable program provides many [sub-commands that
+provide a command-line interface](cockroach-commands.html). Their
+forward compatibility guarantees are listed below.
+
+## Guarantees common to all sub-commands
+
+| General behavior                                     | Status                        |
+|------------------------------------------------------|-------------------------------|
+| Output of `--help` or `help`                         | [public and non-programmable] |
+| Output on `stderr`                                   | [public and non-programmable] |
+| Exit status                                          | [public and programmable]     |
+| Logging output, prefix before log messages           | [public and programmable]     |
+| Logging output, content of log messages after prefix | [public and non-programmable] |
+
+## Guarantees per command
+
+| Command and behavior                                                                                      | Status                                                  |
+|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `cockroach cert`, input format                                                                            | [public and programmable]                               |
+| `cockroach cert`, output on stdout/stderr                                                                 | [public and non-programmable]                           |
+| `cockroach cert`, output files                                                                            | [public and programmable], see note 2 below             |
+| `cockroach debug`, input/output                                                                           | [reserved]                                              |
+| `cockroach init`, input/output                                                                            | [public and programmable]                               |
+| `cockroach node`, input/output                                                                            | [public and programmable], see note 2 below             |
+| `cockroach quit`, input/output                                                                            | [public and programmable]                               |
+| `cockroach start`/`start-single-node`, input format                                                       | [public and programmable]                               |
+| `cockroach start`/`start-single-node`, status variables displayed when server ready                       | [public and programmable], see note 2 below             |
+| `cockroach start`/`start-single-node`, informative and warning messages                                   | [public and non-programmable]                           |
+| `cockroach start`/`start-single-node`, location of data and log files                                     | [public and programmable]                               |
+| `cockroach start`/`start-single-node`, content of data files                                              | [public and non-programmable]                           |
+| `cockroach user` (deprecated), input/output                                                               | [public and programmable], see note 2 below             |
+| `cockroach version`, input/output                                                                         | [public and programmable], see note 2 below             |
+| [`cockroach demo`], input/output                                                                          | [public and non-programmable]                           |
+| [`cockroach sql`] input/output when ran interactively                                                     | [public and non-programmable]                           |
+| [`cockroach sql`] non-interactive, SQL and `\cmd` inputs                                                  | [public and programmable], see note 2 below             |
+| [`cockroach sql`] non-interactive, SQL result output, format `raw`, `csv` or `tsv`                        | [public and programmable], see note 2 below             |
+| [`cockroach sql`] non-interactive, SQL result output, other display formats (`html`, `sql`, `table`, etc) | [public and non-programmable]                           |
+| [`cockroach sql`] non-interactive, non-SQL output (eg. time measurements)                                 | [public and non-programmable]                           |
+| `cockroach dump` input format                                                                             | [public and programmable], see note 2 below             |
+| `cockroach dump` output format                                                                            | [reserved], see note 1 below                            |
+| `cockroach gen`, input format                                                                             | [public and programmable], see note 2 below             |
+| `cockroach gen`, output format                                                                            | [public and non-programmable]                           |
+| [`cockroach sqlfmt`], input format                                                                        | [public and programmable], see note 2 below             |
+| [`cockroach sqlfmt`], output format                                                                       | [public and non-programmable]                           |
+| `cockroach systembench`, input/output                                                                     | [reserved]                                              |
+| [`cockroach workload`], input format                                                                      | [public and programmable], but currently [experimental] |
+| [`cockroach workload`], output format                                                                     | [public and non-programmable]                           |
+
+[`cockroach sql`]: use-the-built-in-sql-client.html
+[`cockroach demo`]: cockroach-demo.html
+[`cockroach workload`]: cockroach-workload.html
+[`cockroach sqlfmt`]: use-the-query-formatter.html
+
+Note 1: the output format of `cockroach dump` may change between
+revisions, but the following guarantee is preserved: the database and
+table contents that result from loading the output of `cockroach dump`
+into another CockroachDB instance will be stable in the same way as
+other public and programmable interfaces.
+
+Note 2: new features may be added to the various `cockroach`
+sub-commands across revisions, including extending the existing output
+formats with additional details / columns. Automated tooling that
+reads and parses the output of `cockroach` command must be built to
+ignore input they do not understand.
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces
+[experimental]: experimental-feature-lifecycle.html

--- a/v19.2/programmability-of-other-interfaces.md
+++ b/v19.2/programmability-of-other-interfaces.md
@@ -1,0 +1,92 @@
+---
+title: Programmability of RPC, HTTP and other interfaces
+summary: Which other interfaces other than SQL and the CLI are programmable and forward compatibility guarantees.
+toc: true
+---
+
+CockroachDB provides several other interfaces besides the [command
+line](programmability-of-command-line-interfaces.html) and
+[SQL](overview-of-apis-and-interfaces.html):
+
+- the embedded [Admin UI](admin-ui-overview.html),
+- [HTTP status endpoints](monitoring-and-alerting.html),
+- RPC endpoints served for CLI commands and other clients.
+
+For each of them, the accompanying [forward compatibility
+guarantees](compatibility-and-programmability-guarantees.html) are
+listed below.
+
+## Web UI components
+
+| Component                            | Status                      |
+|--------------------------------------|-----------------------------|
+| pages linked from the entry page     | [public and non-programmable] |
+| pages not linked from the entry page | [reserved]                    |
+
+## HTTP status endpoints
+
+| Component                                                 | Status                    |
+|-----------------------------------------------------------|---------------------------|
+| [`/health`](monitoring-and-alerting.html)                 | [public and programmable] |
+| [`/monitoring`](monitor-cockroachdb-with-prometheus.html) | [public and programmable] |
+| `/debug`                                                  | [reserved]                |
+
+## RPC endpoints
+
+See [`server/serverpb/admin.proto` in the source code
+repository](https://github.com/cockroachdb/cockroach/blob/master/pkg/server/serverpb/admin.proto)
+for a detaild list of the supported RPC endpoints.
+
+Note: we mirror these RPC endpoints (defined using [gRPC](https://grpc.io/)) as REST-style
+HTTP endpoints on the HTTP port. These are separate facilities from
+the HTTP status endpoints described above.
+
+
+| Component                                                                     | Status                  |
+|-------------------------------------------------------------------------------|-------------------------|
+| `ChartCatalog(ChartCatalogRequest) -> ChartCatalogResponse`                   | [public and programmable] |
+| `Cluster(ClusterRequest) -> ClusterResponse`                                  | [public and programmable] |
+| `Databases(DatabasesRequest) -> DatabasesResponse`                            | [public and programmable] |
+| `Decommission(DecommissionRequest) -> DecommissionResponse`                   | [public and programmable] |
+| `DecommissionStatus(DecommissionStatusRequest) -> DecommissionStatusResponse` | [public and programmable] |
+| `Drain(DrainRequest) -> DrainResponse`                                        | [public and programmable] |
+| `Events(EventsRequest) -> EventsResponse`                                     | [public and programmable] |
+| `Locations(LocationsRequest) -> LocationsResponse`                            | [public and programmable] |
+| `MetricMetadata(MetricMetadataRequest) -> MetricMetadataResponse`             | [public and programmable] |
+| `QueryPlan(QueryPlanRequest) -> QueryPlanResponse`                            | [public and programmable] |
+| `RangeLog(RangeLogRequest) -> RangeLogResponse`                               | [public and programmable] |
+| `Settings(SettingsRequest) -> SettingsResponse`                               | [public and programmable] |
+| `Users(UsersRequest) -> UsersResponse`                                        | [public and programmable] |
+| `DataDistribution(DataDistributionRequest) -> DataDistributionResponse`       | [reserved]                |
+| `DatabaseDetails(DatabasesDetailsRequest) -> DatabasesDetailsResponse`        | [reserved]                |
+| `EnqueueRange(EnqueueRangeRequest) -> EnqueueRangeResponse`                   | [reserved]                |
+| `GetUIData(GetUIDataRequest) -> GetUIDataResponse`                            | [reserved]                |
+| `Health(HealthRequest) -> HealthResponse`                                     | [reserved]                |
+| `Jobs(JobsRequest) -> JobsResponse`                                           | [reserved]                |
+| `Liveness(LivenessRequest) -> LivenessResponse`                               | [reserved]                |
+| `NonTableStats(NonTableStatsRequest) -> NonTableStatsResponse`                | [reserved]                |
+| `SetUIData(SetUIDataRequest) -> SetUIDataResponse`                            | [reserved]                |
+| `TableDetails(TableDetailsRequest) -> TableDetailsResponse`                   | [reserved]                |
+| `TableStats(TableStatsRequest) -> TableStatsResponse`                         | [reserved]                |
+
+## Cluster settings
+
+| Component                                                                                                                                             | Status if feature documented on this site                                                    | Status if not documented on this site |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
+| Effect and configurability of settings whose name contains the word `experimental`                                                                    | [public and programmable] with  [“experimental” status](experimental-feature-lifecycle.html) | [reserved]                            |
+| Effect and configurability of hidden settings (now listed in `SHOW ALL CLUSTER SETTINGS`)                                                             | [reserved]                                                                                   | [reserved]                            |
+| Effect and configurability of settings pertaining to low-level CockroachDB internals, e.g., whose name starts with `kv.`, `server.`, `rocksdb.`, etc. | [public and non-programmable]                                                                | [reserved]                            |
+| Effect and configurability of other settings                                                                                                          | [public and programmable]                                                                    | [reserved]                            |
+
+For more details, see the page on [Cluster Settings](cluster-settings.html).
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces

--- a/v19.2/programmability-of-session-variables.md
+++ b/v19.2/programmability-of-session-variables.md
@@ -1,0 +1,39 @@
+---
+title: Programmability of SQL session variables
+summary: Which session variables can be considered programmable and future compatibility guarantees.
+toc: false
+---
+
+The SQL session variables are customizable in each separate client
+session using [`SET`](set-vars.html) and can be queried using
+e.g. [`SHOW`](show-vars.html).
+
+The set of supproted session variable is a combination of
+
+- a subset of session variables also supported by PostgreSQL, where
+  they are also called "run-time parameters".
+- additional session variables specific to CockroachDB.
+
+The specific [stability and forward compatibility
+guarantees](compatibility-and-programmability-guarantees.html)
+associated with session variables are listed in the table below.
+
+| Component                                                                          | Status if feature documented on this site                                                    | Status if not documented on this site |
+|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
+| Effect and configurability of variable whose name contains the word `experimental` | [public and programmable] with  [“experimental” status](experimental-feature-lifecycle.html) | [reserved]                            |
+| Effect and configurability of variable, when identical to PostgreSQL               | [public and programmable]                                                                    | [public and programmable]             |
+| Effect and configurability of variable, when incomplete compared to PostgreSQL     | [public and programmable] with  [“experimental” status](experimental-feature-lifecycle.html) | [public and non-programmable]         |
+| Effect and configurability of variable, when CockroachDB-specific                  | [public and programmable]                                                                    | [reserved]                            |
+
+## See also
+
+- [`SET` (session variable)](set-vars.html)
+- [`SHOW` (session variable)](show-vars.html)
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces

--- a/v19.2/query-order.md
+++ b/v19.2/query-order.md
@@ -107,6 +107,10 @@ non-deterministic order. "Non-deterministic" means that the actual order
 can depend on the logical plan, the order of data on disk, the topology
 of the CockroachDB cluster, and is generally variable over time.
 
+See also the [programmability and forward compatibility guarantees
+related to row
+ordering](sql-functional-behavior-guarantees.html#data-manipulation-language).
+
 ## Sorting using simple column selections
 
 Considering the following table:

--- a/v19.2/scalar-expressions.md
+++ b/v19.2/scalar-expressions.md
@@ -701,7 +701,7 @@ specified explicitly using a type annotation. For example:
 
 {{site.data.alerts.callout_success}}To convert the results of a subquery to an array, use <a href="#conversion-of-subquery-results-to-an-array"><code>ARRAY(...)</code></a> instead.{{site.data.alerts.end}}
 
-{{site.data.alerts.callout_success}}CockroachDB also recognizes the syntax <code>ARRAY(a, b, c)</code> as an alias for <code>ARRAY[a, b, c]</code>. This is an experimental, CockroachDB-specific SQL extension and may be removed in a later version of CockroachDB.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}CockroachDB also recognizes the syntax <code>ARRAY(a, b, c)</code> as an alias for <code>ARRAY[a, b, c]</code>. This is an <a href="experimental-feature-lifecycle.html">experimental</a>, CockroachDB-specific SQL extension and may be removed in a later version of CockroachDB.{{site.data.alerts.end}}
 
 #### Typing rule
 

--- a/v19.2/serial.md
+++ b/v19.2/serial.md
@@ -40,10 +40,10 @@ There are three possible translation modes for `SERIAL`:
 | Mode                                                                            | Description                                                                                                                   |
 |---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
 | `rowid` (default)                                                               | `SERIAL` implies `DEFAULT unique_rowid()`. The real data type is always `INT`.                                                    |
-| `virtual_sequence` (experimental) | `SERIAL` creates a virtual sequence and implies `DEFAULT nextval(<seqname>)`.  The real data type is always `INT`.                |
-| `sql_sequence` (experimental)     | `SERIAL` creates a regular SQL sequence and implies `DEFAULT nextval(<seqname>)`. The real data type depends on `SERIAL` variant. |
+| `virtual_sequence` ([experimental]) | `SERIAL` creates a virtual sequence and implies `DEFAULT nextval(<seqname>)`.  The real data type is always `INT`.                |
+| `sql_sequence` ([experimental])     | `SERIAL` creates a regular SQL sequence and implies `DEFAULT nextval(<seqname>)`. The real data type depends on `SERIAL` variant. |
 
-These modes can be configured with the experimental (unsupported) [session variable](set-vars.html) `experimental_serial_normalization`.
+These modes can be configured with the [experimental] [session variable](set-vars.html) `experimental_serial_normalization`.
 
 {{site.data.alerts.callout_info}}
 The particular choice of `DEFAULT` expression when clients use the
@@ -53,7 +53,7 @@ specifically must use the full explicit syntax `INT DEFAULT
 unique_rowid()` and avoid `SERIAL` altogether.
 
 Moreover, the existence of multiple translation modes for `SERIAL` is
-an experimental feature in CockroachDB 2.1 aimed at studying
+an [experimental] feature in CockroachDB 2.1 aimed at studying
 compatibility with existing PostgreSQL applications and may be removed
 in subsequent releases.
 {{site.data.alerts.end}}
@@ -80,7 +80,7 @@ latter setting also creates a virtual (pseudo) sequence in the
 database. However in both cases the `unique_rowid()` function is
 ultimately used to generate new values.
 
-This behavior of `virtual_sequence` is experimental and may be removed
+This behavior of `virtual_sequence` is [experimental] and may be removed
 in a later version of CockroachDB.
 {{site.data.alerts.end}}
 
@@ -113,7 +113,7 @@ entry](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
 instead of sequences when possible.
 
 {{site.data.alerts.callout_info}}
-This mode `sql_sequence` is an experimental feature provided for testing compatibility with existing PostgreSQL clients.
+This mode `sql_sequence` is an [experimental] feature provided for testing compatibility with existing PostgreSQL clients.
 
 It is subject to change without notice and may be removed in later versions of CockroachDB.
 {{site.data.alerts.end}}
@@ -278,3 +278,5 @@ If this happens, CockroachDB cannot guarantee whether `x < y` or `x > y`. Even t
 
 - [FAQ: How do I auto-generate unique row IDs in CockroachDB?](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
 - [Data Types](data-types.html)
+
+[experimental]: experimental-feature-lifecycle.html

--- a/v19.2/set-vars.md
+++ b/v19.2/set-vars.md
@@ -232,6 +232,7 @@ All timezone abbreviations are case-sensitive and must be uppercase, with the ex
 
 ## See also
 
+- [Programmability and forward compatibility guarantees for session variables](programmability-of-session-variables.html)
 - [`RESET`](reset-vars.html)
 - [`SET TRANSACTION`](set-transaction.html)
 - [`SET CLUSTER SETTING`](set-cluster-setting.html)

--- a/v19.2/show-backup.md
+++ b/v19.2/show-backup.md
@@ -92,3 +92,4 @@ Time: 30.337ms
 
 - [`BACKUP`](backup.html)
 - [`RESTORE`](restore.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-cluster-setting.md
+++ b/v19.2/show-cluster-setting.md
@@ -77,3 +77,4 @@ Parameter | Description
 - [`SHOW GRANTS`](show-grants.html)
 - [`SHOW INDEX`](show-index.html)
 - [`SHOW USERS`](show-users.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-columns.md
+++ b/v19.2/show-columns.md
@@ -107,3 +107,4 @@ You can use [`COMMENT ON`](comment-on.html) to add comments on a column.
 - [Information Schema](information-schema.html)
 - [Other SQL Statements](sql-statements.html)
 - [`COMMENT ON`](comment-on.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-constraints.md
+++ b/v19.2/show-constraints.md
@@ -82,3 +82,4 @@ Field | Description
 - [`CREATE TABLE`](create-table.html)
 - [Information Schema](information-schema.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-create.md
+++ b/v19.2/show-create.md
@@ -139,3 +139,4 @@ To get just a view's `SELECT` statement, you can query the `views` table in the 
 - [`CREATE TABLE`](create-sequence.html)
 - [Information Schema](information-schema.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-databases.md
+++ b/v19.2/show-databases.md
@@ -106,3 +106,4 @@ The `postgres` and `defaultdb` databases can be [deleted](drop-database.html) if
 - [`SHOW SCHEMAS`](show-schemas.html)
 - [Information Schema](information-schema.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-grants.md
+++ b/v19.2/show-grants.md
@@ -257,3 +257,4 @@ SHOW GRANTS ON ROLE FOR carl;
 - [Manage Users](authorization.html#create-and-manage-users)
 - [Other Cockroach Commands](cockroach-commands.html)
 - [Information Schema](information-schema.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-index.md
+++ b/v19.2/show-index.md
@@ -116,3 +116,4 @@ Field | Description
 - [`RENAME INDEX`](rename-index.html)
 - [Information Schema](information-schema.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-jobs.md
+++ b/v19.2/show-jobs.md
@@ -162,3 +162,4 @@ You can show just schema change jobs by using `SHOW JOBS` as the data source for
 - [`ALTER TABLE`](alter-table.html)
 - [`BACKUP`](backup.html)
 - [`RESTORE`](restore.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-locality.md
+++ b/v19.2/show-locality.md
@@ -86,3 +86,4 @@ For a more extensive example, see [Create a table with node locality information
 - [Locality](cockroach-start.html#locality)
 - [Orchestrated Deployment](orchestration.html)
 - [Manual Deployment](manual-deployment.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-partitions.md
+++ b/v19.2/show-partitions.md
@@ -237,3 +237,4 @@ If a partitioned table has no zones configured, the `SHOW CREATE TABLE` output i
 - [Define Table Partitions](partitioning.html)
 - [SQL Statements](sql-statements.html)
 - [Geo-Partitioning](demo-low-latency-multi-region-deployment.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-queries.md
+++ b/v19.2/show-queries.md
@@ -210,3 +210,4 @@ To cancel this long-running query, and stop it from consuming resources, you not
 - [`SHOW SESSIONS`](show-sessions.html)
 - [`SHOW JOBS`](show-jobs.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-ranges.md
+++ b/v19.2/show-ranges.md
@@ -123,3 +123,4 @@ Field | Description
 - [Partitioning tables](partitioning.html)
 + [Follow-the-Workload](demo-follow-the-workload.html)
 + [Architecture Overview](architecture/overview.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-roles.md
+++ b/v19.2/show-roles.md
@@ -42,3 +42,4 @@ The user must have the [`SELECT`](select-clause.html) [privilege](authorization.
 - [`GRANT <roles>`](grant-roles.html)
 - [`REVOKE <roles>`](revoke-roles.html)
 - [Manage Users](authorization.html#create-and-manage-users)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-schemas.md
+++ b/v19.2/show-schemas.md
@@ -52,3 +52,4 @@ Parameter | Description
 - [`SHOW DATABASES`](show-databases.html)
 - [Information Schema](information-schema.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-sequences.md
+++ b/v19.2/show-sequences.md
@@ -47,3 +47,4 @@ Parameter | Description
 - [`CREATE SEQUENCE`](create-sequence.html)
 - [`DROP SEQUENCE`](drop-sequence.html)
 - [`ALTER SEQUENCE`](alter-sequence.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-sessions.md
+++ b/v19.2/show-sessions.md
@@ -194,3 +194,4 @@ Alternatively, if you know that you want to cancel the query based on the detail
 - [`SHOW QUERIES`](show-queries.html)
 - [`CANCEL QUERY`](cancel-query.html)
 - [Other SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-statistics.md
+++ b/v19.2/show-statistics.md
@@ -58,3 +58,4 @@ CREATE STATISTICS
 - [`INSERT`](insert.html)
 - [`IMPORT`](import.html)
 - [SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-tables.md
+++ b/v19.2/show-tables.md
@@ -223,3 +223,4 @@ To view virtual tables with comments and documentation links, use `SHOW TABLES F
 - [`CREATE VIEW`](create-view.html)
 - [`COMMENT ON`](comment-on.html)
 - [Information Schema](information-schema.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-trace.md
+++ b/v19.2/show-trace.md
@@ -516,3 +516,4 @@ In this example, we use session tracing to show an [automatic transaction retry]
 
 - [`EXPLAIN`](explain.html)
 - [`SET (session settings)`](set-vars.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-users.md
+++ b/v19.2/show-users.md
@@ -52,3 +52,4 @@ The user must have the [`SELECT`](select-clause.html) [privilege](authorization.
 
 - [`CREATE USER`](create-user.html)
 - [Manage Users](authorization.html#create-and-manage-users)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/show-vars.md
+++ b/v19.2/show-vars.md
@@ -122,6 +122,7 @@ Special syntax cases supported for compatibility:
 
 ## See also
 
+- [Programmability and forward compatibility guarantees for session variables](programmability-of-session-variables.html)
 - [`SET` (session variable)](set-vars.html)
 - [Transactions](transactions.html), including [Priority levels](transactions.html#transaction-priorities)
 - [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
@@ -132,3 +133,5 @@ Special syntax cases supported for compatibility:
 - [`SHOW GRANTS`](show-grants.html)
 - [`SHOW INDEX`](show-index.html)
 - [`SHOW USERS`](show-users.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)

--- a/v19.2/show-zone-configurations.md
+++ b/v19.2/show-zone-configurations.md
@@ -92,3 +92,4 @@ CONFIGURE ZONE 1
 - [`ALTER RANGE`](alter-range.html)
 - [`ALTER TABLE`](alter-table.html)
 - [SQL Statements](sql-statements.html)
+- [SQL Introspection Interfaces](introspection-interfaces.html) and their forward compatibility guarantees

--- a/v19.2/sql-functional-behavior-guarantees.md
+++ b/v19.2/sql-functional-behavior-guarantees.md
@@ -1,0 +1,108 @@
+---
+title: SQL functional behavior guarantees
+summary: Which part of SQL execution can be considered forward-compatible.
+toc: true
+---
+
+This page details the various facets of CockroachDB's SQL dialect and
+which [programmability and forward compatibility
+guarantees](compatibility-and-programmability-guarantees.html) are
+provided for each of them.
+
+## Built-in functions
+
+| Component                                                                                   | Status if feature documented on this site                                                    | Status if not documented on this site |
+|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
+| Built-in function exists both in CockroachDB and PostgreSQL, and behaves like in PostgreSQL | [public and programmable]                                                                    | [public and programmable]             |
+| Built-in function exists both in CockroachDB and PostgreSQL, and behaves unlike PostgreSQL  | [public and programmable]                                                                    | [reserved]                            |
+| Name of built-in function exists in namespace `crdb_internal`                               | [reserved]                                                                                   | [reserved]                            |
+| Description of built-in function says function is “experimental”                            | [public and programmable] with  [“experimental” status](experimental-feature-lifecycle.html) | [reserved]                            |
+| Description of built-in function says function is “for internal use”                        | [reserved]                                                                                   | [reserved]                            |
+| Built-in function exists only in CockroachDB                                                | [public and programmable]                                                                    | [reserved]                            |
+| Other built-in functions, other than above                                                  | [public and programmable]                                                                    | [reserved]                            |
+
+For a list of supported built-in functions, see [Functions and Operators](functions-and-operators.html).
+
+## Data manipulation language
+
+Interface common to `SELECT`, `TABLE`, `VALUES`, `INSERT`, `UPDATE`, `DELETE`, `UPSERT`:
+
+| Component                                                                                 | Status if feature documented on this site | Status if not documented on this site |
+|-------------------------------------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| SQL inputs, when query valid both in CockroachDB and PostgreSQL                           | [public and programmable]                 | [public and programmable]             |
+| SQL inputs, when query valid only in CockroachDB                                          | [public and programmable]                 | [reserved]                            |
+| Output row set (regardless of order), when query valid both in CockroachDB and PostgreSQL | [public and programmable]                 | [public and programmable]             |
+| Output row set (regardless of order), when query valid only in CockroachDB                | [public and programmable]                 | [reserved]                            |
+| Output row order, when query is ordered and valid both in CockroachDB and PostgreSQL      | [public and programmable]                 | [public and non-programmable]         |
+| Output row count, when query valid both in CockroachDB and PostgreSQL                     | [public and programmable]                 | [public and non-programmable]         |
+| Output row order, when query is ordered and valid only in CockroachDB                     | [public and programmable]                 | [reserved]                            |
+| Output row count, when query valid only in CockroachDB                                    | [public and programmable]                 | [reserved]                            |
+| Output row order, when query is not ordered                                               | [public and non-programmable]             | [reserved]                            |
+
+For more details about row ordering, see [Ordering of Query Results](query-order.html).
+
+## Data definition language
+
+Interface common to DDL statements: `CREATE`, `DROP`, `ALTER`, `TRUNCATE` on database objects (databases, tables, views, sequences, etc.):
+
+| Component                                                                                                                                | Status if feature documented on this site | Status if not documented on this site |
+|------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| SQL inputs, when query valid both in CockroachDB and PostgreSQL                                                                          | [public and programmable]                 | [public and programmable]             |
+| SQL inputs, when query valid only in CockroachDB                                                                                         | [public and programmable]                 | [reserved]                            |
+| Effect and isolation when ran as a standalone statement outside of BEGIN/COMMIT, when statement valid both in CockroachDB and PostgreSQL | [public and programmable]                 | [public and programmable]             |
+| Effect and isolation when ran as a standalone statement outside of BEGIN/COMMIT, when statement valid only in CockroachDB                | [public and programmable]                 | [public and non-programmable]         |
+| Effect and isolation when ran inside BEGIN/COMMIT                                                                                        | [public and programmable]                 | [public and non-programmable]         |
+| Output row count                                                                                                                         | [reserved]                                | [reserved]                            |
+
+## Privilege management
+
+Interface common to `CREATE`/`DROP` for  `USER` or `ROLE`, `GRANT`, `REVOKE`:
+
+| Component                                                       | Status if feature documented on this site | Status if not documented on this site |
+|-----------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| SQL inputs, when query valid both in CockroachDB and PostgreSQL | [public and programmable]                 | [public and programmable]             |
+| SQL inputs, when query valid only in CockroachDB                | [public and programmable]                 | [reserved]                            |
+| Effect and isolation                                            | [public and programmable]                 | [public and non-programmable]         |
+| Output row count                                                | [public and programmable]                 | [reserved]                            |
+
+## Bulk I/O statements
+
+| Component                                    | Status if feature documented on this site | Status if not documented on this site |
+|----------------------------------------------|-------------------------------------------|---------------------------------------|
+| `BACKUP`/`EXPORT` SQL parameters and output  | [public and programmable]                 | [reserved]                            |
+| `BACKUP` result data files                   | [reserved], see note 1 below              | [reserved], see note 1 below          |
+| `EXPORT` result data files                   | [public and programmable]                 | [reserved]                            |
+| `RESTORE`/`IMPORT` SQL parameters and output | [public and programmable]                 | [reserved]                            |
+| `RESTORE` input data files                   | [reserved], see note 1 below              | [reserved], see note 1 below          |
+| `IMPORT` input data files                    | [public and programmable]                 | [reserved]                            |
+
+Note 1: the output format of `BACKUP` may change between revisions, but
+the following guarantee is preserved: the database and table contents
+that result from `RESTORE`ing a backup into another CockroachDB instance
+will be stable in the same way as other public and programmable
+interfaces.
+
+## Other SQL statements or constructs
+
+| Component                                                                      | Status if feature documented on this site                                                | Status if not documented on this site |
+|--------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------|
+| `EXPLAIN` inputs and outputs                                                   | [public and non-programmable]                                                            | [reserved]                            |
+| `SHOW` inputs                                                                  | [public and programmable]                                                                | [reserved]                            |
+| `SHOW` outputs                                                                 | [public and non-programmable]                                                            | [reserved]                            |
+| `CANCEL`, `PAUSE`, `RESUME` inputs                                             | [public and programmable]                                                                | [reserved]                            |
+| `CANCEL`, `PAUSE`, `RESUME` success/error status                               | [public and programmable]                                                                | [reserved]                            |
+| `CANCEL`, `PAUSE`, `RESUME` outputs                                            | [public and non-programmable]                                                            | [reserved]                            |
+| `SCRUB` inputs and outputs                                                     | [public and programmable] in [“experimental” phase](experimental-feature-lifecycle.html) | [reserved]                            |
+| Tabular data produced by set-generating functions also supported in PostgreSQL | [public and programmable]                                                                | [public and programmable]             |
+| Tabular data produced by set-generating functions specific to CockroachDB      | [public and programmable]                                                                | [reserved]                            |
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces

--- a/v19.2/time-and-memory-cost-model.md
+++ b/v19.2/time-and-memory-cost-model.md
@@ -1,0 +1,47 @@
+---
+title: Time and memory cost model
+summary: Recommended time and space costing functions for common operations inside CockroachDB.
+toc: false
+---
+
+The following table uses [big-O
+notation](https://en.wikipedia.org/wiki/Big_O_notation) to indicate
+the expected performance class of various SQL relational
+operators. The variables are:
+
+- **n**  number of rows processed,
+- **r** number of data ranges accessed,
+- **p** number of logical processors performing the computation during execution,
+- **g**  number of aggregation groups,
+- **m** for the max data size of rows,
+- **N** for n x m,
+- **k** for the max data size of key, aggregation or sort columns,
+- **K** for n x k,
+
+| Operation                                             | Time complexity | Space complexity | Status                      |
+|-------------------------------------------------------|-----------------|------------------|-----------------------------|
+| point lookups in tables or indexes                    | O(1)            | O(m x p=r)       | [public and non-programmable] |
+| range scans in tables or indexes                      | O(K/p=r)        | O(m x p=r)       | [public and non-programmable] |
+| ordered inner joins                                   | O(K/p)          | O(N)             | [public and non-programmable] |
+| outer joins                                           | O(K/p+K)        | O(Np)            | [public and non-programmable] |
+| sorts                                                 | O(K/p log K/p)  | O(N)             | [public and non-programmable] |
+| non-expanding aggregations (see note 1 below)         | O(K/p)          | O(kg)            | [public and non-programmable] |
+| expanding aggregations (see note 1 below)             | O(K/p)          | O(K)             | [public and non-programmable] |
+| accesss to virtual tables or set-generating functions | O(N)            | O(1)             | [public and non-programmable] |
+| sequence access or increment                          | O(1)            | O(1)             | [public and non-programmable] |
+| window function application                           | O(N^2)          | O(N)             | [public and non-programmable] |
+
+Note 1: aggregations operators like `array_agg` produce results whose
+size is proportional to the sum of the size of the inputs. This can
+cause large memory usage during an aggregation if applied to a large
+number of inputs.
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[public and programmable]: interface-types.html#public-and-programmable-interfaces
+[public and non-programmable]: interface-types.html#public-and-non-programmable-interfaces
+[reserved]: interface-types.html#reserved-interfaces

--- a/v19.2/timestamp.md
+++ b/v19.2/timestamp.md
@@ -114,13 +114,15 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
+`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
 `TIME` | Converts to the time portion (HH:MM:SS) of the timestamp
-`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB [experimental] feature which may be changed without notice.
 `DATE` | --
 `STRING` | --
 
 ## See also
 
 [Data Types](data-types.html)
+
+[experimental]: experimental-feature-lifecycle.html


### PR DESCRIPTION
Here is a doc which does two things:

- it clarifies what external users can depend on
- it clarifies "experimental" vs "beta" vs "stable"

cc @BramGruneir @mjibson @bobvawter @jordanlewis for checking this is aligned with our actual practices so far and aspirations for the future.

cc @rmloveland for further editing and integration in the docs.

cc @bdarnell to sign off on the stability commitments.

cc @rolandcrosby @awoods187 to acknowledge the compatibility and visibility commitments.