### PR TITLE
Faster local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ standard-build: bootstrap
 
 .PHONY: standard
 standard: jekyll-action := serve --port 4000
-standard: standard-build
+standard: bootstrap
+	bundle exec jekyll $(jekyll-action) --incremental --config _config_base.yml,_config_standard.yml,_config_standard_local.yml,$(extra-config)
 
 .PHONY: managed-build
 managed-build: bootstrap

--- a/_config_base.yml
+++ b/_config_base.yml
@@ -57,7 +57,11 @@ training:
   aws_secret_access_key: wVevB0LO5CDf5lxI9tpy%2FXuE0UZi%2Bmpahiwoa3YL
 
 include: ["_redirects"]
-exclude: ["ci", "vendor", "v1.1/training/unused", "v2.0/training/unused", "v2.1/training/unused", "v19.1/training/unused", "hackathon.md"]
+exclude:
+- "ci"
+- "scripts"
+- "vendor"
+- "hackathon.md"
 
 keep_files: [_internal]
 

--- a/_config_standard_local.yml
+++ b/_config_standard_local.yml
@@ -1,0 +1,8 @@
+exclude:
+- "v1.0"
+- "v1.1"
+- "v2.0"
+- "ci"
+- "scripts"
+- "vendor"
+- "hackathon.md"


### PR DESCRIPTION
This PR adds `_config_standard_local.yml` and adjusts the Makefile to call this config as part of `make standard`. The config excludes the markdown files for all versions earlier than 2.1 and 19.1, dramatically cutting the number of files that get built.

Once we have 19.2 docs, we'll need to update this, and then again when 19.2 becomes the stable version. There's probably a less fragile way to do this, but this is a good first step.

Builds for our live site aren't affected, as they use the `standard-build` and `managed-build` make targets. Local builds of the managed docs also are not affected.

**Performance comparison**

On `master`, a fresh build (`rm -rf _site` and then `make standard`) takes ~42s and incremental changes take ~25s. Subsequent full builds, without clearing `_site`, take ~25s as well.

```
~/go/src/github.com/cockroachdb/docs$ make standard
bundle exec jekyll serve --port 4000 --incremental --config _config_base.yml,_config_standard.yml,
Configuration file: _config_base.yml
Configuration file: _config_standard.yml
Configuration file: _config_base.yml
Configuration file: _config_standard.yml
            Source: /Users/jesseseldess/go/src/github.com/cockroachdb/docs
       Destination: _site/docs
 Incremental build: enabled
      Generating...
                    done in 42.642 seconds.
 Auto-regeneration: enabled for '/Users/jesseseldess/go/src/github.com/cockroachdb/docs'
Configuration file: _config_base.yml
Configuration file: _config_standard.yml
    Server address: http://127.0.0.1:4000/docs/
  Server running... press ctrl-c to stop.
      Regenerating: 1 file(s) changed at 2019-05-18 10:11:07 ...done in 26.331992 seconds.
      Regenerating: 1 file(s) changed at 2019-05-18 10:12:03 ...done in 25.458943 seconds.
```
In contrast, on this branch, a fresh build takes ~25s and incremental changes take ~13s.

```
~/go/src/github.com/cockroachdb/docs$ make standard
bundle exec jekyll serve --port 4000 --incremental --config _config_base.yml,_config_standard.yml,_config_standard_local.yml,
Configuration file: _config_base.yml
Configuration file: _config_standard.yml
Configuration file: _config_standard_local.yml
Configuration file: _config_base.yml
Configuration file: _config_standard.yml
Configuration file: _config_standard_local.yml
            Source: /Users/jesseseldess/go/src/github.com/cockroachdb/docs
       Destination: _site/docs
 Incremental build: enabled
      Generating...
                    done in 25.889 seconds.
 Auto-regeneration: enabled for '/Users/jesseseldess/go/src/github.com/cockroachdb/docs'
Configuration file: _config_base.yml
Configuration file: _config_standard.yml
Configuration file: _config_standard_local.yml
    Server address: http://127.0.0.1:4000/docs/
  Server running... press ctrl-c to stop.
      Regenerating: 1 file(s) changed at 2019-05-18 11:01:46 ...done in 13.403847 seconds.
      Regenerating: 1 file(s) changed at 2019-05-18 11:02:08 ...done in 13.023623 seconds.
```

