### PR TITLE
SQL Dump Known Issue

### DIFF
--- a/_includes/v19.1/known-limitations/import-interleaved-table.md
+++ b/_includes/v19.1/known-limitations/import-interleaved-table.md
@@ -1,0 +1,1 @@
+After using [`cockroach dump`](sql-dump.html) to dump the schema and data of an interleaved table, the output must be edited before it can be imported via [`IMPORT`](import.html). See [#35462](https://github.com/cockroachdb/cockroach/issues/35462) for the workaround and more details.

--- a/_includes/v2.1/known-limitations/import-interleaved-table.md
+++ b/_includes/v2.1/known-limitations/import-interleaved-table.md
@@ -1,0 +1,1 @@
+After using [`cockroach dump`](sql-dump.html) to dump the schema and data of an interleaved table, the output must be edited before it can be imported via [`IMPORT`](import.html). See [#35462](https://github.com/cockroachdb/cockroach/issues/35462) for the workaround and more details.

--- a/v19.1/known-limitations.md
+++ b/v19.1/known-limitations.md
@@ -139,6 +139,10 @@ Currently, the built-in SQL shell provided with CockroachDB (`cockroach sql` / `
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16392)
 
+### Importing an interleaved table from a `cockroach dump` output
+
+{% include {{page.version.version}}/known-limitations/import-interleaved-table.md %}
+
 ### Silent validation error with `DECIMAL` values
 
 Under the following conditions, the value received by CockroachDB will be different than that sent by the client and may cause incorrect data to be inserted or read from the database, without a visible error message:

--- a/v19.1/sql-dump.md
+++ b/v19.1/sql-dump.md
@@ -10,7 +10,6 @@ The `cockroach dump` [command](cockroach-commands.html) outputs the SQL statemen
 CockroachDB [enterprise license](https://www.cockroachlabs.com/pricing/) users can also back up their cluster's data using [`BACKUP`](backup.html).
 {{site.data.alerts.end}}
 
-
 ## Considerations
 
 When `cockroach dump` is executed:
@@ -23,6 +22,10 @@ When `cockroach dump` is executed:
 {{site.data.alerts.callout_info}}
 The user must have the `SELECT` privilege on the target table(s).
 {{site.data.alerts.end}}
+
+## Known limitations
+
+{% include {{page.version.version}}/known-limitations/import-interleaved-table.md %}
 
 ## Synopsis
 

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -12,7 +12,7 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 Change data capture (CDC) provides efficient, distributed, row-level change feeds into Apache Kafka for downstream processing such as reporting, caching, or full-text indexing.
 
-{% include v2.1/known-limitations/cdc.md %}
+{% include {{page.version.version}}/known-limitations/cdc.md %}
 
 ### Admin UI may become inaccessible for secure clusters
 
@@ -135,6 +135,10 @@ Currently, the built-in SQL shell provided with CockroachDB (`cockroach sql` / `
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16392)
 
+### Importing an interleaved table from a `cockroach dump` output
+
+{% include {{page.version.version}}/known-limitations/import-interleaved-table.md %}
+
 ## Unresolved limitations
 
 ### Silent validation error with `DECIMAL` values
@@ -191,15 +195,15 @@ It is currently not possible to [add a column](add-column.html) to a table when 
 
 ### Available capacity metric in the Admin UI
 
-{% include v2.1/misc/available-capacity-metric.md %}
+{% include {{page.version.version}}/misc/available-capacity-metric.md %}
 
 ### Schema changes within transactions
 
-{% include v2.1/misc/schema-changes-within-transactions.md %}
+{% include {{page.version.version}}/misc/schema-changes-within-transactions.md %}
 
 ### Schema changes between executions of prepared statements
 
-{% include v2.1/misc/schema-changes-between-prepared-statements.md %}
+{% include {{page.version.version}}/misc/schema-changes-between-prepared-statements.md %}
 
 ### `INSERT ON CONFLICT` vs. `UPSERT`
 

--- a/v2.1/sql-dump.md
+++ b/v2.1/sql-dump.md
@@ -10,7 +10,6 @@ The `cockroach dump` [command](cockroach-commands.html) outputs the SQL statemen
 CockroachDB [enterprise license](https://www.cockroachlabs.com/pricing/) users can also back up their cluster's data using [`BACKUP`](backup.html).
 {{site.data.alerts.end}}
 
-
 ## Considerations
 
 When `cockroach dump` is executed:
@@ -23,6 +22,10 @@ When `cockroach dump` is executed:
 {{site.data.alerts.callout_info}}
 The user must have the `SELECT` privilege on the target table(s).
 {{site.data.alerts.end}}
+
+## Known limitations
+
+{% include {{page.version.version}}/known-limitations/import-interleaved-table.md %}
 
 ## Synopsis
 


### PR DESCRIPTION
Documenting that dump won't work without manual edits when interleaved tables are present.

I'm hoping this will avoid some consternation for someone trying to restore down the road. Better to inform them if basic functionality won't work as expected, especially if the fix is easy. This could free up the bulk IO team to work on things without a workaround.

@jseldess AFAIK we haven't actually referred to issues in the docs before, so let me know if this is alright with you.