### PR TITLE
Add docs for "transaction deadline exceeded" error, again

### DIFF
--- a/v19.1/common-errors.md
+++ b/v19.1/common-errors.md
@@ -89,13 +89,13 @@ Uncertainty errors are a form of transaction conflict. For more information abou
 
 <span class="version-tag">New in v19.1</span>: Errors which were previously reported to the client as opaque `TransactionStatusError`s are now transaction retry errors with the error message "transaction deadline exceeded" and error code `40001`.
 
-This error can occur in the following cases:
-
-- If long-running transactions (with execution time on the order of minutes) also experience conflicts with other transactions and thus attempt to commit at a timestamp different than their original timestamp. The mechanics of this process are described in [Life of a Distributed Transaction](architecture/life-of-a-distributed-transaction.html).
-
-- If the timestamp at which the transaction attempts to commit is above a "deadline" imposed by the various schema elements that the transaction has used (i.e. table structures).
+This error can occur for long-running transactions (with execution time on the order of minutes) that also experience conflicts with other transactions and thus attempt to commit at a timestamp different than their original timestamp. If the timestamp at which the transaction attempts to commit is above a "deadline" imposed by the various schema elements that the transaction has used (i.e. table structures), then this error might get returned to the client.
 
 When this error occurs, the application must retry the transaction. For more information about how to retry transactions, see [Transaction retries](transactions.html#transaction-retries).
+
+{{site.data.alerts.callout_info}}
+For more information about the mechanics of the transaction conflict resolution process described above, see [Life of a Distributed Transaction](architecture/life-of-a-distributed-transaction.html).
+{{site.data.alerts.end}}
 
 <!-- ### write too old -->
 


### PR DESCRIPTION
(Still) fixes #4552.

Original discussion in #4667 .  This change fixes a technical error I introduced while copy-editing some text of that PR.

Summary of changes (is still):

- Update 'Common Errors' page with:

  - the retry error message

  - a recommendation that the user add retries to their app

  - a description of the state that leads to such errors (kindly
    contributed by Andrei Matei)

  - also spruced up the txn restart section intro with some links to
    reference docs on how txns work in CockroachDB for the curious.