### PR TITLE
CRDB interface stability docs

### DIFF
--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -1950,6 +1950,35 @@
             ]
           }
         ]
+      },
+      {
+          "title": "Programming Interfaces",
+          "items": [
+			  {
+				  "title": "Overview",
+				  "urls": [
+					  "/${VERSION}/overview-of-apis-and-interfaces.html"
+				  ]
+			  },
+			  {
+				  "title": "Interface types",
+				  "urls": [
+					  "/${VERSION}/interface-types.html"
+				  ]
+			  },
+			  {
+				  "title": "Stability Guarantees",
+				  "urls": [
+					  "/${VERSION}/compatibility-and-programmability-guarantees.html"
+				  ]
+			  },
+			  {
+			  	  "title": "Feature lifecycle",
+			  	  "urls": [
+			  		  "/${VERSION}/experimental-feature-lifecycle.html"
+			  	  ]
+			  }
+		   ]
       }
     ]
   },

--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -1967,7 +1967,7 @@
 				  ]
 			  },
 			  {
-				  "title": "Stability Guarantees",
+				  "title": "Version Compatibility Guarantees",
 				  "urls": [
 					  "/${VERSION}/compatibility-and-programmability-guarantees.html"
 				  ]
@@ -1976,6 +1976,12 @@
 			  	  "title": "Feature lifecycle",
 			  	  "urls": [
 			  		  "/${VERSION}/experimental-feature-lifecycle.html"
+			  	  ]
+			  },
+        {
+			  	  "title": "SQL Interface Stability",
+			  	  "urls": [
+			  		  "/${VERSION}/sql-functional-behavior-guarantees.html"
 			  	  ]
 			  }
 		   ]

--- a/v19.2/compatibility-and-programmability-guarantees.md
+++ b/v19.2/compatibility-and-programmability-guarantees.md
@@ -1,0 +1,125 @@
+---
+title: Stability Guarantees
+summary: Stability commitment of various APIs throughout the lifecycle of CockroachDB.
+toc: true
+---
+
+This page outlines the stability guarantees for CockroachDB's [interfaces](overview-of-apis-and-interfaces.html) around CockroachDB's lifecycle.
+
+## Overview
+
+### Interface stability in CockroachDB's lifecycle
+
+Cockroach Labs pushes bug fixes and other updates as patch revisions to CockroachDB, with the goal that the changes will not break user applications. For [programmable interfaces](interface-types.html), we provide an API stability guarantee across patch revisions. Note that [exceptions to these stability guarantees](#exceptions-to-stability-guarantees) apply.
+
+Note that users are required to step through intermediate major versions when migrating to a newer version, as major
+changes are only introduced in major version releases. This process reduces the internal complexity of CockroachDB around live
+upgrades.
+
+### New interfaces
+
+When introducing new features or changes to CockroachDB,
+Cockroach Labs reserves a period of time to process and incorporate feedback
+from users. During these [intermediate **experimental** and **beta**
+stages](experimental-feature-lifecycle.html), changes to new interfaces can be larger and more frequent.
+
+### Interface updates
+
+In the presence of serious concerns about the behavior of a public interface, Cockroach Labs might need to update the interface.
+Updates to stable interfaces are rare, and typically occur in cases of security vulnerabilities, or cases where CockroachDB's behavior is
+incompatible with 3rd-party PostgreSQL client applications or frameworks.
+To introduce API changes, we use patch revisions that preserve compatibility with
+existing CockroachDB client applications. We enumerate the [**exceptions
+to the stability guarantees**](#exceptions-to-stability-guarantees) below.
+
+## Version and patch definitions
+
+Major versions are identified by the first two numbers in the full
+version string, and patch revisions are identified by the last number
+in the string.
+
+For example:
+
+| Version string | Major version | Patch revision |
+|----------------|---------------|----------------|
+| 2.1            | 2.1           | 0              |
+| 2.1.4          | 2.1           | 4              |
+| 19.1           | 19.1          | 0              |
+| 19.1.2         | 19.1          | 2              |
+
+## Exceptions to stability guarantees
+
+Cockroach Labs attempts to preserve compatibility between a CockroachDB major version *N* and existing applications built on major versions *N*, *N*+1, and later. There are four main exceptions to this rule: [Implementation errors](#implementation-errors) (bugs), [Incompatibility with PostgreSQL](#compatibility-with-postgresql), [Architectural changes](#architectural-changes), and [Product changes](#product-changes).
+
+| Issue in “stable” phase of major version *N*                  | Earliest version where change can occur, if backward-compatible with existing apps | Earliest version where change can occur, when backward-incompatible |
+|-----------------------------------------------------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Implementation errors (bugs)          | *N*.(X+1)  (patch revision)                                                          | *N*.(X+1) or *N*+1 depending on severity                                |
+| Incompatibility with PostgreSQL | *N*.(X+1)  (patch revision)                                                          | *N*.(X+1) opt-in<br>*N*+1 opt-out<br>*N*+2  definitive                    |
+| Architectural changes                | *N*+1                                                                                | *N*+2                                                                 |
+| Product changes                      | *N*+1                                                                                | *N*+2                                                                 |
+
+Examples:
+
+- A bug is found in version 19.1.2. A bug fix is available, which does
+  not require changes to client apps. This fix may be implemented in
+  version 19.1.3.
+- A minor bug is found in version 19.1.3. A bug fix is available, but
+  requires minor changes to client apps or a cluster configuration
+  variable. This fix may be implemented no earlier than version 19.2.
+
+### Implementation errors
+
+If a public interface does not behave as expected, this interface may be fixed
+in a subsequent patch revision.
+
+For example, the check for SQL access privileges, or the
+output of a SQL built-in function on edge case inputs, can be
+corrected across patch revisions.
+
+Cockroach Labs uses extensive testing to ensure that existing
+clients and tools are not negatively impacted by bug fixes.
+Note that bug fixes are worked into patch releases with no consideration for
+tooling that relies on mis-behaving interfaces.
+
+### Compatibility with PostgreSQL
+
+Cockroach Labs might determine that a CockroachDB feature needs to be updated to behave like PostgreSQL if:
+
+- The feature is supported by both CockroachDB and PostgreSQL.
+- The feature has a programmable interface.
+- The feature's behavior differs between CockroachDB and PostgreSQL.
+- There are well-known or sufficiently-widely used 3rd-party tools built for PostgreSQL that do not work well with existing CockroachDB behavior.
+- Changing the feature to behave more like PostgreSQL would not be overly disruptive to existing CockroachDB-specific applications or features.
+
+For example, the rules to derive data types for intermediate results in complex [SQL scalar expressions](scalar-expressions.html) might be subject to change in order to behave more like PostgreSQL.
+
+Changes for PostgreSQL compatibility may occur in a new patch revision if there is a way to make the
+change without disrupting existing CockroachDB applications or features. If the change also requires changing
+existing CockroachDB applications or features, after the change is
+prepared by Cockroach Labs, it will be finalized and published at the
+latest in major version *N*+2.
+
+During an update's development period,
+compatibility with PostgreSQL may also be configurable with other CockroachDB interfaces,
+such as [session variables](set-vars.html) or [cluster settings](cluster-settings.html).
+
+### Architectural changes
+
+If a feature is based on an architectural choice inside CockroachDB,
+and the architecture of CockroachDB changes in such a way that the
+feature is no longer needed, that feature might be changed or removed in the next major release.
+
+For example, the output of the [`EXPLAIN` statement](explain.html) has changed significantly across major versions of
+CockroachDB due to the evolution of the [query optimizer](cost-based-optimizer.html).
+
+### Product changes
+
+When Cockroach Labs decides to change CockroachDB to better match the needs of users, some existing public interfaces may change. In such cases, existing clients will continue to work for patch revisions in the current major version and next, but may need to change in version *N*+2.
+
+For example, the features and data output of [`cockroach` commands](cockroach-commands.html) have changed across releases.
+
+## See also
+
+- [Interface Types](interface-types.html)
+- [The Lifecycle of Experimental, Beta, and Stable Features](experimental-feature-lifecycle.html)
+- [Overview of CockroachDB Interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/compatibility-and-programmability-guarantees.md
+++ b/v19.2/compatibility-and-programmability-guarantees.md
@@ -1,5 +1,5 @@
 ---
-title: Stability Guarantees
+title: Version Compatibility Guarantees
 summary: Stability commitment of various APIs throughout the lifecycle of CockroachDB.
 toc: true
 ---

--- a/v19.2/experimental-feature-lifecycle.md
+++ b/v19.2/experimental-feature-lifecycle.md
@@ -1,0 +1,40 @@
+---
+title: The Lifecycle of Experimental, Beta, and Stable Features
+summary: The expected lifecycle of features initially marked as "experimental".
+toc: true
+---
+
+Cockroach Labs works with users and customers to design and prototype features such that the initial release of a new feature in a new major
+version of CockroachDB can be considered stable and ready for use. Some features, however, require a longer trial periods in which Cockroach Labs can gather and incorporate feedback from users in real-world scenarios.
+
+As features are released with varying levels of stability, we document all features that are not stable for production environments as “experimental” or "beta". After extensive testing, [experimental features](experimental-features.html) might be marked as “beta”. Then, after patch revisions from user feedback and design iterations have stabilized the feature, it can be considered stable.
+
+These three stages correspond to different levels of commitment from Cockroach Labs to provide support and guarantee forward
+compatibility for feature-specific APIs:
+
+| Guarantee                                                                               | Experimental | Beta              | Stable          |
+|-----------------------------------------------------------------------------------------|--------------|-------------------|-----------------|
+| Client/app built on patch revision *N*.X works on revision *N*.X+1                          | No guarantee | Yes (best effort) | Yes             |
+| Client/app built on major version *N* works on version *N*+1 with only configuration change | No guarantee | Yes (best effort) | Yes             |
+| Client/app built on major version *N* works on version *N*+1 without any changes            | No guarantee | No guarantee      | Yes (see below) |
+| Client/app built on major version *N* works on version *N*+2 with only configuration change | No guarantee | No guarantee      | Yes (see below) |
+| Client/app built on major version *N* works on version *N*+2 without any changes            | No guarantee | No guarantee      | Yes (see below) |
+
+Stable features are linked to [stronger API stability and forward compatibility guarantees](compatibility-and-programmability-guarantees.html).
+
+## Experimental markers in the SQL syntax
+
+In addition to mentioning the “experimental” or “beta” status in the documentation, a feature may be marked as such directly in its API:
+
+- By including the prefix `experimental_` in the name of an
+  identifier, for example in [session variables](show-vars.html) or
+  [built-in functions](functions-and-operators.html).
+- By including the keyword `EXPERIMENTAL` in the SQL syntax,
+  for example in [SQL statements](sql-statements.html).
+
+## See also
+
+- [The Lifecycle of Experimental, Beta, and Stable Features](experimental-features.html)
+- [Interface Types](interface-types.html)
+- [Stability Guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of CockroachDB Interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/experimental-feature-lifecycle.md
+++ b/v19.2/experimental-feature-lifecycle.md
@@ -36,5 +36,5 @@ In addition to mentioning the “experimental” or “beta” status in the doc
 
 - [The Lifecycle of Experimental, Beta, and Stable Features](experimental-features.html)
 - [Interface Types](interface-types.html)
-- [Stability Guarantees](compatibility-and-programmability-guarantees.html)
+- [Version Compatibility Guarantees](compatibility-and-programmability-guarantees.html)
 - [Overview of CockroachDB Interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/interface-types.md
+++ b/v19.2/interface-types.md
@@ -1,0 +1,51 @@
+---
+title: Interface Types
+summary: Programmable, non-programmable and reserved interfaces in CockroachDB.
+toc: true
+---
+
+To offer stability for tooling and automation, we separate CockroachDB interfaces into two stability categories: [**programmable**](#programmable-interfaces) interfaces, which are suitable for automation, testing, and other tooling, and [**non-programmable**](#non-programmable-interfaces) interfaces, which are meant for human consumption.
+
+To enable the rapid development and improvement of CockroachDB features, our [API stability and forward compatibility guarantees](compatibility-and-programmability-guarantees.html) are limited to **programmable** interfaces.
+
+Some CockroachDB features were created for the engineers who develop CockroachDB. These internal features are not meant to be consumed by users, but are often discovered through exposed interfaces. To prevent users from relying on unstable internal interfaces, we do not document how to use these features, and we refer to them as [**reserved**](#reserved-interfaces) interfaces.
+
+## Programmable interfaces
+
+Programmable interfaces are meant for interfacing with automated third-party tools. For example, the output of a [`SELECT`](selection-queries.html) query is programmable, as its output is stable across releases and ready for consumption by automated tooling.
+
+For programmable interfaces, an application or client that works with major version *N* is
+expected to work with [all releases of CockroachDB](compatibility-and-programmability-guarantees.html#version-and-patch-definitions). Compatibility with version
+*N*+1 and later depends on the stability phase, as detailed in
+[Experimental feature lifecycle](experimental-feature-lifecycle.html).
+
+Cockroach Labs is committed to documenting all programmable interfaces over time, but some interfaces might not yet be documented. If there is a programmable feature that you believe should be documented, please open a GitHub issue in our [open-source documentation repo](https://github.com/cockroachdb/docs/issues/new).
+
+## Non-programmable interfaces
+
+Non-programmable interfaces are meant to be consumed by humans and are not suitable for automation. For example, the output of a SQL [`SHOW`](show-vars.html)
+statement is exposed and documented, but non-programmable, as the output it meant to be read, but it may change significantly across minor releases.
+
+Although Cockroach Labs aims for stable input/output formats for these interfaces, the stability guarantees for non-programmable interfaces are as follows:
+
+- The data format of the inputs and outputs may change across patch
+  revisions.
+- The data format of the inputs and outputs are likely to change
+  across major versions.
+
+Not all of the non-programmable interfaces are documented. If you have a question or request regarding the usage of a non-programmable interface, please let us know on [the CockroachDB forum](https://forum.cockroachlabs.com/), or open a GitHub issue in our [open-source documentation repo](https://github.com/cockroachdb/docs/issues/new).
+
+## Reserved interfaces
+
+Reserved interfaces are meant for use by CockroachDB developers and are not suitable for any other use. These interfaces contrast with other programmable and non-programmable public interfaces. All other interfaces that are not explicitly documented as programmable or non-programmable, public features should be considered reserved. For example, some tables in the `crdb_internal` SQL virtual schema are reserved.
+
+For reserved interfaces, the stability guarantees are as follows:
+
+- The particular data format of inputs or outputs may change between
+  patch revisions.
+- We cannot guarantee accurate and up-to-date documentation.
+
+## See also
+
+- [Stability Guarantees](compatibility-and-programmability-guarantees.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/interface-types.md
+++ b/v19.2/interface-types.md
@@ -47,5 +47,5 @@ For reserved interfaces, the stability guarantees are as follows:
 
 ## See also
 
-- [Stability Guarantees](compatibility-and-programmability-guarantees.html)
+- [Version Compatibility Guarantees](compatibility-and-programmability-guarantees.html)
 - [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)

--- a/v19.2/overview-of-apis-and-interfaces.md
+++ b/v19.2/overview-of-apis-and-interfaces.md
@@ -1,0 +1,26 @@
+---
+title: Overview of CockroachDB Interfaces
+summary: High-level list of interfaces to CockroachDB.
+toc: true
+---
+
+Interfaces to CockroachDB include:
+
+- The [command-line interface](cockroach-commands.html), which consists of the `cockroach` commands.
+- The [SQL interface](sql-feature-support.html), which includes standard SQL with CockroachDB and PostgreSQL extensions.
+
+    The CockroachDB SQL interface also includes:
+  - The client-server protocol for SQL clients. CockroachDB uses a subset of PostgreSQL's low level client-server byte protocol, called [pgwire](https://godoc.org/github.com/cockroachdb/cockroach/pkg/sql/pgwire), for data flow between CockroachDB clients and nodes.
+  - SQL [session variables](show-vars.html), which configure a SQL session.
+  - SQL introspection interfaces, as exposed by the `information_schema`, `pg_catalog` and `crdb_internal` schemas.
+- The [Admin UI](admin-ui-overview.html), which consists of an in-browser cluster visualization and management panel.
+- The [HTTP status endpoints](monitoring-and-alerting.html), which provide access to CockroachDB status variables.
+- The [RPC endpoints](https://github.com/cockroachdb/cockroach/blob/master/pkg/server/serverpb/admin.proto), which provide access to CockroachDB internal status and APIs.
+- The [cluster settings](cluster-settings.html), which configure nodes in a cluster.
+
+Each interface has parts that are programmable and non-programmable. For more information about the stability categories of interfaces for programmability, see [Interface Types](interface-types.html).
+
+## See also
+
+- [Interface Types](interface-types.html)
+- [Stability Guarantees](compatibility-and-programmability-guarantees.html)

--- a/v19.2/overview-of-apis-and-interfaces.md
+++ b/v19.2/overview-of-apis-and-interfaces.md
@@ -7,12 +7,12 @@ toc: true
 Interfaces to CockroachDB include:
 
 - The [command-line interface](cockroach-commands.html), which consists of the `cockroach` commands.
-- The [SQL interface](sql-feature-support.html), which includes standard SQL with CockroachDB and PostgreSQL extensions.
-
-    The CockroachDB SQL interface also includes:
+- The [SQL interface](sql-feature-support.html), which includes standard SQL with CockroachDB and PostgreSQL extensions. The CockroachDB SQL interface also includes:
   - The client-server protocol for SQL clients. CockroachDB uses a subset of PostgreSQL's low level client-server byte protocol, called [pgwire](https://godoc.org/github.com/cockroachdb/cockroach/pkg/sql/pgwire), for data flow between CockroachDB clients and nodes.
   - SQL [session variables](show-vars.html), which configure a SQL session.
   - SQL introspection interfaces, as exposed by the `information_schema`, `pg_catalog` and `crdb_internal` schemas.
+
+    For information about stability guarantees, see [SQL Interface Stability Guarantees](sql-functional-behavior-guarantees.html).
 - The [Admin UI](admin-ui-overview.html), which consists of an in-browser cluster visualization and management panel.
 - The [HTTP status endpoints](monitoring-and-alerting.html), which provide access to CockroachDB status variables.
 - The [RPC endpoints](https://github.com/cockroachdb/cockroach/blob/master/pkg/server/serverpb/admin.proto), which provide access to CockroachDB internal status and APIs.
@@ -23,4 +23,5 @@ Each interface has parts that are programmable and non-programmable. For more in
 ## See also
 
 - [Interface Types](interface-types.html)
-- [Stability Guarantees](compatibility-and-programmability-guarantees.html)
+- [Version Compatibility Guarantees](compatibility-and-programmability-guarantees.html)
+- [SQL Interface Stability Guarantees](sql-functional-behavior-guarantees.html)

--- a/v19.2/sql-functional-behavior-guarantees.md
+++ b/v19.2/sql-functional-behavior-guarantees.md
@@ -1,0 +1,148 @@
+---
+title: SQL Interface Stability Guarantees
+summary: Which part of SQL execution can be considered forward-compatible.
+toc: true
+---
+
+This page includes the [programmability and forward compatibility guarantees](compatibility-and-programmability-guarantees.html) for CockroachDB's SQL interface, including [built-in functions](functions-and-operators.html) and the [standard SQL statements](sql-statements.html).
+
+## Built-in functions
+
+| Function description                                                                                   | Interface type (if documented)                                                    | Interface type (if not documented) |
+|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|---------------------------------------|
+| Supported in PostgreSQL and CockroachDB, with PostgreSQL-like behavior. | [Programmable]                                                                    | [Programmable]             |
+| Supported in PostgreSQL and CockroachDB, with behavior unlike PostgreSQL. | [Programmable]                                                                    | [Reserved]                            |
+| Supported only in CockroachDB.                                                | [Programmable]                                                                    | [Reserved]                            |
+| Name exists in namespace `crdb_internal`.                               | [Reserved]                                                                                   | [Reserved]                            |
+| [Function help](use-the-built-in-sql-client.html#help) labels function as “experimental”.                            | [Programmable] with  [“experimental” status](experimental-feature-lifecycle.html) | [Reserved]                            |
+| [Function help](use-the-built-in-sql-client.html#help) labels function as “for internal use”.                        | [Reserved]                                                                                   | [Reserved]                            |
+| Other                                                  | [Programmable]                                                                    | [Reserved]                            |
+
+For a list of supported built-in functions, see [Functions and Operators](functions-and-operators.html).
+
+## Data manipulation language
+
+<!-- [`DELETE`](delete.html), [`EXPORT`](export.html), [`IMPORT`](import.html), [`INSERT`](insert.html), [`SELECT`](select-clause.html), [`TABLE`](selection-queries.html#table-clause), [`TRUNCATE`](truncate.html), [`UPDATE`](update.html), [`UPSERT`](upsert.html), and [`VALUES`](selection-queries.html#values-clause)-->
+
+[DML statements](sql-statements.html#data-manipulation-statements):
+
+| Description                                                                                 | Interface type (if documented) | Interface type (if not documented) |
+|-------------------------------------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| SQL inputs, when query is valid in CockroachDB and PostgreSQL                           | [Programmable]                 | [Programmable]             |
+| SQL inputs, when query is valid only in CockroachDB                                          | [Programmable]                 | [Reserved]                            |
+| Output row set, regardless of order, when query is valid in CockroachDB and PostgreSQL | [Programmable]                 | [Programmable]             |
+| Output row set, regardless of order, when query is valid only in CockroachDB                | [Programmable]                 | [Reserved]                            |
+| Output row order, when query is ordered and valid in CockroachDB and PostgreSQL      | [Programmable]                 | [Non-programmable]         |
+| Output row order, when query is ordered and valid only in CockroachDB                     | [Programmable]                 | [Reserved]                            |
+| Output row order, when query is not ordered                                               | [Non-programmable]             | [Reserved]
+| Output row count, when query is valid in CockroachDB and PostgreSQL                     | [Programmable]                 | [Non-programmable]         |
+| Output row count, when query is valid only in CockroachDB                                    | [Programmable]                 | [Reserved]                            |
+                           |
+
+For more details about row ordering, see [Ordering of Query Results](query-order.html).
+
+## Data definition language
+
+[DDL statements](sql-statements.html#data-definition-statements) on database objects (e.g., databases, tables, views, and sequences):
+
+| Description                                                                                                                                | Interface type (if documented) | Interface type (if not documented) |
+|------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| SQL inputs, when query is valid in CockroachDB and PostgreSQL                                                                          | [Programmable]                 | [Programmable]             |
+| SQL inputs, when query is valid only in CockroachDB                                                                                         | [Programmable]                 | [Reserved]                            |
+| Effect and isolation when ran as a standalone statement outside of [`BEGIN`](begin-transaction.html)/[`COMMIT`](commit-transaction.html), and statement is valid in CockroachDB and PostgreSQL | [Programmable]                 | [Programmable]             |
+| Effect and isolation when ran as a standalone statement outside of `BEGIN`/`COMMIT`, and statement is valid only in CockroachDB                | [Programmable]                 | [Non-programmable]         |
+| Effect and isolation when ran inside `BEGIN`/`COMMIT`                                                                                        | [Programmable]                 | [Non-programmable]         |
+| Output row count                                                                                                                         | [Reserved]                                | [Reserved]                            |
+
+## Access management
+
+[Access management statements](sql-statements.html#access-management-statements):
+
+| Description                                                       | Interface type (if documented) | Interface type (if not documented) |
+|-----------------------------------------------------------------|-------------------------------------------|---------------------------------------|
+| SQL inputs, when query is valid in CockroachDB and PostgreSQL | [Programmable]                 | [Programmable]             |
+| SQL inputs, when query is valid only in CockroachDB                | [Programmable]                 | [Reserved]                            |
+| Effect and isolation                                            | [Programmable]                 | [Non-programmable]         |
+| Output row count                                                | [Programmable]                 | [Reserved]                            |
+
+## Bulk I/O statements
+
+| Description                                  | Interface type (if documented) | Interface type (if not documented) |
+|----------------------------------------------|-------------------------------------------|---------------------------------------|
+| [`BACKUP`](backup.html)/[`EXPORT`](export.html) SQL parameters and output  | [Programmable]                 | [Reserved]                            |
+| `BACKUP` result data files                   | [Reserved]<br>See [note below](#backup-restore-note).             | [Reserved]<br>See [note below](#backup-restore-note).          |
+| `EXPORT` result data files                   | [Programmable]                 | [Reserved]                            |
+| [`RESTORE`](restore.html)/[`IMPORT`](import.html) SQL parameters and output | [Programmable]                 | [Reserved]                            |
+| `RESTORE` input data files                   | [Reserved]<br>See [note below](#backup-restore-note).              | [Reserved]<br>See [note below](#backup-restore-note).         |
+| `IMPORT` input data files                    | [Programmable]                 | [Reserved]                            |
+
+
+<a name="backup-restore-note"></a>
+
+
+{{site.data.alerts.callout_info}}
+The output format of [`BACKUP`](backup.html) may change across revisions. [`RESTORE`](restore.html) retains Programmable stability guarantees across revisions when used to load database and table contents from a backup into another CockroachDB instance.
+{{site.data.alerts.end}}
+
+## Other SQL statements or constructs
+
+| Description                                  | Interface type (if documented) | Interface type (if not documented) |
+|--------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------|
+| [`EXPLAIN`](explain.html) inputs and outputs                                                   | [Non-programmable]                                                            | [Reserved]                            |
+| [`SHOW`](show-vars.html) inputs                                                                  | [Programmable]                                                                | [Reserved]                            |
+| `SHOW` outputs                                                                 | [Non-programmable]                                                            | [Reserved]                            |
+| [`CANCEL`](cancel-job.html), [`PAUSE`](pause-job.html), [`RESUME`](resume-job.html) inputs                                             | [Programmable]                                                                | [Reserved]                            |
+| `CANCEL`, `PAUSE`, `RESUME` success/error status                               | [Programmable]                                                                | [Reserved]                            |
+| `CANCEL`, `PAUSE`, `RESUME` outputs                                            | [Non-programmable]                                                            | [Reserved]                            |
+| [`SCRUB`](experimental-features.html#check-for-constraint-violations-with-scrub) inputs and outputs                                                     | [Programmable] in [“experimental” phase](experimental-feature-lifecycle.html) | [Reserved]                            |
+| Tabular data produced by set-generating functions supported in PostgreSQL and CockroachDB | [Programmable]                                                                | [Programmable]             |
+| Tabular data produced by set-generating functions supported only in CockroachDB      | [Programmable]                                                                | [Reserved]                            |
+
+## Time and memory cost model
+
+The following table uses [big-O notation](https://en.wikipedia.org/wiki/Big_O_notation) to indicate
+the expected performance class of various SQL relational operators.
+
+The variables are:
+
+- **n**  number of rows processed,
+- **r** number of data ranges accessed,
+- **p** number of logical processors performing the computation during execution,
+- **g**  number of aggregation groups,
+- **m** for the max data size of rows,
+- **N** for n x m,
+- **k** for the max data size of key, aggregation or sort columns,
+- **K** for n x k,
+
+| Operation                                             | Time complexity | Space complexity | Status                      |
+|-------------------------------------------------------|-----------------|------------------|-----------------------------|
+| Point lookups in tables or indexes                    | O(1)            | O(m x p=r)       | [Non-programmable] |
+| Range scans in tables or indexes                      | O(K/p=r)        | O(m x p=r)       | [Non-programmable] |
+| Ordered inner joins                                   | O(K/p)          | O(N)             | [Non-programmable] |
+| Outer joins                                           | O(K/p+K)        | O(Np)            | [Non-programmable] |
+| Sorts                                                 | O(K/p log K/p)  | O(N)             | [Non-programmable] |
+| Non-expanding aggregations<br>See [note below](#aggregation-note).       | O(K/p)          | O(kg)            | [Non-programmable] |
+| Expanding aggregations<br>See [note below](#aggregation-note).             | O(K/p)          | O(K)             | [Non-programmable] |
+| Access to virtual tables or set-generating functions | O(N)            | O(1)             | [Non-programmable] |
+| Sequence access or increment                          | O(1)            | O(1)             | [Non-programmable] |
+| Window function application                           | O(N^2)          | O(N)             | [Non-programmable] |
+
+
+<a name="aggregation-note"></a>
+
+
+{{site.data.alerts.callout_info}}
+Aggregations operators like `array_agg` produce results with a size proportional to the sum of the size of the inputs.
+This can cause large memory usage during an aggregation if applied to a large number of inputs.
+{{site.data.alerts.end}}
+
+## See also
+
+- [Interface types](interface-types.html)
+- [Compatibility and programmability guarantees](compatibility-and-programmability-guarantees.html)
+- [Experimental feature lifecycle](experimental-feature-lifecycle.html)
+- [Overview of APIs and interfaces](overview-of-apis-and-interfaces.html)
+
+[Programmable]: interface-types.html#programmable-interfaces
+[Non-programmable]: interface-types.html#non-programmable-interfaces
+[Reserved]: interface-types.html#reserved-interfaces


### PR DESCRIPTION
This commit includes the following new pages:
- Overview of CockroachDB Interfaces
- Interface Types
- Stability Guarantees
- The Lifecycle of Experimental, Beta, and Stable Features

This commit is a modified version of @knz's API stability doc (#4326)

This commit will also inform #5454, which *could* form a basis for how we document API stability for each interface.