### PR TITLE
Added MSO security docs

### DIFF
--- a/_includes/sidebar-data-v19.1.managed.json
+++ b/_includes/sidebar-data-v19.1.managed.json
@@ -69,6 +69,35 @@
     "is_top_level": true,
     "items": [
       {
+        "title": "Secure Your Cluster",
+        "items": [
+          {
+            "title": "Security Overview",
+            "urls": [
+              "/${VERSION}/managed-security-overview.html"
+            ]
+          },
+          {
+            "title": "Authentication",
+            "urls": [
+              "/${VERSION}/managed-authentication.html"
+            ]
+          },
+          {
+            "title": "Authorization",
+            "urls": [
+              "/${VERSION}/managed-authorization.html"
+            ]
+          },
+          {
+            "title": "SQL Audit Logging",
+            "urls": [
+              "/${VERSION}/managed-sql-audit-logging.html"
+            ]
+          }
+        ]
+      },
+      {
         "title": "Migrate Data",
         "items": [
           {
@@ -109,12 +138,6 @@
     "title": "Manage Your Account",
     "is_top_level": true,
     "items": [
-      {
-        "title": "User Management",
-        "urls": [
-          "/${VERSION}/managed-user-management.html"
-        ]
-      },
       {
         "title": "Cluster Management",
         "urls": [

--- a/v19.1/managed-authentication.md
+++ b/v19.1/managed-authentication.md
@@ -1,0 +1,30 @@
+---
+title: Authentication
+summary: Learn about the authentication features for Managed CockroachDB clusters.
+toc: true
+build_for: [managed]
+---
+
+Managed CockroachDB uses TLS 1.2 digital certificates for inter-node authentication, [SSL modes](https://www.postgresql.org/docs/11/libpq-ssl.html) for node identity verification, and password authentication for client identity verification.
+
+## Node identity verification
+
+Managed CockroachDB uses the `verify-full` [SSL mode](https://www.postgresql.org/docs/11/libpq-ssl.html) by default to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Man in the Middle) attacks, impersonation attacks, and eavesdropping.
+
+To connect securely to your cluster using the `verify-full` mode:
+
+1. Download the CA certificate and place it in the `certs` directory. The Certificate Authority (CA) certificate is the file that the client uses to verify the identity of the CockroachDB node.
+2. When connecting to the cluster, specify the path to the `certs` directory in the connection string. See [Connect to your cluster](managed-connect-to-your-cluster.html) for more details.
+
+Managed CockroachDB also supports the `require` SSL mode, although we do not recommend using it since it can make the cluster susceptible to MITM and impersonation attacks. For more information, see the "Protection Provided in Different Modes" section in PostgreSQL's [SSL Support](https://www.postgresql.org/docs/9.4/libpq-ssl.html) document.
+
+## Client identity verification
+
+Managed CockroachDB uses password authentication for verifying a client’s identity. If no password has been set up for a user, password authentication will always fail for that user and you won’t be able to connect to the cluster.
+
+To set a password for a SQL user, [use the Console](managed-authorization.html#use-the-console) or the  [`ALTER USER`](alter-user.html) command.
+
+## See also
+
+- [Client Connection Parameters](connection-parameters.html)
+- [Connect to Your Managed Cluster](managed-connect-to-your-cluster.html)

--- a/v19.1/managed-authentication.md
+++ b/v19.1/managed-authentication.md
@@ -9,7 +9,7 @@ Managed CockroachDB uses TLS 1.2 for inter-node and client-node communication, d
 
 ## Node identity verification
 
-Use the `verify-full` [SSL mode](https://www.postgresql.org/docs/11/libpq-ssl.html) to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Man in the Middle) attacks, impersonation attacks, and eavesdropping.
+The [connection string](managed-connect-to-your-cluster.html) generated to connect to your application uses the `verify-full` [SSL mode](https://www.postgresql.org/docs/11/libpq-ssl.html) by default to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Man in the Middle) attacks, impersonation attacks, and eavesdropping.
 
 To connect securely to your cluster using the `verify-full` mode:
 

--- a/v19.1/managed-authentication.md
+++ b/v19.1/managed-authentication.md
@@ -5,18 +5,18 @@ toc: true
 build_for: [managed]
 ---
 
-Managed CockroachDB uses TLS 1.2 digital certificates for inter-node authentication, [SSL modes](https://www.postgresql.org/docs/11/libpq-ssl.html) for node identity verification, and password authentication for client identity verification.
+Managed CockroachDB uses TLS 1.2 for inter-node and client-node communication, digital certificates for inter-node authentication, [SSL modes](https://www.postgresql.org/docs/11/libpq-ssl.html) for node identity verification, and password authentication for client identity verification.
 
 ## Node identity verification
 
-Managed CockroachDB uses the `verify-full` [SSL mode](https://www.postgresql.org/docs/11/libpq-ssl.html) by default to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Man in the Middle) attacks, impersonation attacks, and eavesdropping.
+Use the `verify-full` [SSL mode](https://www.postgresql.org/docs/11/libpq-ssl.html) to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Man in the Middle) attacks, impersonation attacks, and eavesdropping.
 
 To connect securely to your cluster using the `verify-full` mode:
 
 1. Download the CA certificate and place it in the `certs` directory. The Certificate Authority (CA) certificate is the file that the client uses to verify the identity of the CockroachDB node.
 2. When connecting to the cluster, specify the path to the `certs` directory in the connection string. See [Connect to your cluster](managed-connect-to-your-cluster.html) for more details.
 
-Managed CockroachDB also supports the `require` SSL mode, although we do not recommend using it since it can make the cluster susceptible to MITM and impersonation attacks. For more information, see the "Protection Provided in Different Modes" section in PostgreSQL's [SSL Support](https://www.postgresql.org/docs/9.4/libpq-ssl.html) document.
+You can also use the `require` SSL mode, although we do not recommend using it since it can make the cluster susceptible to MITM and impersonation attacks. For more information, see the "Protection Provided in Different Modes" section in PostgreSQL's [SSL Support](https://www.postgresql.org/docs/9.4/libpq-ssl.html) document.
 
 ## Client identity verification
 

--- a/v19.1/managed-authorization.md
+++ b/v19.1/managed-authorization.md
@@ -1,22 +1,36 @@
 ---
-title: User Management
-summary: Learn how to create SQL users.
+title: Authorization
+summary: Learn about the authorization features for Managed CockroachDB clusters.
 toc: true
 build_for: [managed]
 ---
 
+Managed CockroachDB supports network authorization and user authorization.
+
+## Network authorization
+
+Managed CockroachDB requires you to authorize the networks that can access the cluster. This helps prevent denial-of-service and brute force password attacks.
+
+Authorize your application server’s network and your local machine’s network by adding the IP addresses in the CIDR notation using the [Networking page](managed-connect-to-your-cluster.html#authorize-your-network). If you change your location, you will need to authorize the new location’s network, else the connection from that network will be rejected.
+
+{{site.data.alerts.callout_info}}
+While developing and testing your application, you may whitelist `0.0.0.0/0`, which allows all networks. However, before moving into production, make sure you delete the `0.0.0.0/0` network since it allows anybody who uses your password to access the database and makes your application vulnerable to security breaches.
+{{site.data.alerts.end}}
+
+## User authorization
+
 An `admin` SQL user has full [privileges](authorization.html#assign-privileges) for all databases and tables in your cluster. This user can also create additional users and grant them appropriate privileges.
 
-## Before you begin
+### Before you begin
 
 Make sure you have already [connected to the cluster](managed-connect-to-your-cluster.html) with your `admin` SQL user.
 
-## Create a SQL user
+#### Create a SQL user
 
 - [Use the Console](#use-the-console)
 - [Use the CockroachDB SQL client](#use-the-cockroachdb-sql-client)
 
-### Use the Console
+#### Use the Console
 
 Once you are [logged in](managed-sign-up-for-a-cluster.html#sign-in), you can use the Console to create a new user:
 
@@ -33,7 +47,7 @@ Once you are [logged in](managed-sign-up-for-a-cluster.html#sign-in), you can us
 
     Currently, all new users are created with full privileges. For more information and to change the default settings, see [Granting privileges](#granting-privileges) and [Using roles](#using-roles).
 
-### Use the CockroachDB SQL client
+#### Use the CockroachDB SQL client
 
 Once you have [connected to the cluster's SQL client](managed-connect-to-your-cluster.html#use-the-cockroachdb-sql-client), you can create a new user.
 
@@ -48,7 +62,7 @@ To create a new user, use the [`CREATE USER ... WITH PASSWORD`](create-user.html
 Be sure to create a password for each new user. Without a password, a user cannot connect to the cluster or access the admin UI. To add or change a password for a user, use the [`ALTER USER`](alter-user.html) statement.
 {{site.data.alerts.end}}
 
-## Granting privileges
+### Granting privileges
 
 Access to the data in your cluster is controlled by [privileges](authorization.html#assign-privileges). When a user connects to a database, either via the CockroachDB SQL client or a Postgres driver or ORM, CockroachDB checks the user's privileges for each statement executed. If the user does not have sufficient privileges for a statement, CockroachDB returns an error.
 
@@ -68,7 +82,7 @@ To assign a user more limited privileges for one table in a database:
 
 For more details, see [Privileges](authorization.html#assign-privileges) and [`GRANT`](grant.html).
 
-## Managing SQL users
+### Managing SQL users
 
 - To change a users password, use the [`ALTER USER`](alter-user.html) statement:
 
@@ -95,7 +109,7 @@ For more details, see [Privileges](authorization.html#assign-privileges) and [`G
     All of a user's privileges must be [revoked](#managing-privileges) before the user can be dropped.
     {{site.data.alerts.end}}
 
-## Managing privileges
+### Managing privileges
 
 - To show privileges granted to a user, use the [`SHOW GRANTS`](show-grants.html) statement:
 
@@ -111,7 +125,7 @@ For more details, see [Privileges](authorization.html#assign-privileges) and [`G
     > REVOKE INSERT ON <database>.<table> FROM <user>;
     ~~~
 
-## Using roles
+### Using roles
 
 Role-based access control is an Enterprise feature available to all managed clusters that lets you simplify how you manage privileges. In essence, a role is a group containing any number of other roles and users as members. You can assign privileges to a role, and all direct and indirect members of the role will inherit the privileges.
 
@@ -162,3 +176,8 @@ Role-based access control is an Enterprise feature available to all managed clus
     {{site.data.alerts.callout_info}}
     All of a role's privileges must be [revoked](#managing-privileges) before the user can be dropped.
     {{site.data.alerts.end}}
+
+## See also
+
+- [Client Connection Parameters](connection-parameters.html)
+- [Connect to Your Managed Cluster](managed-connect-to-your-cluster.html)

--- a/v19.1/managed-authorization.md
+++ b/v19.1/managed-authorization.md
@@ -131,6 +131,11 @@ Role-based access control is an Enterprise feature available to all managed clus
 
 - To create a role, use the [`CREATE ROLE`](create-role.html) statement:
 
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > CREATE ROLE <role>;
+    ~~~
+
 - To grant privileges to a role, use the [`GRANT <privilege>`](grant.html) statement:
 
     {% include copy-clipboard.html %}

--- a/v19.1/managed-authorization.md
+++ b/v19.1/managed-authorization.md
@@ -14,7 +14,7 @@ Managed CockroachDB requires you to authorize the networks that can access the c
 Authorize your application server’s network and your local machine’s network by adding the IP addresses in the CIDR notation using the [Networking page](managed-connect-to-your-cluster.html#authorize-your-network). If you change your location, you will need to authorize the new location’s network, else the connection from that network will be rejected.
 
 {{site.data.alerts.callout_info}}
-While developing and testing your application, you may whitelist `0.0.0.0/0`, which allows all networks. However, before moving into production, make sure you delete the `0.0.0.0/0` network since it allows anybody who uses your password to access the database and makes your application vulnerable to security breaches.
+While developing and testing your application, you may whitelist `0.0.0.0/0`, which allows all networks. However, before moving into production, make sure you delete the `0.0.0.0/0` network since it allows anybody who uses your password to reach the CockroachDB nodes.
 {{site.data.alerts.end}}
 
 ## User authorization

--- a/v19.1/managed-authorization.md
+++ b/v19.1/managed-authorization.md
@@ -19,7 +19,7 @@ While developing and testing your application, you may whitelist `0.0.0.0/0`, wh
 
 ## User authorization
 
-An `admin` SQL user has full [privileges](authorization.html#assign-privileges) for all databases and tables in your cluster. This user can also create additional users and grant them appropriate privileges.
+By default, a new SQL user created using the Console is assigned to the `admin` role. An `admin` SQL user has full [privileges](authorization.html#assign-privileges) for all databases and tables in your cluster. This user can also create additional users and grant them appropriate privileges.
 
 ### Before you begin
 
@@ -84,7 +84,7 @@ For more details, see [Privileges](authorization.html#assign-privileges) and [`G
 
 ### Managing SQL users
 
-- To change a users password, use the [`ALTER USER`](alter-user.html) statement:
+- To change a user's password, use the [`ALTER USER`](alter-user.html) statement:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/v19.1/managed-cluster-management.md
+++ b/v19.1/managed-cluster-management.md
@@ -5,7 +5,7 @@ toc: true
 build_for: [managed]
 ---
 
-While you manage your [schema](learn-cockroachdb-sql.html), [data](migration-overview.html), and [users](managed-user-management.html) yourself, for any of the following cluster management tasks, please reach out to Cockroach Labs at [support.cockroachlabs.com](https://support.cockroachlabs.com) and a member of our team will assist you:
+While you manage your [schema](learn-cockroachdb-sql.html), [data](migration-overview.html), and [users](managed-authorization.html#use-the-console) yourself, for any of the following cluster management tasks, please reach out to Cockroach Labs at [support.cockroachlabs.com](https://support.cockroachlabs.com) and a member of our team will assist you:
 
 - Adding or removing nodes
 - Restoring data from a backup

--- a/v19.1/managed-connect-to-your-cluster.md
+++ b/v19.1/managed-connect-to-your-cluster.md
@@ -15,7 +15,7 @@ Once your Managed CockroachDB cluster is available and you've [set your password
 
 2. Make sure you have a SQL user and password to use in your connection string.
 
-    For details on creating additional users, see [User Management](managed-user-management.html).
+    For details on creating additional users, see [User Management](managed-authorization.html#use-the-console).
 
 ## Authorize your network
 

--- a/v19.1/managed-monitoring-page.md
+++ b/v19.1/managed-monitoring-page.md
@@ -17,10 +17,10 @@ To access the Admin UI:
 
     You can also access the Admin UI by navigating to `https://<cluster-name>crdb.io:8080/#/metrics/overview/cluster`. Replace the `<cluster-name>` placeholder with the name of your cluster.
 
-2. Log in with your [SQL username](managed-user-management.html) and password.
+2. Log in with your [SQL username](managed-authorization.html#use-the-console) and password.
 
 {{site.data.alerts.callout_info}}
-For details on creating additional users that can connect to the cluster and access the Admin UI, see [User Management](managed-user-management.html).
+For details on creating additional users that can connect to the cluster and access the Admin UI, see [User Management](managed-authorization.html#use-the-console).
 {{site.data.alerts.end}}
 
 ## Explore the Admin UI

--- a/v19.1/managed-security-overview.md
+++ b/v19.1/managed-security-overview.md
@@ -1,0 +1,17 @@
+---
+title: Managed CockroachDB Security
+summary: Learn about the authentication, encryption, authorization, and audit log features for Managed CockroachDB clusters.
+toc: true
+build_for: [managed]
+---
+
+A Managed CockroachDB cluster is single-tenant (no shared machines) running in a Virtual Private Cloud (no shared network) and has data encryption-in-flight enabled by default. Additionally, Managed CockroachDB provides authentication, authorization, and SQL audit logging features to secure your clusters.
+
+The following table summarizes the Managed CockroachDB security features and provides links to detailed documentation for each feature where applicable.
+
+Security feature | Description
+-------------|------------
+[Authentication](managed-authentication.html) | <ul><li>Inter-node and node identity authentication using TLS 1.2</li><li>Client identity authentication using TLS 1.2 or username/password</li></ul>
+Encryption | <ul><li>Encryption in flight using TLS 1.2</li>
+[Authorization](managed-authorization.html) | <ul><li>User Authorization: <ul><li>Users and privileges</li><li> Role-based access control</li></ul><li>Network authorization</li></ul>
+[Audit logging](managed-sql-audit-logging.html) | `ALTER TABLE...EXPERIMENTAL AUDIT` to get detailed information about queries being executed against your system

--- a/v19.1/managed-sql-audit-logging.md
+++ b/v19.1/managed-sql-audit-logging.md
@@ -1,0 +1,23 @@
+---
+title: SQL Audit Logging
+summary: Learn about the SQL Audit Logging feature for Managed CockroachDB clusters.
+toc: true
+build_for: [managed]
+---
+
+SQL audit logging gives you detailed information about queries being executed against your system. This feature is especially useful when you want to log all queries that are run against a table containing personally identifiable information (PII).
+
+To enable the feature, [enable auditing](#enable-auditing) for a table and then [contact us](https://support.cockroachlabs.com/hc/en-us) to request the audit logs.
+
+## Enable auditing
+
+Use the [`EXPERIMENTAL_AUDIT`](experimental-audit.html) subcommand of [`ALTER TABLE`](alter-table.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE customers EXPERIMENTAL_AUDIT SET READ WRITE;
+~~~
+
+{{site.data.alerts.callout_info}}
+To turn on auditing for more than one table, issue a separate `ALTER` statement for each table.
+{{site.data.alerts.end}}

--- a/v19.1/managed-sql-users-page.md
+++ b/v19.1/managed-sql-users-page.md
@@ -11,4 +11,4 @@ The **SQL Users** page displays a list of SQL users who can access the cluster. 
 
 <img src="{{ 'images/v19.1/managed/sql-users.png' | relative_url }}" alt="SQL users" style="border:1px solid #eee;max-width:100%" />
 
-From the **SQL Users** page, you can add a user by clicking **+ Add User** in the top right corner. For more information, see [User Management](managed-user-management.html).
+From the **SQL Users** page, you can add a user by clicking **+ Add User** in the top right corner. For more information, see [User Management](managed-authorization.html#use-the-console).


### PR DESCRIPTION
Closes #4039

**Summary:**

- Created MSO security docs
- Deleted the user management doc and merged the content with the new managed-authorization doc
- Updated the sidebar nav

**Note for all reviewers:**
I have left out the 'how certs work' section and other conceptual info because I don't think MSO users need to worry about those details. However, I am open to including the details as well - let me know what you think. 

@jseldess After the IA discussion in our last 1:1, I thought it was better to make new documents for the managed security docs since I didn't find much content overlap with the CRDB docs. However, I am open to reuse the CRDB docs and use MSO-specific tags instead. Let me know what you prefer.
