### PR TITLE
fix prompt marker detection

### DIFF
--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -185,11 +185,11 @@ $(function() {
 
 
   function isPromptMarker(el, ch) {
-    return el.innerText.trim() === ch && (!el.previousSibling || el.previousSibling.textContent.trim() === "");
+    return el.innerText.trim() === ch && (!el.previousSibling || el.previousSibling.textContent.endsWith('\n'));
   }
 
   // This section makes shell terminal prompt markers ($) totally unselectable
-  // in syntax-highlighted code samples. The sybtax highlighter styles all
+  // in syntax-highlighted code samples. The syntax highlighter styles all
   // terminal markers with this class.
   var terminalMarkers = document.getElementsByClassName("nv");
   for (var i = 0; i < terminalMarkers.length; i++) {


### PR DESCRIPTION
Previously we would mark something as a prompt if it matched the
character and was preceeded by nothing or a string of only whitespace
characters. However with strings like `id > 0` the space before the `>`
would be seen as empty since the `id` was a non-text DOM node.

To fix this, require that the `>` be after a newline.

Fixes #5480