### PR TITLE
Makefile: mark vendor as an order-only dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,6 @@ test: bootstrap
 vendor:
 	gem install bundler
 
-bootstrap: Gemfile Gemfile.lock vendor
+bootstrap: Gemfile Gemfile.lock | vendor
 	bundle install
 	touch $@


### PR DESCRIPTION
Bundler shouldn't be reinstalled just because the vendor directory is
out of date. (Directories appear out of date whenever a direntry is
changed; i.e., whenever a file is added or removed.) This was causing CI
to fail whenever vendor got an earlier mtime than bootstrap, because it
looked like bootstrap was out of date and thus dependencies were being
reinstalled.