### PR TITLE
Updated table expression diagram and page for row sources

### DIFF
--- a/_includes/v19.2/sql/diagrams/table_ref.html
+++ b/_includes/v19.2/sql/diagrams/table_ref.html
@@ -1,4 +1,4 @@
-<div><svg width="1231" height="333">
+<div><svg width="1251" height="421">
 <polygon points="9 61 1 57 1 65"></polygon>
 <polygon points="17 61 9 57 9 65"></polygon><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
 <rect x="71" y="47" width="96" height="32"></rect>
@@ -13,12 +13,12 @@
 <rect x="69" y="121" width="124" height="32" class="nonterminal"></rect>
 <text class="nonterminal" x="79" y="141">func_application</text></a><rect x="71" y="167" width="26" height="32" rx="10"></rect>
 <rect x="69" y="165" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="79" y="185">[</text><a xlink:href="sql-grammar.html#preparable_stmt" xlink:title="preparable_stmt">
-<rect x="117" y="167" width="126" height="32"></rect>
-<rect x="115" y="165" width="126" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="125" y="185">preparable_stmt</text></a><rect x="263" y="167" width="26" height="32" rx="10"></rect>
-<rect x="261" y="165" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="271" y="185">]</text>
+<text class="terminal" x="79" y="185">[</text><a xlink:href="sql-grammar.html#row_source_extension_stmt" xlink:title="row_source_extension_stmt">
+<rect x="117" y="167" width="200" height="32"></rect>
+<rect x="115" y="165" width="200" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="125" y="185">row_source_extension_stmt</text></a><rect x="337" y="167" width="26" height="32" rx="10"></rect>
+<rect x="335" y="165" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="345" y="185">]</text>
 <rect x="71" y="211" width="26" height="32" rx="10"></rect>
 <rect x="69" y="209" width="26" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="79" y="229">(</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
@@ -30,30 +30,43 @@
 <text class="nonterminal" x="145" y="273">joined_table</text></a><rect x="277" y="211" width="26" height="32" rx="10"></rect>
 <rect x="275" y="209" width="26" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="285" y="229">)</text>
-<rect x="437" y="79" width="58" height="32" rx="10"></rect>
-<rect x="435" y="77" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="445" y="97">WITH</text>
-<rect x="515" y="79" width="108" height="32" rx="10"></rect>
-<rect x="513" y="77" width="108" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="523" y="97">ORDINALITY</text>
-<rect x="703" y="79" width="38" height="32" rx="10"></rect>
-<rect x="701" y="77" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="711" y="97">AS</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="781" y="47" width="134" height="32"></rect>
-<rect x="779" y="45" width="134" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="789" y="65">table_alias_name</text></a><rect x="955" y="47" width="26" height="32" rx="10"></rect>
-<rect x="953" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="963" y="65">(</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
-<rect x="1021" y="47" width="56" height="32"></rect>
-<rect x="1019" y="45" width="56" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="1029" y="65">name</text></a><rect x="1021" y="3" width="24" height="32" rx="10"></rect>
-<rect x="1019" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="1029" y="21">,</text>
-<rect x="1117" y="47" width="26" height="32" rx="10"></rect>
-<rect x="1115" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="1125" y="65">)</text><a xlink:href="sql-grammar.html#joined_table" xlink:title="joined_table">
-<rect x="51" y="299" width="100" height="32"></rect>
-<rect x="49" y="297" width="100" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="59" y="317">joined_table</text></a><path class="line" d="m17 61 h2 m40 0 h10 m96 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-326 -32 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v56 m346 0 v-56 m-346 56 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m124 0 h10 m0 0 h182 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m0 0 h88 m-336 -10 v20 m346 0 v-20 m-346 20 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m26 0 h10 m20 0 h10 m94 0 h10 m0 0 h6 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -44 h10 m26 0 h10 m0 0 h74 m40 -164 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m60 -32 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m20 44 h10 m26 0 h10 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v14 m228 0 v-14 m-228 14 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m0 0 h198 m-500 -34 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v46 m520 0 v-46 m-520 46 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m0 0 h490 m-1152 -66 h20 m1152 0 h20 m-1192 0 q10 0 10 10 m1172 0 q0 -10 10 -10 m-1182 10 v232 m1172 0 v-232 m-1172 232 q0 10 10 10 m1152 0 q10 0 10 -10 m-1162 10 h10 m100 0 h10 m0 0 h1032 m23 -252 h-3"></path>
-<polygon points="1221 61 1229 57 1229 65"></polygon>
-<polygon points="1221 61 1213 57 1213 65"></polygon></svg></div>
+<rect x="71" y="299" width="80" height="32" rx="10"></rect>
+<rect x="69" y="297" width="80" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="79" y="317">LATERAL</text>
+<rect x="191" y="299" width="26" height="32" rx="10"></rect>
+<rect x="189" y="297" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="199" y="317">(</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="237" y="299" width="94" height="32"></rect>
+<rect x="235" y="297" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="245" y="317">select_stmt</text></a><rect x="351" y="299" width="26" height="32" rx="10"></rect>
+<rect x="349" y="297" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="359" y="317">)</text><a xlink:href="sql-grammar.html#func_application" xlink:title="func_application">
+<rect x="191" y="343" width="124" height="32"></rect>
+<rect x="189" y="341" width="124" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="199" y="361">func_application</text></a><rect x="457" y="79" width="58" height="32" rx="10"></rect>
+<rect x="455" y="77" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="465" y="97">WITH</text>
+<rect x="535" y="79" width="108" height="32" rx="10"></rect>
+<rect x="533" y="77" width="108" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="543" y="97">ORDINALITY</text>
+<rect x="723" y="79" width="38" height="32" rx="10"></rect>
+<rect x="721" y="77" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="731" y="97">AS</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="801" y="47" width="134" height="32"></rect>
+<rect x="799" y="45" width="134" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="809" y="65">table_alias_name</text></a><rect x="975" y="47" width="26" height="32" rx="10"></rect>
+<rect x="973" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="983" y="65">(</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="1041" y="47" width="56" height="32"></rect>
+<rect x="1039" y="45" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="1049" y="65">name</text></a><rect x="1041" y="3" width="24" height="32" rx="10"></rect>
+<rect x="1039" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="1049" y="21">,</text>
+<rect x="1137" y="47" width="26" height="32" rx="10"></rect>
+<rect x="1135" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="1145" y="65">)</text><a xlink:href="sql-grammar.html#joined_table" xlink:title="joined_table">
+<rect x="51" y="387" width="100" height="32"></rect>
+<rect x="49" y="385" width="100" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="59" y="405">joined_table</text></a><path class="line" d="m17 61 h2 m40 0 h10 m96 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m32 0 h10 m0 0 h10 m98 0 h10 m20 -32 h20 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v56 m366 0 v-56 m-366 56 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m124 0 h10 m0 0 h202 m-356 -10 v20 m366 0 v-20 m-366 20 v24 m366 0 v-24 m-366 24 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m26 0 h10 m0 0 h10 m200 0 h10 m0 0 h10 m26 0 h10 m0 0 h34 m-356 -10 v20 m366 0 v-20 m-366 20 v24 m366 0 v-24 m-366 24 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m26 0 h10 m20 0 h10 m94 0 h10 m0 0 h6 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -44 h10 m26 0 h10 m0 0 h94 m-356 -10 v20 m366 0 v-20 m-366 20 v68 m366 0 v-68 m-366 68 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m80 0 h10 m20 0 h10 m26 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v24 m226 0 v-24 m-226 24 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m124 0 h10 m0 0 h62 m60 -296 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m60 -32 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m20 44 h10 m26 0 h10 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v14 m228 0 v-14 m-228 14 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m0 0 h198 m-500 -34 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v46 m520 0 v-46 m-520 46 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m0 0 h490 m-1172 -66 h20 m1172 0 h20 m-1212 0 q10 0 10 10 m1192 0 q0 -10 10 -10 m-1202 10 v320 m1192 0 v-320 m-1192 320 q0 10 10 10 m1172 0 q10 0 10 -10 m-1182 10 h10 m100 0 h10 m0 0 h1052 m23 -340 h-3"></path>
+<polygon points="1241 61 1249 57 1249 65"></polygon>
+<polygon points="1241 61 1233 57 1233 65"></polygon></svg></div>

--- a/v19.2/table-expressions.md
+++ b/v19.2/table-expressions.md
@@ -27,7 +27,7 @@ Parameter | Description
 `name` | One or more aliases for the column names, to use in an [aliased table expression](#aliased-table-expressions).
 `index_name` | Optional syntax to [force index selection](#force-index-selection).
 `func_application` | [Results from a function](#results-from-a-function).
-`preparable_stmt` | [Use the result rows](#using-the-output-of-other-statements) of a [preparable statement](sql-grammar.html#preparable_stmt).
+`row_source_extension_stmt` | [Result rows](#using-the-output-of-other-statements) from a [supported statement](sql-grammar.html#row_source_extension_stmt).
 `select_stmt` | A [selection query](selection-queries.html) to use as [subquery](#subqueries-as-table-expressions).
 `joined_table` | A [join expression](joins.html).
 
@@ -85,7 +85,7 @@ For example:
 
 #### Force index selection
 
-{% include {{page.version.version}}/misc/force-index-selection.md %} 
+{% include {{page.version.version}}/misc/force-index-selection.md %}
 
 ### Access a common table expression
 
@@ -326,15 +326,23 @@ For example:
 Syntax:
 
 ~~~
-[ <statement> ]
+SELECT .. FROM [ <stmt> ]
 ~~~
 
-An [explainable statement](sql-grammar.html#preparable_stmt)
-between square brackets in a table expression context designates the
-output of executing said statement.
+A [statement](sql-grammar.html#row_source_extension_stmt) between square brackets in a table expression context designates the output of executing the statement as a row source. The following statements are supported as row sources for table expressions:
+
+- [`DELETE`](delete.html)
+- [`EXPLAIN`](explain.html)
+- [`INSERT`](insert.html)
+- [`SELECT`](select.html)
+- [`SHOW`](sql-statements.html#data-definition-statements)
+- [`UPDATE`](update.html)
+- [`UPSERT`](upsert.html)
+
+ `SELECT .. FROM [ <stmt> ]` is equivalent to `WITH table_expr AS ( <stmt> ) SELECT .. FROM table_expr`
 
 {{site.data.alerts.callout_info}}
-This is a CockroachDB extension. This syntax complements the [subquery syntax using parentheses](#subqueries-as-table-expressions), which is restricted to [selection queries](selection-queries.html). It was introduced to enable use of any [explainable statement](sql-grammar.html#preparable_stmt) as subquery, including `SHOW` and other non-query statements.
+This CockroachDB extension syntax complements the [subquery syntax using parentheses](#subqueries-as-table-expressions), which is restricted to [selection queries](selection-queries.html). It was introduced to enable the use of [statements](sql-grammar.html#row_source_extension_stmt) as [subqueries](subqueries.html).
 {{site.data.alerts.end}}
 
 For example:


### PR DESCRIPTION
Fixes #4886.

- Updated table expression diagram.
- Updated parameters on table expression page.
- Updated "Using the output of other statements" section on table expression page.


I'm not really finding any examples in doc where we use newly-invalid row sources in selection clauses. The only area of prose/syntax doc that I'd be concerned about is [table expressions](https://www.cockroachlabs.com/docs/v19.2/table-expressions.html). The [selection queries](https://www.cockroachlabs.com/docs/v19.2/selection-queries.html#using-any-table-expression-as-selection-clause) page reads:

> Any table expression can be used as a selection clause (and thus also a selection query) by prefixing it with TABLE or by using it as an operand to SELECT * FROM.

@RaduBerinde 
In https://github.com/cockroachdb/cockroach/pull/36977, you write "This change restricts the set of statements that can be used as row sources", the context being "Only SELECT, INSERT, UPDATE, UPSERT, DELETE, SHOW, EXPLAIN are supported as data sources using the SELECT ... FROM [ ... ] syntax." Looking at the changes, it looks to me like this only affects the way we define table expression syntax, specifically the change from [preparable statements](https://www.cockroachlabs.com/docs/v19.2/sql-grammar.html#preparable_stmt) to what I am now calling "a subset of explainable statements" and "[row source statements](https://www.cockroachlabs.com/docs/v19.2/sql-grammar.html#row_source_extension_stmt)". Please review the doc changes I've made for more detail. Thanks!
