### PR TITLE
Document join reordering by the optimizer

### DIFF
--- a/_includes/v2.2/misc/session-vars.html
+++ b/_includes/v2.2/misc/session-vars.html
@@ -98,6 +98,18 @@
   </tr>
 
   <tr>
+   <td>
+    <code>experimental_reorder_joins_limit</code>
+   </td>
+   <td>Maximum number of joins that the optimizer will attempt to reorder when searching for an optimal query execution plan. For more information, see <a href="cost-based-optimizer.html#join-reordering">Join reordering</a>.</td>
+   <td>
+    <code>4</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
    <td><code>force_savepoint_restart</code></td>
    <td>When set to <code>true</code>, allows the <a href="savepoint.html"><code>SAVEPOINT</code></a> statement to accept any name for a savepoint.</td>
    <td>

--- a/v2.2/cost-based-optimizer.md
+++ b/v2.2/cost-based-optimizer.md
@@ -143,6 +143,25 @@ The query plan cache is still under development and has the following limitation
 - If you use the query plan cache in conjunction with table statistics, cached plans do not yet get invalidated when new statistics are created.
 {{site.data.alerts.end}}
 
+## Join reordering
+
+<span class="version-tag">New in v2.2</span>: The cost-based optimizer will explore additional join orderings in an attempt to find the lowest-cost execution plan for a query involving multiple joins, which can lead to significantly better performance in some cases.
+
+Because this process leads to an exponential increase in the number of possible execution plans for such queries, it's only used to reorder subtrees containing 4 or fewer joins by default.
+
+To change this setting, which is controlled by the `experimental_reorder_joins_limit` [session variable](set-vars.html), run the statement shown below.  To disable this feature, set the variable to `0`.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SET experimental_reorder_joins_limit = 6;
+~~~
+
+{{site.data.alerts.callout_danger}}
+We strongly recommend not setting this value higher than 8 to avoid performance degradation. If set too high, the cost of generating and costing execution plans can end up dominating the total execution time of the query.
+{{site.data.alerts.end}}
+
+For more information about the difficulty of selecting an optimal join ordering, see our blog post [An Introduction to Join Ordering](https://www.cockroachlabs.com/blog/join-ordering-pt1/).
+
 ## How to turn the optimizer off
 
 With the optimizer turned on, the performance of some workloads may change. If your workload performs worse than expected (e.g., lower throughput or higher latency), you can turn off the cost-based optimizer and use the heuristic planner.


### PR DESCRIPTION
Fixes #4330.

Summary of changes:

- Update 'Cost-based optimizer' page with a new section 'Join
  reordering', which discusses the new functionality, as well as
  tradeoffs involved in its operation.  The new
  `experimental_reorder_joins_limit` setting is described, along with
  some warnings to the user about not setting it too high, since that
  may lead to performance degradation.

- Update the session variables page to include the
  `experimental_reorder_joins_limit` variable.