### PR TITLE
Be louder about experimental status of windows build

### DIFF
--- a/v19.1/install-cockroachdb-windows.html
+++ b/v19.1/install-cockroachdb-windows.html
@@ -17,7 +17,7 @@ key: install-cockroachdb.html
 <div id="download-the-binary-windows" class="install-option">
   <h2>Download the Binary</h2>
 
-  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows requires Windows 8 or higher</strong>, is experimental, and has not been extensively tested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged.{{site.data.alerts.end}}
+  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows is experimental</strong>, and is largely untested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged. Windows 8 or higher is required.{{site.data.alerts.end}}
 
   <ol>
     <li>

--- a/v2.1/install-cockroachdb-windows.html
+++ b/v2.1/install-cockroachdb-windows.html
@@ -17,7 +17,7 @@ key: install-cockroachdb.html
 <div id="download-the-binary-windows" class="install-option">
   <h2>Download the Binary</h2>
 
-  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows requires Windows 8 or higher</strong>, is experimental, and has not been extensively tested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged.{{site.data.alerts.end}}
+  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows is experimental</strong>, and is largely untested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged. Windows 8 or higher is required.{{site.data.alerts.end}}
 
   <ol>
     <li>


### PR DESCRIPTION
This "Install CockroachDB on Windows" page has a warning box but the
bolded text is "Native CockroachDB on Windows requires Windows 8 or
higher" and the experimental status is a bit hidden in the rest of the
box. This binary is almost entirely untested, so I'd suggest we swap the
bolded text to be about the experimental status of the binary.
Otherwise, I worry that users may form a bad initial impression of our
performance/stability/maturity (and perhaps don't bother contacting us
as a result).