### PR TITLE
Be more cautious about windows

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -3,188 +3,277 @@
     - date: Jun 17, 2019
       version: v19.1.2
       latest: true
+      no_windows: true
     - date: May 20, 2019
       version: v19.1.1
+      no_windows: true
     - date: Apr 30, 2019
       version: v19.1.0
+      no_windows: true
     - date: May 14, 2019
       version: v2.1.7
+      no_windows: true
     - date: Mar 11, 2019
       version: v2.1.6
+      no_windows: true
     - date: Feb 19, 2019
       version: v2.1.5
+      no_windows: true
     - date: Jan 22, 2019
       version: v2.1.4
+      no_windows: true
     - date: Dec 17, 2018
       version: v2.1.3
+      no_windows: true
     - date: Dec 10, 2018
       version: v2.1.2
+      no_windows: true
     - date: Nov 19, 2018
       version: v2.1.1
+      no_windows: true
     - date: Oct 30, 2018
       version: v2.1.0
+      no_windows: true
     - date: Dec 10, 2018
       version: v2.0.7
+      no_windows: true
     - date: Oct 1, 2018
       version: v2.0.6
+      no_windows: true
     - date: Aug 13, 2018
       version: v2.0.5
+      no_windows: true
     - date: Jul 16, 2018
       version: v2.0.4
+      no_windows: true
     - date: Jun 18, 2018
       version: v2.0.3
+      no_windows: true
     - date: May 21, 2018
       version: v2.0.2
+      no_windows: true
     - date: Apr 23, 2018
       version: v2.0.1
+      no_windows: true
     - date: Apr 4, 2018
       version: v2.0.0
+      no_windows: true
     - date: Oct 1, 2018
       version: v1.1.9
+      no_windows: true
     - date: Apr 23, 2018
       version: v1.1.8
+      no_windows: true
     - date: Mar 26, 2018
       version: v1.1.7
+      no_windows: true
     - date: Mar 12, 2018
       version: v1.1.6
+      no_windows: true
     - date: Feb 5, 2018
       version: v1.1.5
+      no_windows: true
     - date: Jan 8, 2018
       version: v1.1.4
+      no_windows: true
     - date: Nov 27, 2017
       version: v1.1.3
+      no_windows: true
     - date: Nov 2, 2017
       version: v1.1.2
+      no_windows: true
     - date: Oct 19, 2017
       version: v1.1.1
+      no_windows: true
     - date: Oct 12, 2017
       version: v1.1.0
+      no_windows: true
     - date: Feb 13, 2017
       version: v1.0.7
+      no_windows: true
     - date: Sep 14, 2017
       version: v1.0.6
+      no_windows: true
     - date: Aug 24, 2017
       version: v1.0.5
+      no_windows: true
     - date: Jul 27, 2017
       version: v1.0.4
+      no_windows: true
     - date: Jul 6, 2017
       version: v1.0.3
+      no_windows: true
     - date: Jun 15, 2017
       version: v1.0.2
+      no_windows: true
     - date: May 25, 2017
       version: v1.0.1
+      no_windows: true
     - date: May 10, 2017
       version: v1.0
+      no_windows: true
 - title: Testing Releases
   releases:
     - date: Jun 6, 2019
       version: v19.2.0-alpha.20190606
+      no_windows: true
     - date: Apr 25, 2019
       version: v19.1.0-rc.4
+      no_windows: true
     - date: Apr 15, 2019
       version: v19.1.0-rc.3
+      no_windows: true
     - date: Apr 8, 2019
       version: v19.1.0-rc.2
+      no_windows: true
     - date: Apr 2, 2019
       version: v19.1.0-rc.1
+      no_windows: true
     - date: Mar 18, 2019
       version: v19.1.0-beta.20190318
+      no_windows: true
     - date: Mar 4, 2019
       version: v19.1.0-beta.20190304
+      no_windows: true
     - date: Feb 25, 2019
       version: v19.1.0-beta.20190225
+      no_windows: true
     - date: Feb 11, 2019
       version: v2.2.0-alpha.20190211
+      no_windows: true
     - date: Jan 14, 2019
       version: v2.2.0-alpha.20190114
+      no_windows: true
     - date: Dec 17, 2018
       version: v2.2.0-alpha.20181217
+      no_windows: true
     - date: Nov 19, 2018
       version: v2.2.0-alpha.20181119
+      no_windows: true
     - date: Oct 25, 2018
       version: v2.1.0-rc.2
+      no_windows: true
     - date: Oct 22, 2018
       version: v2.1.0-rc.1
+      no_windows: true
     - date: Oct 15, 2018
       version: v2.1.0-beta.20181015
+      no_windows: true
     - date: Oct 8, 2018
       version: v2.1.0-beta.20181008
+      no_windows: true
     - date: Oct 1, 2018
       version: v2.1.0-beta.20181001
+      no_windows: true
     - date: Sep 24, 2018
       version: v2.1.0-beta.20180924
+      no_windows: true
     - date: Sep 17, 2018
       version: v2.1.0-beta.20180917
+      no_windows: true
     - date: Sep 10, 2018
       version: v2.1.0-beta.20180910
+      no_windows: true
     - date: Sep 4, 2018
       version: v2.1.0-beta.20180904
+      no_windows: true
     - date: Aug 27, 2018
       version: v2.1.0-beta.20180827
+      no_windows: true
     - date: Jul 30, 2018
       version: v2.1.0-alpha.20180730
+      no_windows: true
     - date: Jul 02, 2018
       version: v2.1.0-alpha.20180702
+      no_windows: true
     - date: Jun 04, 2018
       version: v2.1.0-alpha.20180604
+      no_windows: true
     - date: May 07, 2018
       version: v2.1.0-alpha.20180507
+      no_windows: true
     - date: Apr 16, 2018
       version: v2.1.0-alpha.20180416
+      no_windows: true
     - date: Apr 2, 2018
       version: v2.0-rc.1
+      no_windows: true
     - date: Mar 26, 2018
       version: v2.0-beta.20180326
+      no_windows: true
     - date: Mar 19, 2018
       version: v2.0-beta.20180319
+      no_windows: true
     - date: Mar 12, 2018
       version: v2.0-beta.20180312
+      no_windows: true
     - date: Mar 5, 2018
       version: v2.0-beta.20180305
+      no_windows: true
     - date: Jan 29, 2018
       version: v2.0-alpha.20180129
       no_windows: true
     - date: Dec 18, 2017
       version: v2.0-alpha.20171218
+      no_windows: true
     - date: Dec 11, 2017
       version: v1.2-alpha.20171211
+      no_windows: true
     - date: Dec 4, 2017
       version: v1.2-alpha.20171204
+      no_windows: true
     - date: Nov 13, 2017
       version: v1.2-alpha.20171113
       no_source: true
+      no_windows: true
     - date: Oct 26, 2017
       version: v1.2-alpha.20171026
+      no_windows: true
     - date: Oct 5, 2017
       version: v1.1.0-rc.1
+      no_windows: true
     - date: Sep 28, 2017
       version: v1.1-beta.20170928
+      no_windows: true
     - date: Sep 21, 2017
       version: v1.1-beta.20170921
+      no_windows: true
     - date: Sep 7, 2017
       version: v1.1-beta.20170907
+      no_windows: true
     - date: Aug 17, 2017
       version: v1.1-alpha.20170817
+      no_windows: true
     - date: Aug 10, 2017
       version: v1.1-alpha.20170810
+      no_windows: true
     - date: Aug 3, 2017
       version: v1.1-alpha.20170803
+      no_windows: true
     - date: Jul 20, 2017
       version: v1.1-alpha.20170720
+      no_windows: true
     - date: Jul 13, 2017
       version: v1.1-alpha.20170713
+      no_windows: true
     - date: Jun 29, 2017
       version: v1.1-alpha.20170629
+      no_windows: true
     - date: Jun 22, 2017
       version: v1.1-alpha.20170622
+      no_windows: true
     - date: Jun 8, 2017
       version: v1.1-alpha.20170608
+      no_windows: true
     - date: Jun 1, 2017
       version: v1.1-alpha.20170601
+      no_windows: true
     - date: May 5, 2017
       version: v1.0-rc.2
+      no_windows: true
     - date: May 1, 2017
       version: v1.0-rc.1
+      no_windows: true
     - date: Apr 20, 2017
       version: beta-20170420
       no_windows: true

--- a/releases/v1.0-rc.1.md
+++ b/releases/v1.0-rc.1.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0-rc.2.md
+++ b/releases/v1.0-rc.2.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0-rc.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.1.md
+++ b/releases/v1.0.1.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.2.md
+++ b/releases/v1.0.2.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.3.md
+++ b/releases/v1.0.3.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.3.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.3.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.3.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.3.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.4.md
+++ b/releases/v1.0.4.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.4.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.4.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.4.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.4.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.5.md
+++ b/releases/v1.0.5.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.5.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.5.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.5.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.5.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.6.md
+++ b/releases/v1.0.6.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.6.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.6.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.6.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.6.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.7.md
+++ b/releases/v1.0.7.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.7.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.7.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.7.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.7.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.0.md
+++ b/releases/v1.0.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.0.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.0.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170601.md
+++ b/releases/v1.1-alpha.20170601.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170601.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170608.md
+++ b/releases/v1.1-alpha.20170608.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170608.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170608.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170608.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170608.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170622.md
+++ b/releases/v1.1-alpha.20170622.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170622.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170622.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170622.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170622.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170629.md
+++ b/releases/v1.1-alpha.20170629.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170629.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170629.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170629.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170629.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170713.md
+++ b/releases/v1.1-alpha.20170713.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170713.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170713.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170713.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170713.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170720.md
+++ b/releases/v1.1-alpha.20170720.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170720.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170720.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170720.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170720.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170803.md
+++ b/releases/v1.1-alpha.20170803.md
@@ -27,7 +27,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170803.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170803.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170803.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170803.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170810.md
+++ b/releases/v1.1-alpha.20170810.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170810.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170810.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170810.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170810.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-alpha.20170817.md
+++ b/releases/v1.1-alpha.20170817.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170817.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170817.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170817.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-alpha.20170817.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-beta.20170907.md
+++ b/releases/v1.1-beta.20170907.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170907.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170907.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170907.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170907.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-beta.20170921.md
+++ b/releases/v1.1-beta.20170921.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170921.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170921.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170921.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170921.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1-beta.20170928.md
+++ b/releases/v1.1-beta.20170928.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170928.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170928.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170928.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1-beta.20170928.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.0-rc.1.md
+++ b/releases/v1.1.0-rc.1.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0-rc.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0-rc.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0-rc.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0-rc.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.0.md
+++ b/releases/v1.1.0.md
@@ -32,7 +32,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.0.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.1.md
+++ b/releases/v1.1.1.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.2.md
+++ b/releases/v1.1.2.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.3.md
+++ b/releases/v1.1.3.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.3.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.3.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.3.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.3.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.4.md
+++ b/releases/v1.1.4.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.4.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.4.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.4.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.4.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.5.md
+++ b/releases/v1.1.5.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
     <div id="os-tabs" class="clearfix">
         <a href="https://binaries.cockroachdb.com/cockroach-v1.1.5.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
         <a href="https://binaries.cockroachdb.com/cockroach-v1.1.5.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-        <a href="https://binaries.cockroachdb.com/cockroach-v1.1.5.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
         <a href="https://binaries.cockroachdb.com/cockroach-v1.1.5.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
     </div>
 

--- a/releases/v1.1.6.md
+++ b/releases/v1.1.6.md
@@ -28,7 +28,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.6.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.6.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.6.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.6.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.7.md
+++ b/releases/v1.1.7.md
@@ -28,7 +28,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.7.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.7.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.7.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.7.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.8.md
+++ b/releases/v1.1.8.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.8.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.8.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.8.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.8.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.1.9.md
+++ b/releases/v1.1.9.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.9.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.9.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.1.9.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.1.9.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.2-alpha.20171026.md
+++ b/releases/v1.2-alpha.20171026.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171026.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171026.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171026.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171026.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.2-alpha.20171113.md
+++ b/releases/v1.2-alpha.20171113.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171113.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171113.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171113.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
 </div>
 
 ### Backwards-Incompatible Changes

--- a/releases/v1.2-alpha.20171204.md
+++ b/releases/v1.2-alpha.20171204.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171204.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171204.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171204.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171204.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v1.2-alpha.20171211.md
+++ b/releases/v1.2-alpha.20171211.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171211.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171211.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171211.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v1.2-alpha.20171211.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-beta.20190225.md
+++ b/releases/v19.1.0-beta.20190225.md
@@ -28,7 +28,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190225.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190225.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190225.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190225.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-beta.20190304.md
+++ b/releases/v19.1.0-beta.20190304.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190304.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190304.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190304.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190304.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-beta.20190318.md
+++ b/releases/v19.1.0-beta.20190318.md
@@ -33,7 +33,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190318.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190318.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190318.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-beta.20190318.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-rc.1.md
+++ b/releases/v19.1.0-rc.1.md
@@ -31,7 +31,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-rc.2.md
+++ b/releases/v19.1.0-rc.2.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-rc.3.md
+++ b/releases/v19.1.0-rc.3.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.3.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.3.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.3.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.3.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0-rc.4.md
+++ b/releases/v19.1.0-rc.4.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.4.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.4.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.4.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0-rc.4.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.0.md
+++ b/releases/v19.1.0.md
@@ -36,7 +36,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.0.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.1.md
+++ b/releases/v19.1.1.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.1.2.md
+++ b/releases/v19.1.2.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.1.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.1.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v19.2.0-alpha.20190606.md
+++ b/releases/v19.2.0-alpha.20190606.md
@@ -32,7 +32,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v19.2.0-alpha.20190606.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.2.0-alpha.20190606.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v19.2.0-alpha.20190606.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v19.2.0-alpha.20190606.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0-alpha.20171218.md
+++ b/releases/v2.0-alpha.20171218.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20171218.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20171218.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20171218.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-alpha.20171218.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0-beta.20180305.md
+++ b/releases/v2.0-beta.20180305.md
@@ -34,7 +34,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180305.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180305.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180305.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180305.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0-beta.20180312.md
+++ b/releases/v2.0-beta.20180312.md
@@ -31,7 +31,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180312.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180312.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180312.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180312.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0-beta.20180319.md
+++ b/releases/v2.0-beta.20180319.md
@@ -30,7 +30,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180319.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180319.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180319.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180319.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0-beta.20180326.md
+++ b/releases/v2.0-beta.20180326.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180326.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180326.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180326.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-beta.20180326.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0-rc.1.md
+++ b/releases/v2.0-rc.1.md
@@ -31,7 +31,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-rc.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-rc.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0-rc.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0-rc.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.0.md
+++ b/releases/v2.0.0.md
@@ -32,7 +32,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.0.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.0.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.0.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.0.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.1.md
+++ b/releases/v2.0.1.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.2.md
+++ b/releases/v2.0.2.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.3.md
+++ b/releases/v2.0.3.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.3.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.3.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.3.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.3.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.4.md
+++ b/releases/v2.0.4.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.4.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.4.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.4.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.4.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.5.md
+++ b/releases/v2.0.5.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.5.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.5.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.5.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.5.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.6.md
+++ b/releases/v2.0.6.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.6.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.6.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.6.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.6.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.0.7.md
+++ b/releases/v2.0.7.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.7.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.7.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.0.7.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.0.7.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-alpha.20180416.md
+++ b/releases/v2.1.0-alpha.20180416.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180416.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180416.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180416.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180416.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-alpha.20180507.md
+++ b/releases/v2.1.0-alpha.20180507.md
@@ -30,7 +30,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180507.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180507.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180507.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180507.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-alpha.20180604.md
+++ b/releases/v2.1.0-alpha.20180604.md
@@ -32,7 +32,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180604.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180604.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180604.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180604.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-alpha.20180702.md
+++ b/releases/v2.1.0-alpha.20180702.md
@@ -36,7 +36,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180702.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-alpha.20180730.md
+++ b/releases/v2.1.0-alpha.20180730.md
@@ -34,7 +34,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180730.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180730.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180730.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-alpha.20180730.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20180827.md
+++ b/releases/v2.1.0-beta.20180827.md
@@ -32,7 +32,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180827.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180827.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180827.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180827.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20180904.md
+++ b/releases/v2.1.0-beta.20180904.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180904.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180904.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180904.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180904.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20180910.md
+++ b/releases/v2.1.0-beta.20180910.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180910.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180910.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180910.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180910.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20180917.md
+++ b/releases/v2.1.0-beta.20180917.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180917.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180917.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180917.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180917.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20180924.md
+++ b/releases/v2.1.0-beta.20180924.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180924.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180924.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180924.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20180924.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20181001.md
+++ b/releases/v2.1.0-beta.20181001.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181001.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181001.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181001.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181001.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20181008.md
+++ b/releases/v2.1.0-beta.20181008.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181008.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181008.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181008.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181008.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-beta.20181015.md
+++ b/releases/v2.1.0-beta.20181015.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181015.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181015.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181015.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-beta.20181015.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-rc.1.md
+++ b/releases/v2.1.0-rc.1.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0-rc.2.md
+++ b/releases/v2.1.0-rc.2.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0-rc.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.0.md
+++ b/releases/v2.1.0.md
@@ -31,7 +31,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.0.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.1.md
+++ b/releases/v2.1.1.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.1.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.1.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.1.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.1.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.2.md
+++ b/releases/v2.1.2.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.3.md
+++ b/releases/v2.1.3.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.3.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.3.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.3.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.3.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.4.md
+++ b/releases/v2.1.4.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.4.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.4.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.4.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.4.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.5.md
+++ b/releases/v2.1.5.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.5.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.5.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.5.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.5.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.6.md
+++ b/releases/v2.1.6.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.6.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.6.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.6.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.6.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.1.7.md
+++ b/releases/v2.1.7.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.7.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.7.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.1.7.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.1.7.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.2.0-alpha.20181119.md
+++ b/releases/v2.2.0-alpha.20181119.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181118.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181118.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181118.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181118.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.2.0-alpha.20181217.md
+++ b/releases/v2.2.0-alpha.20181217.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181217.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181217.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181217.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20181217.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.2.0-alpha.20190114.md
+++ b/releases/v2.2.0-alpha.20190114.md
@@ -26,7 +26,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190114.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190114.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190114.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190114.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/releases/v2.2.0-alpha.20190211.md
+++ b/releases/v2.2.0-alpha.20190211.md
@@ -32,7 +32,6 @@ Get future release notes emailed to you:
 <div id="os-tabs" class="clearfix">
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190211.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190211.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190211.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v2.2.0-alpha.20190211.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 

--- a/v1.0/install-cockroachdb.html
+++ b/v1.0/install-cockroachdb.html
@@ -531,7 +531,7 @@ $(document).ready(function(){
     <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
   </li>
   <li>
-    <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
+    <p>Open PowerShell, navigate to the directory containing the binary, and make sure The CockroachDB executable for Windows works:</p>
 
     <div class="copy-clipboard">
       <div class="copy-clipboard__text windows-binary-button" id="windows-binary-button-{{ page.version.version }}" data-eventcategory="windows-binary-button">copy</div>

--- a/v1.1/install-cockroachdb.html
+++ b/v1.1/install-cockroachdb.html
@@ -476,7 +476,7 @@ $(document).ready(function(){
     <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
   </li>
   <li>
-    <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
+    <p>Open PowerShell, navigate to the directory containing the binary, and make sure The CockroachDB executable for Windows works:</p>
 
     <div class="copy-clipboard">
       <div class="copy-clipboard__text windows-binary-button" id="windows-binary-button-{{ page.version.version }}" data-eventcategory="windows-binary-button">copy</div>

--- a/v19.1/install-cockroachdb-windows.html
+++ b/v19.1/install-cockroachdb-windows.html
@@ -15,16 +15,16 @@ key: install-cockroachdb.html
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-windows" class="install-option">
-  <h2>Download the Binary</h2>
+  <h2>Download the executable</h2>
 
-  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows is experimental</strong>, and is largely untested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged. Windows 8 or higher is required.{{site.data.alerts.end}}
+  {{site.data.alerts.callout_danger}}The CockroachDB executable for Windows is experimental and not suitable for production deployments. Windows 8 or higher is required.{{site.data.alerts.end}}
 
   <ol>
     <li>
       <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
     </li>
     <li>
-      <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
+      <p>Open PowerShell, navigate to the directory containing the executable, and make sure it works:</p>
 
       <div class="copy-clipboard">
         <div class="copy-clipboard__text windows-binary-button" id="windows-binary-button-{{ page.version.version }}" data-eventcategory="windows-binary-button">copy</div>

--- a/v19.2/install-cockroachdb-windows.html
+++ b/v19.2/install-cockroachdb-windows.html
@@ -15,17 +15,16 @@ key: install-cockroachdb.html
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-windows" class="install-option">
-  <h2>Download the Binary</h2>
+  <h2>Download the executable</h2>
 
-  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows is experimental</strong>, and is largely untested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged. Windows 8 or higher is required.{{site.data.alerts.end}}
+  {{site.data.alerts.callout_danger}}The CockroachDB executable for Windows is experimental and not suitable for production deployments. Windows 8 or higher is required.{{site.data.alerts.end}}
 
   <ol>
     <li>
       <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
     </li>
     <li>
-      <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
-
+      <p>Open PowerShell, navigate to the directory containing the executable, and make sure it works:</p>
       <div class="copy-clipboard">
         <div class="copy-clipboard__text windows-binary-button" id="windows-binary-button-{{ page.version.version }}" data-eventcategory="windows-binary-button">copy</div>
         <svg data-eventcategory="windows-binary-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>

--- a/v2.0/install-cockroachdb.html
+++ b/v2.0/install-cockroachdb.html
@@ -480,14 +480,14 @@ $(document).ready(function(){
 
 <div id="download-the-binary-windows" class="install-option">
 
-{{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows requires Windows 8 or higher</strong>, is experimental, and has not been extensively tested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged.{{site.data.alerts.end}}
+{{site.data.alerts.callout_danger}}The CockroachDB executable for Windows is experimental and not suitable for production deployments. Windows 8 or higher is required.{{site.data.alerts.end}}
 
 <ol>
   <li>
     <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
   </li>
   <li>
-    <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
+    <p>Open PowerShell, navigate to the directory containing the executable, and make sure it works:</p>
 
     <div class="copy-clipboard">
       <div class="copy-clipboard__text windows-binary-button" id="windows-binary-button-{{ page.version.version }}" data-eventcategory="windows-binary-button">copy</div>

--- a/v2.1/install-cockroachdb-windows.html
+++ b/v2.1/install-cockroachdb-windows.html
@@ -15,16 +15,16 @@ key: install-cockroachdb.html
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
 <div id="download-the-binary-windows" class="install-option">
-  <h2>Download the Binary</h2>
+  <h2>Download the executable</h2>
 
-  {{site.data.alerts.callout_danger}}<strong>Native CockroachDB on Windows is experimental</strong>, and is largely untested by Cockroach Labs. This prebuilt binary is provided as a convenience for local development and experimentation; production deployments of CockroachDB on Windows are strongly discouraged. Windows 8 or higher is required.{{site.data.alerts.end}}
+  {{site.data.alerts.callout_danger}}The CockroachDB executable for Windows is experimental and not suitable for production deployments. Windows 8 or higher is required.{{site.data.alerts.end}}
 
   <ol>
     <li>
       <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
     </li>
     <li>
-      <p>Open PowerShell, navigate to the directory containing the binary, and make sure the CockroachDB executable works:</p>
+      <p>Open PowerShell, navigate to the directory containing the executable, and make sure it works:</p>
 
       <div class="copy-clipboard">
         <div class="copy-clipboard__text windows-binary-button" id="windows-binary-button-{{ page.version.version }}" data-eventcategory="windows-binary-button">copy</div>


### PR DESCRIPTION
- Improve warning on windows install pages
- Remove windows download link from all relase notes pages

Fixes #4935.