### PR TITLE
Update ORM docs with foreign key note

### DIFF
--- a/v19.1/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v19.1/build-a-go-app-with-cockroachdb-gorm.md
@@ -44,7 +44,7 @@ $ go get -u github.com/jinzhu/gorm
 
 ## Step 3. Generate a certificate for the `maxroach` user
 
-Create a certificate and key for the `maxroach` user by running the following command.  The code samples will run as this user.
+Create a certificate and key for the `maxroach` user by running the following command. The code samples will run as this user.
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -22,6 +22,10 @@ We have tested the [psycopg2 driver](http://initd.org/psycopg/docs/) and [SQLAlc
 The example code on this page uses Python 3.
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+SQLAlchemy relies on the existence of [foreign keys](foreign-key.html) to generate [`JOIN` expressions](joins.html) from your application code. If you remove foreign keys from your schema, SQLAlchemy won't generate joins for you. As a workaround, you can [create a "custom foreign condition" by adding a `relationship` field to your table objects](https://stackoverflow.com/questions/37806625/sqlalchemy-create-relations-but-without-foreign-key-constraint-in-db), or do the equivalent work in your application.
+{{site.data.alerts.end}}
+
 ## Step 1. Install SQLAlchemy
 
 To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.com/cockroachdb/cockroachdb-python) that accounts for some differences between CockroachDB and PostgreSQL, run the following command:

--- a/v19.1/build-a-ruby-app-with-cockroachdb-activerecord.md
+++ b/v19.1/build-a-ruby-app-with-cockroachdb-activerecord.md
@@ -43,7 +43,7 @@ The exact command above will vary depending on the desired version of ActiveReco
 
 ## Step 3. Generate a certificate for the `maxroach` user
 
-Create a certificate and key for the `maxroach` user by running the following command.  The code samples will run as this user.
+Create a certificate and key for the `maxroach` user by running the following command. The code samples will run as this user.
 
 {% include copy-clipboard.html %}
 ~~~ shell


### PR DESCRIPTION
Fixes #4669.

Summary of changes:

- Note that these ORMs rely on foreign keys to generate joins.  If you
  disable FKs, they won't build the joins for you.  For each ORM, also
  link to the likely API for emitting raw SQL.