### PR TITLE
Update correlated subquery docs

### DIFF
--- a/v19.1/cost-based-optimizer.md
+++ b/v19.1/cost-based-optimizer.md
@@ -46,6 +46,7 @@ The cost-based optimizer supports most SQL statements. Specifically, the followi
 - All [`SELECT`](select.html) statements that do not include window functions
 - All `UNION` statements that do not include window functions
 - All `VALUES` statements that do not include window functions
+- Most correlated subqueries &emdash; for exceptions, see [Correlated subqueries](subqueries.html#correlated-subqueries).
 
 This is not meant to be an exhaustive list. To check whether a particular query will be run with the cost-based optimizer, follow the instructions in the [View query plan](#view-query-plan) section.
 
@@ -335,7 +336,6 @@ Changing the cluster setting does not immediately turn the optimizer off; instea
 ## Known limitations
 
 - Some features are not supported by the cost-based optimizer; however, the optimizer will fall back to the heuristic planner for this functionality. If performance is worse than in previous versions of CockroachDB, you can [turn the optimizer off](#how-to-turn-the-optimizer-off) to manually force it to fallback to the heuristic planner.
-- Some [correlated subqueries](subqueries.html#correlated-subqueries) are not supported by the cost-based optimizer yet. If you come across an unsupported correlated subquery, please [file a Github issue](file-an-issue.html).
 
 ## See also
 

--- a/v19.1/sql-faqs.md
+++ b/v19.1/sql-faqs.md
@@ -52,11 +52,9 @@ Contention](performance-best-practices-overview.html#understanding-and-avoiding-
 
 ## Does CockroachDB support `JOIN`?
 
-[CockroachDB supports SQL joins](joins.html).  We are
-working to improve their execution performance.
+[CockroachDB supports SQL joins](joins.html).  We are working to improve their execution performance.
 
-At this time, some correlated joins, including `LATERAL` joins, are
-not yet supported.
+At this time `LATERAL` joins are not yet supported.  For details, see [this Github issue](https://github.com/cockroachdb/cockroach/issues/24560).
 
 ## When should I use interleaved tables?
 

--- a/v19.1/sql-feature-support.md
+++ b/v19.1/sql-feature-support.md
@@ -123,7 +123,7 @@ table tr td:nth-child(2) {
  Table and View references | ✓ | Standard | [Table expressions documentation](table-expressions.html#table-or-view-names)
  `AS` in table expressions | ✓ | Standard | [Aliased table expressions documentation](table-expressions.html#aliased-table-expressions)
  `JOIN` (`INNER`, `LEFT`, `RIGHT`, `FULL`, `CROSS`) | [Functional](https://www.cockroachlabs.com/blog/better-sql-joins-in-cockroachdb/) | Standard | [Join expressions documentation](table-expressions.html#join-expressions)
- Sub-queries as table expressions | Partial | Standard | Non-correlated subqueries are [supported](table-expressions.html#subqueries-as-table-expressions); some [correlated subqueries](subqueries.html#correlated-subqueries) are not.
+ Sub-queries as table expressions | Partial | Standard | Non-correlated subqueries are [supported](table-expressions.html#subqueries-as-table-expressions), as are most [correlated subqueries](subqueries.html#correlated-subqueries).
  Table generator functions | Partial | PostgreSQL Extension | [Table generator functions documentation](table-expressions.html#table-generator-functions)
  `WITH ORDINALITY` | ✓ | CockroachDB Extension | [Ordinality annotation documentation](table-expressions.html#ordinality-annotation)
 
@@ -139,8 +139,8 @@ table tr td:nth-child(2) {
  `LIKE`/`ILIKE`  | ✓ | Standard | [String pattern matching documentation](scalar-expressions.html#string-pattern-matching)
  `SIMILAR TO` | ✓ | Standard | [SQL regexp pattern matching documentation](scalar-expressions.html#string-matching-using-sql-regular-expressions)
  Matching using POSIX regular expressions  | ✓ | Common Extension | [POSIX regexp pattern matching documentation](scalar-expressions.html#string-matching-using-posix-regular-expressions)
- `EXISTS` | Partial | Standard | Non-correlated subqueries are [supported](scalar-expressions.html#existence-test-on-the-result-of-subqueries); correlated are not. Currently works only with small data sets.
- Scalar subqueries | Partial | Standard | Non-correlated subqueries are [supported](scalar-expressions.html#scalar-subqueries); correlated are not. Currently works only with small data sets.
+ `EXISTS` | Partial | Standard | Non-correlated subqueries are [supported](scalar-expressions.html#existence-test-on-the-result-of-subqueries), as are most [correlated subqueries](subqueries.html#correlated-subqueries). Currently works only with small data sets.
+ Scalar subqueries | Partial | Standard | Non-correlated subqueries are [supported](scalar-expressions.html#scalar-subqueries), as are most [correlated subqueries](subqueries.html#correlated-subqueries). Currently works only with small data sets.
  Bitwise arithmetic | ✓ | Common Extension | [Operators documentation](scalar-expressions.html#unary-and-binary-operations)
  Array constructors and subscripting | Partial | PostgreSQL Extension | Array expression documentation: [Constructor syntax](scalar-expressions.html#array-constructors) and [Subscripting](scalar-expressions.html#subscripted-expressions)
  `COLLATE`| ✓ | Standard | [Collation expressions documentation](scalar-expressions.html#collation-expressions)


### PR DESCRIPTION
Summary of changes:

- Update various docs to note that we now support most correlated
  subqueries, specifically:

  - Correlated subquery section of 'Subqueries' page

  - 'Cost-based Optimizer' page

  - 'SQL FAQ' and 'SQL Feature Support' pages

Fixes #4000.