### PR TITLE
Document \d client-side command with no argument

### DIFF
--- a/v19.2/frequently-asked-questions.md
+++ b/v19.2/frequently-asked-questions.md
@@ -145,7 +145,7 @@ For more insight, see [CockroachDB in Comparison](cockroachdb-in-comparison.html
 
 ## Can a PostgreSQL or MySQL application be migrated to CockroachDB?
 
-Yes. Most users should be able to follow the instructions in [Migrate from Postgres](migrate-from-postgres.html) or [Migrate from MySQL](migrate-from-mysql.html) (both of which are in **beta** as of v2.1).  Due to differences in available features and syntax, some features supported by these databases may require manual effort to port to CockroachDB.  Check those pages for details.
+Yes. Most users should be able to follow the instructions in [Migrate from Postgres](migrate-from-postgres.html) or [Migrate from MySQL](migrate-from-mysql.html). Due to differences in available features and syntax, some features supported by these databases may require manual effort to port to CockroachDB. Check those pages for details.
 
 We also fully support [importing your data via CSV](migrate-from-csv.html).
 

--- a/v19.2/sql-dump.md
+++ b/v19.2/sql-dump.md
@@ -15,7 +15,7 @@ CockroachDB [enterprise license](https://www.cockroachlabs.com/pricing/) users c
 When `cockroach dump` is executed:
 
 - Table, sequence, and view schemas and table data are dumped as they appeared at the time that the command is started. Any changes after the command starts will not be included in the dump.
-- Table and view schemas are dumped in the order in which they can successfully be recreated. As of v2.0, this is true of sequences as well.
+- Table and view schemas are dumped in the order in which they can successfully be recreated. This is true of sequences as well.
 - If the dump takes longer than the [`ttlseconds`](configure-replication-zones.html) replication setting for the table (25 hours by default), the dump may fail.
 - Reads, writes, and schema changes can happen while the dump is in progress, but will not affect the output of the dump.
 

--- a/v19.2/sql-faqs.md
+++ b/v19.2/sql-faqs.md
@@ -68,7 +68,7 @@ At this time `LATERAL` joins are not yet supported.  For details, see [this Gith
 
 ## Does CockroachDB support JSON or Protobuf datatypes?
 
-Yes, as of v2.0, the [`JSONB`](jsonb.html) data type is supported.
+Yes, the [`JSONB`](jsonb.html) data type is supported.
 
 ## How do I know which index CockroachDB will select for a query?
 

--- a/v19.2/use-the-built-in-sql-client.md
+++ b/v19.2/use-the-built-in-sql-client.md
@@ -121,10 +121,10 @@ Command | Usage
 `\set <option>`<br>`\unset <option>` | Enable or disable a client-side option. For more details, see [Client-side options](#client-side-options).<br><br>You can also use the [`--set` flag](#general) to enable or disable client-side options before starting the SQL shell.
 `\show` | During a multi-line statement or transaction, show the SQL entered so far.
 `\h <statement>`<br>`\hf <function>` | View help for specific SQL statements or functions. See [SQL shell help](#help) for more details.
-`\l` | <span class="version-tag">New in v19.2:</span> List all databases in the CockroachDB cluster.
-`\dt` | <span class="version-tag">New in v19.2:</span> Show the tables of the current schema in the current database.
-`\du` | <span class="version-tag">New in v19.2:</span> List the users for all databases.
-`\d <table>` | <span class="version-tag">New in v19.2:</span> Show details about columns in the specified table.
+`\l` | <span class="version-tag">New in v19.2:</span> List all databases in the CockroachDB cluster. This command is equivalent to [`SHOW DATABASES`](show-databases.html).
+`\dt`<br>`d` | <span class="version-tag">New in v19.2:</span> Show the tables of the current schema in the current database. These commands are equivalent to [`SHOW TABLES`](show-tables.html).
+`\du` | <span class="version-tag">New in v19.2:</span> List the users for all databases. This command is equivalent to [`SHOW USERS`](show-users.html).
+`\d <table>` | <span class="version-tag">New in v19.2:</span> Show details about columns in the specified table. This command is equivalent to [`SHOW COLUMNS`](show-columns.html).
 
 ### Client-side options
 

--- a/v19.2/use-the-built-in-sql-client.md
+++ b/v19.2/use-the-built-in-sql-client.md
@@ -129,10 +129,10 @@ Command | Usage
 ### Client-side options
 
 - To view option descriptions and how they are currently set, use `\set` without any options.
-- To enable or disable an option, use `\set <option> <value>` or `\unset <option> <value>`. As of v2.1, you can also use the form `<option>=<value>`.
+- To enable or disable an option, use `\set <option> <value>` or `\unset <option> <value>`. You can also use the form `<option>=<value>`.
 - If an option accepts a boolean value:
     - `\set <option>` without `<value>` is equivalent to `\set <option> true`, and `\unset <option>` without `<value>` is equivalent to `\set <option> false`.
-    - As of v2.1, `on` and `0` are aliases for `true`, and `off` and `1` are aliases for `false`.
+    - `on` and `0` are aliases for `true`, and `off` and `1` are aliases for `false`.
 
 Client Options | Description
 ---------------|------------


### PR DESCRIPTION
Also link to corresponding `SHOW` statements for client-side
commands, where relevant, and remove "as of xxx" references 
to older versions.

Fixes #5376.
