### PR TITLE
CDC cluster settings, envelope format, unsupported values in avro

### DIFF
--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -386,7 +386,7 @@
                 ]
               },
               {
-                "title": "Change Data Capture (Enterprise)",
+                "title": "Change Data Capture",
                 "urls": [
                   "/${VERSION}/change-data-capture.html"
                 ]

--- a/_includes/sidebar-data-v2.2.json
+++ b/_includes/sidebar-data-v2.2.json
@@ -338,6 +338,12 @@
                 ]
               },
               {
+                "title": "Enable the Node Map",
+                "urls": [
+                  "/${VERSION}/enable-node-map.html"
+                ]
+              },
+              {
                 "title": "Use Prometheus and Alertmanager",
                 "urls": [
                   "/${VERSION}/monitor-cockroachdb-with-prometheus.html"
@@ -365,32 +371,21 @@
             ]
           },
           {
+            "title": "Table Partitioning",
+            "urls": [
+              "/${VERSION}/partitioning.html"
+            ]
+          },
+          {
+            "title": "Change Data Capture",
+            "urls": [
+              "/${VERSION}/change-data-capture.html"
+            ]
+          },
+          {
             "title": "Enterprise Features",
-            "items": [
-              {
-                "title": "Request an Enterprise License",
-                "urls": [
-                  "/${VERSION}/enterprise-licensing.html"
-                ]
-              },
-              {
-                "title": "Table Partitioning",
-                "urls": [
-                  "/${VERSION}/partitioning.html"
-                ]
-              },
-              {
-                "title": "Node Map",
-                "urls": [
-                  "/${VERSION}/enable-node-map.html"
-                ]
-              },
-              {
-                "title": "Change Data Capture (Enterprise)",
-                "urls": [
-                  "/${VERSION}/change-data-capture.html"
-                ]
-              }
+            "urls": [
+              "/${VERSION}/enterprise-licensing.html"
             ]
           }
         ]

--- a/_includes/v2.2/known-limitations/cdc.md
+++ b/_includes/v2.2/known-limitations/cdc.md
@@ -1,11 +1,8 @@
 The following are limitations in the v2.2 release and will be addressed in the future:
 
-- The CockroachDB core changefeed is not ready for external testing.
 - Changefeeds only work on tables with a single [column family](column-families.html) (which is the default for new tables).
 - Many DDL queries (including [`TRUNCATE`](truncate.html) and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. You will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html).
 - Changefeed behavior under most types of failures/degraded conditions is not yet tuned.
-- Changefeeds use a pull model, but will use a push model in the future, lowering latencies considerably.
 - Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).
-- Additional envelope options will be added, including one that displays the old and new values for the changed row.
 - Additional target options will be added, including partitions and ranges of primary key rows.

--- a/v2.2/change-data-capture.md
+++ b/v2.2/change-data-capture.md
@@ -114,6 +114,20 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 [3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
 ~~~
 
+## Enable rangefeeds to reduce latency
+
+<span class="version-tag">New in v2.2:</span> By default, changefeeds collect changes by periodically sending a request for any recent changes. However, you now have the option to connect a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes as well as transaction restarts on tables being watched by a changefeed for some workloads.
+
+Rangefeeds are disabled by default because they currently have a small performance cost, whether or not the rangefeed is being using in a changefeed. To enable rangefeeds, set the `kv.rangefeed.enabled` [cluster setting](cluster-settings.html) to `true`.
+
+Rangefeeds also require the `changefeed.push.enabled` [cluster setting](cluster-settings.html) to be `true`. This is the default, so no change is necessary to enable rangefeeds. To revert back to the previous behavior, set this setting to `false`. Note that this setting will be removed in a future release, so if you have to use the fallback, please [file a Github issue](file-an-issue.html).
+
+The `kv.closed_timestamp.target_duration` [cluster setting](cluster-settings.html) can be used when rangefeeds are enabled. Resolved timestamps will always be behind by at least this setting's duration; however, decreasing the duration leads to more transaction restarts in your cluster, which can affect performance.
+
+{{site.data.alerts.callout_info}}
+To enable rangefeeds for an existing changefeed, you must also restart the changefeed. For an enterprise changefeed, [pause](#pause) and [resume](#resume) the changefeed. For a core changefeed, cut the connection (**CTRL+C**) and reconnect using the `cursor` option.
+{{site.data.alerts.end}}
+
 ## Configure a changefeed
 
 ### Create

--- a/v2.2/create-changefeed.md
+++ b/v2.2/create-changefeed.md
@@ -46,10 +46,23 @@ Option | Value | Description
 -------|-------|------------
 `updated` | N/A | Include updated timestamps with each row.
 `resolved` | [`INTERVAL`](interval.html) | Periodically emit resolved timestamps to the changefeed. Optionally, set a minimum duration between emitting resolved timestamps. If unspecified, all resolved timestamps are emitted.<br><br>Example: `resolved='10s'`
-`envelope` | `key_only` / `row` | Use `key_only` to emit only the key and no value, which is faster if you only want to know when the key changes.<br><br>Default: `envelope=row`
+`envelope` | `key_only` / `wrapped` | Use `key_only` to emit only the key and no value, which is faster if you only want to know when the key changes.<br><br>Default: `envelope=wrapped`
 `cursor` | [Timestamp](as-of-system-time.html#parameters)  | Emits any changes after the given timestamp, but does not output the current state of the table first. If `cursor` is not specified, the changefeed starts by doing a consistent scan of all the watched rows and emits the current value, then moves to emitting any changes that happen after the scan.<br><br>`cursor` can be used to [start a new changefeed where a previous changefeed ended.](#start-a-new-changefeed-where-another-ended)<br><br>Example: `CURSOR=1536242855577149065.0000000000`
-`format` | `json` / `experimental_avro` | Format of the emitted record. Currently, support for Avro is limited and experimental. <br><br>Default: `format=json`.
+`format` | `json` / `experimental_avro` | Format of the emitted record. Currently, support for [Avro is limited and experimental](#avro-limitations). <br><br>Default: `format=json`.
 `confluent_schema_registry` | Schema Registry address | The [Schema Registry](https://docs.confluent.io/current/schema-registry/docs/index.html#sr) address is required to use `experimental_avro`.
+
+#### Avro limitations
+
+Currently, support for Avro is limited and experimental. Below is a list of unsupported SQL types and values for Avro changefeeds:
+
+- [Decimals](decimal.html) must have precision specified.
+- [Decimals](decimal.html) with `NaN` or infinite values cannot be written in Avro.
+
+    {{site.data.alerts.callout_info}}
+    To avoid `NaN` or infinite values, add a [`CHECK` constraint](check.html) to prevent these values from being inserted into decimal columns.
+    {{site.data.alerts.end}}
+
+- [`TIME`, `DATE`, `INTERVAL`](https://github.com/cockroachdb/cockroach/issues/32472), [`UUID`, `INET`](https://github.com/cockroachdb/cockroach/issues/34417), [`ARRAY`](https://github.com/cockroachdb/cockroach/issues/34420), [`JSONB`](https://github.com/cockroachdb/cockroach/issues/34421), `BIT`, and collated `STRING` are not supported in Avro yet.
 
 ## Examples
 


### PR DESCRIPTION
CDC updates, including:

- New cluster settings
- Updated default envelope format,
- List of unsupported SQL types/values in avro

Other changes: Rearranged the sidebar

Addresses some of the changes laid out in #3992. Note: core changefeed and cloud storages updates coming next.