### PR TITLE
Force index selection for DELETE and UPDATE statements

### DIFF
--- a/v19.2/delete.md
+++ b/v19.2/delete.md
@@ -81,6 +81,32 @@ If you are deleting a large amount of data using iterative `DELETE ... LIMIT` st
 
 For an explanation of why this happens, and for instructions showing how to iteratively delete rows in constant time, see [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
 
+## Force index selection for deletes
+
+<span class="version-tag">New in v19.2:</span> By using the explicit index annotation (also known as "index hinting"), you can override [CockroachDB's index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/) and use a specific [index](indexes.html) for deleting rows of a named table.
+
+{{site.data.alerts.callout_info}}
+Index selection can impact [performance](performance-best-practices-overview.html), but does not change the result of a query.
+{{site.data.alerts.end}}
+
+The syntax to force a specific index for a delete is:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DELETE FROM table@my_idx;
+~~~
+
+This is equivalent to the longer expression:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DELETE FROM table@{FORCE_INDEX=my_idx};
+~~~
+
+To view how the index hint modifies the [query plan](cost-based-optimizer.html#view-query-plan) that CockroachDB follows for deleting rows, use an [`EXPLAIN (OPT)`](explain.html#opt-option) statement. To see all indexes available on a table, use [`SHOW INDEXES`](show-index.html).
+
+For examples, see [Delete with index hints](#delete-with-index-hints).
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}
@@ -216,6 +242,72 @@ To sort and return deleted rows, use a statement like the following:
   crime_experience_certainly | Prepare right teacher mouth student. Trouble condition weight during scene something stand.                                                                                                                    | 2019-01-27 03:04:05+00:00 | 2019-01-31 03:04:05+00:00 | {"type": "percent_discount", "value": "10%"}
   policy_its_wife            | Player either she something good minute or. Nearly policy player receive. Somebody mean book store fire realize.                                                                                               | 2019-01-27 03:04:05+00:00 | 2019-01-31 03:04:05+00:00 | {"type": "percent_discount", "value": "10%"}
 (5 rows)
+~~~
+
+### Delete with index hints
+
+Suppose you create a multi-column index on the `users` table with the `name` and `city` columns.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE INDEX ON users (name, city);
+~~~
+
+Now suppose you want to delete the two users named "Michael Brown". You can use the [`EXPLAIN (OPT)`](explain.html#opt-option) command to see how the [cost-based optimizer](cost-based-optimizer.html) decides to perform the delete:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPLAIN (OPT) DELETE FROM users WHERE name='Michael Brown';
+~~~
+
+~~~
+                                 text
++---------------------------------------------------------------------+
+  delete users
+   └── scan users@users_name_city_idx
+        └── constraint: /8/7/6: [/'Michael Brown' - /'Michael Brown']
+(3 rows)
+~~~
+
+The output of the `EXPLAIN` statement shows that the optimizer scans the newly-created `users_name_city_idx` index when performing the delete. This makes sense, as you are performing a delete based on the `name` column.
+
+Now suppose that instead you want to perform a delete, but using the `id` column instead.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPLAIN (OPT) DELETE FROM users WHERE id IN ('70a3d70a-3d70-4400-8000-000000000016', '3d70a3d7-0a3d-4000-8000-00000000000c');
+~~~
+
+~~~
+                                                  text
++-------------------------------------------------------------------------------------------------------+
+  delete users
+   └── select
+        ├── scan users@users_name_city_idx
+        └── filters
+             └── id IN ('3d70a3d7-0a3d-4000-8000-00000000000c', '70a3d70a-3d70-4400-8000-000000000016')
+(5 rows)
+~~~
+
+The optimizer still scans the newly-created `users_name_city_idx` index when performing the delete. Although scanning the table on this index could still be the most efficient, you may want to assess the performance difference between using `users_name_city_idx` and an index on the `id` column, as you are performing a delete with a filter on the `id` column.
+
+If you provide an index hint (i.e. force the index selection) to use the primary index on the column instead, the CockroachDB will scan the users table using the primary index, on `city`, and `id`.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPLAIN (OPT) DELETE FROM users@primary WHERE id IN ('70a3d70a-3d70-4400-8000-000000000016', '3d70a3d7-0a3d-4000-8000-00000000000c');
+~~~
+
+~~~
+                                                  text
++-------------------------------------------------------------------------------------------------------+
+  delete users
+   └── select
+        ├── scan users
+        │    └── flags: force-index=primary
+        └── filters
+             └── id IN ('3d70a3d7-0a3d-4000-8000-00000000000c', '70a3d70a-3d70-4400-8000-000000000016')
+(6 rows)
 ~~~
 
 ## See also

--- a/v19.2/indexes.md
+++ b/v19.2/indexes.md
@@ -31,7 +31,7 @@ To create the most useful secondary indexes, you should also check out our [best
 
 Because each query can use only a single index, CockroachDB selects the index it calculates will scan the fewest rows (i.e., the fastest). For more detail, check out our blog post [Index Selection in CockroachDB](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/), which will show you how to use the [`EXPLAIN`](explain.html) statement for your query to see which index is being used.
 
-To override CockroachDB's index selection, you can also force [queries to use a specific index](table-expressions.html#force-index-selection) (also known as "index hinting").
+To override CockroachDB's index selection, you can also force queries [to use a specific index](table-expressions.html#force-index-selection) (also known as "index hinting"). Index hinting is supported for [`SELECT`](select-clause.html#select-from-a-specific-index), [`DELETE`](delete.html#force-index-selection-for-deletes), and [`UPDATE`](update.html#force-index-selection-for-updates) statements.
 
 ### Storage
 

--- a/v19.2/table-expressions.md
+++ b/v19.2/table-expressions.md
@@ -87,6 +87,10 @@ For example:
 
 {% include {{page.version.version}}/misc/force-index-selection.md %}
 
+{{site.data.alerts.callout_info}}
+You can also force index selection for [`DELETE`](delete.html#force-index-selection-for-deletes) and [`UPDATE`](update.html#force-index-selection-for-updates) statements.
+{{site.data.alerts.end}}
+
 ### Access a common table expression
 
 A single identifier in a table expression context can refer to a

--- a/v19.2/update.md
+++ b/v19.2/update.md
@@ -38,6 +38,32 @@ Parameter | Description
 `limit_clause` | A `LIMIT` clause. See [Limiting Query Results](limit-offset.html) for more details.
 `RETURNING target_list` | Return values based on rows updated, where `target_list` can be specific column names from the table, `*` for all columns, or computations using [scalar expressions](scalar-expressions.html). <br><br>To return nothing in the response, not even the number of rows updated, use `RETURNING NOTHING`.
 
+## Force index selection for updates
+
+<span class="version-tag">New in v19.2:</span> By using the explicit index annotation (also known as "index hinting"), you can override [CockroachDB's index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/) and use a specific [index](indexes.html) for updating rows of a named table.
+
+{{site.data.alerts.callout_info}}
+Index selection can impact [performance](performance-best-practices-overview.html), but does not change the result of a query.
+{{site.data.alerts.end}}
+
+The syntax to force an update for a specific index is:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> UPDATE table@my_idx SET ...
+~~~
+
+This is equivalent to the longer expression:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> UPDATE table@{FORCE_INDEX=my_idx} SET ...
+~~~
+
+To view how the index hint modifies the [query plan](cost-based-optimizer.html#view-query-plan) that CockroachDB follows for updating rows, use an [`EXPLAIN (OPT)`](explain.html#opt-option) statement. To see all indexes available on a table, use [`SHOW INDEXES`](show-index.html).
+
+For examples, see [Update with index hints](#update-with-index-hints).
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}
@@ -475,6 +501,59 @@ IDs:
 ~~~
 
 </section>
+
+### Update with index hints
+
+Suppose that you create a multi-column index on the `users` table with the `name` and `city` columns.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE INDEX ON users (name, city);
+~~~
+
+Now suppose you want to update a couple rows in the table, based on their contents. You can use the [`EXPLAIN (OPT)`](explain.html#opt-option) command to see how the [cost-based optimizer](cost-based-optimizer.html) decides to perform the `UPDATE` statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPLAIN (opt) UPDATE users SET name='Michael Brown (there are two)' WHERE name='Michael Brown';
+~~~
+
+~~~
+                                      text
++-------------------------------------------------------------------------------+
+  update users
+   └── project
+        ├── index-join users
+        │    └── scan users@users_name_city_idx
+        │         └── constraint: /8/7/6: [/'Michael Brown' - /'Michael Brown']
+        └── projections
+             └── const: 'Michael Brown (there are two)'
+(7 rows)
+~~~
+
+The output of the `EXPLAIN` statement shows that the optimizer scans the newly-created `users_name_city_idx` index when performing the update. This makes sense, as you are performing an update based on the `name` column.
+
+Although `users_name_city_idx` is likely the most efficient index for the table scan, you may want to assess the performance difference between scanning on `users_name_city_idx` and scanning on the primary index. You can provide an index hint (i.e. force the index selection) to use the primary key of the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPLAIN (opt) UPDATE users@primary SET name='Michael Brown (there are two)' WHERE name='Michael Brown';
+~~~
+
+~~~
+                          text
++-------------------------------------------------------+
+  update users
+   └── project
+        ├── select
+        │    ├── scan users
+        │    │    └── flags: force-index=primary
+        │    └── filters
+        │         └── name = 'Michael Brown'
+        └── projections
+             └── const: 'Michael Brown (there are two)'
+(9 rows)
+~~~
 
 ## See also
 


### PR DESCRIPTION
Fixes #5547.

Changes include:
- New sections in DELETE and UPDATE statement pages
- New examples in DELETE and UPDATE statement pages
- Callout on Indexes and Table Expressions pages