### PR TITLE
Remove nanoseconds from INTERVAL docs

### DIFF
--- a/v19.1/interval.md
+++ b/v19.1/interval.md
@@ -6,6 +6,9 @@ toc: true
 
 The `INTERVAL` [data type](data-types.html) stores a value that represents a span of time.
 
+## Aliases
+
+There are no aliases for the interval type. However, CockroachDB supports using uninterpreted [string literals](sql-constants.html#string-literals) in contexts where an `INTERVAL` value is otherwise expected.
 
 ## Syntax
 
@@ -25,17 +28,22 @@ SQL Standard | `INTERVAL 'Y-M D H:M:S'`<br><br>`Y-M D`: Using a single value def
 ISO 8601 | `INTERVAL 'P1Y2M3DT4H5M6S'`
 Traditional PostgreSQL | `INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'`
 Abbreviated PostgreSQL | `INTERVAL '1 yr 2 mons 3 d 4 hrs 5 mins 6 secs'`
-Golang | `INTERVAL '1h2m3s4ms5us6ns'`<br><br>Note that `ms` is milliseconds, `us` is microseconds, and `ns` is nanoseconds. Also, all fields support both integers and floats.
 
 CockroachDB also supports using uninterpreted
 [string literals](sql-constants.html#string-literals) in contexts
-where a `INTERVAL` value is otherwise expected.
-
-Intervals are stored internally as months, days, and nanoseconds.
+where an `INTERVAL` value is otherwise expected.
 
 ## Size
 
-An `INTERVAL` column supports values up to 24 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
+An `INTERVAL` column supports values up to 24 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata. Intervals are stored internally as months, days, and microseconds.
+
+## Precision
+
+<span class="version-tag">New in v19.1</span>: Intervals are stored with microsecond precision instead of nanoseconds, and it is no longer possible to create intervals with nanosecond precision.  As a result, parsing from a [string](string.html) or converting from a [float](float.html) or [decimal](decimal.html) will round to the nearest microsecond, as will any arithmetic [operation](functions-and-operators.html#supported-operations) (add, sub, mul, div) on intervals. CockroachDB rounds (instead of truncating) to match the behavior of Postgres.
+
+{{site.data.alerts.callout_danger}}
+When upgrading to 19.1, existing intervals with nanoseconds will no longer be able to return their nanosecond part. An existing table `t` with nanoseconds in intervals of column `s` can round them to the nearest microsecond with `UPDATE t SET s = s + '0s'`. Note that this could cause uniqueness problems if the interval is being used as a [primary key](primary-key.html).
+{{site.data.alerts.end}}
 
 ## Example
 
@@ -50,25 +58,20 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 ~~~
 
 ~~~
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-| column_name | data_type | is_nullable | column_default | generation_expression |   indices   |
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-| a           | INT       |    false    | NULL           |                       | {"primary"} |
-| b           | INTERVAL  |    true     | NULL           |                       | {}          |
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
+ column_name | data_type | is_nullable | column_default | generation_expression |  indices  | is_hidden 
+-------------+-----------+-------------+----------------+-----------------------+-----------+-----------
+ a           | INT8      | f           |                |                       | {primary} | f
+ b           | INTERVAL  | t           |                |                       | {}        | f
 (2 rows)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO intervals VALUES
-  (1, INTERVAL '1h2m3s4ms5us6ns'),
-  (2, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'),
-  (3, INTERVAL '1-2 3 4:5:6');
-~~~
-
-~~~
-INSERT 3
+> INSERT INTO
+    intervals
+    VALUES (1, INTERVAL '1 year 2 months 3 days 4 hours 5 minutes 6 seconds'), 
+           (2, INTERVAL '1-2 3 4:5:6'),
+           (3, '1-2 3 4:5:6');
 ~~~
 
 {% include copy-clipboard.html %}
@@ -77,13 +80,11 @@ INSERT 3
 ~~~
 
 ~~~
-+---+------------------+
-| a |        b         |
-+---+------------------+
-| 1 | 1h2m3.004005006s |
-| 2 | 14m3d4h5m6s      |
-| 3 | 14m3d4h5m6s      |
-+---+------------------+
+ a |               b               
+---+-------------------------------
+ 1 | 1 year 2 mons 3 days 04:05:06
+ 2 | 1 year 2 mons 3 days 04:05:06
+ 3 | 1 year 2 mons 3 days 04:05:06
 (3 rows)
 ~~~
 
@@ -94,9 +95,9 @@ INSERT 3
 Type | Details
 -----|--------
 `INT` | Converts to number of seconds (second precision)
-`DECIMAL` | Converts to number of seconds (nanosecond precision)
+`DECIMAL` | Converts to number of seconds (microsecond precision)
 `FLOAT` | Converts to number of picoseconds
-`STRING` | Converts to `h-m-s` format (nanosecond precision)
+`STRING` | Converts to `h-m-s` format (microsecond precision)
 `TIME` | Converts to `HH:MM:SS.SSSSSS`, the time equivalent to the interval after midnight (microsecond precision)
 
 ## See also


### PR DESCRIPTION
Fixes #4375.

Summary of changes:

- Update `INTERVAL` docs with a new section on 'Precision', where we
  note that as of 19.1, nanoseconds are going away in favor of
  microseconds only

- Remove description of Golang-ish interval syntax which mentioned
  nanoseconds

- s/nano/micro/g (which may not have made sense in all cases, pending
  engineering review).

- Add new 'aliases' section to match other data types, where we note
  that you can specify intervals with string literals in some contexts.

- Move information about internal representation to the 'Size' section.

- Update Examples to use new output format.