### PR TITLE
Single-region secure cluster on EKS

### DIFF
--- a/_includes/v19.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-secure.md
@@ -1,7 +1,3 @@
-{{site.data.alerts.callout_info}}
-If you want to use a different certificate authority than the one Kubernetes uses, or if your Kubernetes cluster doesn't fully support certificate-signing requests (e.g., in Amazon EKS), use [these configuration files](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/bring-your-own-certs) instead of the ones referenced below.
-{{site.data.alerts.end}}
-
 1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.2/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-secure.md
@@ -1,7 +1,3 @@
-{{site.data.alerts.callout_info}}
-If you want to use a different certificate authority than the one Kubernetes uses, or if your Kubernetes cluster doesn't fully support certificate-signing requests (e.g., in Amazon EKS), use [these configuration files](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/bring-your-own-certs) instead of the ones referenced below.
-{{site.data.alerts.end}}
-
 1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
 
     {% include copy-clipboard.html %}

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -30,7 +30,7 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 [pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one of more Docker containers. In this tutorial, each pod will run on a separate instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods and grow to 4.
 [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A StatefulSet is a group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
 [persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A persistent volume is a piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
-[CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) | A CSR, or Certificate Signing Request, is a request to have a TLS certificate signed by the Kubernetes cluster's built-in CA. As each pod is created, it issues a CSR for the CockroachDB node running in the pod, which must be manually checked and approved. The same is true for clients as they connect to the cluster.
+[CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) | A CSR, or Certificate Signing Request, is a request to have a TLS certificate signed by the Kubernetes cluster's built-in CA. As each pod is created, it issues a CSR for the CockroachDB node running in the pod, which must be manually checked and approved. The same is true for clients as they connect to the cluster. Note that Kubernetes environments that don't support CSRs, such as Amazon EKS, can [use a different certificate authority](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/bring-your-own-certs) than the one Kubernetes uses.
 [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) | RBAC, or Role-Based Access Control, is the system Kubernetes uses to manage permissions within the cluster. In order to take an action (e.g., `get` or `create`) on an API resource (e.g., a `pod` or `CSR`), the client must have a `Role` that allows it to do so. This tutorial creates the RBAC resources necessary for CockroachDB to create and access certificates.
 
 ### Limitations
@@ -44,6 +44,10 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 ## Step 2. Start CockroachDB
 
 To start your CockroachDB cluster, you can either use our StatefulSet configuration and related files directly, or you can use the [Helm](https://helm.sh/) package manager for Kubernetes to simplify the process.
+
+{{site.data.alerts.callout_info}}
+When running on Amazon EKS, certificates signed by Kubernetes' built-in CA are not supported, so use [this configuration file](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml) instead of the one referenced below, and follow the steps in the comments at the top of the file. Also note that [secure CockroachDB deployments on EKS via Helm are not yet supported](https://github.com/cockroachdb/cockroach/issues/38847); in the meantime, use the configuration file referenced above.  
+{{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">
     <button class="filter-button" data-scope="helm">Use Helm</button>

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -30,7 +30,7 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 [pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one of more Docker containers. In this tutorial, each pod will run on a separate instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods and grow to 4.
 [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A StatefulSet is a group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
 [persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A persistent volume is a piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
-[CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) | A CSR, or Certificate Signing Request, is a request to have a TLS certificate signed by the Kubernetes cluster's built-in CA. As each pod is created, it issues a CSR for the CockroachDB node running in the pod, which must be manually checked and approved. The same is true for clients as they connect to the cluster.
+[CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) | A CSR, or Certificate Signing Request, is a request to have a TLS certificate signed by the Kubernetes cluster's built-in CA. As each pod is created, it issues a CSR for the CockroachDB node running in the pod, which must be manually checked and approved. The same is true for clients as they connect to the cluster. Note that Kubernetes environments that don't support CSRs, such as Amazon EKS, can [use a different certificate authority](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/bring-your-own-certs) than the one Kubernetes uses.
 [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) | RBAC, or Role-Based Access Control, is the system Kubernetes uses to manage permissions within the cluster. In order to take an action (e.g., `get` or `create`) on an API resource (e.g., a `pod` or `CSR`), the client must have a `Role` that allows it to do so. This tutorial creates the RBAC resources necessary for CockroachDB to create and access certificates.
 
 ### Limitations
@@ -44,6 +44,10 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 ## Step 2. Start CockroachDB
 
 To start your CockroachDB cluster, you can either use our StatefulSet configuration and related files directly, or you can use the [Helm](https://helm.sh/) package manager for Kubernetes to simplify the process.
+
+{{site.data.alerts.callout_info}}
+When running on Amazon EKS, certificates signed by Kubernetes' built-in CA are not supported, so use [this configuration file](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/bring-your-own-certs/cockroachdb-statefulset.yaml) instead of the one referenced below, and follow the steps in the comments at the top of the file. Also note that [secure CockroachDB deployments on EKS via Helm are not yet supported](https://github.com/cockroachdb/cockroach/issues/38847); in the meantime, use the configuration file referenced above.  
+{{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">
     <button class="filter-button" data-scope="helm">Use Helm</button>


### PR DESCRIPTION
This PR adds a note about using custom config for secure EKS deployment and calls out that secure EKS via Helm is not supported.

It is a continuation of https://github.com/cockroachdb/docs/pull/5047. 

Fixes #5042.