### PR TITLE
Mark 1.0 as unsupported and 1.1 as soon-unsupported in docs

### DIFF
--- a/_includes/unsupported-version-soon.md
+++ b/_includes/unsupported-version-soon.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_info}}
-Cockroach Labs supports the current <a href="../stable/install-cockroachdb.html">stable release</a> and two releases prior. Therefore, this version will no longer be supported after the Spring 2019 release.
+Cockroach Labs supports the current <a href="https://www.cockroachlabs.com/docs/stable/install-cockroachdb-mac.html">stable release</a> and two releases prior. Therefore, this version will no longer be supported after the Spring 2019 release.
 {{site.data.alerts.end}}

--- a/_includes/unsupported-version-soon.md
+++ b/_includes/unsupported-version-soon.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+Cockroach Labs supports the current <a href="../stable/install-cockroachdb.html">stable release</a> and two releases prior. Therefore, this version will no longer be supported after the Spring 2019 release.
+{{site.data.alerts.end}}

--- a/_includes/unsupported-version.md
+++ b/_includes/unsupported-version.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-This version of CockroachDB is no longer supported. Cockroach Labs supports the current <a href="../stable/install-cockroachdb.html">stable release</a> and two releases prior. Please use one of these supported versions.
+This version of CockroachDB is no longer supported. Cockroach Labs supports the current <a href="https://www.cockroachlabs.com/docs/stable/install-cockroachdb-mac.html">stable release</a> and two releases prior. Please use one of these supported versions.
 {{site.data.alerts.end}}

--- a/_includes/unsupported-version.md
+++ b/_includes/unsupported-version.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_danger}}
+This version of CockroachDB is no longer supported. Cockroach Labs supports the current <a href="../stable/install-cockroachdb.html">stable release</a> and two releases prior. Please use one of these supported versions.
+{{site.data.alerts.end}}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -19,6 +19,14 @@ layout: default
       <div id="toc"></div>
    {% endif %}
 
+   {% if page.url contains 'v1.0' %}
+      {% include unsupported-version.md %}
+   {% endif %}
+
+   {% if page.url contains 'v1.1' %}
+      {% include unsupported-version-soon.md %}
+   {% endif %}
+
    {{content}}
 
    {% if page.feedback != false %}

--- a/v19.1/install-cockroachdb-linux.html
+++ b/v19.1/install-cockroachdb-linux.html
@@ -12,7 +12,7 @@ key: install-cockroachdb.html
   <a href="install-cockroachdb-windows.html"><button id="windows" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button></a>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="linux-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}.</p>
+<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-linux" class="install-option">
   <h2>Download the Binary</h2>

--- a/v19.1/install-cockroachdb-mac.html
+++ b/v19.1/install-cockroachdb-mac.html
@@ -12,7 +12,7 @@ key: install-cockroachdb.html
   <a href="install-cockroachdb-windows.html"><button id="windows" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button></a>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. </p>
+<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 {% if page.version.stable %}
 <div id="use-homebrew" class="install-option">

--- a/v19.1/install-cockroachdb-windows.html
+++ b/v19.1/install-cockroachdb-windows.html
@@ -12,7 +12,7 @@ key: install-cockroachdb.html
     <button id="windows" class="current" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="windows-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. </p>
+<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-windows" class="install-option">
   <h2>Download the Binary</h2>

--- a/v2.1/install-cockroachdb-linux.html
+++ b/v2.1/install-cockroachdb-linux.html
@@ -12,7 +12,7 @@ key: install-cockroachdb.html
   <a href="install-cockroachdb-windows.html"><button id="windows" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button></a>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="linux-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}.</p>
+<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-linux" class="install-option">
   <h2>Download the Binary</h2>

--- a/v2.1/install-cockroachdb-mac.html
+++ b/v2.1/install-cockroachdb-mac.html
@@ -12,7 +12,7 @@ key: install-cockroachdb.html
   <a href="install-cockroachdb-windows.html"><button id="windows" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button></a>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. </p>
+<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 {% if page.version.stable %}
 <div id="use-homebrew" class="install-option">

--- a/v2.1/install-cockroachdb-windows.html
+++ b/v2.1/install-cockroachdb-windows.html
@@ -12,7 +12,7 @@ key: install-cockroachdb.html
     <button id="windows" class="current" data-eventcategory="buttonClick-doc-os" data-eventaction="windows">Windows</button>
 </div>
 
-<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="windows-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. </p>
+<p>See <a href="../releases/{{page.release_info.version}}.html" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-windows" class="install-option">
   <h2>Download the Binary</h2>


### PR DESCRIPTION
Fixes #4430.

<img width="1435" alt="screen shot 2019-02-25 at 10 49 13 pm" src="https://user-images.githubusercontent.com/15893490/53386311-aed67280-394f-11e9-89ce-d9d61c3abbc1.png">
