### PR TITLE
Add docs for optimizer join hints

### DIFF
--- a/v19.1/cost-based-optimizer.md
+++ b/v19.1/cost-based-optimizer.md
@@ -140,6 +140,46 @@ We strongly recommend not setting this value higher than 8 to avoid performance 
 
 For more information about the difficulty of selecting an optimal join ordering, see our blog post [An Introduction to Join Ordering](https://www.cockroachlabs.com/blog/join-ordering-pt1/).
 
+## Join hints
+
+<span class="version-tag">New in v19.1</span>: The optimizer supports hint syntax to force the use of a specific join algorithm. The algorithm is specified between the join type (`INNER`, `LEFT`, etc.) and the `JOIN` keyword, for example:
+
+- `INNER HASH JOIN`
+- `OUTER MERGE JOIN`
+- `LEFT LOOKUP JOIN`
+
+Note that the hint cannot be specified with a bare hint keyword (e.g., `MERGE`) - in that case, the `INNER` keyword must be added. For example, `a INNER MERGE JOIN b` will work, but `a MERGE JOIN b` will not work.
+
+{{site.data.alerts.callout_info}}
+Join hints cannot be specified with a bare hint keyword (e.g., `MERGE`) due to SQL's implicit `AS` syntax. If you're not careful you can make `MERGE` be an alias for a table; for example, `a MERGE JOIN b` will be interpreted as having an implicit `AS` and be executed as `a AS MERGE JOIN b`, which is just a long way of saying `a JOIN b`. Because the resulting query might execute without returning any hint-related error (because it is valid SQL), it will seem like the join hint "worked", but actually it didn't affect which join algorithm was used. In this case, the correct syntax is `a INNER MERGE JOIN b`.
+{{site.data.alerts.end}}
+
+### Supported join algorithms
+
+- `HASH`: Forces a hash join; in other words, it disables merge and lookup joins. A hash join is always possible, even if there are no equality columns - CockroachDB considers the nested loop join with no index a degenerate case of the hash join (i.e., a hash table with one bucket).
+
+- `MERGE`: Forces a merge join, even if it requires re-sorting both sides of the join.
+
+- `LOOKUP`: Forces a lookup join into the right side; the right side must be a table with a suitable index. Note that `LOOKUP` can only be used with `INNER` and `LEFT` joins.
+
+If it is not possible to use the algorithm specified in the hint, an error is signaled.
+
+### Additional considerations
+
+- CockroachDB does not support a `CROSS <hint> JOIN`, but the same effect can be achieved with `a INNER <hint> JOIN b ON true`.
+
+- This syntax is consistent with the [SQL Server syntax for join hints](https://docs.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-join?view=sql-server-2017), except that:
+
+   - SQL Server uses `LOOP` instead of `LOOKUP`.
+
+   - CockroachDB does not support `LOOP` and instead supports `LOOKUP` for the specific case of nested loop joins with an index.
+
+- When a join hint is specified, the two tables will not be reordered by the optimizer. The reordering behavior has the following characteristics, which can be affected by hints:
+
+   - Given `a JOIN b`, CockroachDB will not try to commute to `b JOIN a`. This means that you will need to pay attention to this ordering, which is especially important for lookup joins. Without a hint, `a JOIN b` might be executed as `b INNER LOOKUP JOIN a` using an index into `a`, whereas `a INNER LOOKUP JOIN b` requires an index into `b`.
+
+   - `(a JOIN b) JOIN c` might be changed to `a JOIN (b JOIN c)`, but this does not happen if `a JOIN b` uses a hint; the hint forces that particular join to happen as written in the query.
+
 ## How to turn the optimizer off
 
 With the optimizer turned on, the performance of some workloads may change. If your workload performs worse than expected (e.g., lower throughput or higher latency), you can turn off the cost-based optimizer and use the heuristic planner.

--- a/v19.1/joins.md
+++ b/v19.1/joins.md
@@ -8,6 +8,9 @@ Join expressions, also called "joins", combine the results of two or more table 
 
 Join expressions define a data source in the `FROM` sub-clause of [simple `SELECT` clauses](select-clause.html), or as parameter to [`TABLE`](selection-queries.html#table-clause). Joins are a particular kind of [table expression](table-expressions.html).
 
+{{site.data.alerts.callout_success}}
+<span class="version-tag">New in v19.1</span>: The [cost-based optimizer](cost-based-optimizer.html) supports hint syntax to force the use of a specific join algorithm.  For more information, see [Join hints](cost-based-optimizer.html#join-hints).
+{{site.data.alerts.end}}
 
 ## Synopsis
 
@@ -167,6 +170,7 @@ Lookup joins are performed on two tables as follows:
 
 ## See also
 
+- [Cost-based Optimizer: Join Hints](cost-based-optimizer.html#join-hints)
 - [Scalar Expressions](scalar-expressions.html)
 - [Table Expressions](table-expressions.html)
 - [Simple `SELECT` Clause](select-clause.html)


### PR DESCRIPTION
Fixes #2012.

Summary of changes:

- Added a section to the CBO page, 'Join hints', which describes:

  - Join hint syntax

  - Supported join algorithms, and how they work