### PR TITLE
Quick hyperlink reference for ENUM data type

### DIFF
--- a/v19.1/migration-overview.md
+++ b/v19.1/migration-overview.md
@@ -40,7 +40,7 @@ Above a certain size, many data types such as [`STRING`](string.html)s, [`DECIMA
 
 ## Unsupported data types
 
-CockroachDB does not provide `ENUM` or `SET` data types.
+CockroachDB does not provide [`ENUM`](https://en.wikipedia.org/wiki/Enumerated_type) or `SET` data types.
 
 In Postgres, you can emulate an `ENUM` type using a [`CHECK` constraint](check.html) as shown below.  For MySQL, we perform this conversion automatically during the import.
 


### PR DESCRIPTION
Knowing ENUM data type of different database (MySQL and Postgres) helps the users to understand what would be the replaceable data type in cockroach DB