### PR TITLE
Edit ApplicationName param for JDBC

### DIFF
--- a/_includes/v19.1/app/BasicSample.java
+++ b/_includes/v19.1/app/BasicSample.java
@@ -24,6 +24,7 @@ public class BasicSample {
         props.setProperty("sslrootcert", "certs/ca.crt");
         props.setProperty("sslkey", "certs/client.maxroach.pk8");
         props.setProperty("sslcert", "certs/client.maxroach.crt");
+        props.setProperty("ApplicationName", "roachtest");
 
         Connection db = DriverManager
             .getConnection("jdbc:postgresql://127.0.0.1:26257/bank", props);

--- a/_includes/v19.1/app/TxnSample.java
+++ b/_includes/v19.1/app/TxnSample.java
@@ -107,6 +107,7 @@ public class TxnSample {
         props.setProperty("sslrootcert", "certs/ca.crt");
         props.setProperty("sslkey", "certs/client.maxroach.pk8");
         props.setProperty("sslcert", "certs/client.maxroach.crt");
+        props.setProperty("ApplicationName", "roachtest");
 
         Connection db = DriverManager
             .getConnection("jdbc:postgresql://127.0.0.1:26257/bank", props);

--- a/_includes/v2.1/app/BasicSample.java
+++ b/_includes/v2.1/app/BasicSample.java
@@ -24,6 +24,7 @@ public class BasicSample {
         props.setProperty("sslrootcert", "certs/ca.crt");
         props.setProperty("sslkey", "certs/client.maxroach.pk8");
         props.setProperty("sslcert", "certs/client.maxroach.crt");
+        props.setProperty("ApplicationName", "roachtest");
 
         Connection db = DriverManager
             .getConnection("jdbc:postgresql://127.0.0.1:26257/bank", props);

--- a/_includes/v2.1/app/TxnSample.java
+++ b/_includes/v2.1/app/TxnSample.java
@@ -107,6 +107,7 @@ public class TxnSample {
         props.setProperty("sslrootcert", "certs/ca.crt");
         props.setProperty("sslkey", "certs/client.maxroach.pk8");
         props.setProperty("sslcert", "certs/client.maxroach.crt");
+        props.setProperty("ApplicationName", "roachtest");
 
         Connection db = DriverManager
             .getConnection("jdbc:postgresql://127.0.0.1:26257/bank", props);

--- a/v19.1/connection-parameters.md
+++ b/v19.1/connection-parameters.md
@@ -75,7 +75,7 @@ The following additional parameters can be passed after the `?` character in the
 
 Parameter | Description | Default value
 ----------|-------------|---------------
-`application_name` | An initial value for the [`application_name` session variable](set-vars.html). | Empty string.
+`application_name` | An initial value for the [`application_name` session variable](set-vars.html).<br><br>Note: For [Java JBDC](build-a-java-app-with-cockroachdb.html), use `ApplicationName`. | Empty string.
 `sslmode` | Which type of secure connection to use: `disable`, `allow`, `prefer`, `require`, `verify-ca` or `verify-full`. See [Secure Connections With URLs](#secure-connections-with-urls) for details. | `disable`
 `sslrootcert` | Path to the [CA certificate](create-security-certificates.html), when `sslmode` is not `disable`. | Empty string.
 `sslcert` | Path to the [client certificate](create-security-certificates.html), when `sslmode` is not `disable`. | Empty string.

--- a/v2.1/connection-parameters.md
+++ b/v2.1/connection-parameters.md
@@ -75,7 +75,7 @@ The following additional parameters can be passed after the `?` character in the
 
 Parameter | Description | Default value
 ----------|-------------|---------------
-`application_name` | An initial value for the [`application_name` session variable](set-vars.html). | Empty string.
+`application_name` | An initial value for the [`application_name` session variable](set-vars.html).<br><br>Note: For [Java JBDC](build-a-java-app-with-cockroachdb.html), use `ApplicationName`. | Empty string.
 `sslmode` | Which type of secure connection to use: `disable`, `allow`, `prefer`, `require`, `verify-ca` or `verify-full`. See [Secure Connections With URLs](#secure-connections-with-urls) for details. | `disable`
 `sslrootcert` | Path to the [CA certificate](create-security-certificates.html), when `sslmode` is not `disable`. | Empty string.
 `sslcert` | Path to the [client certificate](create-security-certificates.html), when `sslmode` is not `disable`. | Empty string.


### PR DESCRIPTION
- Searched for mentions of `application_name` for JDBC and didn't find anything to clean up.
- Added a note to Connection Parameters to call out `ApplicationName` for JDBC.

Closes #4294.