### PR TITLE
Document specifying scan direction in index hint

### DIFF
--- a/_includes/v19.1/misc/force-index-selection.md
+++ b/_includes/v19.1/misc/force-index-selection.md
@@ -1,0 +1,61 @@
+By using the explicit index annotation, you can override [CockroachDB's index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/) and use a specific [index](indexes.html) when reading from a named table.
+
+{{site.data.alerts.callout_info}}
+Index selection can impact [performance](performance-best-practices-overview.html), but does not change the result of a query.
+{{site.data.alerts.end}}
+
+The syntax to force a scan of a specific index is:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM table@my_idx;
+~~~
+
+This is equivalent to the longer expression:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM table@{FORCE_INDEX=my_idx};
+~~~
+
+<span class="version-tag">New in v19.1</span>: The syntax to force a **reverse scan** of a specific index is:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM table@{FORCE_INDEX=my_idx,DESC};
+~~~
+
+Forcing a reverse can is sometimes useful during [performance tuning](performance-best-practices-overview.html). For reference, the full syntax for choosing an index and its scan direction is
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT * FROM table@{FORCE_INDEX=idx[,DIRECTION]}
+~~~
+
+where the optional `DIRECTION` is either `ASC` (ascending) or `DESC` (descending).
+
+When a direction is specified, that scan direction is forced; otherwise the [cost-based optimizer](cost-based-optimizer.html) is free to choose the direction it calculates will result in the best performance.
+
+You can verify that the optimizer is choosing your desired scan direction using [`EXPLAIN (OPT)`](explain.html#opt-option). For example, given the table
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE kv (K INT PRIMARY KEY, v INT);
+~~~
+
+you can check the scan direction with:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPLAIN (opt) SELECT * FROM kv@{FORCE_INDEX=primary,DESC};
+~~~
+
+~~~
+                text
+-------------------------------------
+ scan kv,rev
+  └── flags: force-index=primary,rev
+(2 rows)
+~~~
+
+To see all indexes available on a table, use [`SHOW INDEXES`](show-index.html).

--- a/v19.1/indexes.md
+++ b/v19.1/indexes.md
@@ -7,14 +7,13 @@ toc_not_nested: true
 
 Indexes improve your database's performance by helping SQL locate data without having to look through every row of a table.
 
-
 ## How do indexes work?
 
 When you create an index, CockroachDB "indexes" the columns you specify, which creates a copy of the columns and then sorts their values (without sorting the values in the table itself).
 
 After a column is indexed, SQL can easily filter its values using the index instead of scanning each row one-by-one. On large tables, this greatly reduces the number of rows SQL has to use, executing queries exponentially faster.
 
-For example, if you index an `INT` column and then filter it <code>WHERE &lt;indexed column&gt; = 10</code>, SQL can use the index to find values starting at 10 but less than 11. In contrast, without an index, SQL would have to evaluate _every_ row in the column for values equaling 10.
+For example, if you index an `INT` column and then filter it <code>WHERE &lt;indexed column&gt; = 10</code>, SQL can use the index to find values starting at 10 but less than 11. In contrast, without an index, SQL would have to evaluate _every_ row in the table for values equaling 10.  This is also known as a "full table scan", and it can be very bad for query performance.
 
 ### Creation
 
@@ -55,6 +54,10 @@ We recommend creating indexes for all of your common queries. To design the most
 - [Index all columns](#indexing-columns) in the `WHERE` clause.
 - [Store columns](#storing-columns) that are _only_ in the `FROM` clause.
 
+{{site.data.alerts.callout_success}}
+For more information about how to tune CockroachDB's performance, see [SQL Performance Best Practices](performance-best-practices-overview.html) and the [Performance Tuning](performance-tuning.html) tutorial.
+{{site.data.alerts.end}}
+
 ### Indexing columns
 
 When designing indexes, it's important to consider which columns you index and the order you list them. Here are a few guidelines to help you make the best choices:
@@ -94,6 +97,8 @@ You could create a single index of `col1` and `col2` that stores `col3`:
 ## See also
 
 - [Inverted Indexes](inverted-indexes.html)
+- [SQL Performance Best Practices](performance-best-practices-overview.html)
+- [Select from a specific index](select-clause.html#select-from-a-specific-index)
 - [`CREATE INDEX`](create-index.html)
 - [`DROP INDEX`](drop-index.html)
 - [`RENAME INDEX`](rename-index.html)

--- a/v19.1/select-clause.md
+++ b/v19.1/select-clause.md
@@ -410,6 +410,9 @@ HAVING COUNT(name) > 1;
 +----------------+--------------+
 ~~~
 
+### Select from a specific index
+
+{% include {{page.version.version}}/misc/force-index-selection.md %}
 
 ### Select historical data (time-travel)
 

--- a/v19.1/table-expressions.md
+++ b/v19.1/table-expressions.md
@@ -85,39 +85,7 @@ For example:
 
 #### Force index selection
 
-By using the explicit index annotation, you can override [CockroachDB's index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/) and use a specific [index](indexes.html) when reading from a named table.
-
-{{site.data.alerts.callout_info}}Index selection can impact performance, but does not change the result of a query.{{site.data.alerts.end}}
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SHOW INDEXES FROM accounts;
-~~~
-~~~
-+----------+-------------------+--------+-----+--------+-----------+---------+----------+
-|  Table   |       Name        | Unique | Seq | Column | Direction | Storing | Implicit |
-+----------+-------------------+--------+-----+--------+-----------+---------+----------+
-| accounts | primary           | true   |   1 | id     | ASC       | false   | false    |
-| accounts | accounts_name_idx | false  |   1 | name   | ASC       | false   | false    |
-| accounts | accounts_name_idx | false  |   2 | id     | ASC       | false   | true     |
-+----------+-------------------+--------+-----+--------+-----------+---------+----------+
-(3 rows)
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SELECT name, balance
-FROM accounts@accounts_name_idx
-WHERE name = 'Edna Barath';
-~~~
-~~~
-+-------------+---------+
-|    name     | balance |
-+-------------+---------+
-| Edna Barath |     750 |
-| Edna Barath |    2200 |
-+-------------+---------+
-~~~
+{% include {{page.version.version}}/misc/force-index-selection.md %} 
 
 ### Access a common table expression
 


### PR DESCRIPTION
Fixes #4363.

Summary of changes:

- Write a new set of instructions for forcing index selection, including
  the `FORCE_INDEX` and new `ASC`/`DESC` scan direction keywords.

- Use the above as an include so it can be used to:

  - Replace the existing content in 'Table Expressions'

  - Add a new section to the `SELECT` page

- Finally, made some small updates to the 'Indexes' page to link more
  things together.