### PR TITLE
Database renames are not transactional

### DIFF
--- a/v19.1/known-limitations.md
+++ b/v19.1/known-limitations.md
@@ -12,6 +12,12 @@ None identified yet.
 
 ## Unresolved limitations
 
+### Database and table renames are not transactional
+
+Database and table renames using [`RENAME DATABASE`](rename-database.html) and [`RENAME TABLE`](rename-table.html) are not transactional.
+
+Specifically, when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. For more information, see [Table renaming considerations](rename-table.html#table-renaming-considerations). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
+
 ### Change data capture
 
 Change data capture (CDC) provides efficient, distributed, row-level change feeds into Apache Kafka for downstream processing such as reporting, caching, or full-text indexing.

--- a/v19.1/rename-database.md
+++ b/v19.1/rename-database.md
@@ -8,6 +8,9 @@ The `RENAME DATABASE` [statement](sql-statements.html) changes the name of a dat
 
 {{site.data.alerts.callout_info}}It is not possible to rename a database referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+Database renames **are not transactional**. For more information, see [Database renaming considerations](#database-renaming-considerations).
+{{site.data.alerts.end}}
 
 ## Synopsis
 
@@ -24,6 +27,18 @@ Only members of the `admin` role can rename databases. By default, the `root` us
 Parameter | Description
 ----------|------------
 `name` | The first instance of `name` is the current name of the database. The second instance is the new name for the database. The new name [must be unique](#rename-fails-new-name-already-in-use) and follow these [identifier rules](keywords-and-identifiers.html#identifiers). You cannot rename a database if it is set as the [current database](sql-name-resolution.html#current-database) or if [`sql_safe_updates = true`](set-vars.html).
+
+## Database renaming considerations
+
+Database renames are not transactional. There are two phases during a rename:
+
+1. The `system.namespace` table is updated. This phase is transactional, and will be rolled back if the transaction aborts.
+2. The database descriptor (an internal data structure) is updated, and announced to every other node. This phase is **not** transactional. The rename will be announced to other nodes only if the transaction commits, but there is no guarantee on how much time this operation will take.
+3. Once the new name has propagated to every node in the cluster, another internal transaction is run that declares the old name ready for reuse in another context.
+
+This yields a surprising and undesirable behavior: when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. This violates A, C, and I in [ACID](https://en.wikipedia.org/wiki/ACID_(computer_science)). Only D is guaranteed: If the transaction commits successfully, the new name will persist after that.
+
+This is a [known limitation](known-limitations.html#database-and-table-renames-are-not-transactional). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
 
 ## Examples
 

--- a/v19.1/rename-table.md
+++ b/v19.1/rename-table.md
@@ -8,6 +8,9 @@ The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table.
 
 {{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+Table renames **are not transactional**. For more information, see [Table renaming considerations](#table-renaming-considerations).
+{{site.data.alerts.end}}
 
 ## Required privileges
 
@@ -26,6 +29,18 @@ The user must have the `DROP` [privilege](authorization.html#assign-privileges) 
  `IF EXISTS` | Rename the table only if a table with the current name exists; if one does not exist, do not return an error.
  `current_name` | The current name of the table.
  `new_name` | The new name of the table, which must be unique within its database and follow these [identifier rules](keywords-and-identifiers.html#identifiers). When the parent database is not set as the default, the name must be formatted as `database.name`.<br><br>The [`UPSERT`](upsert.html) and [`INSERT ON CONFLICT`](insert.html) statements use a temporary table called `excluded` to handle uniqueness conflicts during execution. It's therefore not recommended to use the name `excluded` for any of your tables.
+
+## Table renaming considerations
+
+Table renames are not transactional. There are two phases during a rename:
+
+1. The `system.namespace` table is updated. This phase is transactional, and will be rolled back if the transaction aborts.
+2. The table descriptor (an internal data structure) is updated, and announced to every other node. This phase is **not** transactional. The rename will be announced to other nodes only if the transaction commits, but there is no guarantee on how much time this operation will take.
+3. Once the new name has propagated to every node in the cluster, another internal transaction is run that declares the old name ready for reuse in another context.
+
+This yields a surprising and undesirable behavior: when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. This violates A, C, and I in [ACID](https://en.wikipedia.org/wiki/ACID_(computer_science)). Only D is guaranteed: If the transaction commits successfully, the new name will persist after that.
+
+This is a [known limitation](known-limitations.html#database-and-table-renames-are-not-transactional). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
 
 ## Viewing schema changes
 

--- a/v2.0/known-limitations.md
+++ b/v2.0/known-limitations.md
@@ -141,6 +141,12 @@ It is currently not possible to [add a column](add-column.html) to a table when 
 
 ## Unresolved Limitations
 
+### Database and table renames are not transactional
+
+Database and table renames using [`RENAME DATABASE`](rename-database.html) and [`RENAME TABLE`](rename-table.html) are not transactional.
+
+Specifically, when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. For more information, see [Table renaming considerations](rename-table.html#table-renaming-considerations). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
+
 ### Available capacity metric in the Admin UI
 
 {% include v2.0/misc/available-capacity-metric.md %}

--- a/v2.0/rename-database.md
+++ b/v2.0/rename-database.md
@@ -8,6 +8,9 @@ The `RENAME DATABASE` [statement](sql-statements.html) changes the name of a dat
 
 {{site.data.alerts.callout_info}}It is not possible to rename a database referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+Database renames **are not transactional**. For more information, see [Database renaming considerations](#database-renaming-considerations).
+{{site.data.alerts.end}}
 
 ## Synopsis
 
@@ -24,6 +27,18 @@ Only the `root` user can rename databases.
 Parameter | Description
 ----------|------------
 `name` | The first instance of `name` is the current name of the database. The second instance is the new name for the database. The new name [must be unique](#rename-fails-new-name-already-in-use) and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
+
+## Database renaming considerations
+
+Database renames are not transactional. There are two phases during a rename:
+
+1. The `system.namespace` table is updated. This phase is transactional, and will be rolled back if the transaction aborts.
+2. The database descriptor (an internal data structure) is updated, and announced to every other node. This phase is **not** transactional. The rename will be announced to other nodes only if the transaction commits, but there is no guarantee on how much time this operation will take.
+3. Once the new name has propagated to every node in the cluster, another internal transaction is run that declares the old name ready for reuse in another context.
+
+This yields a surprising and undesirable behavior: when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. This violates A, C, and I in [ACID](https://en.wikipedia.org/wiki/ACID_(computer_science)). Only D is guaranteed: If the transaction commits successfully, the new name will persist after that.
+
+This is a [known limitation](known-limitations.html#database-and-table-renames-are-not-transactional). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
 
 ## Examples
 

--- a/v2.0/rename-table.md
+++ b/v2.0/rename-table.md
@@ -8,8 +8,11 @@ The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table.
 
 {{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+Table renames **are not transactional**. For more information, see [Table renaming considerations](#table-renaming-considerations).
+{{site.data.alerts.end}}
 
-## Required Privileges
+## Required privileges
 
 The user must have the `DROP` [privilege](privileges.html) on the table and the `CREATE` on the parent database. When moving a table from one database to another, the user must have the `CREATE` privilege on both the source and target databases.
 
@@ -30,6 +33,18 @@ The user must have the `DROP` [privilege](privileges.html) on the table and the 
 ## Viewing Schema Changes
 
 {% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
+## Table renaming considerations
+
+Table renames are not transactional. There are two phases during a rename:
+
+1. The `system.namespace` table is updated. This phase is transactional, and will be rolled back if the transaction aborts.
+2. The table descriptor (an internal data structure) is updated, and announced to every other node. This phase is **not** transactional. The rename will be announced to other nodes only if the transaction commits, but there is no guarantee on how much time this operation will take.
+3. Once the new name has propagated to every node in the cluster, another internal transaction is run that declares the old name ready for reuse in another context.
+
+This yields a surprising and undesirable behavior: when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. This violates A, C, and I in [ACID](https://en.wikipedia.org/wiki/ACID_(computer_science)). Only D is guaranteed: If the transaction commits successfully, the new name will persist after that.
+
+This is a [known limitation](known-limitations.html#database-and-table-renames-are-not-transactional). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
 
 ## Examples
 

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -141,6 +141,16 @@ Currently, the built-in SQL shell provided with CockroachDB (`cockroach sql` / `
 
 ## Unresolved limitations
 
+### Database and table renames are not transactional
+
+Database and table renames using [`RENAME DATABASE`](rename-database.html) and [`RENAME TABLE`](rename-table.html) are not transactional.
+
+Specifically, when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. For more information, see [Table renaming considerations](rename-table.html#table-renaming-considerations). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
+
+### Changes to the default replication zone are not applied to existing replication zones
+
+{% include {{page.version.version}}/known-limitations/system-range-replication.md %}
+
 ### Silent validation error with `DECIMAL` values
 
 Under the following conditions, the value received by CockroachDB will be different than that sent by the client and may cause incorrect data to be inserted or read from the database, without a visible error message:

--- a/v2.1/rename-database.md
+++ b/v2.1/rename-database.md
@@ -8,6 +8,9 @@ The `RENAME DATABASE` [statement](sql-statements.html) changes the name of a dat
 
 {{site.data.alerts.callout_info}}It is not possible to rename a database referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+Database renames **are not transactional**. For more information, see [Database renaming considerations](#database-renaming-considerations).
+{{site.data.alerts.end}}
 
 ## Synopsis
 
@@ -24,6 +27,18 @@ Only members of the `admin` role can rename databases. By default, the `root` us
 Parameter | Description
 ----------|------------
 `name` | The first instance of `name` is the current name of the database. The second instance is the new name for the database. The new name [must be unique](#rename-fails-new-name-already-in-use) and follow these [identifier rules](keywords-and-identifiers.html#identifiers). You cannot rename a database if it is set as the [current database](sql-name-resolution.html#current-database) or if [`sql_safe_updates = true`](set-vars.html).
+
+## Database renaming considerations
+
+Database renames are not transactional. There are two phases during a rename:
+
+1. The `system.namespace` table is updated. This phase is transactional, and will be rolled back if the transaction aborts.
+2. The database descriptor (an internal data structure) is updated, and announced to every other node. This phase is **not** transactional. The rename will be announced to other nodes only if the transaction commits, but there is no guarantee on how much time this operation will take.
+3. Once the new name has propagated to every node in the cluster, another internal transaction is run that declares the old name ready for reuse in another context.
+
+This yields a surprising and undesirable behavior: when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. This violates A, C, and I in [ACID](https://en.wikipedia.org/wiki/ACID_(computer_science)). Only D is guaranteed: If the transaction commits successfully, the new name will persist after that.
+
+This is a [known limitation](known-limitations.html#database-and-table-renames-are-not-transactional). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
 
 ## Examples
 

--- a/v2.1/rename-table.md
+++ b/v2.1/rename-table.md
@@ -8,6 +8,9 @@ The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table.
 
 {{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+Table renames **are not transactional**. For more information, see [Table renaming considerations](#table-renaming-considerations).
+{{site.data.alerts.end}}
 
 ## Required privileges
 
@@ -26,6 +29,18 @@ The user must have the `DROP` [privilege](authorization.html#assign-privileges) 
  `IF EXISTS` | Rename the table only if a table with the current name exists; if one does not exist, do not return an error.
  `current_name` | The current name of the table.
  `new_name` | The new name of the table, which must be unique within its database and follow these [identifier rules](keywords-and-identifiers.html#identifiers). When the parent database is not set as the default, the name must be formatted as `database.name`.<br><br>The [`UPSERT`](upsert.html) and [`INSERT ON CONFLICT`](insert.html) statements use a temporary table called `excluded` to handle uniqueness conflicts during execution. It's therefore not recommended to use the name `excluded` for any of your tables.
+
+## Table renaming considerations
+
+Table renames are not transactional. There are two phases during a rename:
+
+1. The `system.namespace` table is updated. This phase is transactional, and will be rolled back if the transaction aborts.
+2. The table descriptor (an internal data structure) is updated, and announced to every other node. This phase is **not** transactional. The rename will be announced to other nodes only if the transaction commits, but there is no guarantee on how much time this operation will take.
+3. Once the new name has propagated to every node in the cluster, another internal transaction is run that declares the old name ready for reuse in another context.
+
+This yields a surprising and undesirable behavior: when run inside a [`BEGIN`](begin-transaction.html) ... [`COMMIT`](commit-transaction.html) block, it’s possible for a rename to be half-done - not persisted in storage, but visible to other nodes or other transactions. This violates A, C, and I in [ACID](https://en.wikipedia.org/wiki/ACID_(computer_science)). Only D is guaranteed: If the transaction commits successfully, the new name will persist after that.
+
+This is a [known limitation](known-limitations.html#database-and-table-renames-are-not-transactional). For an issue tracking this limitation, see [cockroach#12123](https://github.com/cockroachdb/cockroach/issues/12123).
 
 ## Viewing schema changes
 


### PR DESCRIPTION
Fixes #4393.

Summary of changes:

- Update `ALTER TABLE .. RENAME DATABASE` to say that db renames are not
  transactional, explain why, and offer a workaround.

- Update 'Known limitations' page to note that db renames are not
  transactional, with a link to the above page for more information.