### PR TITLE
Partition names reused across primary and secondary indexes

### DIFF
--- a/_includes/v19.2/performance/partition-by-city.md
+++ b/_includes/v19.2/performance/partition-by-city.md
@@ -68,12 +68,12 @@ For this service, the most effective technique for improving read and write late
     --host=<address of any node> \
     --execute="ALTER INDEX vehicles_auto_index_fk_city_ref_users \
     PARTITION BY LIST (city) ( \
-        PARTITION new_york_idx VALUES IN ('new york'), \
-        PARTITION boston_idx VALUES IN ('boston'), \
-        PARTITION washington_dc_idx VALUES IN ('washington dc'), \
-        PARTITION seattle_idx VALUES IN ('seattle'), \
-        PARTITION san_francisco_idx VALUES IN ('san francisco'), \
-        PARTITION los_angeles_idx VALUES IN ('los angeles') \
+        PARTITION new_york VALUES IN ('new york'), \
+        PARTITION boston VALUES IN ('boston'), \
+        PARTITION washington_dc VALUES IN ('washington dc'), \
+        PARTITION seattle VALUES IN ('seattle'), \
+        PARTITION san_francisco VALUES IN ('san francisco'), \
+        PARTITION los_angeles VALUES IN ('los angeles') \
     );"
     ~~~
 
@@ -104,12 +104,12 @@ For this service, the most effective technique for improving read and write late
     --host=<address of any node> \
     --execute="ALTER INDEX rides_auto_index_fk_city_ref_users \
     PARTITION BY LIST (city) ( \
-        PARTITION new_york_idx1 VALUES IN ('new york'), \
-        PARTITION boston_idx1 VALUES IN ('boston'), \
-        PARTITION washington_dc_idx1 VALUES IN ('washington dc'), \
-        PARTITION seattle_idx1 VALUES IN ('seattle'), \
-        PARTITION san_francisco_idx1 VALUES IN ('san francisco'), \
-        PARTITION los_angeles_idx1 VALUES IN ('los angeles') \
+        PARTITION new_york VALUES IN ('new york'), \
+        PARTITION boston VALUES IN ('boston'), \
+        PARTITION washington_dc VALUES IN ('washington dc'), \
+        PARTITION seattle VALUES IN ('seattle'), \
+        PARTITION san_francisco VALUES IN ('san francisco'), \
+        PARTITION los_angeles VALUES IN ('los angeles') \
     );"
     ~~~
 
@@ -121,12 +121,12 @@ For this service, the most effective technique for improving read and write late
     --host=<address of any node> \
     --execute="ALTER INDEX rides_auto_index_fk_vehicle_city_ref_vehicles \
     PARTITION BY LIST (vehicle_city) ( \
-        PARTITION new_york_idx2 VALUES IN ('new york'), \
-        PARTITION boston_idx2 VALUES IN ('boston'), \
-        PARTITION washington_dc_idx2 VALUES IN ('washington dc'), \
-        PARTITION seattle_idx2 VALUES IN ('seattle'), \
-        PARTITION san_francisco_idx2 VALUES IN ('san francisco'), \
-        PARTITION los_angeles_idx2 VALUES IN ('los angeles') \
+        PARTITION new_york VALUES IN ('new york'), \
+        PARTITION boston VALUES IN ('boston'), \
+        PARTITION washington_dc VALUES IN ('washington dc'), \
+        PARTITION seattle VALUES IN ('seattle'), \
+        PARTITION san_francisco VALUES IN ('san francisco'), \
+        PARTITION los_angeles VALUES IN ('los angeles') \
     );"
     ~~~
 
@@ -154,7 +154,7 @@ For this service, the most effective technique for improving read and write late
     Washington DC | `zone=us-east1-b`
     Seattle | `zone=us-west1-a`
     San Francisco | `zone=us-west2-a`
-    Los Angelese | `zone=us-west2-a`
+    Los Angeles | `zone=us-west2-a`
 
     {{site.data.alerts.callout_info}}
     Since our nodes are located in 3 specific GCE zones, we're only going to use the `zone=` portion of node locality. If we were using multiple zones per regions, we would likely use the `region=` portion of the node locality instead.
@@ -215,7 +215,7 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION new_york_idx OF TABLE movr.vehicles CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION new_york OF INDEX vehicles_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -229,7 +229,7 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION boston_idx OF TABLE movr.vehicles CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION boston OF INDEX vehicles_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -243,7 +243,7 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION washington_dc_idx OF TABLE movr.vehicles CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION washington_dc OF INDEX vehicles_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -257,7 +257,7 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION seattle_idx OF TABLE movr.vehicles CONFIGURE ZONE USING constraints='[+zone=us-west1-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION seattle OF INDEX vehicles_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-west1-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -271,7 +271,7 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION san_francisco_idx OF TABLE movr.vehicles CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION san_francisco OF INDEX vehicles_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -285,7 +285,7 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION los_angeles_idx OF TABLE movr.vehicles CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION los_angeles OF INDEX vehicles_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -301,14 +301,14 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION new_york_idx1 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION new_york OF INDEX rides_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION new_york_idx2 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION new_york OF INDEX rides_auto_index_fk_vehicle_city_ref_vehicles CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -322,14 +322,14 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION boston_idx1 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION boston OF INDEX rides_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION boston_idx2 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION boston OF INDEX rides_auto_index_fk_vehicle_city_ref_vehicles CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -343,14 +343,14 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION washington_dc_idx OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION washington_dc OF INDEX rides_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION washington_dc_idx2 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
+    $ cockroach sql --execute="ALTER PARTITION washington_dc OF INDEX rides_auto_index_fk_vehicle_city_ref_vehicles CONFIGURE ZONE USING constraints='[+zone=us-east1-b]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -364,14 +364,14 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION seattle_idx1 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-west1-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION seattle OF INDEX rides_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-west1-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION seattle_idx2 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-west1-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION seattle OF INDEX rides_auto_index_fk_vehicle_city_ref_vehicles CONFIGURE ZONE USING constraints='[+zone=us-west1-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -385,14 +385,14 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION san_francisco_idx1 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION san_francisco OF INDEX rides_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION san_francisco_idx2 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION san_francisco OF INDEX rides_auto_index_fk_vehicle_city_ref_vehicles CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
@@ -406,14 +406,14 @@ For this service, the most effective technique for improving read and write late
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION los_angeles_idx1 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION los_angeles OF INDEX rides_auto_index_fk_city_ref_users CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --execute="ALTER PARTITION los_angeles_idx2 OF TABLE movr.rides CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
+    $ cockroach sql --execute="ALTER PARTITION los_angeles OF INDEX rides_auto_index_fk_vehicle_city_ref_vehicles CONFIGURE ZONE USING constraints='[+zone=us-west2-a]';" \
     {{page.certs}} \
     --host=<address of any node>
     ~~~

--- a/_includes/v19.2/sql/movr-statements-partitioning.md
+++ b/_includes/v19.2/sql/movr-statements-partitioning.md
@@ -6,7 +6,7 @@ To follow along with the partitioning examples below, open a new terminal and ru
 ~~~ shell
 $ cockroach demo movr \
 --nodes=9 \
---demo-locality=region=us-east1,region=us-east1,region=us-east1,region=us-central1,region=us-central1,region=us-central1,region=us-west1,region=us-west1,region=us-west1
+--demo-locality=region=us-east1:region=us-east1:region=us-east1:region=us-central1:region=us-central1:region=us-central1:region=us-west1:region=us-west1:region=us-west1
 ~~~
 
 {% include {{page.version.version}}/sql/partitioning-enterprise.md %}

--- a/_includes/v19.2/zone-configs/create-a-replication-zone-for-a-table-partition.md
+++ b/_includes/v19.2/zone-configs/create-a-replication-zone-for-a-table-partition.md
@@ -30,7 +30,3 @@ CONFIGURE ZONE 1
                                |     lease_preferences = '[]'
 (1 row)
 ~~~
-
-{{site.data.alerts.callout_success}}
-Since the syntax is the same for defining a replication zone for a table or index partition (e.g., `database.table.partition`), give partitions names that communicate what they are partitioning, e.g., `north_america_table` vs `north_america_idx1`.
-{{site.data.alerts.end}}

--- a/v19.2/partitioning.md
+++ b/v19.2/partitioning.md
@@ -112,25 +112,7 @@ The primary key discussed above has two drawbacks:
 
 To ensure uniqueness or fast lookups, create a unique, unpartitioned secondary index on the identifier.
 
-Indexes can also be partitioned, but are not required to be. Each partition is required to have a name that is unique among all partitions on that table and its indexes. For example, the following `CREATE INDEX` scenario will fail because it reuses the name of a partition of the primary key:
-
-{% include copy-clipboard.html %}
-~~~ sql
-CREATE TABLE foo (a STRING PRIMARY KEY, b STRING) PARTITION BY LIST (a) (
-    bar VALUES IN ('bar'),
-    default VALUES IN (DEFAULT)
-);
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-CREATE INDEX foo_b_idx ON foo (b) PARTITION BY LIST (b) (
-    baz VALUES IN ('baz'),
-    default VALUES IN (DEFAULT)
-);
-~~~
-
-Consider using a naming scheme that uses the index name to avoid conflicts. For example, the partitions above could be named `primary_idx_bar`, `primary_idx_default`, `b_idx_baz`, `b_idx_default`.
+Indexes can also be partitioned, but are not required to be.
 
 #### Define partitions on interleaved tables
 

--- a/v19.2/topology-geo-partitioned-leaseholders.md
+++ b/v19.2/topology-geo-partitioned-leaseholders.md
@@ -82,9 +82,9 @@ Assuming you have a [cluster deployed across three regions](#cluster-setup) and 
     {% include copy-clipboard.html %}
     ~~~ sql
     > ALTER INDEX users_last_name_index PARTITION BY LIST (city) (
-        PARTITION la_idx VALUES IN ('los angeles'),
-        PARTITION chicago_idx VALUES IN ('chicago'),
-        PARTITION ny_idx VALUES IN ('new york')
+        PARTITION la VALUES IN ('los angeles'),
+        PARTITION chicago VALUES IN ('chicago'),
+        PARTITION ny VALUES IN ('new york')
     );
     ~~~
 
@@ -112,15 +112,15 @@ Assuming you have a [cluster deployed across three regions](#cluster-setup) and 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > ALTER PARTITION la_idx OF TABLE users
+    > ALTER PARTITION la OF INDEX users_last_name_index
         CONFIGURE ZONE USING
           constraints = '{"+region=us-west":1}',
           lease_preferences = '[[+region=us-west]]';
-      ALTER PARTITION chicago_idx OF TABLE users
+      ALTER PARTITION chicago OF INDEX users_last_name_index
         CONFIGURE ZONE USING
           constraints = '{"+region=us-central":1}',
           lease_preferences = '[[+region=us-central]]';
-      ALTER PARTITION ny_idx OF TABLE users
+      ALTER PARTITION ny OF INDEX users_last_name_index
         CONFIGURE ZONE USING
           constraints = '{"+region=us-east":1}',
           lease_preferences = '[[+region=us-east]]';
@@ -136,7 +136,7 @@ As you scale and add more cities, you can repeat steps 2 and 3 with the new comp
 
 #### Reads
 
-Because each partition's leaseholder is constrained to the relevant region (e.g., the `la` and `la_idx` partitions' leaseholders are located in the `us-west` region), reads that specify the local region key access the relevant leaseholder locally. This makes read latency very low, with the exception of reads that do not specify a region key or that refer to a partition in another region.
+Because each partition's leaseholder is constrained to the relevant region (e.g., the `la` partitions' leaseholders are located in the `us-west` region), reads that specify the local region key access the relevant leaseholder locally. This makes read latency very low, with the exception of reads that do not specify a region key or that refer to a partition in another region.
 
 For example, in the animation below:
 
@@ -150,7 +150,7 @@ For example, in the animation below:
 
 #### Writes
 
-Just like for reads, because each partition's leaseholder is constrained to the relevant region (e.g., the `la` and `la_idx` partitions' leaseholders are located in the `us-west` region), writes that specify the local region key access the relevant leaseholder replicas locally. However, a partition's other replicas are spread across the other regions, so writes involve multiple network hops across regions to achieve consensus. This increases write latency significantly.
+Just like for reads, because each partition's leaseholder is constrained to the relevant region (e.g., the `la` partitions' leaseholders are located in the `us-west` region), writes that specify the local region key access the relevant leaseholder replicas locally. However, a partition's other replicas are spread across the other regions, so writes involve multiple network hops across regions to achieve consensus. This increases write latency significantly.
 
 For example, in the animation below:
 

--- a/v19.2/topology-geo-partitioned-replicas.md
+++ b/v19.2/topology-geo-partitioned-replicas.md
@@ -81,9 +81,9 @@ A geo-partitioned table does not require a secondary index. However, if the tabl
     {% include copy-clipboard.html %}
     ~~~ sql
     > ALTER INDEX users_last_name_index PARTITION BY LIST (city) (
-        PARTITION la_idx VALUES IN ('los angeles'),
-        PARTITION chicago_idx VALUES IN ('chicago'),
-        PARTITION ny_idx VALUES IN ('new york')
+        PARTITION la VALUES IN ('los angeles'),
+        PARTITION chicago VALUES IN ('chicago'),
+        PARTITION ny VALUES IN ('new york')
     );
     ~~~
 
@@ -105,11 +105,11 @@ A geo-partitioned table does not require a secondary index. However, if the tabl
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > ALTER PARTITION la_idx OF TABLE users
+    > ALTER PARTITION la OF INDEX users_last_name_index
         CONFIGURE ZONE USING constraints = '[+region=us-west]';
-      ALTER PARTITION chicago_idx OF TABLE users
+      ALTER PARTITION chicago OF INDEX users_last_name_index
         CONFIGURE ZONE USING constraints = '[+region=us-central]';
-      ALTER PARTITION ny_idx OF TABLE users
+      ALTER PARTITION ny OF INDEX users_last_name_index
         CONFIGURE ZONE USING constraints = '[+region=us-east]';
     ~~~
 
@@ -123,7 +123,7 @@ As you scale and add more cities, you can repeat steps 2 and 3 with the new comp
 
 #### Reads
 
-Because each partition is constrained to the relevant region (e.g., the `la` and `la_idx` partitions are located in the `us-west` region), reads that specify the local region key access the relevant leaseholder locally. This makes read latency very low, with the exception of reads that do not specify a region key or that refer to a partition in another region; such reads will be transactionally consistent but won't have local latencies.
+Because each partition is constrained to the relevant region (e.g., the `la` partitions are located in the `us-west` region), reads that specify the local region key access the relevant leaseholder locally. This makes read latency very low, with the exception of reads that do not specify a region key or that refer to a partition in another region; such reads will be transactionally consistent but won't have local latencies.
 
 For example, in the animation below:
 
@@ -137,7 +137,7 @@ For example, in the animation below:
 
 #### Writes
 
-Just like for reads, because each partition is constrained to the relevant region (e.g., the `la` and `la_idx` partitions are located in the `us-west` region), writes that specify the local region key access the relevant replicas without leaving the region. This makes write latency very low, with the exception of writes that do not specify a region key or that refer to a partition in another region; such writes will be transactionally consistent but won't have local latencies.
+Just like for reads, because each partition is constrained to the relevant region (e.g., the `la` partitions are located in the `us-west` region), writes that specify the local region key access the relevant replicas without leaving the region. This makes write latency very low, with the exception of writes that do not specify a region key or that refer to a partition in another region; such writes will be transactionally consistent but won't have local latencies.
 
 For example, in the animation below:
 


### PR DESCRIPTION
Updated partition examples with secondary indexes to:
- Use the same partition names for primary and secondary index partitions on the same table
- Use `ALTER PARTITION ... OF INDEX` when configuring zone constraints on secondary-index partitions

Fixes #5245. 

Added Solon and Andy to the review as well.