### PR TITLE
Corrected syntax; expanded overview instructions

### DIFF
--- a/_includes/v19.2/sql/movr-start.md
+++ b/_includes/v19.2/sql/movr-start.md
@@ -17,14 +17,14 @@
         <section class="filter-content" markdown="1" data-scope="secure">
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ cockroach workload init movr --certs-dir=certs --host=localhost:26257
+        $ cockroach workload init movr 'postgresql://root@localhost:26257?sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt'
         ~~~
         </section>
 
         <section class="filter-content" markdown="1" data-scope="insecure">
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ cockroach workload init movr --insecure --host=localhost:26257
+        $ cockroach workload init movr 'postgresql://root@localhost:26257?sslmode=disable'
         ~~~
         </section>
     1. Use [`cockroach sql`](use-the-built-in-sql-client.html) to open an interactive SQL shell and set `movr` as the  [current database](sql-name-resolution.html#current-database):

--- a/v19.2/migrate-from-oracle.md
+++ b/v19.2/migrate-from-oracle.md
@@ -243,7 +243,7 @@ Cockroach distributes a table by the [primary key](primary-key.html) or by a def
 
 For more information and examples, refer to the following:
 
-- [`CREATE TABLE` - Create a table (primary key defined)](create-table.html#create-a-table-primary-key-defined)
+- [`CREATE TABLE` - Create a table](create-table.html)
 - [Define Table Partitions](partitioning.html)
 - [Constraints - Supported constraints](constraints.html#supported-constraints)
 

--- a/v19.2/movr.md
+++ b/v19.2/movr.md
@@ -10,7 +10,7 @@ MovR is a fictional vehicle-sharing company created to demonstrate CockroachDB's
 
 The MovR example consists of the following:
 
-- The `movr` dataset, which contains of rows of data that populate tables in the `movr` database. The `movr` dataset is built into [`cockroach demo`](cockroach-demo.html) and [`cockroach workload`](cockroach-workload.html).
+- The `movr` dataset, which contains rows of data that populate tables in the `movr` database. The `movr` dataset is built into [`cockroach demo`](cockroach-demo.html) and [`cockroach workload`](cockroach-workload.html).
 - The MovR application, a fully-functional vehicle-sharing application, written in Python. All of MovR application source code is open-source, and available on the [movr](https://github.com/cockroachdb/movr) GitHub repository.
 
 ## The `movr` database
@@ -30,11 +30,72 @@ Table   |         Description
 
 ## Generating schemas and data for MovR
 
-Use the following `cockroach` commands to load the `movr` database and dataset that are built into the CockroachDB binary:
+You can use the `cockroach demo` and `cockroach workload` commands to load the `movr` database and dataset into a CockroachDB cluster.
 
-- [`cockroach demo movr`](cockroach-demo.html) opens a temporary, in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
+[`cockroach demo`](cockroach-demo.html) opens a SQL shell to a temporary, in-memory cluster. To open a SQL shell to a demo cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database), use the following command:
 
-- [`cockroach workload init movr`](cockroach-workload.html) loads the `movr` database and some sample data to a running cluster.
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach demo movr
+~~~
+
+[`cockroach workload`](cockroach-workload.html) loads sample datasets and workloads into running clusters. To load the `movr` database and some sample data into a running cluster, do the following:
+
+  1. Start a [secure](secure-a-cluster.html) or [insecure](start-a-local-cluster.html) local cluster.
+  1. Use `cockroach workload` to load the `movr` dataset:
+
+      <div class="filters filters-big clearfix">
+        <button class="filter-button" data-scope="secure">Secure</button>
+        <button class="filter-button" data-scope="insecure">Insecure</button>
+      </div>
+
+      <section class="filter-content" markdown="1" data-scope="secure">
+
+      {% include copy-clipboard.html %}
+      ~~~ shell
+      $ cockroach workload init movr 'postgresql://root@localhost:26257?sslcert=certs%2Fclient.root.crt&sslkey=certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=certs%2Fca.crt'
+      ~~~
+
+      </section>
+
+      <section class="filter-content" markdown="1" data-scope="insecure">
+
+      {% include copy-clipboard.html %}
+      ~~~ shell
+      $ cockroach workload init movr 'postgresql://root@localhost:26257?sslmode=disable'
+      ~~~
+
+      </section>
+
+  1. Use [`cockroach sql`](use-the-built-in-sql-client.html) to open an interactive SQL shell and set `movr` as the  [current database](sql-name-resolution.html#current-database):
+
+      <section class="filter-content" markdown="1" data-scope="secure">
+
+      {% include copy-clipboard.html %}
+      ~~~ shell
+      $ cockroach sql --certs-dir=certs --host=localhost:26257
+      ~~~
+
+      {% include copy-clipboard.html %}
+      ~~~ sql
+      > USE movr;
+      ~~~
+
+      </section>
+
+      <section class="filter-content" markdown="1" data-scope="insecure">
+
+      {% include copy-clipboard.html %}
+      ~~~ shell
+      $ cockroach sql --insecure --host=localhost:26257
+      ~~~
+
+      {% include copy-clipboard.html %}
+      ~~~ sql
+      > USE movr;
+      ~~~        
+      
+      </section>
 
 ## How the MovR application works
 


### PR DESCRIPTION
Pretty small PR
- Corrected syntax on cockroach workload in start instructions (cockroach workload needs a connection string - you can't use --host or --insecure or --cert-dir like you can for other cockroach commands)
- Added copy + paste instructions to MovR overview page