### PR TITLE
Fix write syntax in fault tolerance training

### DIFF
--- a/v19.1/training/fault-tolerance-and-automated-repair.md
+++ b/v19.1/training/fault-tolerance-and-automated-repair.md
@@ -239,7 +239,7 @@ To be able to tolerate 2 of 5 nodes failing simultaneously without any service i
     $ cockroach sql \
     --insecure \
     --host=localhost:26257 \
-    --execute="INSERT INTO usertable VALUES ('asdf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);"
+    --execute="INSERT INTO ycsb.usertable VALUES ('asdf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);"
     ~~~
 
     {% include copy-clipboard.html %}

--- a/v19.2/training/fault-tolerance-and-automated-repair.md
+++ b/v19.2/training/fault-tolerance-and-automated-repair.md
@@ -239,7 +239,7 @@ To be able to tolerate 2 of 5 nodes failing simultaneously without any service i
     $ cockroach sql \
     --insecure \
     --host=localhost:26257 \
-    --execute="INSERT INTO usertable VALUES ('asdf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);"
+    --execute="INSERT INTO ycsb.usertable VALUES ('asdf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);"
     ~~~
 
     {% include copy-clipboard.html %}


### PR DESCRIPTION
Updated the Fault Tolerance and Automated Repair training doc in 19.1 and 19.2. This step isn't in previous docs versions.

The analogous 19.2 Fault Tolerance article in Tutorials already has the correct syntax.