### PR TITLE
Update (some) schema change docs with `SHOW JOBS`

### DIFF
--- a/_includes/v19.1/misc/schema-change-view-job.md
+++ b/_includes/v19.1/misc/schema-change-view-job.md
@@ -1,1 +1,1 @@
-Whenever you initiate a schema change, CockroachDB registers it as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
+This schema change statement is registered as a job.  You can view long-running jobs with [`SHOW JOBS`](show-jobs.html).

--- a/v19.1/add-column.md
+++ b/v19.1/add-column.md
@@ -144,7 +144,9 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 ~~~
 
 ## See also
+
 - [`ALTER TABLE`](alter-table.html)
 - [Column-level Constraints](constraints.html)
 - [Collation](collate.html)
 - [Column Families](column-families.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/add-constraint.md
+++ b/v19.1/add-constraint.md
@@ -145,3 +145,4 @@ Adding a foreign key for a non-empty table without an appropriate index will fai
 - [`ALTER COLUMN`](alter-column.html)
 - [`CREATE TABLE`](create-table.html)
 - [`ALTER TABLE`](alter-table.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/alter-column.md
+++ b/v19.1/alter-column.md
@@ -75,3 +75,4 @@ If the column has the [`NOT NULL` constraint](not-null.html) applied to it, you 
 - [`ADD CONSTRAINT`](add-constraint.html)
 - [`DROP CONSTRAINT`](drop-constraint.html)
 - [`ALTER TABLE`](alter-table.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/alter-index.md
+++ b/v19.1/alter-index.md
@@ -10,6 +10,8 @@ The `ALTER INDEX` [statement](sql-statements.html) applies a schema change to an
 
 For information on using `ALTER INDEX`, see the documents for its relevant subcommands.
 
+{% include {{{ page.version.version }}/misc/schema-change-view-job.md %}
+
 Subcommand | Description
 -----------|------------
 [`CONFIGURE ZONE`](configure-zone.html) | [Configure replication zones](configure-replication-zones.html) for an index.

--- a/v19.1/alter-table.md
+++ b/v19.1/alter-table.md
@@ -6,7 +6,11 @@ toc: true
 
 The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table.
 
-{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
+{% include {{ page.version.version }}/misc/schema-change-stmt-note.md %}
+
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
 
 ## Subcommands
 

--- a/v19.1/alter-type.md
+++ b/v19.1/alter-type.md
@@ -33,6 +33,10 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 | `column_name` | The name of the column whose data type you want to change.
 | `typename` | The new [data type](data-types.html) you want to use.
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Success scenario
@@ -78,3 +82,4 @@ pq: type conversion not yet implemented
 
 - [`ALTER TABLE`](alter-table.html)
 - [Other SQL Statements](sql-statements.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/configure-zone.md
+++ b/v19.1/configure-zone.md
@@ -59,6 +59,10 @@ Currently, only the `root` user can configure replication zones.
 
 {% include {{ page.version.version }}/zone-configs/variables.md %}
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Edit a replication zone
@@ -112,5 +116,6 @@ CONFIGURE ZONE 1
 - [`ALTER TABLE`](alter-table.html)
 - [`ALTER INDEX`](alter-index.html)
 - [`ALTER RANGE`](alter-range.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [Table Partitioning](partitioning.html)
 - [Other SQL Statements](sql-statements.html)

--- a/v19.1/create-index.md
+++ b/v19.1/create-index.md
@@ -45,6 +45,10 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 `opt_interleave` | You can potentially optimize query performance by [interleaving indexes](interleave-in-parent.html), which changes how CockroachDB stores your data.
 `opt_partition_by` | Docs coming soon.
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Create standard indexes
@@ -161,5 +165,6 @@ Normally, CockroachDB selects the index that it calculates will scan the fewest 
 - [`SHOW INDEX`](show-index.html)
 - [`DROP INDEX`](drop-index.html)
 - [`RENAME INDEX`](rename-index.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [Other SQL Statements](sql-statements.html)
 - [Online Schema Changes](online-schema-changes.html)

--- a/v19.1/drop-column.md
+++ b/v19.1/drop-column.md
@@ -90,3 +90,4 @@ pq: view "customer_view" does not exist
 - [`DROP CONSTRAINT`](drop-constraint.html)
 - [`DROP INDEX`](drop-index.html)
 - [`ALTER TABLE`](alter-table.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/drop-constraint.md
+++ b/v19.1/drop-constraint.md
@@ -77,3 +77,4 @@ ALTER TABLE
 - [`DROP COLUMN`](drop-column.html)
 - [`DROP INDEX`](drop-index.html)
 - [`ALTER TABLE`](alter-table.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/drop-database.md
+++ b/v19.1/drop-database.md
@@ -25,6 +25,10 @@ Parameter | Description
 `CASCADE` | _(Default)_ Drop all tables and views in the database as well as all objects (such as [constraints](constraints.html) and [views](views.html)) that depend on those tables.<br><br>`CASCADE` does not list objects it drops, so should be used cautiously.
 `RESTRICT` | Do not drop the database if it contains any [tables](create-table.html) or [views](create-view.html).
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Drop a database and its objects (`CASCADE`)
@@ -96,5 +100,6 @@ pq: database "db2" is not empty and CASCADE was not specified
 - [`SHOW DATABASES`](show-databases.html)
 - [`RENAME DATABASE`](rename-database.html)
 - [`SET DATABASE`](set-vars.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [Other SQL Statements](sql-statements.html)
 - [Online Schema Changes](online-schema-changes.html)

--- a/v19.1/drop-index.md
+++ b/v19.1/drop-index.md
@@ -26,6 +26,10 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
  `CASCADE`	| Drop all objects (such as [constraints](constraints.html)) that depend on the indexes. To drop a `UNIQUE INDEX`, you must use `CASCADE`.<br><br>`CASCADE` does not list objects it drops, so should be used cautiously.
  `RESTRICT`	| _(Default)_ Do not drop the indexes if any objects (such as [constraints](constraints.html)) depend on them.
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Remove an index (no dependencies)
@@ -132,3 +136,4 @@ pq: index "orders_auto_index_fk_customer_ref_customers" is in use as a foreign k
 
 - [Indexes](indexes.html)
 - [Online Schema Changes](online-schema-changes.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/drop-table.md
+++ b/v19.1/drop-table.md
@@ -25,6 +25,10 @@ Parameter | Description
 `CASCADE` | Drop all objects (such as [constraints](constraints.html) and [views](views.html)) that depend on the table.<br><br>`CASCADE` does not list objects it drops, so should be used cautiously.
 `RESTRICT`    | _(Default)_ Do not drop the table if any objects (such as [constraints](constraints.html) and [views](views.html)) depend on it.
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Remove a table (no dependencies)
@@ -135,4 +139,5 @@ DROP TABLE
 - [`DELETE`](delete.html)
 - [`DROP INDEX`](drop-index.html)
 - [`DROP VIEW`](drop-view.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [Online Schema Changes](online-schema-changes.html)

--- a/v19.1/experimental-audit.md
+++ b/v19.1/experimental-audit.md
@@ -83,6 +83,10 @@ To store the audit log files in a specific directory, pass the `--sql-audit-dir`
 If your deployment requires particular lifecycle and access policies for audit log files, point `--sql-audit-dir` at a directory that has permissions set so that only CockroachDB can create/delete files.
 {{site.data.alerts.end}}
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Turn on audit logging
@@ -123,3 +127,4 @@ ALTER TABLE customers EXPERIMENTAL_AUDIT SET OFF;
 - [SQL Audit Logging](sql-audit-logging.html)
 - [`ALTER TABLE`](alter-table.html)
 - [`cockroach start` logging flags](start-a-node.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/partition-by.md
+++ b/v19.1/partition-by.md
@@ -37,6 +37,10 @@ Parameter | Description |
 
 The user must have the `CREATE` [privilege](authorization.html#assign-privileges) on the table.
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Define a list partition on an existing table
@@ -95,3 +99,4 @@ Suppose we have an yet another existing table named `students` with the primary 
 - [`CREATE TABLE`](create-table.html)
 - [`ALTER TABLE`](alter-table.html)
 - [Define Table Partitions](partitioning.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/rename-column.md
+++ b/v19.1/rename-column.md
@@ -115,3 +115,4 @@ Then you decide you want distinct columns for each user's first name, last name,
 - [`RENAME DATABASE`](rename-database.html)
 - [`RENAME TABLE`](rename-table.html)
 - [`RENAME CONSTRAINT`](rename-constraint.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/rename-index.md
+++ b/v19.1/rename-index.md
@@ -8,6 +8,7 @@ The `RENAME INDEX` [statement](sql-statements.html) changes the name of an index
 
 {{site.data.alerts.callout_info}}It is not possible to rename an index referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
 
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
 
 ## Synopsis
 
@@ -76,3 +77,4 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 - [`RENAME COLUMN`](rename-column.html)
 - [`RENAME DATABASE`](rename-database.html)
 - [`RENAME TABLE`](rename-table.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/rename-table.md
+++ b/v19.1/rename-table.md
@@ -158,8 +158,9 @@ To move a table from one database to another, use the above syntax but specify t
 
 ## See also
 
-- [`CREATE TABLE`](create-table.html)  
-- [`ALTER TABLE`](alter-table.html)  
-- [`SHOW TABLES`](show-tables.html)  
-- [`DROP TABLE`](drop-table.html)  
+- [`CREATE TABLE`](create-table.html)
+- [`ALTER TABLE`](alter-table.html)
+- [`SHOW TABLES`](show-tables.html)
+- [`DROP TABLE`](drop-table.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [Other SQL Statements](sql-statements.html)

--- a/v19.1/split-at.md
+++ b/v19.1/split-at.md
@@ -6,7 +6,6 @@ toc: true
 
 The `SPLIT AT` [statement](sql-statements.html) forces a key-value layer range split at the specified row in a table or index.
 
-
 ## Synopsis
 
 <div>
@@ -27,6 +26,10 @@ The user must have the `INSERT` [privilege](authorization.html#assign-privileges
 -----------|-------------
  `table_name`<br>`table_name @ index_name` | The name of the table or index that should be split.
  `select_stmt` | A [selection query](selection-queries.html) that produces one or more rows at which to split the table or index.
+
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
 
 ## Why manually split a range?
 
@@ -248,3 +251,4 @@ SHOW EXPERIMENTAL_RANGES FROM TABLE t;
 - [Selection Queries](selection-queries.html)
 - [Distribution Layer](architecture/distribution-layer.html)
 - [Replication Layer](architecture/replication-layer.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.1/truncate.md
+++ b/v19.1/truncate.md
@@ -34,6 +34,10 @@ Parameter | Description
 
 `TRUNCATE` is a schema change, and as such is not transactional. For more information about how schema changes work, see [Online Schema Changes](online-schema-changes.html).
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 ### Truncate a table (no foreign key dependencies)
@@ -155,5 +159,6 @@ pq: "customers" is referenced by foreign key from table "orders"
 ## See also
 
 - [`DELETE`](delete.html)
+- [`SHOW JOBS`](show-jobs.html)
 - [Foreign Key constraint](foreign-key.html)
 - [Online Schema Changes](online-schema-changes.html)

--- a/v19.1/validate-constraint.md
+++ b/v19.1/validate-constraint.md
@@ -25,6 +25,10 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
  `table_name`      | The name of the table in which the constraint you'd like to validate lives.
  `constraint_name` | The name of the constraint on `table_name` you'd like to validate.          
 
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
+
 ## Examples
 
 In [`ADD CONSTRAINT`](add-constraint.html), we [added a foreign key constraint](add-constraint.html#add-the-foreign-key-constraint-with-cascade) like so:
@@ -53,3 +57,4 @@ If present in a [`CREATE TABLE`](create-table.html) statement, the table is cons
 - [`RENAME CONSTRAINT`](rename-constraint.html)
 - [`DROP CONSTRAINT`](drop-constraint.html)
 - [`CREATE TABLE`](create-table.html)
+- [`SHOW JOBS`](show-jobs.html)


### PR DESCRIPTION
Fixes #4015.

Summary of changes:

- Revise generic "schema change = SHOW JOBS" to make narrower claim
  about which of them will appear in SHOW JOBS, since it isn't all of
  them yet.

- Update various statement and sub-statement pages that will show up in
  the jobs table to say (roughly) that "this statement is a job, and
  will show up when you run SHOW JOBS".