### PR TITLE
Changed the port for zookeeper from 8081 to 2181

### DIFF
--- a/v19.1/change-data-capture.md
+++ b/v19.1/change-data-capture.md
@@ -612,7 +612,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
     ~~~ shell
     $ ./bin/kafka-topics \
     --create \
-    --zookeeper localhost:8081 \
+    --zookeeper localhost:2181 \
     --replication-factor 1 \
     --partitions 1 \
     --topic office_dogs


### PR DESCRIPTION
In the first section in which the document describes connecting to Kafka it uses 2181 but then in the example using Kafka with Avro it says 8081 which is the schema registry, not zookeeper. 