### PR TITLE
Update Production Checklist

### DIFF
--- a/v19.1/performance-benchmarking-with-tpc-c.md
+++ b/v19.1/performance-benchmarking-with-tpc-c.md
@@ -261,7 +261,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
     ~~~ shell
     $  ./workload.LATEST fixtures load tpcc \
     --warehouses=10000 \
-    "postgres://root@<node1 address>?sslmode=disable postgres://root@<node2 address>?sslmode=disable postgres://root@<node3 address>?sslmode=disable [...space separated list]"
+    "postgres://root@<node1 address>?sslmode=disable"
     ~~~
 
     This command runs the TPC-C workload against the cluster. This will take at about an hour and loads 10,000 "warehouses" of data.

--- a/v19.1/recommended-production-settings.md
+++ b/v19.1/recommended-production-settings.md
@@ -43,15 +43,9 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ## Hardware
 
-### Terminology
-
-To properly select your cluster's hardware, it's important to review define basic hardware terminology:
-
-Term | Definition
------|------------
-**CPU** | The [physical central processing unit (CPU)](https://en.wikipedia.org/wiki/Central_processing_unit) that runs a CockroachDB server run on a (virtual) machine.</br>Also known as: central processor, main processor
-**vCPU** | Four virtual central processing units (vCPU) comprise a CPU. vCPUs increase a core's performance by running multiple tasks simultaneously. </br>Also known as: hyperthread, scheduling unit
-**Core** | A core is the basic unit for processing instructions in a CPU. A rule of thumb for cloud providers is that there are typically 2 vCPUs per core.
+{{site.data.alerts.callout_info}}
+Mentions of "CPU resources" refer to vCPUs, which are also known as hyperthreads.
+{{site.data.alerts.end}}
 
 ### Basic hardware recommendations
 

--- a/v19.1/recommended-production-settings.md
+++ b/v19.1/recommended-production-settings.md
@@ -63,7 +63,7 @@ Nodes should have sufficient CPU, RAM, network, and storage capacity to handle y
 
 - The ideal configuration is 4-16 vCPUs, 8-64 GB memory nodes (2-4 GB of memory per vCPU).
 
-    To add more processing power (up to 16 vCPUs), adding more vCPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher vCPU per node; higher vCPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
+    To add more processing power (up to 16 vCPUs), adding more vCPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher vCPUs per node; higher vCPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
 
 - For more resilient clusters, use many smaller nodes instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes. We recommend using 4 vCPUs per node.
 
@@ -97,7 +97,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 - Use `m` (general purpose) or `c` (compute-optimized) [instances](https://aws.amazon.com/ec2/instance-types/).
 
-    For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
+    For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPUs and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
 
     {{site.data.alerts.callout_danger}}
     Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on CPU resources.

--- a/v19.1/recommended-production-settings.md
+++ b/v19.1/recommended-production-settings.md
@@ -45,23 +45,23 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ### Basic hardware recommendations
 
-Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
+Nodes should have sufficient vCPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
 
-#### CPU and memory
+#### vCPU and memory
 
-- At a bare minimum, each node should have **2 GB of RAM and 2 CPUs**.
+- At a bare minimum, each node should have **2 GB of RAM and 2 vCPUs**.
 
-    More data, complex workloads, higher concurrency, and faster performance require additional resources; as a general rule of thumb, increase the number of CPUs and additional memory to match the requirements of the workload.
+    More data, complex workloads, higher concurrency, and faster performance require additional resources; as a general rule of thumb, increase the number of vCPUs and additional memory to match the requirements of the workload.
 
     {{site.data.alerts.callout_danger}}
-    Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
+    Avoid "burstable" or "shared-core" virtual machines that limit the load on vCPU resources.
     {{site.data.alerts.end}}
 
-- The ideal configuration is 4-16 CPUs, 8-64 GB memory nodes (2-4 GB of memory per CPU).
+- The ideal configuration is 4-16 vCPUs, 8-64 GB memory nodes (2-4 GB of memory per vCPU).
 
-    To add more processing power (up to 16 CPUs), adding more CPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher CPU per node; higher CPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
+    To add more processing power (up to 16 vCPUs), adding more vCPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher vCPU per node; higher vCPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
 
-- For more resilient clusters, use many smaller nodes instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes. We recommend using 4 CPUs per node.
+- For more resilient clusters, use many smaller nodes instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes. We recommend using 4 vCPUs per node.
 
 #### Storage
 
@@ -93,25 +93,25 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 - Use `m` (general purpose) or `c` (compute-optimized) [instances](https://aws.amazon.com/ec2/instance-types/).
 
-    For example, Cockroach Labs has used `c5d.4xlarge` (16 CPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
+    For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on CPU resources.
+    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on vCPU resources.
     {{site.data.alerts.end}}
 
 - Use `c5` instances with EBS as a primary AWS configuration. To simulate bare-metal deployments, use `c5d` with [SSD Instance Store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html).
 
     [Provisioned IOPS SSD-backed (`io1`) EBS volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html#EBSVolumeTypes_piops) need to have IOPS provisioned, which can be very expensive. Cheaper `gp2` volumes can be used instead, if your performance needs are less demanding. Allocating more disk space than you will use can improve performance of `gp2` volumes.
 
-- We recommend using 16 CPUs, 32-64 GiB memory each.
+- We recommend using 16 vCPUs, 32-64 GiB memory each.
 
 #### Azure
 
 - Use storage-optimized [Ls-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-storage) VMs.
-    For example, Cockroach Labs has used `Standard_L4s` VMs (4 CPUs and 32 GiB of RAM per VM) for internal testing.
+    For example, Cockroach Labs has used `Standard_L4s` VMs (4 vCPUs and 32 GiB of RAM per VM) for internal testing.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on CPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
+    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on vCPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
     {{site.data.alerts.end}}
 
 - Use [Premium Storage](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage) or local SSD storage with a Linux filesystem such as `ext4` (not the Windows `ntfs` filesystem). Note that [the size of a Premium Storage disk affects its IOPS](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#premium-storage-disk-limits).
@@ -128,10 +128,10 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `n1-standard-16` for [performance benchmarking](performance-benchmarking-with-tpc-c.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
-    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.
+    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on vCPU resources.
     {{site.data.alerts.end}}
 
-- Use [Local SSDs](https://cloud.google.com/compute/docs/disks/#localssds) or [SSD persistent disks](https://cloud.google.com/compute/docs/disks/#pdspecs). Note that [the IOPS of SSD persistent disks depends both on the disk size and number of CPUs on the machine](https://cloud.google.com/compute/docs/disks/performance#optimizessdperformance).
+- Use [Local SSDs](https://cloud.google.com/compute/docs/disks/#localssds) or [SSD persistent disks](https://cloud.google.com/compute/docs/disks/#pdspecs). Note that [the IOPS of SSD persistent disks depends both on the disk size and number of vCPUs on the machine](https://cloud.google.com/compute/docs/disks/performance#optimizessdperformance).
 - `nobarrier` can be used with SSDs, but only if it has battery-backed write cache. Without one, data can be corrupted in the event of a crash.
 
     Cockroach Labs conducts most of our [internal performance tests](https://www.cockroachlabs.com/blog/2018_cloud_report/) using `nobarrier` to demonstrate the best possible performance, but understand that not all use cases can support this option.
@@ -508,6 +508,6 @@ This section, "File Descriptors Limit", is in part derivative of the chapter *Op
 When running CockroachDB on Kubernetes, making the following minimal customizations will result in better, more reliable performance:
 
 * Use [SSDs instead of traditional HDDs](kubernetes-performance.html#disk-type).
-* Configure CPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
+* Configure vCPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
 
 For more information and additional customization suggestions, see our full detailed guide to [CockroachDB Performance on Kubernetes](kubernetes-performance.html).

--- a/v19.1/recommended-production-settings.md
+++ b/v19.1/recommended-production-settings.md
@@ -45,16 +45,16 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ### Basic hardware recommendations
 
-Nodes should have sufficient vCPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
+Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
 
-#### vCPU and memory
+#### CPU and memory
 
 - At a bare minimum, each node should have **2 GB of RAM and 2 vCPUs**.
 
     More data, complex workloads, higher concurrency, and faster performance require additional resources; as a general rule of thumb, increase the number of vCPUs and additional memory to match the requirements of the workload.
 
     {{site.data.alerts.callout_danger}}
-    Avoid "burstable" or "shared-core" virtual machines that limit the load on vCPU resources.
+    Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
     {{site.data.alerts.end}}
 
 - The ideal configuration is 4-16 vCPUs, 8-64 GB memory nodes (2-4 GB of memory per vCPU).
@@ -96,7 +96,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on vCPU resources.
+    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on CPU resources.
     {{site.data.alerts.end}}
 
 - Use `c5` instances with EBS as a primary AWS configuration. To simulate bare-metal deployments, use `c5d` with [SSD Instance Store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html).
@@ -111,7 +111,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `Standard_L4s` VMs (4 vCPUs and 32 GiB of RAM per VM) for internal testing.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on vCPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
+    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on CPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
     {{site.data.alerts.end}}
 
 - Use [Premium Storage](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage) or local SSD storage with a Linux filesystem such as `ext4` (not the Windows `ntfs` filesystem). Note that [the size of a Premium Storage disk affects its IOPS](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#premium-storage-disk-limits).
@@ -128,7 +128,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `n1-standard-16` for [performance benchmarking](performance-benchmarking-with-tpc-c.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
-    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on vCPU resources.
+    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.
     {{site.data.alerts.end}}
 
 - Use [Local SSDs](https://cloud.google.com/compute/docs/disks/#localssds) or [SSD persistent disks](https://cloud.google.com/compute/docs/disks/#pdspecs). Note that [the IOPS of SSD persistent disks depends both on the disk size and number of vCPUs on the machine](https://cloud.google.com/compute/docs/disks/performance#optimizessdperformance).
@@ -508,6 +508,6 @@ This section, "File Descriptors Limit", is in part derivative of the chapter *Op
 When running CockroachDB on Kubernetes, making the following minimal customizations will result in better, more reliable performance:
 
 * Use [SSDs instead of traditional HDDs](kubernetes-performance.html#disk-type).
-* Configure vCPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
+* Configure CPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
 
 For more information and additional customization suggestions, see our full detailed guide to [CockroachDB Performance on Kubernetes](kubernetes-performance.html).

--- a/v19.1/recommended-production-settings.md
+++ b/v19.1/recommended-production-settings.md
@@ -43,6 +43,16 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ## Hardware
 
+### Terminology
+
+To properly select your cluster's hardware, it's important to review define basic hardware terminology:
+
+Term | Definition
+-----|------------
+**CPU** | The [physical central processing unit (CPU)](https://en.wikipedia.org/wiki/Central_processing_unit) that runs a CockroachDB server run on a (virtual) machine.</br>Also known as: central processor, main processor
+**vCPU** | Four virtual central processing units (vCPU) comprise a CPU. vCPUs increase a core's performance by running multiple tasks simultaneously. </br>Also known as: hyperthread, scheduling unit
+**Core** | A core is the basic unit for processing instructions in a CPU. A rule of thumb for cloud providers is that there are typically 2 vCPUs per core.
+
 ### Basic hardware recommendations
 
 Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.

--- a/v2.1/performance-benchmarking-with-tpc-c.md
+++ b/v2.1/performance-benchmarking-with-tpc-c.md
@@ -261,7 +261,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
     ~~~ shell
     $  ./workload.LATEST fixtures load tpcc \
     --warehouses=10000 \
-    "postgres://root@<node1 address>?sslmode=disable postgres://root@<node2 address>?sslmode=disable postgres://root@<node3 address>?sslmode=disable [...space separated list]"
+    "postgres://root@<node1 address>?sslmode=disable"
     ~~~
 
     This command runs the TPC-C workload against the cluster. This will take at about an hour and loads 10,000 "warehouses" of data.
@@ -308,7 +308,7 @@ Next, [partition your database](partitioning.html) to divide all of the TPC-C ta
     --scatter \
     --warehouses=10000 \
     --duration=1s \
-    "postgres://root@<node31 address>?sslmode=disable"
+    "postgres://root@<node1 address>?sslmode=disable postgres://root@<node2 address>?sslmode=disable postgres://root@<node3 address>?sslmode=disable [...space separated list]"
     ~~~
 
     This command runs the TPC-C workload against the cluster for 1 second, long enough to add the partitions.

--- a/v2.1/recommended-production-settings.md
+++ b/v2.1/recommended-production-settings.md
@@ -45,16 +45,16 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ### Basic hardware recommendations
 
-Nodes should have sufficient vCPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
+Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
 
-#### vCPU and memory
+#### CPU and memory
 
 - At a bare minimum, each node should have **2 GB of RAM and 2 vCPUs**.
 
     More data, complex workloads, higher concurrency, and faster performance require additional resources; as a general rule of thumb, increase the number of vCPUs and additional memory to match the requirements of the workload.
 
     {{site.data.alerts.callout_danger}}
-    Avoid "burstable" or "shared-core" virtual machines that limit the load on vCPU resources.
+    Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
     {{site.data.alerts.end}}
 
 - The ideal configuration is 4-16 vCPUs, 8-64 GB memory nodes (2-4 GB of memory per vCPU).
@@ -96,7 +96,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on vCPU resources.
+    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on CPU resources.
     {{site.data.alerts.end}}
 
 - Use `c5` instances with EBS as a primary AWS configuration. To simulate bare-metal deployments, use `c5d` with [SSD Instance Store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html).
@@ -111,7 +111,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `Standard_L4s` VMs (4 vCPUs and 32 GiB of RAM per VM) for internal testing.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on vCPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
+    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on CPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
     {{site.data.alerts.end}}
 
 - Use [Premium Storage](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage) or local SSD storage with a Linux filesystem such as `ext4` (not the Windows `ntfs` filesystem). Note that [the size of a Premium Storage disk affects its IOPS](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#premium-storage-disk-limits).
@@ -128,7 +128,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `n1-standard-16` for [performance benchmarking](performance-benchmarking-with-tpc-c.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
-    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on vCPU resources.
+    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.
     {{site.data.alerts.end}}
 
 - Use [Local SSDs](https://cloud.google.com/compute/docs/disks/#localssds) or [SSD persistent disks](https://cloud.google.com/compute/docs/disks/#pdspecs). Note that [the IOPS of SSD persistent disks depends both on the disk size and number of vCPUs on the machine](https://cloud.google.com/compute/docs/disks/performance#optimizessdperformance).
@@ -506,6 +506,6 @@ This section, "File Descriptors Limit", is in part derivative of the chapter *Op
 When running CockroachDB on Kubernetes, making the following minimal customizations will result in better, more reliable performance:
 
 * Use [SSDs instead of traditional HDDs](kubernetes-performance.html#disk-type).
-* Configure vCPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
+* Configure CPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
 
 For more information and additional customization suggestions, see our full detailed guide to [CockroachDB Performance on Kubernetes](kubernetes-performance.html).

--- a/v2.1/recommended-production-settings.md
+++ b/v2.1/recommended-production-settings.md
@@ -43,15 +43,9 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ## Hardware
 
-### Terminology
-
-To properly select your cluster's hardware, it's important to review define basic hardware terminology:
-
-Term | Definition
------|------------
-**CPU** | The [physical central processing unit (CPU)](https://en.wikipedia.org/wiki/Central_processing_unit) that runs a CockroachDB server run on a (virtual) machine.</br>Also known as: central processor, main processor
-**vCPU** | Four virtual central processing units (vCPU) comprise a CPU. vCPUs increase a core's performance by running multiple tasks simultaneously. </br>Also known as: hyperthread, scheduling unit
-**Core** | A core is the basic unit for processing instructions in a CPU. A rule of thumb for cloud providers is that there are typically 2 vCPUs per core.
+{{site.data.alerts.callout_info}}
+Mentions of "CPU resources" refer to vCPUs, which are also known as hyperthreads.
+{{site.data.alerts.end}}
 
 ### Basic hardware recommendations
 

--- a/v2.1/recommended-production-settings.md
+++ b/v2.1/recommended-production-settings.md
@@ -63,7 +63,7 @@ Nodes should have sufficient CPU, RAM, network, and storage capacity to handle y
 
 - The ideal configuration is 4-16 vCPUs, 8-64 GB memory nodes (2-4 GB of memory per vCPU).
 
-    To add more processing power (up to 16 vCPUs), adding more vCPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher vCPU per node; higher vCPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
+    To add more processing power (up to 16 vCPUs), adding more vCPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher vCPUs per node; higher vCPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
 
 - For more resilient clusters, use many smaller nodes instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes. We recommend using 4 vCPUs per node.
 
@@ -97,7 +97,7 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 - Use `m` (general purpose) or `c` (compute-optimized) [instances](https://aws.amazon.com/ec2/instance-types/).
 
-    For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
+    For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPUs and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
 
     {{site.data.alerts.callout_danger}}
     Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on CPU resources.

--- a/v2.1/recommended-production-settings.md
+++ b/v2.1/recommended-production-settings.md
@@ -45,23 +45,23 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ### Basic hardware recommendations
 
-Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
+Nodes should have sufficient vCPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
 
-#### CPU and memory
+#### vCPU and memory
 
-- At a bare minimum, each node should have **2 GB of RAM and 2 CPUs**.
+- At a bare minimum, each node should have **2 GB of RAM and 2 vCPUs**.
 
-    More data, complex workloads, higher concurrency, and faster performance require additional resources; as a general rule of thumb, increase the number of CPUs and additional memory to match the requirements of the workload.
+    More data, complex workloads, higher concurrency, and faster performance require additional resources; as a general rule of thumb, increase the number of vCPUs and additional memory to match the requirements of the workload.
 
     {{site.data.alerts.callout_danger}}
-    Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
+    Avoid "burstable" or "shared-core" virtual machines that limit the load on vCPU resources.
     {{site.data.alerts.end}}
 
-- The ideal configuration is 4-16 CPUs, 8-64 GB memory nodes (2-4 GB of memory per CPU).
+- The ideal configuration is 4-16 vCPUs, 8-64 GB memory nodes (2-4 GB of memory per vCPU).
 
-    To add more processing power (up to 16 CPUs), adding more CPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher CPU per node; higher CPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
+    To add more processing power (up to 16 vCPUs), adding more vCPUs is better than adding more RAM. Otherwise, add more nodes rather than using higher vCPU per node; higher vCPUs will have NUMA implications. Our internal testing results indicate this is the sweet spot for OLTP workloads. It is a best practice to use uniform nodes so SQL performance is consistent.
 
-- For more resilient clusters, use many smaller nodes instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes. We recommend using 4 CPUs per node.
+- For more resilient clusters, use many smaller nodes instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes. We recommend using 4 vCPUs per node.
 
 #### Storage
 
@@ -93,25 +93,25 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 - Use `m` (general purpose) or `c` (compute-optimized) [instances](https://aws.amazon.com/ec2/instance-types/).
 
-    For example, Cockroach Labs has used `c5d.4xlarge` (16 CPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
+    For example, Cockroach Labs has used `c5d.4xlarge` (16 vCPU and 32 GiB of RAM per instance, NVMe SSD) for internal testing. Note that the instance type depends on whether EBS is used or not. If you're using EBS, use a `c5` instance.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on CPU resources.
+    Do not use ["burstable" `t` instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances.html), which limit the load on vCPU resources.
     {{site.data.alerts.end}}
 
 - Use `c5` instances with EBS as a primary AWS configuration. To simulate bare-metal deployments, use `c5d` with [SSD Instance Store volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ssd-instance-store.html).
 
     [Provisioned IOPS SSD-backed (`io1`) EBS volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html#EBSVolumeTypes_piops) need to have IOPS provisioned, which can be very expensive. Cheaper `gp2` volumes can be used instead, if your performance needs are less demanding. Allocating more disk space than you will use can improve performance of `gp2` volumes.
 
-- We recommend using 16 CPUs, 32-64 GiB memory each.
+- We recommend using 16 vCPUs, 32-64 GiB memory each.
 
 #### Azure
 
 - Use storage-optimized [Ls-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-storage) VMs.
-    For example, Cockroach Labs has used `Standard_L4s` VMs (4 CPUs and 32 GiB of RAM per VM) for internal testing.
+    For example, Cockroach Labs has used `Standard_L4s` VMs (4 vCPUs and 32 GiB of RAM per VM) for internal testing.
 
     {{site.data.alerts.callout_danger}}
-    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on CPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
+    Do not use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on vCPU resources. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.
     {{site.data.alerts.end}}
 
 - Use [Premium Storage](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage) or local SSD storage with a Linux filesystem such as `ext4` (not the Windows `ntfs` filesystem). Note that [the size of a Premium Storage disk affects its IOPS](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage#premium-storage-disk-limits).
@@ -128,10 +128,10 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
     For example, Cockroach Labs has used `n1-standard-16` for [performance benchmarking](performance-benchmarking-with-tpc-c.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
-    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.
+    Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on vCPU resources.
     {{site.data.alerts.end}}
 
-- Use [Local SSDs](https://cloud.google.com/compute/docs/disks/#localssds) or [SSD persistent disks](https://cloud.google.com/compute/docs/disks/#pdspecs). Note that [the IOPS of SSD persistent disks depends both on the disk size and number of CPUs on the machine](https://cloud.google.com/compute/docs/disks/performance#optimizessdperformance).
+- Use [Local SSDs](https://cloud.google.com/compute/docs/disks/#localssds) or [SSD persistent disks](https://cloud.google.com/compute/docs/disks/#pdspecs). Note that [the IOPS of SSD persistent disks depends both on the disk size and number of vCPUs on the machine](https://cloud.google.com/compute/docs/disks/performance#optimizessdperformance).
 - `nobarrier` can be used with SSDs, but only if it has battery-backed write cache. Without one, data can be corrupted in the event of a crash.
 
     Cockroach Labs conducts most of our [internal performance tests](https://www.cockroachlabs.com/blog/2018_cloud_report/) using `nobarrier` to demonstrate the best possible performance, but understand that not all use cases can support this option.
@@ -506,6 +506,6 @@ This section, "File Descriptors Limit", is in part derivative of the chapter *Op
 When running CockroachDB on Kubernetes, making the following minimal customizations will result in better, more reliable performance:
 
 * Use [SSDs instead of traditional HDDs](kubernetes-performance.html#disk-type).
-* Configure CPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
+* Configure vCPU and memory [resource requests and limits](kubernetes-performance.html#resource-requests-and-limits).
 
 For more information and additional customization suggestions, see our full detailed guide to [CockroachDB Performance on Kubernetes](kubernetes-performance.html).

--- a/v2.1/recommended-production-settings.md
+++ b/v2.1/recommended-production-settings.md
@@ -43,6 +43,16 @@ For added context about CockroachDB's fault tolerance and automated repair capab
 
 ## Hardware
 
+### Terminology
+
+To properly select your cluster's hardware, it's important to review define basic hardware terminology:
+
+Term | Definition
+-----|------------
+**CPU** | The [physical central processing unit (CPU)](https://en.wikipedia.org/wiki/Central_processing_unit) that runs a CockroachDB server run on a (virtual) machine.</br>Also known as: central processor, main processor
+**vCPU** | Four virtual central processing units (vCPU) comprise a CPU. vCPUs increase a core's performance by running multiple tasks simultaneously. </br>Also known as: hyperthread, scheduling unit
+**Core** | A core is the basic unit for processing instructions in a CPU. A rule of thumb for cloud providers is that there are typically 2 vCPUs per core.
+
 ### Basic hardware recommendations
 
 Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.


### PR DESCRIPTION
- Clarify that we are talking about vCPU instead of CPU.
- Fix connection string info in the workload instructions of benchmarking a large cluster.

Closes #4301, #4304, #4287.