### PR TITLE
Fix the documentation on bytes/string conversions, explain bytea_output.

### DIFF
--- a/_includes/v19.1/misc/session-vars.html
+++ b/_includes/v19.1/misc/session-vars.html
@@ -28,6 +28,16 @@
 
   <tr>
    <td>
+    <code>bytea_output</code>
+   </td>
+   <td>The <a href="bytes.html#supported-conversions">mode for conversions from <code>STRING</code> to <code>BYTES</code></a>.</td>
+   <td>hex</td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>database</code>
    </td>
    <td>The <a href="sql-name-resolution.html#current-database">current database</a>.</td>

--- a/v19.1/bytes.md
+++ b/v19.1/bytes.md
@@ -60,11 +60,31 @@ The size of a `BYTES` value is variable, but it's recommended to keep values und
 
 `BYTES` values can be
 [cast](data-types.html#data-type-conversions-and-casts) explicitly to
-`STRING`. The conversion verifies that the byte array contains only
-valid UTF-8 byte sequences; an error is reported otherwise.
+[`STRING`](string.html). This conversion always succeeds. Two
+conversion modes are supported, controlled by the
+[session variable](set-vars.html#supported-variables) `bytea_output`:
+
+- `hex` (default): The output of the conversion starts with the two
+  characters `\`, `x` and the rest of the string is composed by the
+  hexadecimal encoding of each byte in the input. For example,
+  `x'48AA'::STRING` produces `'\x48AA'`.
+
+- `escape`: The output of the conversion contains each byte in the
+  input, as-is if it is an ASCII character, or encoded using the octal
+  escape format `\NNN` otherwise. For example, `x'48AA'::STRING`
+  produces `'0\252'`.
 
 `STRING` values can be cast explicitly to `BYTES`. This conversion
-always succeeds.
+will fail if the hexadecimal digits are not valid, or if there is an
+odd number of them. Two conversion modes are supported:
+
+- If the string starts with the two special characters `\` and `x`
+  (e.g. `\xAABB`), the rest of the string is interpreted as a sequence
+  of hexadecimal digits. The string is then converted to a byte array
+  where each pair of hexadecimal digits is converted to one byte.
+
+- Otherwise, the string is converted to a byte array that contains its
+  UTF-8 encoding.
 
 ## See also
 

--- a/v19.1/sql-constants.md
+++ b/v19.1/sql-constants.md
@@ -184,14 +184,13 @@ with character escapes are as follows:
 ### Hexadecimal-encoded byte array literals
 
 This is a CockroachDB-specific extension to express byte array
-literals: the delimiter `x'` or `e'\\x` followed by an arbitrary sequence of
+literals: the delimiter `x'` followed by an arbitrary sequence of
 hexadecimal digits, followed by a closing `'`.
 
 For example, all the following formats are equivalent to `b'cat'`:
 
 - `x'636174'`
 - `X'636174'`
-- `e'\\x636174'::BYTES`
 
 ## Interpreted literals
 

--- a/v19.1/string.md
+++ b/v19.1/string.md
@@ -119,7 +119,7 @@ The size of a `STRING` value is variable, but it's recommended to keep values un
 Type | Details
 -----|--------
 `BOOL` | Requires supported [`BOOL`](bool.html) string format, e.g., `'true'`.
-`BYTES` | Requires supported [`BYTES`](bytes.html) string format, e.g., `b'\141\061\142\062\143\063'`.
+`BYTES` | Always supported. For more details, [see here](bytes.html#supported-conversions).
 `DATE` | Requires supported [`DATE`](date.html) string format, e.g., `'2016-01-25'`.
 `DECIMAL` | Requires supported [`DECIMAL`](decimal.html) string format, e.g., `'1.1'`.
 `FLOAT` | Requires supported [`FLOAT`](float.html) string format, e.g., `'1.1'`.

--- a/v2.0/bytes.md
+++ b/v2.0/bytes.md
@@ -60,11 +60,22 @@ The size of a `BYTES` value is variable, but it's recommended to keep values und
 
 `BYTES` values can be
 [cast](data-types.html#data-type-conversions-casts) explicitly to
-`STRING`. The conversion verifies that the byte array contains only
-valid UTF-8 byte sequences; an error is reported otherwise.
+[`STRING`](string.html). The output of the conversion starts with the
+two characters `\`, `x` and the rest of the string is composed by the
+hexadecimal encoding of each byte in the input. For example,
+`x'48AA'::STRING` produces `'\x48AA'`.
 
 `STRING` values can be cast explicitly to `BYTES`. This conversion
-always succeeds.
+will fail if the hexadecimal digits are not valid, or if there is an
+odd number of them. Two conversion modes are supported:
+
+- If the string starts with the two special characters `\` and `x`
+  (e.g. `\xAABB`), the rest of the string is interpreted as a sequence
+  of hexadecimal digits. The string is then converted to a byte array
+  where each pair of hexadecimal digits is converted to one byte.
+
+- Otherwise, the string is converted to a byte array that contains
+  its UTF-8 encoding.
 
 ## See Also
 

--- a/v2.0/import.md
+++ b/v2.0/import.md
@@ -48,7 +48,7 @@ The tabular data to import must be valid [CSV files](https://tools.ietf.org/html
 
 CockroachDB-specific requirements:
 
-- If a column is of type [`BYTES`](bytes.html), it can either be a valid UTF-8 string or a [hex-encoded byte literal](sql-constants.html#hexadecimal-encoded-byte-array-literals) beginning with `\x`. For example, a field whose value should be the bytes `1`, `2` would be written as `\x0102`.
+- If a column is of type [`BYTES`](bytes.html), it can either be a valid UTF-8 string or a [string literal](sql-constants.html#string-literals) beginning with the two characters `\`, `x`. For example, a field whose value should be the bytes `1`, `2` would be written as `\x0102`.
 
 ### Object Dependencies
 

--- a/v2.0/sql-constants.md
+++ b/v2.0/sql-constants.md
@@ -180,14 +180,13 @@ with character escapes are as follows:
 ### Hexadecimal-encoded byte array literals
 
 This is a CockroachDB-specific extension to express byte array
-literals: the delimiter `x'` or `e'\\x` followed by an arbitrary sequence of
+literals: the delimiter `x'` followed by an arbitrary sequence of
 hexadecimal digits, followed by a closing `'`.
 
 For example, all the following formats are equivalent to `b'cat'`:
 
 - `x'636174'`
 - `X'636174'`
-- `e'\\x636174'::BYTES`
 
 ## Interpreted literals
 

--- a/v2.0/string.md
+++ b/v2.0/string.md
@@ -91,7 +91,7 @@ The size of a `STRING` value is variable, but it's recommended to keep values un
 Type | Details
 -----|--------
 `BOOL` | Requires supported [`BOOL`](bool.html) string format, e.g., `'true'`.
-`BYTES` | Requires supported [`BYTES`](bytes.html) string format, e.g., `b'\141\061\142\062\143\063'`.
+`BYTES` | For more details, [see here](bytes.html#supported-conversions).
 `DATE` | Requires supported [`DATE`](date.html) string format, e.g., `'2016-01-25'`.
 `DECIMAL` | Requires supported [`DECIMAL`](decimal.html) string format, e.g., `'1.1'`.
 `FLOAT` | Requires supported [`FLOAT`](float.html) string format, e.g., `'1.1'`.

--- a/v2.1/bytes.md
+++ b/v2.1/bytes.md
@@ -60,11 +60,31 @@ The size of a `BYTES` value is variable, but it's recommended to keep values und
 
 `BYTES` values can be
 [cast](data-types.html#data-type-conversions-and-casts) explicitly to
-`STRING`. The conversion verifies that the byte array contains only
-valid UTF-8 byte sequences; an error is reported otherwise.
+[`STRING`](string.html). This conversion always succeeds. Two
+conversion modes are supported, controlled by the
+[session variable](set-vars.html#supported-variables) `bytea_output`:
+
+- `hex` (default): The output of the conversion starts with the two
+  characters `\`, `x` and the rest of the string is composed by the
+  hexadecimal encoding of each byte in the input. For example,
+  `x'48AA'::STRING` produces `'\x48AA'`.
+
+- `escape`: The output of the conversion contains each byte in the
+  input, as-is if it is an ASCII character, or encoded using the octal
+  escape format `\NNN` otherwise. For example, `x'48AA'::STRING`
+  produces `'0\252'`.
 
 `STRING` values can be cast explicitly to `BYTES`. This conversion
-always succeeds.
+will fail if the hexadecimal digits are not valid, or if there is an
+odd number of them. Two conversion modes are supported:
+
+- If the string starts with the two special characters `\` and `x`
+  (e.g. `\xAABB`), the rest of the string is interpreted as a sequence
+  of hexadecimal digits. The string is then converted to a byte array
+  where each pair of hexadecimal digits is converted to one byte.
+
+- Otherwise, the string is converted to a byte array that contains
+  its UTF-8 encoding.
 
 ## See also
 

--- a/v2.1/show-vars.md
+++ b/v2.1/show-vars.md
@@ -34,6 +34,7 @@ The variable name is case insensitive. It may be enclosed in double quotes; this
  Variable name | Description | Initial value |  Can be modified with [`SET`](set-vars.html)?
 ---------------|-------------|---------------|-----------------------------------------------
  `application_name` | The current application name for statistics collection. | Empty string, or `cockroach` for sessions from the [built-in SQL client](use-the-built-in-sql-client.html)  | Yes
+ `bytea_output` | The [mode for conversions from `STRING` to `BYTES`](bytes.html#supported-conversions). | `hex` | Yes |
  `database` | The [current database](sql-name-resolution.html#current-database). Database in connection string, or empty if not specified | Yes |
  `default_transaction_isolation` | All transactions execute with `SERIALIZABLE` isolation. See [Transactions: Isolation levels](transactions.html#isolation-levels). | `SERIALIZABLE`  | No
  `default_transaction_read_only` | The default transaction access mode for the current session. If set to `on`, only read operations are allowed in transactions in the current session; if set to `off`, both read and write operations are allowed. See [`SET TRANSACTION`](set-transaction.html) for more details. | `off` | Yes

--- a/v2.1/sql-constants.md
+++ b/v2.1/sql-constants.md
@@ -184,14 +184,13 @@ with character escapes are as follows:
 ### Hexadecimal-encoded byte array literals
 
 This is a CockroachDB-specific extension to express byte array
-literals: the delimiter `x'` or `e'\\x` followed by an arbitrary sequence of
+literals: the delimiter `x'` followed by an arbitrary sequence of
 hexadecimal digits, followed by a closing `'`.
 
 For example, all the following formats are equivalent to `b'cat'`:
 
 - `x'636174'`
 - `X'636174'`
-- `e'\\x636174'::BYTES`
 
 ## Interpreted literals
 

--- a/v2.1/string.md
+++ b/v2.1/string.md
@@ -119,7 +119,7 @@ The size of a `STRING` value is variable, but it's recommended to keep values un
 Type | Details
 -----|--------
 `BOOL` | Requires supported [`BOOL`](bool.html) string format, e.g., `'true'`.
-`BYTES` | Requires supported [`BYTES`](bytes.html) string format, e.g., `b'\141\061\142\062\143\063'`.
+`BYTES` | For more details, [see here](bytes.html#supported-conversions).
 `DATE` | Requires supported [`DATE`](date.html) string format, e.g., `'2016-01-25'`.
 `DECIMAL` | Requires supported [`DECIMAL`](decimal.html) string format, e.g., `'1.1'`.
 `FLOAT` | Requires supported [`FLOAT`](float.html) string format, e.g., `'1.1'`.


### PR DESCRIPTION
Fixes #3324.
Also fixes an incorrectness introduced by mistake in #2134.

@rmloveland would appreciate if you could take this over and add the finishing touches.