### PR TITLE
Refine tocs on some deployment tutorials

### DIFF
--- a/v19.1/deploy-cockroachdb-on-aws-insecure.md
+++ b/v19.1/deploy-cockroachdb-on-aws-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -111,7 +110,7 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-aws.md
+++ b/v19.1/deploy-cockroachdb-on-aws.md
@@ -116,7 +116,7 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v19.1/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to deploy an insecure multi-node CockroachDB cluster on 
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -88,7 +87,7 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-digital-ocean.md
+++ b/v19.1/deploy-cockroachdb-on-digital-ocean.md
@@ -15,7 +15,6 @@ This page shows you how to deploy a secure multi-node CockroachDB cluster on Dig
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -92,7 +91,7 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v19.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -39,13 +38,13 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Admin UI
 
- Field | Recommended Value 
+ Field | Recommended Value
 -------|-------------------
- Name | **cockroachadmin** 
- Source filter | IP ranges 
- Source IP ranges | Your local network's IP ranges 
- Allowed protocols... | **tcp:8080** 
- Target tags | **cockroachdb** 
+ Name | **cockroachadmin**
+ Source filter | IP ranges
+ Source IP ranges | Your local network's IP ranges
+ Allowed protocols... | **tcp:8080**
+ Target tags | **cockroachdb**
 
 #### Application data
 
@@ -71,7 +70,7 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 {% include {{ page.version.version }}/prod-deployment/synchronize-clocks.md %}
 
-## Step 4. Set up TCP Proxy Load Balancing
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -111,7 +110,7 @@ To use GCE's TCP Proxy Load Balancing service:
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v19.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -48,7 +48,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it cannot be used across regions. You might also consider using the HAProxy load balancer (see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance).{{site.data.alerts.end}}
 

--- a/v19.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v19.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -48,7 +48,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it cannot be used across regions. You might also consider using the HAProxy load balancer (see the <a href="deploy-cockroachdb-on-premises.html">On-Premises</a> tutorial for guidance).{{site.data.alerts.end}}
 

--- a/v19.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v19.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -39,13 +38,13 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Admin UI
 
- Field | Recommended Value 
+ Field | Recommended Value
 -------|-------------------
- Name | **cockroachadmin** 
- Source filter | IP ranges 
- Source IP ranges | Your local network's IP ranges 
- Allowed protocols... | **tcp:8080** 
- Target tags | **cockroachdb** 
+ Name | **cockroachadmin**
+ Source filter | IP ranges
+ Source IP ranges | Your local network's IP ranges
+ Allowed protocols... | **tcp:8080**
+ Target tags | **cockroachdb**
 
 #### Application data
 
@@ -71,7 +70,7 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 {% include {{ page.version.version }}/prod-deployment/synchronize-clocks.md %}
 
-## Step 4. Set up TCP Proxy Load Balancing
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -115,7 +114,7 @@ To use GCE's TCP Proxy Load Balancing service:
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v19.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -40,32 +39,32 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachadmin** 
-         Source | **IP Addresses** 
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **8080** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Name | **cockroachadmin**
+         Source | **IP Addresses**
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **8080**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
     - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you will not need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachapp** 
+         Name | **cockroachapp**
          Source | **IP Addresses**
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **26257** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **26257**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
 
 
 ## Step 2. Create VMs
@@ -122,7 +121,7 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v19.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -38,32 +37,32 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachadmin** 
-         Source | **IP Addresses** 
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **8080** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Name | **cockroachadmin**
+         Source | **IP Addresses**
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **8080**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
     - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you will not need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachapp** 
-         Source | **IP Addresses** 
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **26257** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Name | **cockroachapp**
+         Source | **IP Addresses**
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **26257**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
 
 ## Step 2. Create VMs
 
@@ -123,7 +122,7 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-premises-insecure.md
+++ b/v19.1/deploy-cockroachdb-on-premises-insecure.md
@@ -40,7 +40,7 @@ This tutorial shows you how to manually deploy an insecure multi-node CockroachD
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-cluster.md %}
 
-## Step 5. Set up HAProxy load balancers
+## Step 5. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -101,7 +101,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 7. Set up monitoring and alerting
+## Step 7. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/deploy-cockroachdb-on-premises.md
+++ b/v19.1/deploy-cockroachdb-on-premises.md
@@ -44,7 +44,7 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-cluster.md %}
 
-## Step 6. Set up HAProxy load balancers
+## Step 6. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -95,7 +95,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 8. Set up monitoring and alerting
+## Step 8. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.1/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v19.1/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -1,6 +1,6 @@
 ---
 title: Orchestration with Kubernetes (Insecure)
-summary: Orchestrate the deployment and management of an local cluster using Kubernetes.
+summary: Orchestrate the deployment and management of a local cluster using Kubernetes.
 toc: true
 ---
 

--- a/v19.1/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v19.1/orchestrate-a-local-cluster-with-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 title: Orchestrate a Local Cluster with Kubernetes
-summary: Orchestrate the deployment and management of an local cluster using Kubernetes.
+summary: Orchestrate the deployment and management of a local cluster using Kubernetes.
 toc: true
 secure: true
 redirect_from: orchestration-with-kubernetes.html

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -2,6 +2,7 @@
 title: Orchestrate CockroachDB in a Single Kubernetes Cluster (Insecure)
 summary: How to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster with Kubernetes.
 toc: true
+toc_not_nested: true
 ---
 
 <div class="filters filters-big clearfix">
@@ -21,6 +22,9 @@ If you plan to use CockroachDB in production, we strongly recommend using a secu
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
 
+- [Kubernetes terminology](#kubernetes-terminology)
+- [Limitations](#limitations)
+
 ### Kubernetes terminology
 
 Feature | Description
@@ -29,6 +33,7 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 [pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one of more Docker containers. In this tutorial, each pod will run on a separate instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods and grow to 4.
 [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A StatefulSet is a group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
 [persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A persistent volume is a piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
+</details>
 
 ### Limitations
 
@@ -67,11 +72,16 @@ To start your CockroachDB cluster, you can either use our StatefulSet configurat
 
 {% include {{ page.version.version }}/orchestration/kubernetes-simulate-failure.md %}
 
-## Step 6. Set up monitoring and alerting
+## Step 6. Monitor the cluster
 
 {% include {{ page.version.version }}/orchestration/kubernetes-prometheus-alertmanager.md %}
 
 ## Step 7. Maintain the cluster
+
+- [Add nodes](#add-nodes)
+- [Remove nodes](#remove-nodes)
+- [Upgrade the cluster](#upgrade-the-cluster)
+- [Stop the cluster](#stop-the-cluster)
 
 ### Add nodes
 

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -2,6 +2,7 @@
 title: Orchestrate CockroachDB Across Multiple Kubernetes Clusters
 summary: How to use Kubernetes to orchestrate the deployment, management, and monitoring of an insecure CockroachDB cluster across multiple Kubernetes clusters in different regions.
 toc: true
+toc_not_nested: true
 redirect_from: orchetrate-cockroachdb-with-kubernetes-multi-region.html
 ---
 
@@ -12,6 +13,10 @@ To deploy in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
+
+- [Kubernetes terminology](#kubernetes-terminology)
+- [UX differences from running in a single cluster](ux-differences-from-running-in-a-single-cluster)
+- [Limitations](#limitations)
 
 ### Kubernetes terminology
 
@@ -410,6 +415,10 @@ To see this in action:
     ~~~
 
 ## Step 6. Maintain the cluster
+
+- [Scale the cluster](#scale-the-cluster)
+- [Upgrade the cluster](#upgrade-the-cluster)
+- [Stop the cluster](#stop-the-cluster)
 
 ### Scale the cluster
 

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -15,7 +15,7 @@ To deploy in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
 
 - [Kubernetes terminology](#kubernetes-terminology)
-- [UX differences from running in a single cluster](ux-differences-from-running-in-a-single-cluster)
+- [UX differences from running in a single cluster](#ux-differences-from-running-in-a-single-cluster)
 - [Limitations](#limitations)
 
 ### Kubernetes terminology

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -2,6 +2,7 @@
 title: Orchestrate CockroachDB in a Single Kubernetes Cluster
 summary: How to orchestrate the deployment, management, and monitoring of a secure 3-node CockroachDB cluster with Kubernetes.
 toc: true
+toc_not_nested: true
 secure: true
 ---
 
@@ -17,6 +18,9 @@ To deploy across multiple Kubernetes clusters in different geographic regions in
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
+
+- [Kubernetes terminology](#kubernetes-terminology)
+- [Limitations](#limitations)
 
 ### Kubernetes terminology
 
@@ -66,11 +70,16 @@ To start your CockroachDB cluster, you can either use our StatefulSet configurat
 
 {% include {{ page.version.version }}/orchestration/kubernetes-simulate-failure.md %}
 
-## Step 6. Set up monitoring and alerting
+## Step 6. Monitor the cluster
 
 {% include {{ page.version.version }}/orchestration/kubernetes-prometheus-alertmanager.md %}
 
 ## Step 7. Maintain the cluster
+
+- [Add nodes](#add-nodes)
+- [Remove nodes](#remove-nodes)
+- [Upgrade the cluster](#upgrade-the-cluster)
+- [Stop the cluster](#stop-the-cluster)
 
 ### Add nodes
 

--- a/v19.1/recommended-production-settings.md
+++ b/v19.1/recommended-production-settings.md
@@ -208,11 +208,11 @@ For guidance on load balancing, see the tutorial for your deployment environment
 
 Environment | Featured Approach
 ------------|---------------------
-[On-Premises](deploy-cockroachdb-on-premises.html#step-6-set-up-haproxy-load-balancers) | Use HAProxy.
+[On-Premises](deploy-cockroachdb-on-premises.html#step-6-set-up-load-balancing) | Use HAProxy.
 [AWS](deploy-cockroachdb-on-aws.html#step-4-set-up-load-balancing) | Use Amazon's managed load balancing service.
 [Azure](deploy-cockroachdb-on-microsoft-azure.html#step-4-set-up-load-balancing) | Use Azure's managed load balancing service.
 [Digital Ocean](deploy-cockroachdb-on-digital-ocean.html#step-3-set-up-load-balancing) | Use Digital Ocean's managed load balancing service.
-[GCP](deploy-cockroachdb-on-google-cloud-platform.html#step-4-set-up-tcp-proxy-load-balancing) | Use GCP's managed TCP proxy load balancing service.
+[GCP](deploy-cockroachdb-on-google-cloud-platform.html#step-4-set-up-load-balancing) | Use GCP's managed TCP proxy load balancing service.
 
 ## Monitoring and alerting
 

--- a/v19.2/deploy-cockroachdb-on-aws-insecure.md
+++ b/v19.2/deploy-cockroachdb-on-aws-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -111,7 +110,7 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-aws.md
+++ b/v19.2/deploy-cockroachdb-on-aws.md
@@ -16,7 +16,6 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -116,7 +115,7 @@ AWS offers fully-managed load balancing to distribute traffic between instances.
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v19.2/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to deploy an insecure multi-node CockroachDB cluster on 
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -88,7 +87,7 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-digital-ocean.md
+++ b/v19.2/deploy-cockroachdb-on-digital-ocean.md
@@ -15,7 +15,6 @@ This page shows you how to deploy a secure multi-node CockroachDB cluster on Dig
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -92,7 +91,7 @@ For guidance, you can use Digital Ocean's guide to configuring firewalls based o
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v19.2/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -39,13 +38,13 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Admin UI
 
- Field | Recommended Value 
+ Field | Recommended Value
 -------|-------------------
- Name | **cockroachadmin** 
- Source filter | IP ranges 
- Source IP ranges | Your local network's IP ranges 
- Allowed protocols... | **tcp:8080** 
- Target tags | **cockroachdb** 
+ Name | **cockroachadmin**
+ Source filter | IP ranges
+ Source IP ranges | Your local network's IP ranges
+ Allowed protocols... | **tcp:8080**
+ Target tags | **cockroachdb**
 
 #### Application data
 
@@ -71,7 +70,7 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 {% include {{ page.version.version }}/prod-deployment/synchronize-clocks.md %}
 
-## Step 4. Set up TCP Proxy Load Balancing
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -111,7 +110,7 @@ To use GCE's TCP Proxy Load Balancing service:
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v19.2/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -48,7 +48,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it cannot be used across regions. You might also consider using the HAProxy load balancer (see <a href="manual-deployment-insecure.html">Manual Deployment</a> for guidance).{{site.data.alerts.end}}
 

--- a/v19.2/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v19.2/deploy-cockroachdb-on-google-cloud-platform.md
@@ -48,7 +48,7 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Application data
 
-Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-tcp-proxy-load-balancing).
+Applications will not connect directly to your CockroachDB nodes. Instead, they'll connect to GCE's TCP Proxy Load Balancing service, which automatically routes traffic to the instances that are closest to the user. Because this service is implemented at the edge of the Google Cloud, you'll need to create a firewall rule to allow traffic from the load balancer and health checker to your instances. This is covered in [Step 4](#step-4-set-up-load-balancing).
 
 {{site.data.alerts.callout_danger}}When using TCP Proxy Load Balancing, you cannot use firewall rules to control access to the load balancer. If you need such control, consider using <a href="https://cloud.google.com/compute/docs/load-balancing/network/">Network TCP Load Balancing</a> instead, but note that it cannot be used across regions. You might also consider using the HAProxy load balancer (see the <a href="deploy-cockroachdb-on-premises.html">On-Premises</a> tutorial for guidance).{{site.data.alerts.end}}
 

--- a/v19.2/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v19.2/deploy-cockroachdb-on-google-cloud-platform.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -39,13 +38,13 @@ When creating firewall rules, we recommend using Google Cloud Platform's **tag**
 
 #### Admin UI
 
- Field | Recommended Value 
+ Field | Recommended Value
 -------|-------------------
- Name | **cockroachadmin** 
- Source filter | IP ranges 
- Source IP ranges | Your local network's IP ranges 
- Allowed protocols... | **tcp:8080** 
- Target tags | **cockroachdb** 
+ Name | **cockroachadmin**
+ Source filter | IP ranges
+ Source IP ranges | Your local network's IP ranges
+ Allowed protocols... | **tcp:8080**
+ Target tags | **cockroachdb**
 
 #### Application data
 
@@ -71,7 +70,7 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 {% include {{ page.version.version }}/prod-deployment/synchronize-clocks.md %}
 
-## Step 4. Set up TCP Proxy Load Balancing
+## Step 4. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -115,7 +114,7 @@ To use GCE's TCP Proxy Load Balancing service:
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v19.2/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy an insecure multi-node CockroachDB cl
 
 {{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/insecure-requirements.md %}
@@ -40,32 +39,32 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachadmin** 
-         Source | **IP Addresses** 
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **8080** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Name | **cockroachadmin**
+         Source | **IP Addresses**
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **8080**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
     - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you will not need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachapp** 
+         Name | **cockroachapp**
          Source | **IP Addresses**
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **26257** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **26257**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
 
 
 ## Step 2. Create VMs
@@ -122,7 +121,7 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 9. Set up monitoring and alerting
+## Step 9. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v19.2/deploy-cockroachdb-on-microsoft-azure.md
@@ -15,7 +15,6 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -38,32 +37,32 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 3. [Create a Network Security Group](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-create-nsg-arm-pportal) that uses your **Resource Group**, and then add the following **inbound** rules to it:
     - **Admin UI support**:
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachadmin** 
-         Source | **IP Addresses** 
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **8080** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Name | **cockroachadmin**
+         Source | **IP Addresses**
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **8080**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
     - **Application support**:
 
         {{site.data.alerts.callout_success}}If your application is also hosted on the same Azure     Virtual Network, you will not need to create a firewall rule for your application to communicate     with your load balancer.{{site.data.alerts.end}}
 
-         Field | Recommended Value 
+         Field | Recommended Value
         -------|-------------------
-         Name | **cockroachapp** 
-         Source | **IP Addresses** 
-         Source IP addresses/CIDR ranges | Your local network’s IP ranges 
-         Source port ranges | * 
-         Destination | **Any** 
-         Destination port range | **26257** 
-         Protocol | **TCP** 
-         Action | **Allow** 
-         Priority | Any value > 1000 
+         Name | **cockroachapp**
+         Source | **IP Addresses**
+         Source IP addresses/CIDR ranges | Your local network’s IP ranges
+         Source port ranges | *
+         Destination | **Any**
+         Destination port range | **26257**
+         Protocol | **TCP**
+         Action | **Allow**
+         Priority | Any value > 1000
 
 ## Step 2. Create VMs
 
@@ -123,7 +122,7 @@ Microsoft Azure offers fully-managed load balancing to distribute traffic betwee
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 10. Set up monitoring and alerting
+## Step 10. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-premises-insecure.md
+++ b/v19.2/deploy-cockroachdb-on-premises-insecure.md
@@ -40,7 +40,7 @@ This tutorial shows you how to manually deploy an insecure multi-node CockroachD
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-cluster.md %}
 
-## Step 5. Set up HAProxy load balancers
+## Step 5. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -101,7 +101,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 {% include {{ page.version.version }}/prod-deployment/insecure-test-load-balancing.md %}
 
-## Step 7. Set up monitoring and alerting
+## Step 7. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/deploy-cockroachdb-on-premises.md
+++ b/v19.2/deploy-cockroachdb-on-premises.md
@@ -15,7 +15,6 @@ This tutorial shows you how to manually deploy a secure multi-node CockroachDB c
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
-
 ## Requirements
 
 {% include {{ page.version.version }}/prod-deployment/secure-requirements.md %}
@@ -44,7 +43,7 @@ If you are only testing CockroachDB, or you are not concerned with protecting ne
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-cluster.md %}
 
-## Step 6. Set up HAProxy load balancers
+## Step 6. Set up load balancing
 
 Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to ensure client performance and reliability, it's important to use load balancing:
 
@@ -95,7 +94,7 @@ Each CockroachDB node is an equally suitable SQL gateway to your cluster, but to
 
 {% include {{ page.version.version }}/prod-deployment/secure-test-load-balancing.md %}
 
-## Step 8. Set up monitoring and alerting
+## Step 8. Monitor the cluster
 
 {% include {{ page.version.version }}/prod-deployment/monitor-cluster.md %}
 

--- a/v19.2/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v19.2/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -1,6 +1,6 @@
 ---
 title: Orchestration with Kubernetes (Insecure)
-summary: Orchestrate the deployment and management of an local cluster using Kubernetes.
+summary: Orchestrate the deployment and management of a local cluster using Kubernetes.
 toc: true
 ---
 

--- a/v19.2/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v19.2/orchestrate-a-local-cluster-with-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 title: Orchestrate a Local Cluster with Kubernetes
-summary: Orchestrate the deployment and management of an local cluster using Kubernetes.
+summary: Orchestrate the deployment and management of a local cluster using Kubernetes.
 toc: true
 secure: true
 redirect_from: orchestration-with-kubernetes.html

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -2,6 +2,7 @@
 title: Orchestrate CockroachDB in a Single Kubernetes Cluster (Insecure)
 summary: How to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster with Kubernetes.
 toc: true
+toc_not_nested: true
 ---
 
 <div class="filters filters-big clearfix">
@@ -20,6 +21,9 @@ If you plan to use CockroachDB in production, we strongly recommend using a secu
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
+
+- [Kubernetes terminology](#kubernetes-terminology)
+- [Limitations](#limitations)
 
 ### Kubernetes terminology
 
@@ -67,11 +71,16 @@ To start your CockroachDB cluster, you can either use our StatefulSet configurat
 
 {% include {{ page.version.version }}/orchestration/kubernetes-simulate-failure.md %}
 
-## Step 6. Set up monitoring and alerting
+## Step 6. Monitor the cluster
 
 {% include {{ page.version.version }}/orchestration/kubernetes-prometheus-alertmanager.md %}
 
 ## Step 7. Maintain the cluster
+
+- [Add nodes](#add-nodes)
+- [Remove nodes](#remove-nodes)
+- [Upgrade the cluster](#upgrade-the-cluster)
+- [Stop the cluster](#stop-the-cluster)
 
 ### Add nodes
 

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -2,6 +2,7 @@
 title: Orchestrate CockroachDB Across Multiple Kubernetes Clusters
 summary: How to use Kubernetes to orchestrate the deployment, management, and monitoring of an insecure CockroachDB cluster across multiple Kubernetes clusters in different regions.
 toc: true
+toc_not_nested: true
 redirect_from: orchetrate-cockroachdb-with-kubernetes-multi-region.html
 ---
 
@@ -12,6 +13,10 @@ To deploy in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
+
+- [Kubernetes terminology](#kubernetes-terminology)
+- [UX differences from running in a single cluster](ux-differences-from-running-in-a-single-cluster)
+- [Limitations](#limitations)
 
 ### Kubernetes terminology
 
@@ -410,6 +415,10 @@ To see this in action:
     ~~~
 
 ## Step 6. Maintain the cluster
+
+- [Scale the cluster](#scale-the-cluster)
+- [Upgrade the cluster](#upgrade-the-cluster)
+- [Stop the cluster](#stop-the-cluster)
 
 ### Scale the cluster
 

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -15,7 +15,7 @@ To deploy in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
 
 - [Kubernetes terminology](#kubernetes-terminology)
-- [UX differences from running in a single cluster](ux-differences-from-running-in-a-single-cluster)
+- [UX differences from running in a single cluster](#ux-differences-from-running-in-a-single-cluster)
 - [Limitations](#limitations)
 
 ### Kubernetes terminology

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -2,6 +2,7 @@
 title: Orchestrate CockroachDB in a Single Kubernetes Cluster
 summary: How to orchestrate the deployment, management, and monitoring of a secure 3-node CockroachDB cluster with Kubernetes.
 toc: true
+toc_not_nested: true
 secure: true
 ---
 
@@ -17,6 +18,9 @@ To deploy across multiple Kubernetes clusters in different geographic regions in
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.
+
+- [Kubernetes terminology](#kubernetes-terminology)
+- [Limitations](#limitations)
 
 ### Kubernetes terminology
 
@@ -66,11 +70,16 @@ To start your CockroachDB cluster, you can either use our StatefulSet configurat
 
 {% include {{ page.version.version }}/orchestration/kubernetes-simulate-failure.md %}
 
-## Step 6. Set up monitoring and alerting
+## Step 6. Monitor the cluster
 
 {% include {{ page.version.version }}/orchestration/kubernetes-prometheus-alertmanager.md %}
 
 ## Step 7. Maintain the cluster
+
+- [Add nodes](#add-nodes)
+- [Remove nodes](#remove-nodes)
+- [Upgrade the cluster](#upgrade-the-cluster)
+- [Stop the cluster](#stop-the-cluster)
 
 ### Add nodes
 

--- a/v19.2/recommended-production-settings.md
+++ b/v19.2/recommended-production-settings.md
@@ -208,11 +208,11 @@ For guidance on load balancing, see the tutorial for your deployment environment
 
 Environment | Featured Approach
 ------------|---------------------
-[On-Premises](deploy-cockroachdb-on-premises.html#step-6-set-up-haproxy-load-balancers) | Use HAProxy.
+[On-Premises](deploy-cockroachdb-on-premises.html#step-6-set-up-load-balancing) | Use HAProxy.
 [AWS](deploy-cockroachdb-on-aws.html#step-4-set-up-load-balancing) | Use Amazon's managed load balancing service.
 [Azure](deploy-cockroachdb-on-microsoft-azure.html#step-4-set-up-load-balancing) | Use Azure's managed load balancing service.
 [Digital Ocean](deploy-cockroachdb-on-digital-ocean.html#step-3-set-up-load-balancing) | Use Digital Ocean's managed load balancing service.
-[GCP](deploy-cockroachdb-on-google-cloud-platform.html#step-4-set-up-tcp-proxy-load-balancing) | Use GCP's managed TCP proxy load balancing service.
+[GCP](deploy-cockroachdb-on-google-cloud-platform.html#step-4-set-up-load-balancing) | Use GCP's managed TCP proxy load balancing service.
 
 ## Monitoring and alerting
 


### PR DESCRIPTION
- Use consistent terminology across pages.
- Exclude h3s from these tocs but add links under relevent h2s.

This increases the whitespace under tocs for other purposes.

Fixes #4980.