### PR TITLE
Landing page tweak

### DIFF
--- a/_includes/sidebar-data-v19.1.json
+++ b/_includes/sidebar-data-v19.1.json
@@ -125,7 +125,7 @@
         ]
       },
       {
-        "title": "Explore Features",
+        "title": "Explore Capabilities",
         "items": [
           {
             "title": "Data Replication",

--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -125,7 +125,7 @@
         ]
       },
       {
-        "title": "Explore Features",
+        "title": "Explore Capabilities",
         "items": [
           {
             "title": "Data Replication",

--- a/v19.1/index.md
+++ b/v19.1/index.md
@@ -40,11 +40,11 @@ CockroachDB is the SQL database for building global, scalable cloud services tha
     <div class="col-xs-12 col-sm-6 col-lg-4">
       <p class="landing-column-title">Get Started</p>
       <div class="landing-column-content">
-        <p><a href="frequently-asked-questions.html">What is CockroachDB?</a></p>      
         <p><a href="install-cockroachdb.html">Install CockroachDB</a></p>
         <p><a href="start-a-local-cluster.html">Start a Local Cluster</a></p>
         <p><a href="learn-cockroachdb-sql.html">Learn CockroachDB SQL</a></p>
         <p><a href="build-an-app-with-cockroachdb.html">Build an App</a></p>
+        <p><a href="demo-fault-tolerance-and-recovery.html">Explore Capabilities</a></p>
       </div>
     </div>
     <div class="col-xs-12 col-sm-6 col-lg-4">
@@ -100,8 +100,8 @@ CockroachDB is the SQL database for building global, scalable cloud services tha
     <div class="col-xs-12 col-sm-6 col-lg-4">
       <p class="landing-column-title">Learn More</p>
       <div class="landing-column-content">
+        <p><a href="training/">CockroachDB Training</a></p>      
         <p><a href="architecture/overview.html">Architecture</a></p>
-        <p><a href="demo-fault-tolerance-and-recovery.html">Capabilities</a></p>
         <p><a href="sql-feature-support.html">SQL Feature Support</a></p>
         <p><a href="https://www.cockroachlabs.com/guides/">Whitepapers</a></p>
       </div>

--- a/v2.1/index.md
+++ b/v2.1/index.md
@@ -40,11 +40,11 @@ CockroachDB is the SQL database for building global, scalable cloud services tha
     <div class="col-xs-12 col-sm-6 col-lg-4">
       <p class="landing-column-title">Get Started</p>
       <div class="landing-column-content">
-        <p><a href="frequently-asked-questions.html">What is CockroachDB?</a></p>      
         <p><a href="install-cockroachdb.html">Install CockroachDB</a></p>
         <p><a href="start-a-local-cluster.html">Start a Local Cluster</a></p>
         <p><a href="learn-cockroachdb-sql.html">Learn CockroachDB SQL</a></p>
         <p><a href="build-an-app-with-cockroachdb.html">Build an App</a></p>
+        <p><a href="demo-fault-tolerance-and-recovery.html">Explore Capabilities</a></p>
       </div>
     </div>
     <div class="col-xs-12 col-sm-6 col-lg-4">
@@ -100,8 +100,8 @@ CockroachDB is the SQL database for building global, scalable cloud services tha
     <div class="col-xs-12 col-sm-6 col-lg-4">
       <p class="landing-column-title">Learn More</p>
       <div class="landing-column-content">
+        <p><a href="training/">CockroachDB Training</a></p>      
         <p><a href="architecture/overview.html">Architecture</a></p>
-        <p><a href="demo-fault-tolerance-and-recovery.html">Capabilities</a></p>
         <p><a href="sql-feature-support.html">SQL Feature Support</a></p>
         <p><a href="https://www.cockroachlabs.com/guides/">Whitepapers</a></p>
       </div>


### PR DESCRIPTION
After refreshing the docs landing page, release note sign-ups
dropped noticably. In the previous version, the link to the
Install page was top-left, which is the position that tends to
get the most clicks.

This PR bumps the Install link to the top-left again in the hope
that more users once again go to the install page and, from there,
sign up for release notes.

This PR also adds a link to our training curriculum under
Learn More. It also renames "Explore Features" to "Explore 
Capabilities" in the sidenav. "Features" always felt too narrow.