### PR TITLE
Fix links on doc landing page

### DIFF
--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -74,7 +74,7 @@
 					</div>
 				</div>
 				<a class="desktop-menu__item-link" href="https://www.cockroachlabs.com/customers/" data-proofer-ignore>Customers</a>
-				<a class="desktop-menu__item-link" href="{{ "/stable" | relative_url }}" itemprop="url" data-proofer-ignore>Docs</a>
+				<a class="desktop-menu__item-link" href="{{ "/stable/" | relative_url }}" itemprop="url" data-proofer-ignore>Docs</a>
 				<div class="desktop-menu__item">
 					<div class="desktop-menu__item-link">Resources</div>
 					<div class="desktop-menu__dropdown-container">


### PR DESCRIPTION
When you click "Docs" in the topnav, it sense you to `/docs/stable`, without the final forward slash, ad this seems to mess of the versioning of links on the page. This PR fixes that. 