### PR TITLE
Document CSR naming limitation

### DIFF
--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
@@ -50,7 +50,7 @@
 3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart and setting the `Secure.Enabled` parameter to `true`:
 
     {{site.data.alerts.callout_info}}
-    This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands.
+    This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands. Also be sure to start and end the name with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-secure.md
@@ -36,6 +36,10 @@
         $ kubectl create -f cockroachdb-statefulset-secure.yaml
         ~~~
 
+    {{site.data.alerts.callout_success}}
+    If you change the StatefulSet name from the default `cockroachdb`, be sure to start and end with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names). 
+    {{site.data.alerts.end}}
+
 2. As each pod is created, it issues a Certificate Signing Request, or CSR, to have the node's certificate signed by the Kubernetes CA. You must manually check and approve each node's certificates, at which point the CockroachDB node is started in the pod.
 
     1. Get the name of the `Pending` CSR for the first pod:

--- a/_includes/v19.1/orchestration/test-cluster-secure.md
+++ b/_includes/v19.1/orchestration/test-cluster-secure.md
@@ -13,7 +13,9 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     pod "cockroachdb-client-secure" created
     ~~~
 
-    The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required.
+    {{site.data.alerts.callout_info}}
+    The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required. If you issue client certificates for other users, however, be sure your SQL usernames contain only lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+    {{site.data.alerts.end}}
 
 2. Get a shell into the pod and start the CockroachDB [built-in SQL client](use-the-built-in-sql-client.html):
 
@@ -110,7 +112,9 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
         pod "cockroachdb-client-secure" created
         ~~~
 
-        The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required.
+        {{site.data.alerts.callout_info}}
+        The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required. If you issue client certificates for other users, however, be sure your SQL usernames contain only lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+        {{site.data.alerts.end}}
 
 2. Get a shell into the pod and start the CockroachDB [built-in SQL client](use-the-built-in-sql-client.html):
 

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
@@ -50,7 +50,7 @@
 3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart and setting the `Secure.Enabled` parameter to `true`:
 
     {{site.data.alerts.callout_info}}
-    This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands.
+    This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands. Also be sure to start and end the name with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.2/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-secure.md
@@ -36,6 +36,10 @@
         $ kubectl create -f cockroachdb-statefulset-secure.yaml
         ~~~
 
+    {{site.data.alerts.callout_success}}
+    If you change the StatefulSet name from the default `cockroachdb`, be sure to start and end with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+    {{site.data.alerts.end}}
+
 2. As each pod is created, it issues a Certificate Signing Request, or CSR, to have the node's certificate signed by the Kubernetes CA. You must manually check and approve each node's certificates, at which point the CockroachDB node is started in the pod.
 
     1. Get the name of the `Pending` CSR for the first pod:

--- a/_includes/v19.2/orchestration/test-cluster-secure.md
+++ b/_includes/v19.2/orchestration/test-cluster-secure.md
@@ -13,7 +13,9 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     pod "cockroachdb-client-secure" created
     ~~~
 
-    The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required.
+    {{site.data.alerts.callout_info}}
+    The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required. If you issue client certificates for other users, however, be sure your SQL usernames contain only lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+    {{site.data.alerts.end}}
 
 2. Get a shell into the pod and start the CockroachDB [built-in SQL client](use-the-built-in-sql-client.html):
 
@@ -110,7 +112,9 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
         pod "cockroachdb-client-secure" created
         ~~~
 
-        The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required.
+        {{site.data.alerts.callout_info}}
+        The pod uses the `root` client certificate created earlier to initialize the cluster, so there's no CSR approval required. If you issue client certificates for other users, however, be sure your SQL usernames contain only lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+        {{site.data.alerts.end}}
 
 2. Get a shell into the pod and start the CockroachDB [built-in SQL client](use-the-built-in-sql-client.html):
 

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -37,6 +37,12 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 
 {% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
 
+#### CSR names
+
+When Kubernetes issues a [CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) (Certificate Signing Request) to have a node or client certificate signed by the Kubernetes CA, Kubernetes requires the CSR name to start and end with an alphanumeric character and otherwise consist of lowercase alphanumeric characters, `-`, or `.`
+
+CSR names contain the StatefulSet or Helm chart `name`, so if you customize that value, be sure to conform to these naming requirements. For client certificates, CSR names also contain the username of the SQL user for which the certificate is being generated, so be sure SQL usernames also conform to these naming requirements. For example, avoid using the underscore character (`_`) in these names.
+
 ## Step 1. Start Kubernetes
 
 {% include {{ page.version.version }}/orchestration/start-kubernetes.md %}

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -37,6 +37,12 @@ instance | A physical or virtual machine. In this tutorial, you'll create GCE or
 
 {% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
 
+#### CSR names
+
+When Kubernetes issues a [CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) (Certificate Signing Request) to have a node or client certificate signed by the Kubernetes CA, Kubernetes requires the CSR name to start and end with an alphanumeric character and otherwise consist of lowercase alphanumeric characters, `-`, or `.`
+
+CSR names contain the StatefulSet or Helm chart `name`, so if you customize that value, be sure to conform to these naming requirements. For client certificates, CSR names also contain the username of the SQL user for which the certificate is being generated, so be sure SQL usernames also conform to these naming requirements. For example, avoid using the underscore character (`_`) in these names.  
+
 ## Step 1. Start Kubernetes
 
 {% include {{ page.version.version }}/orchestration/start-kubernetes.md %}


### PR DESCRIPTION
Callout naming requirements for StatefulSet and Helm chart names
and for SQL usernames.

Fixes #5365.