### PR TITLE
The word secondary indexes suites better than the word secondary indices

### DIFF
--- a/v19.1/interleave-in-parent.md
+++ b/v19.1/interleave-in-parent.md
@@ -66,7 +66,7 @@ In general, reads, writes, and joins of values related through the interleave pr
 
 Fast deletes are available for interleaved tables that use [`ON DELETE CASCADE`](add-constraint.html#add-the-foreign-key-constraint-with-cascade).  Deleting rows from such tables will use an optimized code path and run much faster, as long as the following conditions are met:
 
-- The table or any of its interleaved tables do not have any secondary indices.
+- The table or any of its interleaved tables do not have any secondary indexes.
 - The table or any of its interleaved tables are not referenced by any other table outside of them by foreign key.
 - All of the interleaved relationships use `ON DELETE CASCADE` clauses.
 


### PR DESCRIPTION
The word secondary indexes suites better than the word secondary indices. And users can connect with Index word than Indices