### PR TITLE
Server-side redirect of v2.2 urls to v19.1 via netlify

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -7,5 +7,6 @@ build_for: [standard, managed]
 {{ version[0]|relative_url }}/* {{ version[1]|relative_url }}/:splat 200
 {% endfor %}
 
+/docs/v2.2/* /docs/v19.1/:splat 301
 /docs/releases/ /docs/releases/index.html 200!
 /docs /docs/stable/ 301


### PR DESCRIPTION
This PR replaces https://github.com/cockroachdb/docs/pull/4451,
which used client-side redirects.

Fixes #4450.