### PR TITLE
Piping to chmod for workload doesn't work

### DIFF
--- a/_includes/v1.1/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v1.1/prod-deployment/insecure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v1.1/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v1.1/prod-deployment/secure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v19.1/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v19.1/prod-deployment/insecure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v19.1/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v19.1/prod-deployment/secure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v19.2/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v19.2/prod-deployment/insecure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v19.2/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v19.2/prod-deployment/secure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v2.0/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v2.0/prod-deployment/insecure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v2.0/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v2.0/prod-deployment/secure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v2.1/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v2.1/prod-deployment/insecure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/_includes/v2.1/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v2.1/prod-deployment/secure-test-load-balancing.md
@@ -10,7 +10,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/v19.1/performance-benchmarking-with-tpc-c.md
+++ b/v19.1/performance-benchmarking-with-tpc-c.md
@@ -84,7 +84,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:

--- a/v19.1/performance-benchmarking-with-tpc-c.md
+++ b/v19.1/performance-benchmarking-with-tpc-c.md
@@ -245,7 +245,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:

--- a/v19.2/performance-benchmarking-with-tpc-c.md
+++ b/v19.2/performance-benchmarking-with-tpc-c.md
@@ -84,7 +84,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:
@@ -245,7 +245,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:

--- a/v2.0/performance-benchmarking-with-tpc-c.md
+++ b/v2.0/performance-benchmarking-with-tpc-c.md
@@ -119,7 +119,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:
@@ -280,7 +280,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 3. Rename and copy `workload` into the `PATH`:

--- a/v2.1/performance-benchmarking-with-tpc-c.md
+++ b/v2.1/performance-benchmarking-with-tpc-c.md
@@ -84,7 +84,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:
@@ -245,7 +245,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST | chmod 755 workload.LATEST
+    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST ; chmod 755 workload.LATEST
     ~~~
 
 2. Rename and copy `workload` into the `PATH`:


### PR DESCRIPTION
Changing the '|' to a ';' as the pipe does not change the permission of the workload file.