### PR TITLE
Clarify UPSERT vs INSERT ON CONFLICT performance

### DIFF
--- a/v2.1/upsert.md
+++ b/v2.1/upsert.md
@@ -4,7 +4,7 @@ summary: The UPSERT statement inserts rows when values do not violate uniqueness
 toc: true
 ---
 
-The `UPSERT` [statement](sql-statements.html) is short-hand for [`INSERT ON CONFLICT`](insert.html#on-conflict-clause). It inserts rows in cases where specified values do not violate uniqueness constraints, and it updates rows in cases where values do violate uniqueness constraints.
+The `UPSERT` [statement](sql-statements.html) is semantically equivalent to [`INSERT ON CONFLICT`](insert.html#on-conflict-clause), but the two may have slightly different [performance characteristics](#considerations). It inserts rows in cases where specified values do not violate uniqueness constraints, and it updates rows in cases where values do violate uniqueness constraints.
 
 
 ## Considerations


### PR DESCRIPTION
The first sentence appears to contradict info in the following section. They both accomplish the same thing in declarative terms, but they can have quite different performance.