### PR TITLE
UNSPLIT AT statement page and diagrams

### DIFF
--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -1220,6 +1220,12 @@
                 ]
               },
               {
+                "title": "<code>UNSPLIT AT</code>",
+                "urls": [
+                  "/${VERSION}/unsplit-at.html"
+                ]
+              },
+              {
                 "title": "<code>UPDATE</code>",
                 "urls": [
                   "/${VERSION}/update.html"

--- a/_includes/v19.2/sql/diagrams/split_index_at.html
+++ b/_includes/v19.2/sql/diagrams/split_index_at.html
@@ -1,38 +1,38 @@
-<div><svg width="646" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         
-            <rect x="195" y="3" width="90" height="32"></rect>
-            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="21">table_name</text>
-         
-         <rect x="325" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="323" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="53">@</text>
-         
-            <rect x="375" y="35" width="92" height="32"></rect>
-            <rect x="373" y="33" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="383" y="53">index_name</text>
-         
-         <rect x="507" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="505" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="515" y="21">SPLIT</text>
-         <rect x="587" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="585" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="595" y="21">AT</text>
-         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-            <rect x="529" y="101" width="90" height="32"></rect>
-            <rect x="527" y="99" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="119">select_stmt</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="637 115 645 111 645 119"></polygon>
-         <polygon points="637 115 629 111 629 119"></polygon>
-      </svg></div>
+<div><svg width="663" height="179">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="3" width="96" height="32"></rect>
+<rect x="215" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="21">table_name</text><rect x="333" y="3" width="32" height="32" rx="10"></rect>
+<rect x="331" y="1" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="21">@</text>
+<rect x="385" y="3" width="98" height="32"></rect>
+<rect x="383" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="393" y="21">index_name</text><a xlink:href="sql-grammar.html#standalone_index_name" xlink:title="standalone_index_name">
+<rect x="217" y="47" width="176" height="32"></rect>
+<rect x="215" y="45" width="176" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="65">standalone_index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
+<rect x="521" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="531" y="21">SPLIT</text>
+<rect x="603" y="3" width="38" height="32" rx="10"></rect>
+<rect x="601" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="611" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="213" y="113" width="94" height="32"></rect>
+<rect x="211" y="111" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="221" y="131">select_stmt</text></a><rect x="347" y="145" width="58" height="32" rx="10"></rect>
+<rect x="345" y="143" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="163">WITH</text>
+<rect x="425" y="145" width="106" height="32" rx="10"></rect>
+<rect x="423" y="143" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="163">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="551" y="145" width="64" height="32"></rect>
+<rect x="549" y="143" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="163">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m176 0 h10 m0 0 h90 m20 -44 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="653 127 661 123 661 131"></polygon>
+<polygon points="653 127 645 123 645 131"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/split_table_at.html
+++ b/_includes/v19.2/sql/diagrams/split_table_at.html
@@ -1,30 +1,30 @@
-<div><svg width="560" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">TABLE</text>
-         
-            <rect x="195" y="3" width="90" height="32"></rect>
-            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="21">table_name</text>
-         
-         <rect x="305" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="303" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="313" y="21">SPLIT</text>
-         <rect x="385" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="383" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="393" y="21">AT</text>
-         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-            <rect x="443" y="3" width="90" height="32"></rect>
-            <rect x="441" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="451" y="21">select_stmt</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="551 17 559 13 559 21"></polygon>
-         <polygon points="551 17 543 13 543 21"></polygon>
-      </svg></div>
+<div><svg width="565" height="123">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="62" height="32" rx="10"></rect>
+<rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">TABLE</text>
+<rect x="195" y="3" width="96" height="32"></rect>
+<rect x="193" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="203" y="21">table_name</text><rect x="311" y="3" width="60" height="32" rx="10"></rect>
+<rect x="309" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="319" y="21">SPLIT</text>
+<rect x="391" y="3" width="38" height="32" rx="10"></rect>
+<rect x="389" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="399" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="449" y="3" width="94" height="32"></rect>
+<rect x="447" y="1" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="457" y="21">select_stmt</text></a><rect x="249" y="89" width="58" height="32" rx="10"></rect>
+<rect x="247" y="87" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="257" y="107">WITH</text>
+<rect x="327" y="89" width="106" height="32" rx="10"></rect>
+<rect x="325" y="87" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="335" y="107">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="453" y="89" width="64" height="32"></rect>
+<rect x="451" y="87" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="461" y="107">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-358 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="555 71 563 67 563 75"></polygon>
+<polygon points="555 71 547 67 547 75"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/unsplit_index_at.html
+++ b/_includes/v19.2/sql/diagrams/unsplit_index_at.html
@@ -1,0 +1,33 @@
+<div><svg width="625" height="191">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="3" width="96" height="32"></rect>
+<rect x="215" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="21">table_name</text><rect x="333" y="3" width="32" height="32" rx="10"></rect>
+<rect x="331" y="1" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="21">@</text>
+<rect x="385" y="3" width="98" height="32"></rect>
+<rect x="383" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="393" y="21">index_name</text><a xlink:href="sql-grammar.html#standalone_index_name" xlink:title="standalone_index_name">
+<rect x="217" y="47" width="176" height="32"></rect>
+<rect x="215" y="45" width="176" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="65">standalone_index_name</text></a><rect x="523" y="3" width="80" height="32" rx="10"></rect>
+<rect x="521" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="531" y="21">UNSPLIT</text>
+<rect x="425" y="113" width="38" height="32" rx="10"></rect>
+<rect x="423" y="111" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="131">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="483" y="113" width="94" height="32"></rect>
+<rect x="481" y="111" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="491" y="131">select_stmt</text></a><rect x="425" y="157" width="44" height="32" rx="10"></rect>
+<rect x="423" y="155" width="44" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="175">ALL</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m176 0 h10 m0 0 h90 m20 -44 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-242 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m44 0 h10 m0 0 h108 m23 -44 h-3"></path>
+<polygon points="615 127 623 123 623 131"></polygon>
+<polygon points="615 127 607 123 607 131"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/unsplit_table_at.html
+++ b/_includes/v19.2/sql/diagrams/unsplit_table_at.html
@@ -1,0 +1,25 @@
+<div><svg width="631" height="81">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="62" height="32" rx="10"></rect>
+<rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">TABLE</text>
+<rect x="195" y="3" width="96" height="32"></rect>
+<rect x="193" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="203" y="21">table_name</text><rect x="311" y="3" width="80" height="32" rx="10"></rect>
+<rect x="309" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="319" y="21">UNSPLIT</text>
+<rect x="431" y="3" width="38" height="32" rx="10"></rect>
+<rect x="429" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="439" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="489" y="3" width="94" height="32"></rect>
+<rect x="487" y="1" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="497" y="21">select_stmt</text></a><rect x="431" y="47" width="44" height="32" rx="10"></rect>
+<rect x="429" y="45" width="44" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="439" y="65">ALL</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m44 0 h10 m0 0 h108 m23 -44 h-3"></path>
+<polygon points="621 17 629 13 629 21"></polygon>
+<polygon points="621 17 613 13 613 21"></polygon></svg></div>

--- a/_includes/v19.2/sql/movr-start-nodes.md
+++ b/_includes/v19.2/sql/movr-start-nodes.md
@@ -1,4 +1,4 @@
-Run [`cockroach demo`](cockroach-demo.html) with the `--nodes` and `--demo-locality` tags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
+Run [`cockroach demo`](cockroach-demo.html) with the [`--nodes`](cockroach-demo.html#general) and [`--demo-locality`](cockroach-demo.html#general) flags This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
 
     {% include copy-clipboard.html %}
     ~~~ shell

--- a/_includes/v19.2/sql/movr-statements-nodes.md
+++ b/_includes/v19.2/sql/movr-statements-nodes.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the `--nodes` and `--demo-locality` tags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--nodes`](cockroach-demo.html#general) and [`--demo-locality`](cockroach-demo.html#general) flags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v19.2/sql/movr-statements-partitioning.md
+++ b/_includes/v19.2/sql/movr-statements-partitioning.md
@@ -1,6 +1,6 @@
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along with the partitioning examples below, open a new terminal and run [`cockroach demo`](cockroach-demo.html) with the `--nodes` and `--demo-locality` tags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
+To follow along with the partitioning examples below, open a new terminal and run [`cockroach demo`](cockroach-demo.html) with the [`--nodes`](cockroach-demo.html#general) and [`--demo-locality`](cockroach-demo.html#general) flags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v19.2/sql/movr-statements-partitioning.md
+++ b/_includes/v19.2/sql/movr-statements-partitioning.md
@@ -1,6 +1,6 @@
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along with the partitioning examples below, open a new terminal and run [`cockroach demo`](cockroach-demo.html) with the [`--nodes`](cockroach-demo.html#general) and [`--demo-locality`](cockroach-demo.html#general) flags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
+To follow along with the examples below, open a new terminal and run [`cockroach demo`](cockroach-demo.html) with the [`--nodes`](cockroach-demo.html#general) and [`--demo-locality`](cockroach-demo.html#general) flags. This command opens an interactive SQL shell to a temporary, multi-node in-memory cluster with the `movr` database preloaded and set as the [current database](sql-name-resolution.html#current-database).
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -8,5 +8,3 @@ $ cockroach demo \
 --nodes=9 \
 --demo-locality=region=us-east1:region=us-east1:region=us-east1:region=us-central1:region=us-central1:region=us-central1:region=us-west1:region=us-west1:region=us-west1
 ~~~
-
-{% include {{page.version.version}}/sql/partitioning-enterprise.md %}

--- a/v19.2/alter-index.md
+++ b/v19.2/alter-index.md
@@ -16,4 +16,5 @@ Subcommand | Description
 -----------|------------
 [`CONFIGURE ZONE`](configure-zone.html) | [Configure replication zones](configure-replication-zones.html) for an index.
 [`RENAME`](rename-index.html) | Change the name of an index.
-[`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the index.
+[`SPLIT AT`](split-at.html) | Force a range split at the specified row in the index.
+[`UNSPLIT AT`](unsplit-at.html) | <span class="version-tag">New in v19.2:</span> Remove a range split enforcement at a specified row in the index.

--- a/v19.2/alter-table.md
+++ b/v19.2/alter-table.md
@@ -34,7 +34,8 @@ Subcommand | Description | Can combine with other subcommands?
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns. | Yes
 [`RENAME CONSTRAINT`](rename-constraint.html) | Change constraints columns. | Yes
 [`RENAME TABLE`](rename-table.html) | Change the names of tables. | No
-[`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the table. | No
+[`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table. | No
+[`UNSPLIT AT`](unsplit-at.html) | <span class="version-tag">New in v19.2:</span> Remove a range split enforcement at a specified row in the table. | No
 [`VALIDATE CONSTRAINT`](validate-constraint.html) | Check whether values in a column match a [constraint](constraints.html) on the column. | Yes
 
 ## Viewing schema changes

--- a/v19.2/split-at.md
+++ b/v19.2/split-at.md
@@ -1,10 +1,10 @@
 ---
 title: SPLIT AT
-summary: The SPLIT AT statement forces a key-value layer range split at the specified row in a table or index.
+summary: The SPLIT AT statement forces a range split at the specified row in a table or index.
 toc: true
 ---
 
-The `SPLIT AT` [statement](sql-statements.html) forces a key-value layer range split at the specified row in a table or index.
+The `SPLIT AT` [statement](sql-statements.html) forces a range split at the specified row in a table or index.
 
 ## Synopsis
 
@@ -27,14 +27,9 @@ The user must have the `INSERT` [privilege](authorization.html#assign-privileges
  `table_name`<br>`table_name @ index_name` | The name of the table or index that should be split.
  `select_stmt` | A [selection query](selection-queries.html) that produces one or more rows at which to split the table or index.
 
-## Viewing schema changes
-
-{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
-
 ## Why manually split a range?
 
-The key-value layer of CockroachDB is broken into sections of contiguous
-key-space known as ranges. By default, CockroachDB attempts to keep ranges below
+CockroachDB breaks data into ranges. By default, CockroachDB attempts to keep ranges below
 a size of 64MiB. To do this, the system will automatically [split](architecture/distribution-layer.html#range-splits)
 a range if it grows larger than this limit. For most use cases, this automatic
 range splitting is sufficient, and you should never need to worry about
@@ -252,3 +247,4 @@ SHOW RANGES FROM TABLE t;
 - [Distribution Layer](architecture/distribution-layer.html)
 - [Replication Layer](architecture/replication-layer.html)
 - [`SHOW JOBS`](show-jobs.html)
+- <span class="version-tag">New in v19.2:</span> [`UNSPLIT AT`](unsplit-at.html)

--- a/v19.2/sql-statements.md
+++ b/v19.2/sql-statements.md
@@ -77,7 +77,8 @@ Statement | Usage
 [`SHOW TABLES`](show-tables.html) | List tables or views in a database or virtual schema.
 [`SHOW RANGES`](show-ranges.html) | Show range information about a specific table or index.
 [`SHOW ZONE CONFIGURATIONS`](show-zone-configurations.html) | List details about existing [replication zones](configure-replication-zones.html).
-[`SPLIT AT`](split-at.html) | Force a key-value layer range split at the specified row in the table or index.
+[`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table or index.
+[`UNSPLIT AT`](unsplit-at.html) | <span class="version-tag">New in v19.2:</span> Remove a range split enforcement at a specified row in the table or index.
 [`VALIDATE CONSTRAINT`](validate-constraint.html) | Check whether values in a column match a [constraint](constraints.html) on the column.
 
 ## Transaction management statements

--- a/v19.2/unsplit-at.md
+++ b/v19.2/unsplit-at.md
@@ -1,0 +1,190 @@
+---
+title: UNSPLIT AT
+summary: The UNSPLIT AT statement removes a range split enforcement at a specified row in the table or index.
+toc: true
+---
+
+The `UNSPLIT AT` [statement](sql-statements.html) removes a [split enforcement](split-at.html) on a [range split](architecture/distribution-layer.html#range-splits), at a specified row in a table or index.
+
+Removing a split enforcement from a table or index ("unsplitting") allows CockroachDB to merge ranges as needed, to help improve your cluster's performance. For more information, see [Range Merges](range-merges.html).
+
+## Synopsis
+
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/unsplit_table_at.html %}
+</div>
+
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/unsplit_index_at.html %}
+</div>
+
+## Required privileges
+
+The user must have the `INSERT` [privilege](authorization.html#assign-privileges) on the table or index.
+
+## Parameters
+
+ Parameter | Description
+-----------|-------------
+ `table_name` | The name of the table that you want to unsplit.
+ `table_name @ index_name`<br>`standalone_index_name` | The name of the index that you want to unsplit.
+ `select_stmt` | A [selection query](selection-queries.html) that produces one or more rows at which to unsplit a table or index.
+
+## Examples
+
+{% include {{page.version.version}}/sql/movr-statements-nodes.md %}
+
+### Unsplit a table
+
+The `crdb_internal.ranges` table contains information about ranges in your CockroachDB cluster. At this point, just one range contains the data in the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT range_id, start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges WHERE table_name='users';
+~~~
+~~~
+  range_id | start_pretty | end_pretty | split_enforced_until
++----------+--------------+------------+----------------------+
+        21 | /Table/53    | /Table/54  | NULL
+(1 row)
+~~~
+
+Now split the `users` table ranges based on primary key values:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE users SPLIT AT VALUES ('chicago'), ('new york'), ('seattle');
+~~~
+~~~
+              key              |         pretty         |       split_enforced_until
++------------------------------+------------------------+----------------------------------+
+  \275\211\022chicago\000\001  | /Table/53/1/"chicago"  | 2262-04-11 23:47:16.854776+00:00
+  \275\211\022new york\000\001 | /Table/53/1/"new york" | 2262-04-11 23:47:16.854776+00:00
+  \275\211\022seattle\000\001  | /Table/53/1/"seattle"  | 2262-04-11 23:47:16.854776+00:00
+(3 rows)
+~~~
+
+You can see the additional ranges in the `crdb_internal.ranges` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT range_id, start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges WHERE table_name='users';
+~~~
+~~~
+  range_id |      start_pretty      |       end_pretty       |       split_enforced_until
++----------+------------------------+------------------------+----------------------------------+
+        21 | /Table/53              | /Table/53/1/"chicago"  | NULL
+        27 | /Table/53/1/"chicago"  | /Table/53/1/"new york" | 2262-04-11 23:47:16.854776+00:00
+        28 | /Table/53/1/"new york" | /Table/53/1/"seattle"  | 2262-04-11 23:47:16.854776+00:00
+        29 | /Table/53/1/"seattle"  | /Table/54              | 2262-04-11 23:47:16.854776+00:00
+(4 rows)
+~~~
+
+Now unsplit the table to remove the split enforcements:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE users UNSPLIT AT VALUES ('chicago'), ('new york'), ('seattle');
+~~~
+~~~
+              key              |         pretty
++------------------------------+------------------------+
+  \275\211\022chicago\000\001  | /Table/53/1/"chicago"
+  \275\211\022new york\000\001 | /Table/53/1/"new york"
+  \275\211\022seattle\000\001  | /Table/53/1/"seattle"
+(3 rows)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT range_id, start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges WHERE table_name='users';
+~~~
+~~~
+  range_id |      start_pretty      |       end_pretty       | split_enforced_until
++----------+------------------------+------------------------+----------------------+
+        21 | /Table/53              | /Table/53/1/"chicago"  | NULL
+        27 | /Table/53/1/"chicago"  | /Table/53/1/"new york" | NULL
+        28 | /Table/53/1/"new york" | /Table/53/1/"seattle"  | NULL
+        29 | /Table/53/1/"seattle"  | /Table/54              | NULL
+(4 rows)
+~~~
+
+The `users` table is still split into ranges at `'chicago'`, `'new york'`, and `'seattle'`, but the `split_enforced_until` column is now `NULL` for all ranges in the table. The split is no longer enforced, and CockroachDB can merge the data in the table as needed.
+
+### Unsplit an index
+
+Add a new secondary [index](indexes.html) to the `rides` table, on the `revenue` column, and then split the table ranges by secondary index values:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE INDEX revenue_idx ON rides(revenue);
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX rides@revenue_idx SPLIT AT VALUES (25.00), (50.00), (75.00);
+~~~
+~~~
+         key        |      pretty      |       split_enforced_until
++-------------------+------------------+----------------------------------+
+  \277\214*2\000    | /Table/55/4/25   | 2262-04-11 23:47:16.854776+00:00
+  \277\214*d\000    | /Table/55/4/5E+1 | 2262-04-11 23:47:16.854776+00:00
+  \277\214*\226\000 | /Table/55/4/75   | 2262-04-11 23:47:16.854776+00:00
+(3 rows)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT range_id, start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges WHERE table_name='rides';
+~~~
+~~~
+  range_id |   start_pretty   |    end_pretty    |       split_enforced_until
++----------+------------------+------------------+----------------------------------+
+        23 | /Table/55        | /Table/55/4      | NULL
+        32 | /Table/55/4      | /Table/55/4/25   | 2019-09-10 21:27:35.056275+00:00
+        33 | /Table/55/4/25   | /Table/55/4/5E+1 | 2262-04-11 23:47:16.854776+00:00
+        34 | /Table/55/4/5E+1 | /Table/55/4/75   | 2262-04-11 23:47:16.854776+00:00
+        35 | /Table/55/4/75   | /Table/56        | 2262-04-11 23:47:16.854776+00:00
+(5 rows)
+~~~
+
+Now unsplit the index to remove the split enforcements:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX rides@revenue_idx UNSPLIT AT VALUES (25.00), (50.00), (75.00);
+~~~
+~~~
+         key        |      pretty
++-------------------+------------------+
+  \277\214*2\000    | /Table/55/4/25
+  \277\214*d\000    | /Table/55/4/5E+1
+  \277\214*\226\000 | /Table/55/4/75
+(3 rows)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT range_id, start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges WHERE table_name='rides';
+~~~
+~~~
+  range_id |   start_pretty   |    end_pretty    |       split_enforced_until
++----------+------------------+------------------+----------------------------------+
+        23 | /Table/55        | /Table/55/4      | NULL
+        32 | /Table/55/4      | /Table/55/4/25   | 2019-09-10 21:27:35.056275+00:00
+        33 | /Table/55/4/25   | /Table/55/4/5E+1 | NULL
+        34 | /Table/55/4/5E+1 | /Table/55/4/75   | NULL
+        35 | /Table/55/4/75   | /Table/56        | NULL
+(5 rows)
+~~~
+
+The table is still split into ranges at `25.00`, `50.00`, and `75.00`, but the `split_enforced_until` column is now `NULL` for all ranges in the table. The split is no longer enforced, and CockroachDB can merge the data in the table as needed.
+
+## See also
+
+- [`SPLIT AT`](split-at.html)
+- [Selection Queries](selection-queries.html)
+- [Distribution Layer](architecture/distribution-layer.html)
+- [Range Merges](range-merges.html)
+- [Replication Layer](architecture/replication-layer.html)
+- [`SHOW JOBS`](show-jobs.html)

--- a/v19.2/unsplit-at.md
+++ b/v19.2/unsplit-at.md
@@ -49,7 +49,7 @@ The `crdb_internal.ranges` table contains information about ranges in your Cockr
 (1 row)
 ~~~
 
-Now split the `users` table ranges based on primary key values:
+Now [split](split-at.html) the `users` table ranges based on primary key values:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -109,11 +109,11 @@ Now unsplit the table to remove the split enforcements:
 (4 rows)
 ~~~
 
-The `users` table is still split into ranges at `'chicago'`, `'new york'`, and `'seattle'`, but the `split_enforced_until` column is now `NULL` for all ranges in the table. The split is no longer enforced, and CockroachDB can merge the data in the table as needed.
+The `users` table is still split into ranges at `'chicago'`, `'new york'`, and `'seattle'`, but the `split_enforced_until` column is now `NULL` for all ranges in the table. The split is no longer enforced, and CockroachDB can [merge the data](range-merges.html) in the table as needed.
 
 ### Unsplit an index
 
-Add a new secondary [index](indexes.html) to the `rides` table, on the `revenue` column, and then split the table ranges by secondary index values:
+Add a new secondary [index](indexes.html) to the `rides` table, on the `revenue` column, and then [split](split-at.html) the table ranges by secondary index values:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -178,7 +178,7 @@ Now unsplit the index to remove the split enforcements:
 (5 rows)
 ~~~
 
-The table is still split into ranges at `25.00`, `50.00`, and `75.00`, but the `split_enforced_until` column is now `NULL` for all ranges in the table. The split is no longer enforced, and CockroachDB can merge the data in the table as needed.
+The table is still split into ranges at `25.00`, `50.00`, and `75.00`, but the `split_enforced_until` column is now `NULL` for all ranges in the table. The split is no longer enforced, and CockroachDB can [merge the data](range-merges.html) in the table as needed.
 
 ## See also
 


### PR DESCRIPTION
- Added new page for `UNSPLIT AT` statement.
- Added new diagrams for `UNSPLIT AT` statement.
- Added new diagrams/parameter for `SPLIT AT` statement for WITH EXPIRATION.
- Changed all `UNSPLIT AT` examples to use `movr` database.

Fixes #4895.
Fixes #5008.
Fixes #5007.

