### PR TITLE
Added new known limitation

### DIFF
--- a/v19.1/known-limitations.md
+++ b/v19.1/known-limitations.md
@@ -14,12 +14,12 @@ If a cluster contains a large amount of data (>500GiB / node), and all nodes are
 
 To exit this state, you should:
   1. Stop all nodes.
-  2. Set the following environment variables: `COCKROACH_SCHEDULER_CONCURRENCY=100`, `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
+  2. Set the following environment variables: `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
   3. Restart the cluster.
 
 Once restarted, you should monitor the Replica Quiescence graph on the Replication Dashboard. When >90% of the replicas have become Quiescent, you can conduct a rolling restart and remove the environment variables. Be sure to ensure that underreplicated ranges do not increase between restarts.
 
-Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [range_max_bytes](https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables) to 134217728. We always recommend testing changes to max_range_bytes in a development environment before making changes on production.
+Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [range_max_bytes](https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables) to 134217728 (128MiB). We always recommend testing changes to max_range_bytes in a development environment before making changes on production.
 
 [Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117) 
 

--- a/v19.1/known-limitations.md
+++ b/v19.1/known-limitations.md
@@ -13,15 +13,16 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 If a cluster contains a large amount of data (>500GiB / node), and all nodes are stopped and then started at the same time, clusters can enter a state where they're unable to startup without manual intervention. In this state, logs fill up rapidly with messages like `refusing gossip from node x; forwarding to node y`, and data and metrics may become inaccessible.
 
 To exit this state, you should:
-  1. Stop all nodes.
-  2. Set the following environment variables: `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
-  3. Restart the cluster.
 
-Once restarted, you should monitor the Replica Quiescence graph on the Replication Dashboard. When >90% of the replicas have become Quiescent, you can conduct a rolling restart and remove the environment variables. Be sure to ensure that underreplicated ranges do not increase between restarts.
+1. Stop all nodes.
+2. Set the following environment variables: `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
+3. Restart the cluster.
 
-Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [range_max_bytes](https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables) to 134217728 (128MiB). We always recommend testing changes to max_range_bytes in a development environment before making changes on production.
+Once restarted, monitor the Replica Quiescence graph on the [**Replication Dashboard**](admin-ui-replication-dashboard.html). When >90% of the replicas have become quiescent, conduct a rolling restart and remove the environment variables. Make sure that under-replicated ranges do not increase between restarts.
 
-[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117) 
+Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [`range_max_bytes`](configure-zone.html#variables) to 134217728 (128MiB). We always recommend testing changes to `range_max_bytes` in a development environment before making changes on production.
+
+[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117)
 
 ### Requests to restarted node in need of snapshots may hang
 

--- a/v19.2/known-limitations.md
+++ b/v19.2/known-limitations.md
@@ -8,6 +8,22 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 ## Unresolved limitations
 
+### Cold starts of large clusters may require manual intervention
+
+If a cluster contains a large amount of data (>500GiB / node), and all nodes are stopped and then started at the same time, clusters can enter a state where they're unable to startup without manual intervention. In this state, logs fill up rapidly with messages like `refusing gossip from node x; forwarding to node y`, and data and metrics may become inaccessible.
+
+To exit this state, you should:
+
+1. Stop all nodes.
+2. Set the following environment variables: `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
+3. Restart the cluster.
+
+Once restarted, monitor the Replica Quiescence graph on the [**Replication Dashboard**](admin-ui-replication-dashboard.html). When >90% of the replicas have become quiescent, conduct a rolling restart and remove the environment variables. Make sure that under-replicated ranges do not increase between restarts.
+
+Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [`range_max_bytes`](configure-zone.html#variables) to 134217728 (128MiB). We always recommend testing changes to `range_max_bytes` in a development environment before making changes on production.
+
+[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117)
+
 ### Requests to restarted node in need of snapshots may hang
 
 When a node is offline, the [Raft logs](architecture/replication-layer.html#raft-logs) for the ranges on the node get truncated. When the node comes back online, it therefore often needs [Raft snapshots](architecture/replication-layer.html#snapshots) to get many of its ranges back up-to-date. While in this state, requests to a range will hang until its snapshot has been applied, which can take a long time.  

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -20,12 +20,12 @@ If a cluster contains a large amount of data (>500GiB / node), and all nodes are
 
 To exit this state, you should:
   1. Stop all nodes.
-  2. Set the following environment variables: `COCKROACH_SCHEDULER_CONCURRENCY=100`, `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
+  2. Set the following environment variables: `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
   3. Restart the cluster.
 
 Once restarted, you should monitor the Replica Quiescence graph on the Replication Dashboard. When >90% of the replicas have become Quiescent, you can conduct a rolling restart and remove the environment variables. Be sure to ensure that underreplicated ranges do not increase between restarts.
 
-Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [range_max_bytes](https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables) to 134217728. We always recommend testing changes to max_range_bytes in a development environment before making changes on production.
+Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [range_max_bytes](https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables) to 134217728 (128MiB). We always recommend testing changes to max_range_bytes in a development environment before making changes on production.
 
 [Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117)
 

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -14,6 +14,21 @@ Change data capture (CDC) provides efficient, distributed, row-level change feed
 
 {% include {{page.version.version}}/known-limitations/cdc.md %}
 
+### Cold starts of large clusters may require manual intervention
+
+If a cluster contains a large amount of data (>500GiB / node), and all nodes are stopped and then started at the same time, clusters can enter a state where they're unable to startup without manual intervention. In this state, logs fill up rapidly with messages like `refusing gossip from node x; forwarding to node y`, and data and metrics may become inaccessible.
+
+To exit this state, you should:
+  1. Stop all nodes.
+  2. Set the following environment variables: `COCKROACH_SCHEDULER_CONCURRENCY=100`, `COCKROACH_SCAN_INTERVAL=60m`, and `COCKROACH_SCAN_MIN_IDLE_TIME=1s`.
+  3. Restart the cluster.
+
+Once restarted, you should monitor the Replica Quiescence graph on the Replication Dashboard. When >90% of the replicas have become Quiescent, you can conduct a rolling restart and remove the environment variables. Be sure to ensure that underreplicated ranges do not increase between restarts.
+
+Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [range_max_bytes](https://www.cockroachlabs.com/docs/stable/configure-zone.html#variables) to 134217728. We always recommend testing changes to max_range_bytes in a development environment before making changes on production.
+
+[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117)
+
 ### Admin UI may become inaccessible for secure clusters
 
 Accessing the Admin UI for a secure cluster now requires login information (i.e., username and password). This login information is stored in a system table that is replicated like other data in the cluster. If a majority of the nodes with the replicas of the system table data go down, users will be locked out of the Admin UI.


### PR DESCRIPTION
see: 
https://github.com/cockroachdb/cockroach/issues/39117
https://cockroachdb.zendesk.com/agent/tickets/3517

Users can encounter this any time they have a large # of ranges (>500GiB per node), and cold start. I think it's worth documenting given that it can make an entire cluster unavailable until these steps are taken.

@bdarnell please ensure I didn't say anything inaccurate and @jseldess let me know if you think there's a better place for these :)