### PR TITLE
minor fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Once you're ready to contribute:
 
 5. Commit your changes.
 
-5. [Push to your local branch to your remote fork](https://help.github.com/articles/pushing-to-a-remote/).
+5. [Push your local branch to your remote fork](https://help.github.com/articles/pushing-to-a-remote/).
 
 6. Back in the CockroachDB docs repo, [open a pull request](https://github.com/cockroachdb/docs/pulls) and assign it to `jseldess`. If you check the `Allow edits from maintainers` option when creating your pull request, we'll be able to make minor edits or fixes directly, if it seems easier than commenting and asking you to make those revisions, which can streamline the review process.
 

--- a/v2.1/cockroach-workload.md
+++ b/v2.1/cockroach-workload.md
@@ -371,7 +371,7 @@ $ cockroach start \
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach workload run bank \
+    $ cockroach workload run tpcc \
     --duration=10m \
     'postgresql://root@localhost:26257?sslmode=disable'
     ~~~

--- a/v2.1/demo-automatic-rebalancing.md
+++ b/v2.1/demo-automatic-rebalancing.md
@@ -90,7 +90,7 @@ Exit the SQL shell:
 
 ## Step 4. Run a sample workload
 
-CockroachDB comes with [built-in load generators](cockroach-workload.html) for simulating different types of client workloads, printing out per-operation statistics every second and totals after a specific duration or max number of operations. In this tutorial, you'll use the `tpcc` workload to simulates transaction processing using a rich schema of multiple tables.
+CockroachDB comes with [built-in load generators](cockroach-workload.html) for simulating different types of client workloads, printing out per-operation statistics every second and totals after a specific duration or max number of operations. In this tutorial, you'll use the `tpcc` workload to simulate transaction processing using a rich schema of multiple tables.
 
 1. Load the initial schema and data:
 

--- a/v2.1/start-a-local-cluster.md
+++ b/v2.1/start-a-local-cluster.md
@@ -249,7 +249,7 @@ Restart the first node from the parent directory of `cockroach-data/`:
 ~~~ shell
 $ cockroach start \
 --insecure \
---host=localhost
+--listen-addr=localhost
 ~~~
 
 {{site.data.alerts.callout_info}}

--- a/v2.1/start-a-local-cluster.md
+++ b/v2.1/start-a-local-cluster.md
@@ -53,7 +53,7 @@ nodeID:              1
 This command starts a node in insecure mode, accepting most [`cockroach start`](start-a-node.html) defaults.
 
 - The `--insecure` flag makes communication unencrypted.
-- Since this is a purely local cluster, `--listen-addr=localhost` tells the node to listens only on `localhost`, with default ports used for internal and client traffic (`26257`) and for HTTP requests from the Admin UI (`8080`).
+- Since this is a purely local cluster, `--listen-addr=localhost` tells the node to listen only on `localhost`, with default ports used for internal and client traffic (`26257`) and for HTTP requests from the Admin UI (`8080`).
 - Node data is stored in the `cockroach-data` directory.
 - The [standard output](start-a-node.html#standard-output) gives you helpful details such as the CockroachDB version, the URL for the Admin UI, and the SQL URL for clients.
 
@@ -249,7 +249,7 @@ Restart the first node from the parent directory of `cockroach-data/`:
 ~~~ shell
 $ cockroach start \
 --insecure \
---host=localhost:26257
+--host=localhost
 ~~~
 
 {{site.data.alerts.callout_info}}

--- a/v2.2/cockroach-workload.md
+++ b/v2.2/cockroach-workload.md
@@ -371,7 +371,7 @@ $ cockroach start \
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach workload run bank \
+    $ cockroach workload run tpcc \
     --duration=10m \
     'postgresql://root@localhost:26257?sslmode=disable'
     ~~~

--- a/v2.2/demo-automatic-rebalancing.md
+++ b/v2.2/demo-automatic-rebalancing.md
@@ -90,7 +90,7 @@ Exit the SQL shell:
 
 ## Step 4. Run a sample workload
 
-CockroachDB comes with [built-in load generators](cockroach-workload.html) for simulating different types of client workloads, printing out per-operation statistics every second and totals after a specific duration or max number of operations. In this tutorial, you'll use the `tpcc` workload to simulates transaction processing using a rich schema of multiple tables.
+CockroachDB comes with [built-in load generators](cockroach-workload.html) for simulating different types of client workloads, printing out per-operation statistics every second and totals after a specific duration or max number of operations. In this tutorial, you'll use the `tpcc` workload to simulate transaction processing using a rich schema of multiple tables.
 
 1. Load the initial schema and data:
 

--- a/v2.2/start-a-local-cluster.md
+++ b/v2.2/start-a-local-cluster.md
@@ -53,7 +53,7 @@ nodeID:              1
 This command starts a node in insecure mode, accepting most [`cockroach start`](start-a-node.html) defaults.
 
 - The `--insecure` flag makes communication unencrypted.
-- Since this is a purely local cluster, `--listen-addr=localhost` tells the node to listens only on `localhost`, with default ports used for internal and client traffic (`26257`) and for HTTP requests from the Admin UI (`8080`).
+- Since this is a purely local cluster, `--listen-addr=localhost` tells the node to listen only on `localhost`, with default ports used for internal and client traffic (`26257`) and for HTTP requests from the Admin UI (`8080`).
 - Node data is stored in the `cockroach-data` directory.
 - The [standard output](start-a-node.html#standard-output) gives you helpful details such as the CockroachDB version, the URL for the Admin UI, and the SQL URL for clients.
 
@@ -249,7 +249,7 @@ Restart the first node from the parent directory of `cockroach-data/`:
 ~~~ shell
 $ cockroach start \
 --insecure \
---host=localhost:26257
+--listen-addr=localhost
 ~~~
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
some spelling mistakes
one command in restart cluster did not work for a local cluster until port was removed.
tpcc workload was pointing to bank command