### PR TITLE
Update unsupported warning on older doc versions

### DIFF
--- a/_includes/unsupported-version-soon.md
+++ b/_includes/unsupported-version-soon.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_info}}
-Cockroach Labs supports the current <a href="https://www.cockroachlabs.com/docs/stable/install-cockroachdb-mac.html">stable release</a> and two releases prior. Therefore, this version will no longer be supported after the Spring 2019 release.
+Cockroach Labs supports the current <a href="https://www.cockroachlabs.com/docs/stable/install-cockroachdb.html">stable release</a> and two releases prior. Therefore, this version will no longer be supported after the Fall 2019 release.
 {{site.data.alerts.end}}

--- a/_includes/unsupported-version.md
+++ b/_includes/unsupported-version.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-This version of CockroachDB is no longer supported. Cockroach Labs supports the current <a href="https://www.cockroachlabs.com/docs/stable/install-cockroachdb-mac.html">stable release</a> and two releases prior. Please use one of these supported versions.
+This version of CockroachDB is no longer supported. Cockroach Labs supports the current <a href="https://www.cockroachlabs.com/docs/stable/install-cockroachdb.html">stable release</a> and two releases prior. Please use one of these supported versions.
 {{site.data.alerts.end}}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -21,11 +21,11 @@ layout: default
       <div id="toc"></div>
    {% endif %}
 
-   {% if page.url contains 'v1.0' %}
+   {% if page.url contains "v1.0" or page.url contains '1.1' %}
       {% include unsupported-version.md %}
    {% endif %}
 
-   {% if page.url contains 'v1.1' %}
+   {% if page.url contains 'v2.0' %}
       {% include unsupported-version-soon.md %}
    {% endif %}
 


### PR DESCRIPTION
- Mark everything before 2.0 as unsupported.
- Mark 2.0 as soon to be unsupported.

Our policy is that we support stable plus the two versions
prior.

We'll have to adjust this again with the 19.2 release.

Fixes #5477.