### PR TITLE
Adjust shell samples to not start with comments

### DIFF
--- a/_includes/v19.1/prod-deployment/secure-generate-certificates.md
+++ b/_includes/v19.1/prod-deployment/secure-generate-certificates.md
@@ -51,17 +51,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
   	--ca-key=my-safe-directory/ca.key
   	~~~
 
-5. Upload certificates to the first node:
+5. Upload the CA certificate and node certificate and key to the first node:
 
     {% include copy-clipboard.html %}
   	~~~ shell
-  	# Create the certs directory:
   	$ ssh <username>@<node1 address> "mkdir certs"
   	~~~
 
   	{% include copy-clipboard.html %}
   	~~~ shell
-  	# Upload the CA certificate and node certificate and key:
   	$ scp certs/ca.crt \
   	certs/node.crt \
   	certs/node.key \
@@ -95,11 +93,10 @@ Locally, you'll need to [create the following certificates and keys](create-secu
   	--ca-key=my-safe-directory/ca.key
   	~~~
 
-8. Upload certificates to the second node:
+8. Upload the CA certificate and node certificate and key to the second node:
 
     {% include copy-clipboard.html %}
   	~~~ shell
-  	# Create the certs directory:
   	$ ssh <username>@<node2 address> "mkdir certs"
   	~~~
 
@@ -124,17 +121,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
   	--ca-key=my-safe-directory/ca.key
   	~~~
 
-11. Upload certificates to the machine where you will run a sample workload:
+11. Upload the CA certificate and client certificate and key to the machine where you will run a sample workload:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create the certs directory:
     $ ssh <username>@<workload address> "mkdir certs"
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate and client certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
     certs/client.root.key \

--- a/_includes/v19.2/prod-deployment/secure-generate-certificates.md
+++ b/_includes/v19.2/prod-deployment/secure-generate-certificates.md
@@ -51,17 +51,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
   	--ca-key=my-safe-directory/ca.key
   	~~~
 
-5. Upload certificates to the first node:
+5. Upload the CA certificate and node certificate and key to the first node:
 
     {% include copy-clipboard.html %}
   	~~~ shell
-  	# Create the certs directory:
   	$ ssh <username>@<node1 address> "mkdir certs"
   	~~~
 
   	{% include copy-clipboard.html %}
   	~~~ shell
-  	# Upload the CA certificate and node certificate and key:
   	$ scp certs/ca.crt \
   	certs/node.crt \
   	certs/node.key \
@@ -95,11 +93,10 @@ Locally, you'll need to [create the following certificates and keys](create-secu
   	--ca-key=my-safe-directory/ca.key
   	~~~
 
-8. Upload certificates to the second node:
+8. Upload the CA certificate and node certificate and key to the second node:
 
     {% include copy-clipboard.html %}
   	~~~ shell
-  	# Create the certs directory:
   	$ ssh <username>@<node2 address> "mkdir certs"
   	~~~
 
@@ -124,17 +121,15 @@ Locally, you'll need to [create the following certificates and keys](create-secu
   	--ca-key=my-safe-directory/ca.key
   	~~~
 
-11. Upload certificates to the machine where you will run a sample workload:
+11. Upload the CA certificate and client certificate and key to the machine where you will run a sample workload:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create the certs directory:
     $ ssh <username>@<workload address> "mkdir certs"
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate and client certificate and key:
     $ scp certs/ca.crt \
     certs/client.root.crt \
     certs/client.root.key \

--- a/v19.1/configure-replication-zones.md
+++ b/v19.1/configure-replication-zones.md
@@ -214,30 +214,40 @@ For more information, see [`CONFIGURE ZONE`](configure-zone.html).
 
 **Approach:**
 
-Start each node with its datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
+1. Start each node with its datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
 
-~~~ shell
-# Start the two nodes in datacenter 1:
-$ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
-$ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-1 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    Datacenter 1:
 
-# Start the two nodes in datacenter 2:
-$ cockroach start --insecure --advertise-addr=<node3 hostname> --locality=datacenter=us-2 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
-$ cockroach start --insecure --advertise-addr=<node4 hostname> --locality=datacenter=us-2 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~ shell
+    $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-1 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~
 
-# Start the two nodes in datacenter 3:
-$ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=datacenter=us-3 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
-$ cockroach start --insecure --advertise-addr=<node6 hostname> --locality=datacenter=us-3 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    Datacenter 2:
 
-# Initialize the cluster:
-$ cockroach init --insecure --host=<any node hostname>
-~~~
+    ~~~ shell
+    $ cockroach start --insecure --advertise-addr=<node3 hostname> --locality=datacenter=us-2 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    $ cockroach start --insecure --advertise-addr=<node4 hostname> --locality=datacenter=us-2 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~
+
+    Datacenter 3:
+
+    ~~~ shell
+    $ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=datacenter=us-3 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    $ cockroach start --insecure --advertise-addr=<node6 hostname> --locality=datacenter=us-3 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~
+
+2. Initialize the cluster:
+
+    ~~~ shell
+    $ cockroach init --insecure --host=<any node hostname>
+    ~~~
 
 There's no need to make zone configuration changes; by default, the cluster is configured to replicate data three times, and even without explicit constraints, the cluster will aim to diversify replicas across node localities.
 
@@ -252,8 +262,9 @@ There's no need to make zone configuration changes; by default, the cluster is c
 
 1. Start each node with its region and datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
 
+    Start the ffive nodes:
+
     ~~~ shell
-    # Start the four nodes:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=region=us-west1,datacenter=us-west1-a \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=region=us-west1,datacenter=us-west1-b \
@@ -264,8 +275,11 @@ There's no need to make zone configuration changes; by default, the cluster is c
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>
     $ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=region=us-east1,datacenter=us-east1-b \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 
@@ -332,24 +346,31 @@ There's no need to make zone configuration changes; by default, the cluster is c
 
 1. Start each node with its datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
 
+    Three nodes in datacenter 1:
+
     ~~~ shell
-    # Start the three nodes in datacenter 1:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node3 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
+    ~~~
 
-    # Start the three nodes in datacenter 2:
+    Three nodes in datacenter 2:
+
+    ~~~ shell
     $ cockroach start --insecure --advertise-addr=<node4 hostname> --locality=datacenter=us-2 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=datacenter=us-2 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node6 hostname> --locality=datacenter=us-2 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 
@@ -448,8 +469,9 @@ There's no need to make zone configuration changes; by default, the cluster is c
 
 1. Start each node with `ssd` or `hdd` specified as store attributes:
 
+    5 nodes with SSD storage:
+
     ~~~ shell
-    # Start the 5 nodes with SSD storage:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --store=path=node1,attrs=ssd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --store=path=node2,attrs=ssd \
@@ -460,14 +482,20 @@ There's no need to make zone configuration changes; by default, the cluster is c
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node5 hostname> --store=path=node5,attrs=ssd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
+    ~~~
 
-    # Start the 2 nodes with HDD storage:
+    2 nodes with HDD storage:
+
+    ~~~ shell
     $ cockroach start --insecure --advertise-addr=<node6 hostname> --store=path=node6,attrs=hdd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node7 hostname> --store=path=node7,attrs=hdd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 
@@ -533,7 +561,6 @@ There's no need to make zone configuration changes; by default, the cluster is c
 1. Start each node with a different [locality](start-a-node.html#locality) attribute:
 
     ~~~ shell
-    # Start the nodes:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>   
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-2 \
@@ -548,8 +575,11 @@ There's no need to make zone configuration changes; by default, the cluster is c
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node7 hostname> --locality=datacenter=us-7 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 

--- a/v19.1/create-security-certificates-openssl.md
+++ b/v19.1/create-security-certificates-openssl.md
@@ -89,7 +89,7 @@ Note the following:
     You can set the CA certificate expiration period using the `default_days` parameter. We recommend using the CockroachDB default value of the CA certificate expiration period, which is 3660 days.
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL CA configuration file
     [ ca ]
     default_ca = CA_default
@@ -181,7 +181,7 @@ In the following steps, replace the placeholder text in the code with the actual
 1. Create the `node.cnf` file for the first node and copy the following configuration into it:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL node configuration file
     [ req ]
     prompt=no
@@ -214,7 +214,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create Node certificate signing request.
     $ openssl req \
     -new \
     -config node.cnf \
@@ -229,7 +228,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Sign the CSR using the CA key.
     $ openssl ca \
     -config ca.cnf \
     -keyfile my-safe-directory/ca.key \
@@ -247,13 +245,11 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create the certs directory:
     $ ssh <username>@<node1 address> "mkdir certs"
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
     certs/node.crt \
     certs/node.key \
@@ -280,7 +276,7 @@ In the following steps, replace the placeholder text in the code with the actual
 1. Create the `client.cnf` file for the first client and copy the following configuration into it:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL client configuration file
     [ req ]
     prompt=no
@@ -308,7 +304,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create client certificate signing request
     $ openssl req \
     -new \
     -config client.cnf \

--- a/v19.1/monitor-cockroachdb-with-prometheus.md
+++ b/v19.1/monitor-cockroachdb-with-prometheus.md
@@ -159,26 +159,26 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # runtime dashboard: node status, including uptime, memory, and cpu.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/runtime.json
+    # runtime dashboard: node status, including uptime, memory, and cpu.
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # storage dashboard: storage availability.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/storage.json
+    # storage dashboard: storage availability.
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # sql dashboard: sql queries/transactions.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/sql.json
+    # sql dashboard: sql queries/transactions.
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # replicas dashboard: replica information and operations.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replicas.json
+    # replicas dashboard: replica information and operations.
     ~~~
 
 5. [Add the dashboards to Grafana](http://docs.grafana.org/reference/export_import/#importing-a-dashboard).

--- a/v19.2/configure-replication-zones.md
+++ b/v19.2/configure-replication-zones.md
@@ -216,30 +216,40 @@ For more information, see [`CONFIGURE ZONE`](configure-zone.html).
 
 **Approach:**
 
-Start each node with its datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
+1. Start each node with its datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
 
-~~~ shell
-# Start the two nodes in datacenter 1:
-$ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
-$ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-1 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    Datacenter 1:
 
-# Start the two nodes in datacenter 2:
-$ cockroach start --insecure --advertise-addr=<node3 hostname> --locality=datacenter=us-2 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
-$ cockroach start --insecure --advertise-addr=<node4 hostname> --locality=datacenter=us-2 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~ shell
+    $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-1 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~
 
-# Start the two nodes in datacenter 3:
-$ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=datacenter=us-3 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
-$ cockroach start --insecure --advertise-addr=<node6 hostname> --locality=datacenter=us-3 \
---join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    Datacenter 2:
 
-# Initialize the cluster:
-$ cockroach init --insecure --host=<any node hostname>
-~~~
+    ~~~ shell
+    $ cockroach start --insecure --advertise-addr=<node3 hostname> --locality=datacenter=us-2 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    $ cockroach start --insecure --advertise-addr=<node4 hostname> --locality=datacenter=us-2 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~
+
+    Datacenter 3:
+
+    ~~~ shell
+    $ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=datacenter=us-3 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    $ cockroach start --insecure --advertise-addr=<node6 hostname> --locality=datacenter=us-3 \
+    --join=<node1 hostname>,<node3 hostname>,<node5 hostname>
+    ~~~
+
+2. Initialize the cluster:
+
+    ~~~ shell
+    $ cockroach init --insecure --host=<any node hostname>
+    ~~~
 
 There's no need to make zone configuration changes; by default, the cluster is configured to replicate data three times, and even without explicit constraints, the cluster will aim to diversify replicas across node localities.
 
@@ -254,8 +264,9 @@ There's no need to make zone configuration changes; by default, the cluster is c
 
 1. Start each node with its region and datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
 
+    Start the five nodes:
+
     ~~~ shell
-    # Start the four nodes:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=region=us-west1,datacenter=us-west1-a \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=region=us-west1,datacenter=us-west1-b \
@@ -266,8 +277,11 @@ There's no need to make zone configuration changes; by default, the cluster is c
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>
     $ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=region=us-east1,datacenter=us-east1-b \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 
@@ -334,24 +348,31 @@ There's no need to make zone configuration changes; by default, the cluster is c
 
 1. Start each node with its datacenter location specified in the [`--locality`](start-a-node.html#locality) flag:
 
+    Datacenter 1:
+
     ~~~ shell
-    # Start the three nodes in datacenter 1:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node3 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
+    ~~~
 
-    # Start the three nodes in datacenter 2:
+    Datacenter 2:
+
+    ~~~ shell
     $ cockroach start --insecure --advertise-addr=<node4 hostname> --locality=datacenter=us-2 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node5 hostname> --locality=datacenter=us-2 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
     $ cockroach start --insecure --advertise-addr=<node6 hostname> --locality=datacenter=us-2 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>,<node4 hostname>,<node5 hostname>,<node6 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 
@@ -450,8 +471,9 @@ There's no need to make zone configuration changes; by default, the cluster is c
 
 1. Start each node with `ssd` or `hdd` specified as store attributes:
 
+    5 nodes with SSD storage:
+
     ~~~ shell
-    # Start the 5 nodes with SSD storage:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --store=path=node1,attrs=ssd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --store=path=node2,attrs=ssd \
@@ -462,14 +484,20 @@ There's no need to make zone configuration changes; by default, the cluster is c
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node5 hostname> --store=path=node5,attrs=ssd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
+    ~~~
 
-    # Start the 2 nodes with HDD storage:
+    2 nodes with HDD storage:
+
+    ~~~ shell
     $ cockroach start --insecure --advertise-addr=<node6 hostname> --store=path=node6,attrs=hdd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node7 hostname> --store=path=node7,attrs=hdd \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 
@@ -535,7 +563,6 @@ There's no need to make zone configuration changes; by default, the cluster is c
 1. Start each node with a different [locality](start-a-node.html#locality) attribute:
 
     ~~~ shell
-    # Start the nodes:
     $ cockroach start --insecure --advertise-addr=<node1 hostname> --locality=datacenter=us-1 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>   
     $ cockroach start --insecure --advertise-addr=<node2 hostname> --locality=datacenter=us-2 \
@@ -550,8 +577,11 @@ There's no need to make zone configuration changes; by default, the cluster is c
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
     $ cockroach start --insecure --advertise-addr=<node7 hostname> --locality=datacenter=us-7 \
     --join=<node1 hostname>,<node2 hostname>,<node3 hostname>
+    ~~~
 
-    # Initialize the cluster:
+    Initialize the cluster:
+
+    ~~~ shell
     $ cockroach init --insecure --host=<any node hostname>
     ~~~
 

--- a/v19.2/create-security-certificates-openssl.md
+++ b/v19.2/create-security-certificates-openssl.md
@@ -89,7 +89,7 @@ Note the following:
     You can set the CA certificate expiration period using the `default_days` parameter. We recommend using the CockroachDB default value of the CA certificate expiration period, which is 3660 days.
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL CA configuration file
     [ ca ]
     default_ca = CA_default
@@ -181,7 +181,7 @@ In the following steps, replace the placeholder text in the code with the actual
 1. Create the `node.cnf` file for the first node and copy the following configuration into it:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL node configuration file
     [ req ]
     prompt=no
@@ -214,7 +214,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create Node certificate signing request.
     $ openssl req \
     -new \
     -config node.cnf \
@@ -229,7 +228,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Sign the CSR using the CA key.
     $ openssl ca \
     -config ca.cnf \
     -keyfile my-safe-directory/ca.key \
@@ -247,13 +245,11 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create the certs directory:
     $ ssh <username>@<node1 address> "mkdir certs"
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
     certs/node.crt \
     certs/node.key \
@@ -280,8 +276,7 @@ In the following steps, replace the placeholder text in the code with the actual
 1. Create the `client.cnf` file for the first client and copy the following configuration into it:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
-    # OpenSSL client configuration file
+    ~~~
     [ req ]
     prompt=no
     distinguished_name = distinguished_name
@@ -308,7 +303,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create client certificate signing request
     $ openssl req \
     -new \
     -config client.cnf \

--- a/v19.2/monitor-cockroachdb-with-prometheus.md
+++ b/v19.2/monitor-cockroachdb-with-prometheus.md
@@ -159,26 +159,26 @@ Although Prometheus lets you graph metrics, [Grafana](https://grafana.com/) is a
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # runtime dashboard: node status, including uptime, memory, and cpu.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/runtime.json
+    # runtime dashboard: node status, including uptime, memory, and cpu.
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # storage dashboard: storage availability.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/storage.json
+    # storage dashboard: storage availability.
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # sql dashboard: sql queries/transactions.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/sql.json
+    # sql dashboard: sql queries/transactions.
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # replicas dashboard: replica information and operations.
     $ wget https://raw.githubusercontent.com/cockroachdb/cockroach/master/monitoring/grafana-dashboards/replicas.json
+    # replicas dashboard: replica information and operations.
     ~~~
 
 5. [Add the dashboards to Grafana](http://docs.grafana.org/reference/export_import/#importing-a-dashboard).

--- a/v2.1/create-security-certificates-openssl.md
+++ b/v2.1/create-security-certificates-openssl.md
@@ -89,7 +89,7 @@ Note the following:
     You can set the CA certificate expiration period using the `default_days` parameter. We recommend using the CockroachDB default value of the CA certificate expiration period, which is 3660 days.
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL CA configuration file
     [ ca ]
     default_ca = CA_default
@@ -181,7 +181,7 @@ In the following steps, replace the placeholder text in the code with the actual
 1. Create the `node.cnf` file for the first node and copy the following configuration into it:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL node configuration file
     [ req ]
     prompt=no
@@ -214,7 +214,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create Node certificate signing request.
     $ openssl req \
     -new \
     -config node.cnf \
@@ -229,7 +228,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Sign the CSR using the CA key.
     $ openssl ca \
     -config ca.cnf \
     -keyfile my-safe-directory/ca.key \
@@ -247,13 +245,11 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create the certs directory:
     $ ssh <username>@<node1 address> "mkdir certs"
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Upload the CA certificate and node certificate and key:
     $ scp certs/ca.crt \
     certs/node.crt \
     certs/node.key \
@@ -280,7 +276,7 @@ In the following steps, replace the placeholder text in the code with the actual
 1. Create the `client.cnf` file for the first client and copy the following configuration into it:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~
     # OpenSSL client configuration file
     [ req ]
     prompt=no
@@ -308,7 +304,6 @@ In the following steps, replace the placeholder text in the code with the actual
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    # Create client certificate signing request
     $ openssl req \
     -new \
     -config client.cnf \


### PR DESCRIPTION
`$` prompt gets auto-added to the first line. We should remove
that behavior at some point, but this is a fix for now.