### PR TITLE
Add line feed preceding code fence

### DIFF
--- a/v19.1/use-the-built-in-sql-client.md
+++ b/v19.1/use-the-built-in-sql-client.md
@@ -33,6 +33,7 @@ $ cockroach sql <flags> < file-containing-statements.sql
 ~~~
 
 Exit the interactive SQL shell:
+
 ~~~ shell
 $ \q
 ~~~


### PR DESCRIPTION
Current render doesn't lint shell code (screencap)

<img width="691" alt="Screenshot 2019-10-04 at 15 14 24" src="https://user-images.githubusercontent.com/10898767/66214625-f4afa200-e6b9-11e9-817b-e2b801633436.png">

Suggested edit fixes this (screencap)

<img width="638" alt="Screenshot 2019-10-04 at 15 38 26" src="https://user-images.githubusercontent.com/10898767/66216273-165e5880-e6bd-11e9-92f2-e24f478915b3.png">

