### PR TITLE
Make site recognize 19.1.5 as latest stable version

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -32,11 +32,11 @@ release_info:
     build_time: 2019/07/15 14:48:26 (go1.10.3)
     start_time: 2019-07-15 15:10:52.34274101 +0000 UTC
   v19.1:
-    name: v19.1.4
-    version: v19.1.4
+    name: v19.1.5
+    version: v19.1.5
     docker_image: cockroachdb/cockroach
-    build_time: 2019/08/12 14:48:26 (go1.11.6)
-    start_time: 2018-08-12 15:10:52.34274101 +0000 UTC
+    build_time: 2019/09/30 14:48:26 (go1.11.6)
+    start_time: 2018-09-30 15:10:52.34274101 +0000 UTC
   v19.2:
     name: v19.2.0
     version: v19.2.0-beta.20190930


### PR DESCRIPTION
We forgot this in https://github.com/cockroachdb/docs/pull/5498.