### PR TITLE
include third-party database tools, including intellij docs, in 19.1

### DIFF
--- a/_includes/sidebar-data-v19.1.json
+++ b/_includes/sidebar-data-v19.1.json
@@ -174,12 +174,6 @@
             "urls": [
               "/${VERSION}/demo-json-support.html"
             ]
-          },
-          {
-           "title": "Third-Party Database Tools",
-            "urls": [
-                "/${VERSION}/third-party-database-tools.html"
-            ]
           }
         ]
       },
@@ -1691,6 +1685,29 @@
             "title": "Custom Chart Debug Page",
             "urls": [
               "/${VERSION}/admin-ui-custom-chart-debug-page.html"
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Third-Party Database Tools",
+        "items": [
+          {
+            "title": "Overview",
+            "urls": [
+              "/${VERSION}/third-party-database-tools.html"
+            ]
+          },
+          {
+            "title": "DBeaver",
+            "urls": [
+              "/${VERSION}/dbeaver.html"
+            ]
+          },
+          {
+            "title": "IntelliJ IDEA",
+            "urls": [
+              "/${VERSION}/intellij-idea.html"
             ]
           }
         ]

--- a/v19.1/dbeaver.md
+++ b/v19.1/dbeaver.md
@@ -1,0 +1,90 @@
+---
+title: DBeaver
+summary: Learn how to use DBeaver with CockroachDB.
+toc: true
+---
+
+The [DBeaver database tool][dbeaver] is a tool that completely integrates with CockroachDB to provide a GUI for managing your database.
+
+According to the [DBeaver website][dbeaver]:
+
+> DBeaver is a cross-platform Database GUI tool for developers, SQL programmers, database administrators, and analysts.
+
+In this tutorial, you'll work through the process of using DBeaver with a secure CockroachDB cluster.
+
+{{site.data.alerts.callout_success}}
+For more information about using DBeaver, see the [DBeaver documentation](https://dbeaver.io/docs/).
+
+If you run into problems, please file an issue on the [DBeaver issue tracker](https://github.com/dbeaver/dbeaver/issues).
+{{site.data.alerts.end}}
+
+## Before You Begin
+
+To work through this tutorial, take the following steps:
+
+- [Install CockroachDB](install-cockroachdb.html) and [start a secure cluster](secure-a-cluster.html).
+- Download a copy of [DBeaver](https://dbeaver.io/download/) version 5.2.3 or greater.
+
+## Step 1. Start DBeaver and connect to CockroachDB
+
+Start DBeaver, and select **Database > New Connection** from the menu.  In the dialog that appears, select **CockroachDB** from the list.
+
+<img src="{{ 'images/v2.1/dbeaver-01-select-cockroachdb.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+
+## Step 2. Update the connection settings
+
+On the **Create new connection** dialog that appears, click **Network settings**.  
+
+<img src="{{ 'images/v2.1/dbeaver-02-cockroachdb-connection-settings.png' | relative_url }}" alt="DBeaver - CockroachDB connection settings" style="border:1px solid #eee;max-width:100%" />
+
+From the network settings, click the **SSL** tab.  It will look like the screenshot below.
+
+<img src="{{ 'images/v2.1/dbeaver-03-ssl-tab.png' | relative_url }}" alt="DBeaver - SSL tab" style="border:1px solid #eee;max-width:100%" />
+
+Check the **Use SSL** checkbox as shown, and fill in the text areas as follows:
+
+- **Root certificate**: Use the `ca.crt` file you generated for your secure cluster.
+- **SSL certificate**: Use a client certificate generated from your cluster's root certificate.  For the root user, this will be named `client.root.crt`.  For additional security, you may want to create a new database user and client certificate just for use with DBeaver.
+- **SSL certificate key**: Because DBeaver is a Java application, you will need to transform your key file to the `*.pk8` format using an [OpenSSL command](https://wiki.openssl.org/index.php/Command_Line_Utilities#pkcs8_.2F_pkcs5) like the one shown below.  Once you have created the file, enter its location here.  In this example, the filename is `client.root.pk8`.
+    {% include copy-clipboard.html %}
+    ~~~ console
+    $ openssl pkcs8 -topk8 -inform PEM -outform DER -in client.root.key -out client.root.pk8 -nocrypt
+    ~~~
+
+Select **require** from the **SSL mode** dropdown.  There is no need to set the **SSL Factory**, you can let DBeaver use the default.
+
+## Step 3. Test the connection settings
+
+Click **Test Connection ...**.  If everything worked, you will see a **Success** dialog like the one shown below.
+
+<img src="{{ 'images/v2.1/dbeaver-04-connection-success-dialog.png' | relative_url }}" alt="DBeaver - connection success dialog" style="border:1px solid #eee;max-width:100%" />
+
+## Step 4. Start using DBeaver
+
+Click **Finish** to get started using DBeaver with CockroachDB.
+
+<img src="{{ 'images/v2.1/dbeaver-05-movr.png' | relative_url }}" alt="DBeaver - CockroachDB with the movr database" style="max-width:100%" />
+
+For more information about using DBeaver, see the [DBeaver documentation](https://dbeaver.io/docs/).
+
+## Report Issues with DBeaver & CockroachDB
+
+If you run into problems, please file an issue on the [DBeaver issue tracker](https://github.com/dbeaver/dbeaver/issues), including the following details about the environment where you encountered the issue:
+
+- CockroachDB version ([`cockroach version`](view-version-details.html))
+- DBeaver version
+- Operating system
+- Steps to reproduce the behavior
+- If possible, a trace of the SQL statements sent to CockroachDB while the error is being reproduced using [SQL query logging](query-behavior-troubleshooting.html#sql-logging).
+
+## See Also
+
++ [DBeaver documentation](https://dbeaver.io/docs/)
++ [DBeaver issue tracker](https://github.com/dbeaver/dbeaver/issues)
++ [Client connection paramters](connection-parameters.html)
++ [Third-Party Database Tools](third-party-database-tools.html)
++ [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
+
+<!-- Reference Links -->
+
+[dbeaver]: https://dbeaver.io

--- a/v19.1/intellij-idea.md
+++ b/v19.1/intellij-idea.md
@@ -1,0 +1,94 @@
+---
+title: Intellij IDEA
+summary: Learn how to use IntelliJ IDEA with CockroachDB.
+toc: true
+---
+
+You can use CockroachDB in [IntelliJ IDEA](https://www.jetbrains.com/idea/) as a [database data source](https://www.jetbrains.com/help/idea/managing-data-sources.html#data_sources), which lets you accomplish tasks like managing your database's schema from within your IDE.
+
+## Support
+
+As of CockroachDB {{page.version.version}}, IntelliJ IDEA only has **partial support**. This means that the application is mostly functional, but its integration still has a few rough edges.
+
+### Versions
+
+The level of support in this document was tested as of the following versions:
+
+- CockroachDB v19.1.0-beta.20190225
+- IntelliJ IDEA Ultimate 18.1.3
+- PostgreSQL JDBC 41.1
+
+{{site.data.alerts.callout_info}}
+This feature should also work with other JetBrains IDEs, such as PyCharm, but Cockroach Labs has not yet tested its integration.
+{{site.data.alerts.end}}
+
+### Warnings & Errors
+
+Users can expect to encounter the following behaviors when using CockroachDB within IntelliJ IDEA.
+
+- **Warnings** do not require any action on the user's end and can be ignored. Note that even if a message indicates that it is an "error", it can still be treated as a warning by this definition.
+- **Errors** require the user to take action to resolve the problem and cannot be ignored.
+
+#### Warnings
+
+##### [XX000] ERROR: could not decorrelate subquery...
+
+<img src="{{ 'images/v2.1/intellij/XX000_error_could_not_decorrelate_subquery.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+
+Displays once per load of schema.
+
+<hr/>
+
+##### [42883] ERROR: unknown function: pg_function_is_visible() Failed to retrieve...
+
+<img src="{{ 'images/v2.1/intellij/42883_error_pg_function_is_visible.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+
+Display periodically. Does not impact functionality.
+
+#### Errors
+
+##### [42703] org.postgresql.util.PSQLException: ERROR: column "n.xmin" does not exist
+
+<img src="{{ 'images/v2.1/intellij/42073_error_column_n_xmin_does_not_exist.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+
+Requires setting **Introspect using JDBC metadata** ([details below](#set-cockroachdb-as-a-data-source-in-intellij)).
+
+<hr/>
+
+## Set CockroachDB as a Data Source in IntelliJ
+
+1. Launch the **Database** tool window. (**View** > **Tool Windows** > **Database**) <img src="{{ 'images/v2.1/intellij/01_database_tool_window.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+1. Add a PostgreSQL data source. (**New (+)** > **Data Source** > **PostgreSQL**)<img src="{{ 'images/v2.1/intellij/02_postgresql_data_source.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+1. On the **General** tab, enter your database's connection string:
+
+	Field | Value
+	------|-------
+	**Host** | Your CockroachDB cluster's hostname
+	**Port** | Your CockroachDB cluster's port. By default, CockroachDB uses port **26257**.
+	**Database** | The database you want to connect to. Note that CockroachDB's notion of database differs from PostgreSQL's; you can see your cluster's databases through the [`SHOW DATABASES`](show-databases.html) command.
+	**User** | The user to connect as. By default, you can use **root**.
+	**Password** | If your cluster uses password authentication, enter the password.
+	**Driver** | Select or install **PostgreSQL** using a version greater than or equal to 41.1. (Older drivers have not been tested.)
+
+	<img src="{{ 'images/v2.1/intellij/03_general_tab.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+1. Install or select a **PostgreSQL** driver. We recommend a version greater than or equal to 41.1.
+1. If your cluster uses SSL authentication, go to the **SSH/SSL** tab, select **Use SSL** and provide the location of your certificate files.
+1. Go to the **Options** tab, and then select **Introspect using JDBC metadata**.<img src="{{ 'images/v2.1/intellij/04_options_tab.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
+1. Click **OK**.
+
+You can now use IntelliJ's [database tool window](https://www.jetbrains.com/help/idea/working-with-the-database-tool-window.html) to interact with your CockroachDB cluster.
+
+## Report Issues with IntelliJ IDEA & CockroachDB
+
+If you encounter issues other than those outlined above, please [file an issue on the `cockroachdb/cockroach` GitHub repo](https://github.com/cockroachdb/cockroach/issues/new?template=bug_report.md), including the following details about the environment where you encountered the issue:
+
+- CockroachDB version ([`cockroach version`](view-version-details.html))
+- IntelliJ IDEA version
+- Operating system
+- Steps to reproduce the behavior
+- If possible, a trace of the SQL statements sent to CockroachDB while the error is being reproduced using [SQL query logging](query-behavior-troubleshooting.html#sql-logging).
+
+## See Also
+
++ [Client connection paramters](connection-parameters.html)
++ [Third-Party Database Tools](third-party-database-tools.html)

--- a/v19.1/third-party-database-tools.md
+++ b/v19.1/third-party-database-tools.md
@@ -1,82 +1,26 @@
 ---
 title: Third-Party Database Tools
-summary: Learn about third-party software that interoperates with CockroachDB.
+summary: Learn about third-party software that works with CockroachDB.
 toc: true
 ---
 
-CockroachDB supports the Postgres wire protocol. This makes it possible to use Postgres-compatible [drivers](build-an-app-with-cockroachdb.html), [ORMs](build-an-app-with-cockroachdb.html), and other types of third-party database tools with CockroachDB. Some tools are only partially supported at this time, while others have been thoroughly vetted and tested.
+CockroachDB's support of the PostgreSQL wire protocol enables support for many [drivers](build-an-app-with-cockroachdb.html), [ORMs](build-an-app-with-cockroachdb.html), and other types of third-party database tools.
 
-The [DBeaver database tool][dbeaver] is one of the tools for which we claim full support.
+## Support
 
-According to the [DBeaver website][dbeaver]:
+We offer the following levels of support with third-party tools:
 
-> DBeaver is a cross-platform Database GUI tool for developers, SQL programmers, database administrators, and analysts.
+- **Comprehensive support** indicates that the vast majority of the tool's features should work without issue with CockroachDB.
+- **Partial support** indicates that the tool works with CockroachDB, but its integration might require additional steps, lack support for all features, or exhibit undesirable behavior.
 
-In this tutorial, you'll work through the process of using DBeaver with a secure CockroachDB cluster.
+## Graphical User Interface
 
-{{site.data.alerts.callout_success}}
-For more information about using DBeaver, see the [DBeaver documentation](https://dbeaver.io/docs/).
+- [DBeaver](dbeaver.html) _(comprehensive support)_
 
-If you run into problems, please file an issue on the [DBeaver issue tracker](https://github.com/dbeaver/dbeaver/issues).
-{{site.data.alerts.end}}
+## Integrated Development Environment (IDE)
 
-## Before You Begin
-
-To work through this tutorial, take the following steps:
-
-- [Install CockroachDB](install-cockroachdb.html) and [start a secure cluster](secure-a-cluster.html).
-- Download a copy of [DBeaver](https://dbeaver.io/download/) version 5.2.3 or greater.
-
-## Step 1. Start DBeaver and connect to CockroachDB
-
-Start DBeaver, and select **Database > New Connection** from the menu.  In the dialog that appears, select **CockroachDB** from the list.
-
-<img src="{{ 'images/v19.1/dbeaver-01-select-cockroachdb.png' | relative_url }}" alt="DBeaver - Select CockroachDB" style="border:1px solid #eee;max-width:100%" />
-
-## Step 2. Update the connection settings
-
-On the **Create new connection** dialog that appears, click **Network settings**.  
-
-<img src="{{ 'images/v19.1/dbeaver-02-cockroachdb-connection-settings.png' | relative_url }}" alt="DBeaver - CockroachDB connection settings" style="border:1px solid #eee;max-width:100%" />
-
-From the network settings, click the **SSL** tab.  It will look like the screenshot below.
-
-<img src="{{ 'images/v19.1/dbeaver-03-ssl-tab.png' | relative_url }}" alt="DBeaver - SSL tab" style="border:1px solid #eee;max-width:100%" />
-
-Check the **Use SSL** checkbox as shown, and fill in the text areas as follows:
-
-- **Root certificate**: Use the `ca.crt` file you generated for your secure cluster.
-- **SSL certificate**: Use a client certificate generated from your cluster's root certificate.  For the root user, this will be named `client.root.crt`.  For additional security, you may want to create a new database user and client certificate just for use with DBeaver.
-- **SSL certificate key**: Because DBeaver is a Java application, you will need to transform your key file to the `*.pk8` format using an [OpenSSL command](https://wiki.openssl.org/index.php/Command_Line_Utilities#pkcs8_.2F_pkcs5) like the one shown below.  Once you have created the file, enter its location here.  In this example, the filename is `client.root.pk8`.
-    {% include copy-clipboard.html %}
-    ~~~ console
-    $ openssl pkcs8 -topk8 -inform PEM -outform DER -in client.root.key -out client.root.pk8 -nocrypt
-    ~~~
-
-Select **require** from the **SSL mode** dropdown.  There is no need to set the **SSL Factory**, you can let DBeaver use the default.
-
-## Step 3. Test the connection settings
-
-Click **Test Connection ...**.  If everything worked, you will see a **Success** dialog like the one shown below.
-
-<img src="{{ 'images/v19.1/dbeaver-04-connection-success-dialog.png' | relative_url }}" alt="DBeaver - connection success dialog" style="border:1px solid #eee;max-width:100%" />
-
-## Step 4. Start using DBeaver
-
-Click **Finish** to get started using DBeaver with CockroachDB.
-
-<img src="{{ 'images/v19.1/dbeaver-05-movr.png' | relative_url }}" alt="DBeaver - CockroachDB with the movr database" style="max-width:100%" />
-
-For more information about using DBeaver, see the [DBeaver documentation](https://dbeaver.io/docs/).
-
-If you run into problems, please file an issue on the [DBeaver issue tracker](https://github.com/dbeaver/dbeaver/issues).
+- [Intellij IDEA (Java)](intellij-idea.html) _(partial support)_
 
 ## See Also
 
-+ [DBeaver documentation](https://dbeaver.io/docs/)
-+ [DBeaver issue tracker](https://github.com/dbeaver/dbeaver/issues)
-+ [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
-
-<!-- Reference Links -->
-
-[dbeaver]: https://dbeaver.io
+- [Build an App with CockroachDB](build-an-app-with-cockroachdb.html)


### PR DESCRIPTION
Duplicating docs from v2.1 into v19.1, including a string change to an actual version of CockroachDB I tested with Intellij.