### PR TITLE
Update 19.2 Python code with app retry loop

### DIFF
--- a/_includes/v19.2/app/basic-sample.py
+++ b/_includes/v19.2/app/basic-sample.py
@@ -1,37 +1,152 @@
-# Import the driver.
+#!/usr/bin/env python3
+
 import psycopg2
+import psycopg2.errorcodes
+import time
+import logging
+import random
 
-# Connect to the "bank" database.
-conn = psycopg2.connect(
-    database='bank',
-    user='maxroach',
-    sslmode='require',
-    sslrootcert='certs/ca.crt',
-    sslkey='certs/client.maxroach.key',
-    sslcert='certs/client.maxroach.crt',
-    port=26257,
-    host='localhost'
-)
 
-# Make each statement commit immediately.
-conn.set_session(autocommit=True)
+def create_accounts(conn):
+    with conn.cursor() as cur:
+        cur.execute('CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)')
+        cur.execute('UPSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)')
+        logging.debug("create_accounts(): status message: {}".format(cur.statusmessage))
+    conn.commit()
 
-# Open a cursor to perform database operations.
-cur = conn.cursor()
 
-# Create the "accounts" table.
-cur.execute("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)")
+def print_balances(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT id, balance FROM accounts")
+        logging.debug("print_balances(): status message: {}".format(cur.statusmessage))
+        rows = cur.fetchall()
+        conn.commit()
+        print("Balances at {}".format(time.asctime()))
+        for row in rows:
+            print([str(cell) for cell in row])
 
-# Insert two rows into the "accounts" table.
-cur.execute("INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)")
 
-# Print out the balances.
-cur.execute("SELECT id, balance FROM accounts")
-rows = cur.fetchall()
-print('Initial balances:')
-for row in rows:
-    print([str(cell) for cell in row])
+def delete_accounts(conn):
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM bank.accounts")
+        logging.debug("delete_accounts(): status message: {}".format(cur.statusmessage))
+    conn.commit()
 
-# Close the database connection.
-cur.close()
-conn.close()
+
+# Wrapper for a transaction.
+# This automatically re-calls "op" with the open transaction as an argument
+# as long as the database server asks for the transaction to be retried.
+def run_transaction(conn, op):
+    retries = 0
+    max_retries = 3
+    with conn:
+        while True:
+            retries +=1
+            if retries == max_retries:
+                err_msg = "Transaction did not succeed after {} retries".format(max_retries)
+                raise ValueError(err_msg)
+
+            try:
+                op(conn)
+
+                # If we reach this point, we were able to commit, so we break
+                # from the retry loop.
+                break
+            except psycopg2.Error as e:
+                logging.debug("e.pgcode: {}".format(e.pgcode))
+                if e.pgcode == '40001':
+                    # This is a retry error, so we roll back the current
+                    # transaction and sleep for a bit before retrying. The
+                    # sleep time increases for each failed transaction.
+                    conn.rollback()
+                    logging.debug("EXECUTE SERIALIZATION_FAILURE BRANCH")
+                    sleep_ms = (2**retries) * 0.1 * (random.random() + 0.5)
+                    logging.debug("Sleeping {} seconds".format(sleep_ms))
+                    time.sleep(sleep_ms)
+                    continue
+                else:
+                    logging.debug("EXECUTE NON-SERIALIZATION_FAILURE BRANCH")
+                    raise e
+
+
+# This function is used to test the transaction retry logic.  It can be deleted
+# from production code.
+def test_retry_loop(conn):
+    with conn.cursor() as cur:
+        # The first statement in a transaction can be retried transparently on
+        # the server, so we need to add a dummy statement so that our
+        # force_retry() statement isn't the first one.
+        cur.execute('SELECT now()')
+        cur.execute("SELECT crdb_internal.force_retry('1s'::INTERVAL)")
+    logging.debug("test_retry_loop(): status message: {}".format(cur.statusmessage))
+
+
+def transfer_funds(conn, frm, to, amount):
+    with conn.cursor() as cur:
+
+        # Check the current balance.
+        cur.execute("SELECT balance FROM accounts WHERE id = " + str(frm))
+        from_balance = cur.fetchone()[0]
+        if from_balance < amount:
+            err_msg = "Insufficient funds in account {}: have {}, need {}".format(frm, from_balance, amount)
+            raise RuntimeError(err_msg)
+
+        # Perform the transfer.
+        cur.execute("UPDATE accounts SET balance = balance - %s WHERE id = %s",
+                    (amount, frm))
+        cur.execute("UPDATE accounts SET balance = balance + %s WHERE id = %s",
+                    (amount, to))
+    conn.commit()
+    logging.debug("transfer_funds(): status message: {}".format(cur.statusmessage))
+
+
+def main():
+
+    conn = psycopg2.connect(
+        database='bank',
+        user='maxroach',
+        sslmode='require',
+        sslrootcert='certs/ca.crt',
+        sslkey='certs/client.maxroach.key',
+        sslcert='certs/client.maxroach.crt',
+        port=26257,
+        host='localhost'
+    )
+
+    # Uncomment the below to turn on logging to the console.  This was useful
+    # when testing transaction retry handling.  It is not necessary for
+    # production code.
+    # log_level = getattr(logging, 'DEBUG', None)
+    # logging.basicConfig(level=log_level)
+
+    create_accounts(conn)
+
+    print_balances(conn)
+
+    amount = 100
+    fromId = 1
+    toId = 2
+
+    try:
+        run_transaction(conn, lambda conn: transfer_funds(conn, fromId, toId, amount))
+
+        # The function below is used to test the transaction retry logic.  It
+        # can be deleted from production code.
+        # run_transaction(conn, lambda conn: test_retry_loop(conn))
+    except ValueError as ve:
+        # Below, we print the error and continue on so this example is easy to
+        # run (and run, and run...).  In real code you should handle this error
+        # and any others thrown by the database interaction.
+        logging.debug("run_transaction(conn, op) failed: {}".format(ve))
+        pass
+
+    print_balances(conn)
+
+    delete_accounts(conn)
+
+    # Close communication with the database.
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/_includes/v19.2/app/insecure/basic-sample.py
+++ b/_includes/v19.2/app/insecure/basic-sample.py
@@ -1,34 +1,144 @@
-# Import the driver.
+#!/usr/bin/env python3
+
 import psycopg2
+import psycopg2.errorcodes
+import time
+import logging
+import random
 
-# Connect to the "bank" database.
-conn = psycopg2.connect(
-    database='bank',
-    user='maxroach',
-    sslmode='disable',
-    port=26257,
-    host='localhost'
-)
 
-# Make each statement commit immediately.
-conn.set_session(autocommit=True)
+def create_accounts(conn):
+    with conn.cursor() as cur:
+        cur.execute('CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)')
+        cur.execute('UPSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)')
+        logging.debug("create_accounts(): status message: {}".format(cur.statusmessage))
+    conn.commit()
 
-# Open a cursor to perform database operations.
-cur = conn.cursor()
 
-# Create the "accounts" table.
-cur.execute("CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)")
+def print_balances(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT id, balance FROM accounts")
+        logging.debug("print_balances(): status message: {}".format(cur.statusmessage))
+        rows = cur.fetchall()
+        conn.commit()
+        print("Balances at {}".format(time.asctime()))
+        for row in rows:
+            print([str(cell) for cell in row])
 
-# Insert two rows into the "accounts" table.
-cur.execute("INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)")
 
-# Print out the balances.
-cur.execute("SELECT id, balance FROM accounts")
-rows = cur.fetchall()
-print('Initial balances:')
-for row in rows:
-    print([str(cell) for cell in row])
+def delete_accounts(conn):
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM bank.accounts")
+        logging.debug("delete_accounts(): status message: {}".format(cur.statusmessage))
+    conn.commit()
 
-# Close the database connection.
-cur.close()
-conn.close()
+
+# Wrapper for a transaction.
+# This automatically re-calls "op" with the open transaction as an argument
+# as long as the database server asks for the transaction to be retried.
+def run_transaction(conn, op):
+    retries = 0
+    max_retries = 3
+    with conn:
+        while True:
+            retries +=1
+            if retries == max_retries:
+                err_msg = "Transaction did not succeed after {} retries".format(max_retries)
+                raise ValueError(err_msg)
+
+            try:
+                op(conn)
+
+                # If we reach this point, we were able to commit, so we break
+                # from the retry loop.
+                break
+            except psycopg2.Error as e:
+                logging.debug("e.pgcode: {}".format(e.pgcode))
+                if e.pgcode == '40001':
+                    # This is a retry error, so we roll back the current
+                    # transaction and sleep for a bit before retrying. The
+                    # sleep time increases for each failed transaction.
+                    conn.rollback()
+                    logging.debug("EXECUTE SERIALIZATION_FAILURE BRANCH")
+                    sleep_ms = (2**retries) * 0.1 * (random.random() + 0.5)
+                    logging.debug("Sleeping {} seconds".format(sleep_ms))
+                    time.sleep(sleep_ms)
+                    continue
+                else:
+                    logging.debug("EXECUTE NON-SERIALIZATION_FAILURE BRANCH")
+                    raise e
+
+
+# This function is used to test the transaction retry logic.  It can be deleted
+# from production code.
+def test_retry_loop(conn):
+    with conn.cursor() as cur:
+        # The first statement in a transaction can be retried transparently on
+        # the server, so we need to add a dummy statement so that our
+        # force_retry() statement isn't the first one.
+        cur.execute('SELECT now()')
+        cur.execute("SELECT crdb_internal.force_retry('1s'::INTERVAL)")
+    logging.debug("test_retry_loop(): status message: {}".format(cur.statusmessage))
+
+
+def transfer_funds(conn, frm, to, amount):
+    with conn.cursor() as cur:
+
+        # Check the current balance.
+        cur.execute("SELECT balance FROM accounts WHERE id = " + str(frm))
+        from_balance = cur.fetchone()[0]
+        if from_balance < amount:
+            err_msg = "Insufficient funds in account {}: have {}, need {}".format(frm, from_balance, amount)
+            raise RuntimeError(err_msg)
+
+        # Perform the transfer.
+        cur.execute("UPDATE accounts SET balance = balance - %s WHERE id = %s",
+                    (amount, frm))
+        cur.execute("UPDATE accounts SET balance = balance + %s WHERE id = %s",
+                    (amount, to))
+    conn.commit()
+    logging.debug("transfer_funds(): status message: {}".format(cur.statusmessage))
+
+
+def main():
+
+    dsn = 'postgresql://maxroach@localhost:26257/bank?sslmode=disable'
+    conn = psycopg2.connect(dsn)
+
+    # Uncomment the below to turn on logging to the console.  This was useful
+    # when testing transaction retry handling.  It is not necessary for
+    # production code.
+    # log_level = getattr(logging, 'DEBUG', None)
+    # logging.basicConfig(level=log_level)
+
+    create_accounts(conn)
+
+    print_balances(conn)
+
+    amount = 100
+    fromId = 1
+    toId = 2
+
+    try:
+        run_transaction(conn, lambda conn: transfer_funds(conn, fromId, toId, amount))
+
+        # The function below is used to test the transaction retry logic.  It
+        # can be deleted from production code.
+        # run_transaction(conn, lambda conn: test_retry_loop(conn))
+    except ValueError as ve:
+        # Below, we print the error and continue on so this example is easy to
+        # run (and run, and run...).  In real code you should handle this error
+        # and any others thrown by the database interaction.
+        logging.debug("run_transaction(conn, op) failed: {}".format(ve))
+        pass
+
+    print_balances(conn)
+
+    delete_accounts(conn)
+
+    # Close communication with the database.
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/v19.2/build-a-python-app-with-cockroachdb.md
+++ b/v19.2/build-a-python-app-with-cockroachdb.md
@@ -38,7 +38,7 @@ For other ways to install psycopg2, see the [official documentation](http://init
 
 ## Step 3. Generate a certificate for the `maxroach` user
 
-Create a certificate and key for the `maxroach` user by running the following command.  The code samples will run as this user.
+Create a certificate and key for the `maxroach` user by running the following command. The code samples will run as this user.
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -49,14 +49,11 @@ $ cockroach cert create-client maxroach --certs-dir=certs --ca-key=my-safe-direc
 
 Now that you have a database and a user, you'll run the code shown below to:
 
-- Create a table and insert some rows
-- Read and update values as an atomic [transaction](transactions.html)
+- Create an `accounts` table and insert some rows.
+- Transfer funds between two accounts inside a [transaction](transactions.html). To ensure that we [handle transaction retry errors](transactions.html#client-side-intervention), we write an application-level retry loop that, in case of error, sleeps before trying the funds transfer again. If it encounters another retry error, it sleeps for a longer interval, implementing [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff).
+- Finally, we delete the accounts from the table before exiting so we can re-run the example code.
 
-### Basic statements
-
-First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
-
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/basic-sample.py" download><code>basic-sample.py</code></a> file, or create the file yourself and copy the code into it.
+Copy the code or <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{page.version.version}}/app/basic-sample.py" download>download it directly</a>.
 
 {% include copy-clipboard.html %}
 ~~~ python
@@ -70,64 +67,15 @@ Then run the code:
 $ python basic-sample.py
 ~~~
 
-The output should be:
+The output should show the account balances before and after the funds transfer:
 
 ~~~
-Initial balances:
+Balances at Wed Aug  7 12:11:23 2019
 ['1', '1000']
 ['2', '250']
-~~~
-
-### Transaction (with retry logic)
-
-Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
-
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/txn-sample.py" download><code>txn-sample.py</code></a> file, or create the file yourself and copy the code into it.
-
-{{site.data.alerts.callout_info}}CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
-
-{% include copy-clipboard.html %}
-~~~ python
-{% include {{page.version.version}}/app/txn-sample.py %}
-~~~
-
-Then run the code:
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ python txn-sample.py
-~~~
-
-The output should be:
-
-~~~ 
-Balances after transfer:
+Balances at Wed Aug  7 12:11:23 2019
 ['1', '900']
 ['2', '350']
-~~~
-
-To verify that funds were transferred from one account to another, start the [built-in SQL client](use-the-built-in-sql-client.html):
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach sql --certs-dir=certs --database=bank
-~~~
-
-To check the account balances, issue the following statement:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SELECT id, balance FROM accounts;
-~~~
-
-~~~
-+----+---------+
-| id | balance |
-+----+---------+
-|  1 |     900 |
-|  2 |     350 |
-+----+---------+
-(2 rows)
 ~~~
 
 </section>
@@ -142,14 +90,11 @@ To check the account balances, issue the following statement:
 
 Now that you have a database and a user, you'll run the code shown below to:
 
-- Create a table and insert some rows
-- Read and update values as an atomic [transaction](transactions.html)
+- Create an `accounts` table and insert some rows.
+- Transfer funds between two accounts inside a [transaction](transactions.html). To ensure that we [handle transaction retry errors](transactions.html#client-side-intervention), we write an application-level retry loop that, in case of error, sleeps before trying the funds transfer again. If it encounters another retry error, it sleeps for a longer interval, implementing [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff).
+- Finally, we delete the accounts from the table before exiting so we can re-run the example code.
 
-### Basic statements
-
-First, use the following code to connect as the `maxroach` user and execute some basic SQL statements, creating a table, inserting rows, and reading and printing the rows.
-
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/insecure/basic-sample.py" download><code>basic-sample.py</code></a> file, or create the file yourself and copy the code into it.
+Copy the code or <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{page.version.version}}/app/insecure/basic-sample.py" download>download it directly</a>.
 
 {% include copy-clipboard.html %}
 ~~~ python
@@ -163,64 +108,15 @@ Then run the code:
 $ python basic-sample.py
 ~~~
 
-The output should be:
+The output should show the account balances before and after the funds transfer:
 
 ~~~
-Initial balances:
+Balances at Wed Jul 24 15:58:40 2019
 ['1', '1000']
 ['2', '250']
-~~~
-
-### Transaction (with retry logic)
-
-Next, use the following code to again connect as the `maxroach` user but this time execute a batch of statements as an atomic transaction to transfer funds from one account to another, where all included statements are either committed or aborted.
-
-Download the <a href="https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/{{ page.version.version }}/app/insecure/txn-sample.py" download><code>txn-sample.py</code></a> file, or create the file yourself and copy the code into it.
-
-{{site.data.alerts.callout_info}}CockroachDB may require the <a href="transactions.html#transaction-retries">client to retry a transaction</a> in case of read/write contention. CockroachDB provides a generic <strong>retry function</strong> that runs inside a transaction and retries it as needed. You can copy and paste the retry function from here into your code.{{site.data.alerts.end}}
-
-{% include copy-clipboard.html %}
-~~~ python
-{% include {{page.version.version}}/app/insecure/txn-sample.py %}
-~~~
-
-Then run the code:
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ python txn-sample.py
-~~~
-
-The output should be:
-
-~~~ 
-Balances after transfer:
+Balances at Wed Jul 24 15:58:40 2019
 ['1', '900']
 ['2', '350']
-~~~
-
-To verify that funds were transferred from one account to another, start the [built-in SQL client](use-the-built-in-sql-client.html):
-
-{% include copy-clipboard.html %}
-~~~ shell
-$ cockroach sql --insecure --database=bank
-~~~
-
-To check the account balances, issue the following statement:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SELECT id, balance FROM accounts;
-~~~
-
-~~~
-+----+---------+
-| id | balance |
-+----+---------+
-|  1 |     900 |
-|  2 |     350 |
-+----+---------+
-(2 rows)
 ~~~
 
 </section>


### PR DESCRIPTION
Also, delete the comments in the Python code that state that
`crdb_internal.force_retry()` must be run as root.  This restriction was
lifted in https://github.com/cockroachdb/cockroach/pull/39246.

The 19.1 Python code samples were updated in #5085 and #5173.  We then
forgot to port those changes to 19.2.  This commit remedies that
oversight.

Addresses part of #5176.