### PR TITLE
19.1 updates

### DIFF
--- a/_includes/v19.1/misc/automatic-statistics.md
+++ b/_includes/v19.1/misc/automatic-statistics.md
@@ -6,7 +6,7 @@ If you need to turn off automatic statistics collection:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > SET CLUSTER SETTING sql.stats.experimental_automatic_collection.enabled=false
+    > SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
     ~~~
 
 2. Look up what statistics were created by the automatic statistics generator using the [`SHOW STATISTICS`](show-statistics.html) statement.

--- a/v19.1/cost-based-optimizer.md
+++ b/v19.1/cost-based-optimizer.md
@@ -127,11 +127,11 @@ Finally, note that only the following statements use the plan cache:
 
 Because this process leads to an exponential increase in the number of possible execution plans for such queries, it's only used to reorder subtrees containing 4 or fewer joins by default.
 
-To change this setting, which is controlled by the `experimental_reorder_joins_limit` [session variable](set-vars.html), run the statement shown below. To disable this feature, set the variable to `0`.
+To change this setting, which is controlled by the `reorder_joins_limit` [session variable](set-vars.html), run the statement shown below. To disable this feature, set the variable to `0`.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SET experimental_reorder_joins_limit = 6;
+> SET reorder_joins_limit = 6;
 ~~~
 
 {{site.data.alerts.callout_danger}}

--- a/v19.1/install-cockroachdb-linux.html
+++ b/v19.1/install-cockroachdb-linux.html
@@ -130,7 +130,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.11.5 or higher is required.</td>
+          <td>Version 1.11.6 or higher is required.</td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v19.1/install-cockroachdb-mac.html
+++ b/v19.1/install-cockroachdb-mac.html
@@ -159,7 +159,7 @@ If you previously installed CockroachDB using a different method, you may need t
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.11.5.</td>
+          <td>Version 1.11.6.</td>
         </tr>
         <tr>
           <td>Bash</td>


### PR DESCRIPTION
- Remove "experimental" from name of auto stats cluster settings 
- Rename experimental_reorder_joins_limit session variable
- Increase required Go version for building from source 