### PR TITLE
Removal of same statement as it is used multiple times

### DIFF
--- a/v19.1/view-node-details.md
+++ b/v19.1/view-node-details.md
@@ -15,7 +15,7 @@ Subcommand | Usage
 -----------|------
 `ls` | List the ID of each node in the cluster, excluding those that have been decommissioned and are offline.
 `status` | View the status of one or all nodes, excluding nodes that have been decommissioned and taken offline. Depending on flags used, this can include details about range/replicas, disk usage, and decommissioning progress.
-`decommission` | Decommission nodes for permanent removal. See [Remove Nodes](remove-nodes.html) for more details.
+`decommission` | Decommission nodes for permanent [removal](remove-nodes.html).
 `recommission` | Recommission nodes that were accidentally decommissioned. See [Recommission Nodes](remove-nodes.html#recommission-nodes) for more details.
 
 ## Synopsis
@@ -132,8 +132,8 @@ Field | Description
 `is_available` | If `true`, the node is currently available.<br><br>**Required flag:** None
 `is_live` | If `true`, the node is currently live. <br><br>For unavailable clusters (with an unresponsive Admin UI), running the `node status` command and monitoring the `is_live` field is the only way to identify the live nodes in the cluster. However, you need to run the `node status` command on a live node to identify the other live nodes in an unavailable cluster. Figuring out a live node to run the command is a trial-and-error process, so run the command against each node until you get one that responds. <br><br> See [Identify live nodes in an unavailable cluster](#identify-live-nodes-in-an-unavailable-cluster) for more details. <br><br>**Required flag:** None
 `gossiped_replicas` | The number of replicas on the node that are active members of a range. After decommissioning, this should be 0.<br><br>**Required flag:** `--decommission` or `--all`
-`is_decommissioning` | If `true`, the node is marked for decommissioning. See [Remove Nodes](remove-nodes.html) for more details.<br><br>**Required flag:** `--decommission` or `--all`
-`is_draining` | If `true`, the range replicas and range leases are being moved off the node. This happens when a live node is being decommissioned. See [Remove Nodes](remove-nodes.html) for more details.<br><br>**Required flag:** `--decommission` or `--all`
+`is_decommissioning` | If `true`, the node is marked for [decommissioning].<br><br>**Required flag:** `--decommission` or `--all`
+`is_draining` | If `true`, the range replicas and range leases are being moved off the node. This happens when a live node is being [decommissioned](remove-nodes.html).<br><br>**Required flag:** `--decommission` or `--all`
 
 ### `node decommission`
 


### PR DESCRIPTION
Removal Nodes - During decommission need know what Remove nodes means, but stating the same across the documents does not seems to be good for the end user. Instead of that, we can add a reference link near decommission which tells the same thing about Remove node.