### PR TITLE
Warning message in SHOW CREATE TABLE about zone configurations

### DIFF
--- a/v19.2/configure-replication-zones.md
+++ b/v19.2/configure-replication-zones.md
@@ -131,7 +131,7 @@ See [Cluster Topography](recommended-production-settings.html#topology) recommen
 
 Use the [`SHOW ZONE CONFIGURATIONS`](#view-all-replication-zones) statement to view details about existing replication zones.
 
-You can also use the [`SHOW PARTITIONS`](show-partitions.html) statement to view the zone constraints on existing table partitions.
+You can also use the [`SHOW PARTITIONS`](show-partitions.html) statement to view the zone constraints on existing table partitions, or [`SHOW CREATE TABLE`](show-create.html) to view zone configurations for a table.
 
 ## Basic examples
 

--- a/v19.2/show-create.md
+++ b/v19.2/show-create.md
@@ -35,53 +35,63 @@ Field | Description
 
 ## Example
 
+{% include {{page.version.version}}/sql/movr-statements.md %}
+
 ### Show the `CREATE TABLE` statement for a table
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE);
+> CREATE TABLE drivers (
+    id UUID NOT NULL,
+    city STRING NOT NULL,
+    name STRING,
+    dl STRING UNIQUE,
+    address STRING,
+    CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC)
+);
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW CREATE customers;
+> SHOW CREATE TABLE drivers;
 ~~~
 
 ~~~
-+------------+---------------------------------------------------+
-| table_name |                 create_statement                  |
-+------------+---------------------------------------------------+
-| customers  | CREATE TABLE customers (                          |
-|            |                                                   |
-|            |     id INT NOT NULL,                              |
-|            |                                                   |
-|            |     email STRING NULL,                            |
-|            |                                                   |
-|            |     CONSTRAINT "primary" PRIMARY KEY (id ASC),    |
-|            |                                                   |
-|            |     UNIQUE INDEX customers_email_key (email ASC), |
-|            |                                                   |
-|            |     FAMILY "primary" (id, email)                  |
-|            |                                                   |
-|            | )                                                 |
-+------------+---------------------------------------------------+
+  table_name |                     create_statement
++------------+----------------------------------------------------------+
+  drivers    | CREATE TABLE drivers (
+             |     id UUID NOT NULL,
+             |     city STRING NOT NULL,
+             |     name STRING NULL,
+             |     dl STRING NULL,
+             |     address STRING NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     UNIQUE INDEX drivers_dl_key (dl ASC),
+             |     FAMILY "primary" (id, city, name, dl, address)
+             | )
 (1 row)
 ~~~
+
+{{site.data.alerts.callout_info}}
+`SHOW CREATE TABLE` also lists any partitions and zone configurations defined on primary and secondary indexes of a table. If partitions are defined, but no zones are configured, the `SHOW CREATE TABLE` output includes a warning.
+{{site.data.alerts.end}}
 
 ### Show the `CREATE VIEW` statement for a view
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW CREATE bank.user_accounts;
+> CREATE VIEW user_view (city, name) AS SELECT city, name FROM users;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE user_view;
 ~~~
 
 ~~~
-+---------------------------+--------------------------------------------------------------------------+
-|        table_name         |                             create_statement                             |
-+---------------------------+--------------------------------------------------------------------------+
-| bank.public.user_accounts | CREATE VIEW user_accounts (type, email) AS SELECT type, email FROM       |
-|                           | bank.public.accounts                                                     |
-+---------------------------+--------------------------------------------------------------------------+
+  table_name |                                create_statement
++------------+--------------------------------------------------------------------------------+
+  user_view  | CREATE VIEW user_view (city, name) AS SELECT city, name FROM movr.public.users
 (1 row)
 ~~~
 
@@ -93,15 +103,13 @@ To get just a view's `SELECT` statement, you can query the `views` table in the 
 ~~~ sql
 > SELECT view_definition
   FROM information_schema.views
-  WHERE table_name = 'user_accounts';
+  WHERE table_name = 'user_view';
 ~~~
 
 ~~~
-+----------------------------------------------+
-|               view_definition                |
-+----------------------------------------------+
-| SELECT type, email FROM bank.public.accounts |
-+----------------------------------------------+
+              view_definition
++------------------------------------------+
+  SELECT city, name FROM movr.public.users
 (1 row)
 ~~~
 
@@ -118,12 +126,9 @@ To get just a view's `SELECT` statement, you can query the `views` table in the 
 ~~~
 
 ~~~
-+--------------------+--------------------------------------------------------------------------+
-|     table_name     |                             create_statement                             |
-+--------------------+--------------------------------------------------------------------------+
-| desc_customer_list | CREATE SEQUENCE desc_customer_list MINVALUE -9223372036854775808         |
-|                    | MAXVALUE -1 INCREMENT -2 START -1                                        |
-+--------------------+--------------------------------------------------------------------------+
+      table_name     |                                          create_statement
++--------------------+----------------------------------------------------------------------------------------------------+
+  desc_customer_list | CREATE SEQUENCE desc_customer_list MINVALUE -9223372036854775808 MAXVALUE -1 INCREMENT -2 START -1
 (1 row)
 ~~~
 

--- a/v19.2/show-zone-configurations.md
+++ b/v19.2/show-zone-configurations.md
@@ -44,6 +44,8 @@ Parameter | Description
 
 {% include {{ page.version.version }}/zone-configs/view-the-replication-zone-for-a-table.md %}
 
+You can also use [`SHOW CREATE TABLE`](show-create.html) to view zone configurations for a table. If a table is partitioned, but no zones are configured, the `SHOW CREATE TABLE` output includes a warning.
+
 ### View the replication zone for an index
 
 {% include {{ page.version.version }}/zone-configs/view-the-replication-zone-for-an-index.md %}


### PR DESCRIPTION
Fixes #5407.

- Added notes on zone configuration warning message in SHOW CREATE TABLE
- Changed all SHOW CREATE examples to use MovR dataset