### PR TITLE
Non-commutative aggregate functions

### DIFF
--- a/_includes/v19.2/sql/aggregates.md
+++ b/_includes/v19.2/sql/aggregates.md
@@ -1,35 +1,50 @@
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>array_agg(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="time.html">time</a>) &rarr; <a href="time.html">time</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="time.html">time</a>) &rarr; <a href="time.html">time</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>array_agg(arg1: varbit) &rarr; varbit[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: varbit) &rarr; varbit[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
 <tr><td><code>avg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
 </span></td></tr>
@@ -41,17 +56,21 @@
 </span></td></tr>
 <tr><td><code>bool_or(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Calculates the boolean value of <code>OR</code>ing all selected values.</p>
 </span></td></tr>
-<tr><td><code>concat_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values.</p>
+<tr><td><code>concat_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>concat_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values.</p>
+<tr><td><code>concat_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
 <tr><td><code>count(arg1: anyelement) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of selected elements.</p>
 </span></td></tr>
 <tr><td><code>count_rows() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of rows.</p>
 </span></td></tr>
-<tr><td><code>json_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Aggregates values as a JSON or JSONB array.</p>
+<tr><td><code>json_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Aggregates values as a JSON or JSONB array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>jsonb_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Aggregates values as a JSON or JSONB array.</p>
+<tr><td><code>jsonb_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Aggregates values as a JSON or JSONB array.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
 <tr><td><code>max(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
 </span></td></tr>
@@ -129,9 +148,11 @@
 </span></td></tr>
 <tr><td><code>stddev(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
 </span></td></tr>
-<tr><td><code>string_agg(arg1: <a href="bytes.html">bytes</a>, arg2: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values using the provided delimiter.</p>
+<tr><td><code>string_agg(arg1: <a href="bytes.html">bytes</a>, arg2: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values using the provided delimiter.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
-<tr><td><code>string_agg(arg1: <a href="string.html">string</a>, arg2: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values using the provided delimiter.</p>
+<tr><td><code>string_agg(arg1: <a href="string.html">string</a>, arg2: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values using the provided delimiter.
+This aggregate function is non-commutative.</p>
 </span></td></tr>
 <tr><td><code>sum(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
 </span></td></tr>

--- a/v19.2/functions-and-operators.md
+++ b/v19.2/functions-and-operators.md
@@ -40,11 +40,14 @@ functions but have special evaluation rules:
 
 ## Aggregate functions
 
-{{site.data.alerts.callout_success}}
 For examples showing how to use aggregate functions, see [the `SELECT` clause documentation](select-clause.html#aggregate-functions).
+
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v19.2</span>: Non-commutative aggregate functions are sensitive to the order in which the rows are processed in the surrounding [`SELECT` clause](select-clause.html#aggregate-functions). To specify the order in which input rows are processed, you can add an [`ORDER BY`](query-order.html) clause within the function argument list. For examples, see the [`SELECT` clause](select-clause.html#order-aggregate-function-input-rows-by-column) documentation.
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/sql/aggregates.md %}
+
 
 ## Window functions
 

--- a/v19.2/select-clause.md
+++ b/v19.2/select-clause.md
@@ -415,6 +415,75 @@ GROUP BY vehicle_id, city HAVING COUNT(vehicle_id) > 20;
 (3 rows)
 ~~~
 
+#### Order aggregate function input rows by column
+
+<span class="version-tag">New in v19.2</span>: Non-commutative aggregate functions are sensitive to the order in which the rows are processed in the surrounding `SELECT` clause. To specify the order in which input rows are processed, you can add an [`ORDER BY`](query-order.html) clause within the function argument list.
+
+For example, suppose you want to create an array of `name` values, ordered alphabetically, and grouped by `city`. You can use the following statement to do so:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT city, array_agg(name ORDER BY name) AS users FROM users WHERE city IN ('new york', 'chicago', 'seattle') GROUP BY city;
+~~~
+
+~~~
+    city   |                                        users
++----------+-------------------------------------------------------------------------------------+
+  new york | {"Catherine Nelson","Devin Jordan","James Hamilton","Judy White","Robert Murphy"}
+  seattle  | {"Anita Atkinson","Holly Williams","Patricia Herrera","Ryan Hickman"}
+  chicago  | {"Jessica Martinez","John Hines","Kenneth Barnes","Matthew Clay","Samantha Coffey"}
+(3 rows)
+~~~
+
+You can also order input rows using a column different than the input row column. The following statement returns an array of `revenue` values from high-revenue rides, ordered by ride `end_time`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT city, array_agg(revenue ORDER BY end_time) as revenues FROM rides WHERE revenue > 80 GROUP BY city;
+~~~
+
+~~~
+      city      |                                    revenues
++---------------+---------------------------------------------------------------------------------+
+  amsterdam     | {87.00,95.00,87.00,85.00,87.00,85.00,88.00,95.00,86.00,97.00,98.00,87.00,82.00}
+  boston        | {92.00,92.00,86.00,87.00,94.00}
+  detroit       | {89.00,96.00,94.00,92.00,84.00}
+  minneapolis   | {84.00,98.00,86.00,92.00,81.00,99.00,87.00,86.00,88.00,81.00}
+  new york      | {83.00,94.00,86.00,95.00,81.00,91.00,94.00,81.00,81.00,90.00}
+  san francisco | {96.00,85.00,96.00,84.00,94.00,87.00,93.00}
+  chicago       | {82.00,98.00,84.00,99.00,91.00,90.00,83.00,82.00,91.00}
+  los angeles   | {92.00,98.00,92.00,99.00,93.00,87.00,98.00,91.00,89.00,81.00,87.00}
+  paris         | {87.00,94.00,98.00,98.00,95.00,81.00,99.00,94.00,95.00,82.00}
+  rome          | {83.00,96.00,90.00,98.00,95.00,87.00,86.00,97.00}
+  seattle       | {88.00,88.00,82.00,86.00,91.00,81.00,99.00}
+  washington dc | {96.00,94.00,97.00,96.00,88.00,97.00,93.00}
+(12 rows)
+~~~
+
+If you include multiple aggregate functions in a single `SELECT` clause, you can order the input rows of the multiple functions on different columns. For example:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT city, array_agg(revenue ORDER BY revenue) as revenues_by_revenue, array_agg(revenue ORDER BY end_time) as revenues_by_end_time FROM rides WHERE revenue > 90 GROUP BY city;
+~~~
+~~~
+      city      |             revenues_by_revenue             |            revenues_by_end_time
++---------------+---------------------------------------------+---------------------------------------------+
+  amsterdam     | {95.00,95.00,97.00,98.00}                   | {95.00,95.00,97.00,98.00}
+  boston        | {92.00,92.00,94.00}                         | {92.00,92.00,94.00}
+  minneapolis   | {92.00,98.00,99.00}                         | {98.00,92.00,99.00}
+  new york      | {91.00,94.00,94.00,95.00}                   | {94.00,95.00,91.00,94.00}
+  paris         | {94.00,94.00,95.00,95.00,98.00,98.00,99.00} | {94.00,98.00,98.00,95.00,99.00,94.00,95.00}
+  san francisco | {93.00,94.00,96.00,96.00}                   | {96.00,96.00,94.00,93.00}
+  chicago       | {91.00,91.00,98.00,99.00}                   | {98.00,99.00,91.00,91.00}
+  detroit       | {92.00,94.00,96.00}                         | {96.00,94.00,92.00}
+  los angeles   | {91.00,92.00,92.00,93.00,98.00,98.00,99.00} | {92.00,98.00,92.00,99.00,93.00,98.00,91.00}
+  rome          | {95.00,96.00,97.00,98.00}                   | {96.00,98.00,95.00,97.00}
+  seattle       | {91.00,99.00}                               | {91.00,99.00}
+  washington dc | {93.00,94.00,96.00,96.00,97.00,97.00}       | {96.00,94.00,97.00,96.00,97.00,93.00}
+(12 rows)
+~~~
+
 ### Select from a specific index
 
 {% include {{page.version.version}}/misc/force-index-selection.md %}


### PR DESCRIPTION
Added note and examples about ordering non-commutative aggregate function inputs.

Fixes #4801. 

See accompanying cockroach PR: https://github.com/cockroachdb/cockroach/pull/40316