### PR TITLE
Docs: auto-stats on by default, CREATE STATS jobs

### DIFF
--- a/_includes/v19.1/misc/automatic-statistics.md
+++ b/_includes/v19.1/misc/automatic-statistics.md
@@ -1,17 +1,6 @@
-<span class="version-tag">New in v19.1</span>: CockroachDB can generate table statistics automatically as tables are updated.
+<span class="version-tag">New in v19.1</span>: By default, CockroachDB generates table statistics automatically as tables are updated.
 
-To turn on automatic statistics collection:
-
-1. Run the following statement to enable the automatic statistics [cluster setting](cluster-settings.html):
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=true
-    ~~~
-
-2. Restart the nodes in your cluster so it can generate statistics for all tables at startup (including read-only tables).
-
-To turn off automatic statistics collection:
+If you need to turn off automatic statistics collection:
 
 1. Run the following statement to disable the automatic statistics [cluster setting](cluster-settings.html):
 

--- a/v19.1/cost-based-optimizer.md
+++ b/v19.1/cost-based-optimizer.md
@@ -58,7 +58,7 @@ group-by
 (16 rows)
 ~~~
 
-In contrast, queries that are not supported by the cost-based optimizer return errors that begin with the string `pq: unsupported statement: ...` or specific messages like `pq: aggregates with FILTER are not supported yet`.  Such queries will use the legacy heuristic planner instead of the cost-based optimizer.
+In contrast, queries that are not supported by the cost-based optimizer return errors that begin with the string `pq: unsupported statement: ...` or specific messages like `pq: aggregates with FILTER are not supported yet`. Such queries will use the legacy heuristic planner instead of the cost-based optimizer.
 
 ## Types of statements supported by the cost-based optimizer
 
@@ -84,25 +84,23 @@ This is not meant to be an exhaustive list. To check whether a particular query 
 
 The cost-based optimizer can often find more performant query execution plans if it has access to statistical data on the contents of your database's tables. This statistical data needs to be generated from scratch for new tables, and regenerated periodically for existing tables.
 
-There are several ways to generate table statistics:
-
-1. Run the [`CREATE STATISTICS`](create-statistics.html) statement manually.
-2. <span class="version-tag">New in v19.1</span> Enable the automatic table statistics feature.
-
-Each method is described below.
-
-### Automatic table statistics
-
 {% include {{ page.version.version }}/misc/automatic-statistics.md %}
 
-### Manually generating table statistics
+To manually generate statistics for a table, run a [`CREATE STATISTICS`](create-statistics.html) statement like the one shown below. It automatically figures out which columns to get statistics on &mdash; specifically, it chooses:
 
-To manually generate statistics for a table, run a [`CREATE STATISTICS`](create-statistics.html) statement like the one shown below. It automatically figures out which columns to get statistics on &mdash; specifically, it chooses columns which are part of the primary key or an index.
+- Columns that are part of the primary key or an index (in other words, all indexed columns).
+- Up to 100 non-indexed columns.
+
+Note that the above also describes the statistics gathered by the automatic statistics feature, since it runs a query similar to the one shown below.
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE STATISTICS employees_stats FROM employees;
 ~~~
+
+{{site.data.alerts.callout_info}}
+Every time the [`CREATE STATISTICS`](create-statistics.html) statement is executed, it kicks off a background job. For more information, see [View statistics jobs](create-statistics.html#view-statistics-jobs).
+{{site.data.alerts.end}}
 
 ## Query plan cache
 
@@ -129,7 +127,7 @@ Finally, note that only the following statements use the plan cache:
 
 Because this process leads to an exponential increase in the number of possible execution plans for such queries, it's only used to reorder subtrees containing 4 or fewer joins by default.
 
-To change this setting, which is controlled by the `experimental_reorder_joins_limit` [session variable](set-vars.html), run the statement shown below.  To disable this feature, set the variable to `0`.
+To change this setting, which is controlled by the `experimental_reorder_joins_limit` [session variable](set-vars.html), run the statement shown below. To disable this feature, set the variable to `0`.
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v19.1/create-statistics.md
+++ b/v19.1/create-statistics.md
@@ -67,6 +67,26 @@ For more information about how the `AS OF SYSTEM TIME` clause works, including s
 
 {% include {{ page.version.version }}/misc/delete-statistics.md %}
 
+### View statistics jobs
+
+Every time the `CREATE STATISTICS` statement is executed, it kicks off a background job.  This is true for queries issued by your application as well as queries issued by the [automatic stats](#automatic-table-statistics) feature.
+
+To view statistics jobs, issue the following query that uses [`SHOW JOBS`](show-jobs.html).
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM [SHOW JOBS] WHERE job_type LIKE '%CREATE STATS%';
+~~~
+
+~~~
+       job_id       |   job_type   |                                     description                                     | user_name |  status   | running_status |          created           |          started           |          finished          |          modified          | fraction_completed | error | coordinator_id 
+--------------------+--------------+-------------------------------------------------------------------------------------+-----------+-----------+----------------+----------------------------+----------------------------+----------------------------+----------------------------+--------------------+-------+----------------
+ 429997863416791041 | CREATE STATS | CREATE STATISTICS employee_stats FROM test.public.employees AS OF SYSTEM TIME '-1m' | root      | succeeded |                | 2019-02-27 19:22:13.904065 | 2019-02-27 19:22:13.909684 | 2019-02-27 19:22:14.203006 | 2019-02-27 19:22:14.203007 |                  1 |       |              1
+ 429996681838297089 | CREATE STATS | CREATE STATISTICS __auto__ FROM [67] AS OF SYSTEM TIME '-30s'                       | root      | succeeded |                | 2019-02-27 19:16:13.314916 | 2019-02-27 19:16:13.317949 | 2019-02-27 19:16:13.63022  | 2019-02-27 19:16:13.630221 |                  1 |       |              1
+ 429996676782456833 | CREATE STATS | CREATE STATISTICS __auto__ FROM [66] AS OF SYSTEM TIME '-30s'                       | root      | succeeded |                | 2019-02-27 19:16:11.771999 | 2019-02-27 19:16:11.775159 | 2019-02-27 19:16:13.308078 | 2019-02-27 19:16:13.308079 |                  1 |       |              1
+ 429996676018601985 | CREATE STATS | CREATE STATISTICS __auto__ FROM [65] AS OF SYSTEM TIME '-30s'                       | root      | succeeded |                | 2019-02-27 19:16:11.538883 | 2019-02-27 19:16:11.542195 | 2019-02-27 19:16:11.762671 | 2019-02-27 19:16:11.762672 |                  1 |       |              1
+~~~
+
 ## See Also
 
 - [Cost-Based Optimizer](cost-based-optimizer.html)
@@ -74,4 +94,5 @@ For more information about how the `AS OF SYSTEM TIME` clause works, including s
 - [`CREATE TABLE`](create-table.html)
 - [`INSERT`](insert.html)
 - [`IMPORT`](import.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [SQL Statements](sql-statements.html)

--- a/v19.1/show-jobs.md
+++ b/v19.1/show-jobs.md
@@ -6,8 +6,9 @@ toc: true
 
 The `SHOW JOBS` [statement](sql-statements.html) lists all of the types of long-running tasks your cluster has performed, including:
 
-- Schema changes through `ALTER TABLE`, `DROP DATABASE`, `DROP TABLE`, and `TRUNCATE`
-- Enterprise [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html)
+- Schema changes through [`ALTER TABLE`](alter-table.html), [`DROP DATABASE`](drop-database.html), [`DROP TABLE`](drop-table.html), and [`TRUNCATE`](truncate.html).
+- Enterprise [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html).
+- Database [statistics](create-statistics.html) created for use by the [cost-based optimizer](cost-based-optimizer.html).
 
 These details can help you understand the status of crucial tasks that can impact the performance of your cluster, as well as help you control them.
 


### PR DESCRIPTION
Fixes #4374, #4379.

Summary of changes:

- Update automatic statistics mentions to note that it's on by default,
  and remove instructions for turning it on (since it's already on).

- Update CREATE STATS mentions to note that it creates jobs, and can be
  viewed by SHOW JOBS.

- Update SHOW JOBS page to mention automatic stats.