### PR TITLE
Improve UX of IMPORT docs

### DIFF
--- a/_includes/v19.1/sql/diagrams/import_csv.html
+++ b/_includes/v19.1/sql/diagrams/import_csv.html
@@ -1,0 +1,52 @@
+<div><svg width="725" height="223">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="76" height="32" rx="10"></rect>
+<rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">IMPORT</text>
+<rect x="127" y="3" width="62" height="32" rx="10"></rect>
+<rect x="125" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="135" y="21">TABLE</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="209" y="3" width="96" height="32"></rect>
+<rect x="207" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="217" y="21">table_name</text></a><rect x="345" y="3" width="72" height="32" rx="10"></rect>
+<rect x="343" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="353" y="21">CREATE</text>
+<rect x="437" y="3" width="64" height="32" rx="10"></rect>
+<rect x="435" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="445" y="21">USING</text>
+<rect x="521" y="3" width="96" height="32"></rect>
+<rect x="519" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="529" y="21">file_location</text><rect x="345" y="47" width="26" height="32" rx="10"></rect>
+<rect x="343" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="353" y="65">(</text><a xlink:href="sql-grammar.html#table_elem_list" xlink:title="table_elem_list">
+<rect x="391" y="47" width="118" height="32"></rect>
+<rect x="389" y="45" width="118" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="399" y="65">table_elem_list</text></a><rect x="529" y="47" width="26" height="32" rx="10"></rect>
+<rect x="527" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="537" y="65">)</text>
+<rect x="657" y="3" width="46" height="32" rx="10"></rect>
+<rect x="655" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="665" y="21">CSV</text>
+<rect x="147" y="157" width="56" height="32" rx="10"></rect>
+<rect x="145" y="155" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="155" y="175">DATA</text>
+<rect x="223" y="157" width="26" height="32" rx="10"></rect>
+<rect x="221" y="155" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="231" y="175">(</text>
+<rect x="289" y="157" width="96" height="32"></rect>
+<rect x="287" y="155" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="297" y="175">file_location</text><rect x="289" y="113" width="24" height="32" rx="10"></rect>
+<rect x="287" y="111" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="297" y="131">,</text>
+<rect x="425" y="157" width="26" height="32" rx="10"></rect>
+<rect x="423" y="155" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="175">)</text>
+<rect x="491" y="189" width="58" height="32" rx="10"></rect>
+<rect x="489" y="187" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="499" y="207">WITH</text><a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+<rect x="569" y="189" width="108" height="32"></rect>
+<rect x="567" y="187" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="577" y="207">kv_option_list</text></a><path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m96 0 h10 m20 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m96 0 h10 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m26 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m26 0 h10 m0 0 h62 m20 -44 h10 m46 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-600 154 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m-136 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m116 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-116 0 h10 m24 0 h10 m0 0 h72 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
+<polygon points="715 171 723 167 723 175"></polygon>
+<polygon points="715 171 707 167 707 175"></polygon></svg></div>

--- a/_includes/v19.1/sql/diagrams/import_dump.html
+++ b/_includes/v19.1/sql/diagrams/import_dump.html
@@ -1,0 +1,27 @@
+<div><svg width="693" height="155">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="76" height="32" rx="10"></rect>
+<rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">IMPORT</text>
+<rect x="147" y="35" width="62" height="32" rx="10"></rect>
+<rect x="145" y="33" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="155" y="53">TABLE</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="229" y="35" width="96" height="32"></rect>
+<rect x="227" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="237" y="53">table_name</text></a><rect x="345" y="35" width="60" height="32" rx="10"></rect>
+<rect x="343" y="33" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="353" y="53">FROM</text><a xlink:href="sql-grammar.html#import_format" xlink:title="import_format">
+<rect x="445" y="3" width="110" height="32"></rect>
+<rect x="443" y="1" width="110" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="453" y="21">import_format</text></a>
+<rect x="575" y="3" width="96" height="32"></rect>
+<rect x="573" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="583" y="21">file_location</text><rect x="459" y="121" width="58" height="32" rx="10"></rect>
+<rect x="457" y="119" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="467" y="139">WITH</text><a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+<rect x="537" y="121" width="108" height="32"></rect>
+<rect x="535" y="119" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="545" y="139">kv_option_list</text></a><path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h268 m-298 0 h20 m278 0 h20 m-318 0 q10 0 10 10 m298 0 q0 -10 10 -10 m-308 10 v12 m298 0 v-12 m-298 12 q0 10 10 10 m278 0 q10 0 10 -10 m-288 10 h10 m62 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m60 0 h10 m20 -32 h10 m110 0 h10 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-276 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
+<polygon points="683 103 691 99 691 107"></polygon>
+<polygon points="683 103 675 99 675 107"></polygon></svg></div>

--- a/_includes/v2.1/sql/diagrams/import_csv.html
+++ b/_includes/v2.1/sql/diagrams/import_csv.html
@@ -1,0 +1,52 @@
+<div><svg width="725" height="223">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="76" height="32" rx="10"></rect>
+<rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">IMPORT</text>
+<rect x="127" y="3" width="62" height="32" rx="10"></rect>
+<rect x="125" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="135" y="21">TABLE</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="209" y="3" width="96" height="32"></rect>
+<rect x="207" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="217" y="21">table_name</text></a><rect x="345" y="3" width="72" height="32" rx="10"></rect>
+<rect x="343" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="353" y="21">CREATE</text>
+<rect x="437" y="3" width="64" height="32" rx="10"></rect>
+<rect x="435" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="445" y="21">USING</text>
+<rect x="521" y="3" width="96" height="32"></rect>
+<rect x="519" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="529" y="21">file_location</text><rect x="345" y="47" width="26" height="32" rx="10"></rect>
+<rect x="343" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="353" y="65">(</text><a xlink:href="sql-grammar.html#table_elem_list" xlink:title="table_elem_list">
+<rect x="391" y="47" width="118" height="32"></rect>
+<rect x="389" y="45" width="118" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="399" y="65">table_elem_list</text></a><rect x="529" y="47" width="26" height="32" rx="10"></rect>
+<rect x="527" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="537" y="65">)</text>
+<rect x="657" y="3" width="46" height="32" rx="10"></rect>
+<rect x="655" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="665" y="21">CSV</text>
+<rect x="147" y="157" width="56" height="32" rx="10"></rect>
+<rect x="145" y="155" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="155" y="175">DATA</text>
+<rect x="223" y="157" width="26" height="32" rx="10"></rect>
+<rect x="221" y="155" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="231" y="175">(</text>
+<rect x="289" y="157" width="96" height="32"></rect>
+<rect x="287" y="155" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="297" y="175">file_location</text><rect x="289" y="113" width="24" height="32" rx="10"></rect>
+<rect x="287" y="111" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="297" y="131">,</text>
+<rect x="425" y="157" width="26" height="32" rx="10"></rect>
+<rect x="423" y="155" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="175">)</text>
+<rect x="491" y="189" width="58" height="32" rx="10"></rect>
+<rect x="489" y="187" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="499" y="207">WITH</text><a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+<rect x="569" y="189" width="108" height="32"></rect>
+<rect x="567" y="187" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="577" y="207">kv_option_list</text></a><path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m96 0 h10 m20 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m96 0 h10 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m26 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m26 0 h10 m0 0 h62 m20 -44 h10 m46 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-600 154 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m-136 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m116 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-116 0 h10 m24 0 h10 m0 0 h72 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
+<polygon points="715 171 723 167 723 175"></polygon>
+<polygon points="715 171 707 167 707 175"></polygon></svg></div>

--- a/_includes/v2.1/sql/diagrams/import_dump.html
+++ b/_includes/v2.1/sql/diagrams/import_dump.html
@@ -1,0 +1,27 @@
+<div><svg width="693" height="155">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="76" height="32" rx="10"></rect>
+<rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">IMPORT</text>
+<rect x="147" y="35" width="62" height="32" rx="10"></rect>
+<rect x="145" y="33" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="155" y="53">TABLE</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="229" y="35" width="96" height="32"></rect>
+<rect x="227" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="237" y="53">table_name</text></a><rect x="345" y="35" width="60" height="32" rx="10"></rect>
+<rect x="343" y="33" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="353" y="53">FROM</text><a xlink:href="sql-grammar.html#import_format" xlink:title="import_format">
+<rect x="445" y="3" width="110" height="32"></rect>
+<rect x="443" y="1" width="110" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="453" y="21">import_format</text></a>
+<rect x="575" y="3" width="96" height="32"></rect>
+<rect x="573" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="583" y="21">file_location</text><rect x="459" y="121" width="58" height="32" rx="10"></rect>
+<rect x="457" y="119" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="467" y="139">WITH</text><a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+<rect x="537" y="121" width="108" height="32"></rect>
+<rect x="535" y="119" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="545" y="139">kv_option_list</text></a><path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h268 m-298 0 h20 m278 0 h20 m-318 0 q10 0 10 10 m298 0 q0 -10 10 -10 m-308 10 v12 m298 0 v-12 m-298 12 q0 10 10 10 m278 0 q10 0 10 -10 m-288 10 h10 m62 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m60 0 h10 m20 -32 h10 m110 0 h10 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-276 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
+<polygon points="683 103 691 99 691 107"></polygon>
+<polygon points="683 103 675 99 675 107"></polygon></svg></div>

--- a/v19.1/import.md
+++ b/v19.1/import.md
@@ -6,17 +6,17 @@ toc: true
 
 The `IMPORT` [statement](sql-statements.html) imports the following types of data into CockroachDB:
 
-- [CockroachDB dump files](sql-dump.html)
 - [CSV/TSV][csv]
 - [Postgres dump files][postgres]
 - [MySQL dump files][mysql]
+- [CockroachDB dump files](sql-dump.html)
 
 {{site.data.alerts.callout_success}}
 This page has reference information about the `IMPORT` statement.  For instructions and working examples showing how to migrate data from other databases and formats, see the [Migration Overview](migration-overview.html).
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_danger}}
-Note that `IMPORT` only works for creating new tables.  It does not support adding data to existing tables.
+`IMPORT` only works for creating new tables. It does not support adding data to existing tables. Also, `IMPORT` cannot be used within a [transaction](transactions.html).
 {{site.data.alerts.end}}
 
 ## Required privileges
@@ -25,22 +25,38 @@ Only members of the `admin` role can run `IMPORT`. By default, the `root` user b
 
 ## Synopsis
 
+**Import a table from CSV**
+
 <div>
-  {% include {{ page.version.version }}/sql/diagrams/import_table.html %}
+  {% include {{ page.version.version }}/sql/diagrams/import_csv.html %}
 </div>
 
-{{site.data.alerts.callout_info}}The <code>IMPORT</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
+**Import a database or table from dump file**
+
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/import_dump.html %}
+</div>
 
 ## Parameters
 
-| Parameter             | Description                                                                                                                                                                                                                                                   |
-|-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `import_format`       | Currently supported formats: [CSV](#manually-specify-the-columns-of-an-imported-table), [PGDUMP](#import-a-postgres-database-dump), [MYSQLDUMP](#import-a-mysql-database-dump).                                                                               |
-| `file_location`       | The URL of a text file containing one of (depending on its location in the statement): a dump file to import; a CSV file to import; a SQL [`CREATE TABLE`](create-table.html) statement to execute.  For example syntax, see the [Examples](#examples) below. |
-| `table_name`          | The name of the table you want to import/create.                                                                                                                                                                                                              |
-| `table_elem_list`     | The table definition you want to use (see [this example for syntax](#manually-specify-the-columns-of-an-imported-table)).                                                                                                                                     |
-| `file_to_import`      | The URL of the file you want to import.                                                                                                                                                                                                                       |
-| `WITH kv_option_list` | Control your import's behavior with [these options](#import-options).                                                                                                                                                                                         |
+### For import from CSV
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table you want to import/create.
+`table_elem_list` | The table schema you want to use.  
+`CREATE USING file_location` | If not specifying the table schema inline via `table_elem_list`, this is the [URL](#import-file-urls) of a CSV file containing the table schema.
+`file_location` | The [URL](#import-file-urls) of a CSV file containing the table data. This can be a comma-separated list of URLs to CSV files. For an example, see [Import a table from multiple CSV files](#import-a-table-from-multiple-csv-files) below.
+`WITH kv_option_list` | Control your import's behavior with [these options](#import-options).
+
+### For import from dump file
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table you want to import/create. Use this when the dump file contains a specific table. Leave out `TABLE table_name FROM` when the dump file contains an entire database.
+`import_format` | [PGDUMP](#import-a-postgres-database-dump) or [MYSQLDUMP](#import-a-mysql-database-dump)
+`file_location` | The [URL](#import-file-urls) of a dump file you want to import.
+`WITH kv_option_list` | Control your import's behavior with [these options](#import-options).
 
 ### Import file URLs
 
@@ -87,9 +103,9 @@ You can specify the target database in the table name in the `IMPORT` statement.
 
 Your `IMPORT` statement must reference a `CREATE TABLE` statement representing the schema of the data you want to import.  You have several options:
 
-- Specify the table's columns explicitly from the [SQL client](use-the-built-in-sql-client.html).  For an example, see [Manually specify the columns of an imported table](#manually-specify-the-columns-of-an-imported-table) below.
+- Specify the table's columns explicitly from the [SQL client](use-the-built-in-sql-client.html). For an example, see [Import a table from a CSV file](#import-a-table-from-a-csv-file) below.
 
-- Load a file that already contains a `CREATE TABLE` statement.  For an example, see [Import a Postgres database dump](#import-a-postgres-database-dump) below.
+- Load a file that already contains a `CREATE TABLE` statement. For an example, see [Import a Postgres database dump](#import-a-postgres-database-dump) below.
 
 We also recommend [specifying all secondary indexes you want to use in the `CREATE TABLE` statement](create-table.html#create-a-table-with-secondary-and-inverted-indexes). It is possible to [add secondary indexes later](create-index.html), but it is significantly faster to specify them during import.
 
@@ -141,17 +157,9 @@ After the import has been initiated, you can control it with [`PAUSE JOB`](pause
 
 ## Examples
 
-### Use a `CREATE TABLE` statement from a file
+### Import a table from a CSV file
 
-{% include copy-clipboard.html %}
-~~~ sql
-> IMPORT TABLE customers
-CREATE USING 'azure://acme-co/customer-create-table.sql?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co'
-CSV DATA ('azure://acme-co/customer-import-data.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co')
-;
-~~~
-
-### Manually specify the columns of an imported table
+To manually specify the table schema:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -164,7 +172,35 @@ CSV DATA ('azure://acme-co/customer-import-data.csv?AZURE_ACCOUNT_KEY=hash&AZURE
 ;
 ~~~
 
-### Import a tab-separated file
+To use a file to specify the table schema:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> IMPORT TABLE customers
+CREATE USING 'azure://acme-co/customer-create-table.sql?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co'
+CSV DATA ('azure://acme-co/customer-import-data.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co')
+;
+~~~
+
+### Import a table from multiple CSV files
+
+{% include copy-clipboard.html %}
+~~~ sql
+> IMPORT TABLE customers (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		name TEXT,
+		INDEX name_idx (name)
+)
+CSV DATA (
+    'azure://acme-co/customer-import-data1.1.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.2.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.3.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.4.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.5.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',    
+);
+~~~
+
+### Import a table from a TSV file
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -235,7 +271,7 @@ CockroachDB chooses the decompression codec based on the filename (the common ex
 		name TEXT,
 		INDEX name_idx (name)
 )
-CSV DATA ('azure://acme-co/customer-import-data.csv.gz?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co')
+CSV DATA ('azure://acme-co/customer-import-data.csv.gz?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co)'
 ;
 ~~~
 
@@ -263,7 +299,7 @@ WITH
 
 For the command above to succeed, you need to have created the dump file with specific flags to `pg_dump`.  For more information, see [Migrate from Postgres][postgres].
 
-### Import a single table from a Postgres database dump
+### Import a table from a Postgres database dump
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v2.1/import.md
+++ b/v2.1/import.md
@@ -6,17 +6,17 @@ toc: true
 
 The `IMPORT` [statement](sql-statements.html) imports the following types of data into CockroachDB:
 
-- [CockroachDB dump files](sql-dump.html) <span class="version-tag">New in v2.1</span>
 - [CSV/TSV][csv]
 - [Postgres dump files][postgres]
 - [MySQL dump files][mysql]
+- [CockroachDB dump files](sql-dump.html)
 
 {{site.data.alerts.callout_success}}
 This page has reference information about the `IMPORT` statement.  For instructions and working examples showing how to migrate data from other databases and formats, see the [Migration Overview](migration-overview.html).
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_danger}}
-Note that `IMPORT` only works for creating new tables.  It does not support adding data to existing tables.
+`IMPORT` only works for creating new tables. It does not support adding data to existing tables. Also, `IMPORT` cannot be used within a [transaction](transactions.html).
 {{site.data.alerts.end}}
 
 ## Required privileges
@@ -25,22 +25,38 @@ Only members of the `admin` role can run `IMPORT`. By default, the `root` user b
 
 ## Synopsis
 
+**Import a table from CSV**
+
 <div>
-  {% include {{ page.version.version }}/sql/diagrams/import_table.html %}
+  {% include {{ page.version.version }}/sql/diagrams/import_csv.html %}
 </div>
 
-{{site.data.alerts.callout_info}}The <code>IMPORT</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
+**Import a database or table from dump file**
+
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/import_dump.html %}
+</div>
 
 ## Parameters
 
-| Parameter             | Description                                                                                                                                                                                                                                                   |
-|-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `import_format`       | Currently supported formats: [CSV](#manually-specify-the-columns-of-an-imported-table), [PGDUMP](#import-a-postgres-database-dump), [MYSQLDUMP](#import-a-mysql-database-dump).                                                                               |
-| `file_location`       | The URL of a text file containing one of (depending on its location in the statement): a dump file to import; a CSV file to import; a SQL [`CREATE TABLE`](create-table.html) statement to execute.  For example syntax, see the [Examples](#examples) below. |
-| `table_name`          | The name of the table you want to import/create.                                                                                                                                                                                                              |
-| `table_elem_list`     | The table definition you want to use (see [this example for syntax](#manually-specify-the-columns-of-an-imported-table)).                                                                                                                                     |
-| `file_to_import`      | The URL of the file you want to import.                                                                                                                                                                                                                       |
-| `WITH kv_option_list` | Control your import's behavior with [these options](#import-options).                                                                                                                                                                                         |
+### For import from CSV
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table you want to import/create.
+`table_elem_list` | The table schema you want to use.  
+`CREATE USING file_location` | If not specifying the table schema inline via `table_elem_list`, this is the [URL](#import-file-urls) of a CSV file containing the table schema.
+`file_location` | The [URL](#import-file-urls) of a CSV file containing the table data. This can be a comma-separated list of URLs to CSV files. For an example, see [Import a table from multiple CSV files](#import-a-table-from-multiple-csv-files) below.
+`WITH kv_option_list` | Control your import's behavior with [these options](#import-options).
+
+### For import from dump file
+
+Parameter | Description
+----------|------------
+`table_name` | The name of the table you want to import/create. Use this when the dump file contains a specific table. Leave out `TABLE table_name FROM` when the dump file contains an entire database.
+`import_format` | [PGDUMP](#import-a-postgres-database-dump) or [MYSQLDUMP](#import-a-mysql-database-dump)
+`file_location` | The [URL](#import-file-urls) of a dump file you want to import.
+`WITH kv_option_list` | Control your import's behavior with [these options](#import-options).
 
 ### Import file URLs
 
@@ -87,9 +103,9 @@ You can specify the target database in the table name in the `IMPORT` statement.
 
 Your `IMPORT` statement must reference a `CREATE TABLE` statement representing the schema of the data you want to import.  You have several options:
 
-- Specify the table's columns explicitly from the [SQL client](use-the-built-in-sql-client.html).  For an example, see [Manually specify the columns of an imported table](#manually-specify-the-columns-of-an-imported-table) below.
+- Specify the table's columns explicitly from the [SQL client](use-the-built-in-sql-client.html). For an example, see [Import a table from a CSV file](#import-a-table-from-a-csv-file) below.
 
-- Load a file that already contains a `CREATE TABLE` statement.  For an example, see [Import a Postgres database dump](#import-a-postgres-database-dump) below.
+- Load a file that already contains a `CREATE TABLE` statement. For an example, see [Import a Postgres database dump](#import-a-postgres-database-dump) below.
 
 We also recommend [specifying all secondary indexes you want to use in the `CREATE TABLE` statement](create-table.html#create-a-table-with-secondary-and-inverted-indexes). It is possible to [add secondary indexes later](create-index.html), but it is significantly faster to specify them during import.
 
@@ -141,17 +157,9 @@ After the import has been initiated, you can control it with [`PAUSE JOB`](pause
 
 ## Examples
 
-### Use a `CREATE TABLE` statement from a file
+### Import a table from a CSV file
 
-{% include copy-clipboard.html %}
-~~~ sql
-> IMPORT TABLE customers
-CREATE USING 'azure://acme-co/customer-create-table.sql?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co'
-CSV DATA ('azure://acme-co/customer-import-data.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co')
-;
-~~~
-
-### Manually specify the columns of an imported table
+To manually specify the table schema:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -164,7 +172,35 @@ CSV DATA ('azure://acme-co/customer-import-data.csv?AZURE_ACCOUNT_KEY=hash&AZURE
 ;
 ~~~
 
-### Import a tab-separated file
+To use a file to specify the table schema:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> IMPORT TABLE customers
+CREATE USING 'azure://acme-co/customer-create-table.sql?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co'
+CSV DATA ('azure://acme-co/customer-import-data.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co')
+;
+~~~
+
+### Import a table from multiple CSV files
+
+{% include copy-clipboard.html %}
+~~~ sql
+> IMPORT TABLE customers (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		name TEXT,
+		INDEX name_idx (name)
+)
+CSV DATA (
+    'azure://acme-co/customer-import-data1.1.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.2.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.3.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.4.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',
+    'azure://acme-co/customer-import-data1.5.csv?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co',    
+);
+~~~
+
+### Import a table from a TSV file
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -263,7 +299,7 @@ WITH
 
 For the command above to succeed, you need to have created the dump file with specific flags to `pg_dump`.  For more information, see [Migrate from Postgres][postgres].
 
-### Import a single table from a Postgres database dump
+### Import a table from a Postgres database dump
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -276,7 +312,7 @@ For the command above to succeed, you need to have created the dump file with sp
 
 ### Import a CockroachDB dump file
 
-<span class="version-tag">New in v2.1</span> Cockroach dump files can be imported using the `IMPORT PGDUMP`.
+Cockroach dump files can be imported using the `IMPORT PGDUMP`.
 
 {% include copy-clipboard.html %}
 ~~~ sql


### PR DESCRIPTION
- Generate simplified, distinct diagrams for CSV and dump
- Update paramaters and examples accordingly
- Remove parentheses around instances of file_location

Fixes #4065.