### PR TITLE
ci: Deeplink to changed files in PR comments.

### DIFF
--- a/ci/pull-request
+++ b/ci/pull-request
@@ -32,12 +32,47 @@ run make managed-build JEKYLLCONFIG=_config_prod_managed.yml
 # Step 3. Upload the docs to S3.
 run aws s3 cp --recursive --quiet --region=us-east-1 ./_site s3://cockroach-docs-review
 
+# Step 4a. Determine which Markdown files have changed and generate deeplinks
+# to post as a comment on the pull request.
+git fetch origin master
+COMMENT_BODY=$(
+git diff --name-status origin/master | \
+awk -v "base_url=http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/$BUILD_VCS_NUMBER/" '
+BEGIN {
+  print "Online preview: " base_url 
+}
+
+/^[AM]\s+[^_].*\.md/ {
+  if (!header_printed) {
+    print ""
+    print "Edited pages:"
+    header_printed=1
+  }
+  gsub(/^.\s+/, "")
+  gsub(/\.md$/, "")
+  print "- [" $_ ".md](" base_url $_ ".html)"
+}
+'
+)
+
+# Bash JSON string escaping: https://stackoverflow.com/a/11495576/10446461
+COMMENT_BODY=${COMMENT_BODY//\\/\\\\} # \
+COMMENT_BODY=${COMMENT_BODY//\//\\\/} # /
+COMMENT_BODY=${COMMENT_BODY//\'/\\\'} # ' (not strictly needed ?)
+COMMENT_BODY=${COMMENT_BODY//\"/\\\"} # "
+COMMENT_BODY=${COMMENT_BODY//   /\\t} # \t (tab)
+COMMENT_BODY=${COMMENT_BODY//
+/\\\n} # \n (newline)
+COMMENT_BODY=${COMMENT_BODY//^M/\\\r} # \r (carriage return)
+COMMENT_BODY=${COMMENT_BODY//^L/\\\f} # \f (form feed)
+COMMENT_BODY=${COMMENT_BODY//^H/\\\b} # \b (backspace)
+
 # Step 4. Post a link to the docs on the GitHub pull request. We do this before
 # running htmltest to provide fast feedback, as htmltest can take several
 # minutes to complete. No need to do this in the container.
 curl \
   --header "Authorization: token $GITHUB_TOKEN" \
-  --data "{\"body\": \"http://cockroach-docs-review.s3-website-us-east-1.amazonaws.com/$BUILD_VCS_NUMBER/\"}" \
+  --data "{\"body\": \"$COMMENT_BODY\"}" \
   "https://api.github.com/repos/cockroachdb/docs/issues/$BUILD_BRANCH/comments"
 
 # Step 5. Run vale, but don't fail the build if it reports errors.


### PR DESCRIPTION
This change to the `pull-request` CI script attempts to determine
which Markdown files have changed using `git diff`, and adds deep
links to the generated HTML output when commenting on Github.

I'm not sure exactly where this script runs, so this may not work in production, but I've verified that the parts that I changed produce the expected output in isolation.