### PR TITLE
Display inherited constraints in SHOW PARTITIONS

### DIFF
--- a/v19.2/show-partitions.md
+++ b/v19.2/show-partitions.md
@@ -41,7 +41,7 @@ Field | Description
 `column_names` | The names of the columns in the partition definition expression.
 `index_name` | The name of the index for the partition.
 `partition_value` | The value that defines the partition.
-`zone_constraints` | The [zone constraints](configure-replication-zones.html), if replication zones are configured for the partition. `SHOW PARTITIONS` does not show inherited zone constraints.
+`zone_constraints` | The [zone constraints](configure-replication-zones.html), if replication zones are configured for the partition.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #5533. 
(Reverts https://github.com/cockroachdb/docs/pull/5364).

I just removed the note that says that `SHOW PARTITIONS` doesn't show inherited zone configurations.