### PR TITLE
Remove kubectl reference in helm step

### DIFF
--- a/_includes/v19.1/orchestration/kubernetes-remove-nodes-insecure.md
+++ b/_includes/v19.1/orchestration/kubernetes-remove-nodes-insecure.md
@@ -56,7 +56,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
 2. Note the ID of the node with the highest number in its address (in this case, the address including `cockroachdb-3`) and use the [`cockroach node decommission`](view-node-details.html) command to decommission it:
 
     {{site.data.alerts.callout_info}}
-    It's important to decommission the node with the highest number in its address because, when you reduce the `--replica` count, Kubernetes will remove the pod for that node.
+    It's important to decommission the node with the highest number in its address because, when you reduce the replica count, Kubernetes will remove the pod for that node.
     {{site.data.alerts.end}}
 
     <section class="filter-content" markdown="1" data-scope="manual">

--- a/_includes/v19.1/orchestration/kubernetes-remove-nodes-secure.md
+++ b/_includes/v19.1/orchestration/kubernetes-remove-nodes-secure.md
@@ -51,7 +51,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
 2. Note the ID of the node with the highest number in its address (in this case, the address including `cockroachdb-3`) and use the [`cockroach node decommission`](view-node-details.html) command to decommission it:
 
     {{site.data.alerts.callout_info}}
-    It's important to decommission the node with the highest number in its address because, when you reduce the `--replica` count, Kubernetes will remove the pod for that node.
+    It's important to decommission the node with the highest number in its address because, when you reduce the replica count, Kubernetes will remove the pod for that node.
     {{site.data.alerts.end}}
 
     <section class="filter-content" markdown="1" data-scope="manual">
@@ -94,7 +94,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
     No more data reported on target nodes. Please verify cluster health before removing the nodes.
     ~~~
 
-3. Once the node has been decommissioned, use the `kubectl scale` command to remove a pod from your StatefulSet:
+3. Once the node has been decommissioned, remove a pod from your StatefulSet:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}


### PR DESCRIPTION
In the "remove node" instructions of our secure k8s tutorial, we still reference a `kubectl` command. This PR removes that. 