### PR TITLE
updated insecure cluster rust driver sample code to display insecure …

### DIFF
--- a/v19.1/build-a-rust-app-with-cockroachdb.md
+++ b/v19.1/build-a-rust-app-with-cockroachdb.md
@@ -110,7 +110,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, inserting rows and reading and printing the rows.
 
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/basic-sample.rs" download><code>basic-sample.rs</code></a> file, or create the file yourself and copy the code into it.
+Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/insecure/basic-sample.rs" download><code>basic-sample.rs</code></a> file, or create the file yourself and copy the code into it.
 
 {% include copy-clipboard.html %}
 ~~~ rust

--- a/v19.2/build-a-rust-app-with-cockroachdb.md
+++ b/v19.2/build-a-rust-app-with-cockroachdb.md
@@ -110,7 +110,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, inserting rows and reading and printing the rows.
 
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/basic-sample.rs" download><code>basic-sample.rs</code></a> file, or create the file yourself and copy the code into it.
+Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/insecure/basic-sample.rs" download><code>basic-sample.rs</code></a> file, or create the file yourself and copy the code into it.
 
 {% include copy-clipboard.html %}
 ~~~ rust

--- a/v2.1/build-a-rust-app-with-cockroachdb.md
+++ b/v2.1/build-a-rust-app-with-cockroachdb.md
@@ -110,7 +110,7 @@ Now that you have a database and a user, you'll run code to create a table and i
 
 First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, inserting rows and reading and printing the rows.
 
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/basic-sample.rs" download><code>basic-sample.rs</code></a> file, or create the file yourself and copy the code into it.
+Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/insecure/basic-sample.rs" download><code>basic-sample.rs</code></a> file, or create the file yourself and copy the code into it.
 
 {% include copy-clipboard.html %}
 ~~~ rust


### PR DESCRIPTION
Sample code download for rust driver on an insecure cluster was linking to the code for the secure one.

The confusion is coming previously versions of CRDB (v2.0 and below) where the insecure code file path is the same as the secure file path in future versions. 