### PR TITLE
Change "Window Functions" page title to title case

### DIFF
--- a/v1.0/window-functions.md
+++ b/v1.0/window-functions.md
@@ -1,5 +1,5 @@
 ---
-title: WINDOW FUNCTIONS
+title: Window Functions
 summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
 toc: false
 ---

--- a/v1.1/window-functions.md
+++ b/v1.1/window-functions.md
@@ -1,5 +1,5 @@
 ---
-title: WINDOW FUNCTIONS
+title: Window Functions
 summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
 toc: false
 ---

--- a/v19.1/window-functions.md
+++ b/v19.1/window-functions.md
@@ -1,5 +1,5 @@
 ---
-title: WINDOW FUNCTIONS
+title: Window Functions
 summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
 toc: true
 ---

--- a/v2.0/window-functions.md
+++ b/v2.0/window-functions.md
@@ -1,5 +1,5 @@
 ---
-title: WINDOW FUNCTIONS
+title: Window Functions
 summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
 toc: false
 ---

--- a/v2.1/window-functions.md
+++ b/v2.1/window-functions.md
@@ -1,5 +1,5 @@
 ---
-title: WINDOW FUNCTIONS
+title: Window Functions
 summary: A window function performs a calculation across a set of table rows that are somehow related to the current row.
 toc: true
 ---


### PR DESCRIPTION
For some reason, the title of the "Window Functions" page was in ALL CAPS
across all CockroachDB versions. Since "window functions" refers to the
general concept as opposed to a SQL keyword, this should be title case
throughout.