### PR TITLE
Clarify when locality is NULL for SHOW LOCALITY

### DIFF
--- a/v19.2/show-locality.md
+++ b/v19.2/show-locality.md
@@ -6,7 +6,7 @@ toc: true
 
 <span class="version-tag">New in v19.2:</span> The `SHOW LOCALITY` [statement](sql-statements.html) returns the [locality](start-a-node.html#locality) of the current node.
 
-If you are running a single-node cluster with no locality specified, the statement returns an empty row.
+If locality was not specified on node startup, the statement returns an empty row.
 
 ## Required privileges
 


### PR DESCRIPTION
Not just for single-node clusters, but any time a node is started
without `--locality` specified.