### PR TITLE
timezone() and AT TIME ZONE

### DIFF
--- a/_includes/v19.2/sql/function-special-forms.md
+++ b/_includes/v19.2/sql/function-special-forms.md
@@ -1,5 +1,6 @@
 | Special form                                              | Equivalent to                               |
 |-----------------------------------------------------------|---------------------------------------------|
+| `AT TIME ZONE`                                            | `timezone()`                                |
 | `CURRENT_CATALOG`                                         | `current_catalog()`                         |
 | `COLLATION FOR`                                           | `pg_collation_for()`                        |
 | `CURRENT_DATE`                                            | `current_date()`                            |

--- a/v19.2/timestamp.md
+++ b/v19.2/timestamp.md
@@ -21,6 +21,8 @@ The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC,
 
 The difference between these two variants is that `TIMESTAMPTZ` uses the client's session time zone, while the other simply does not. This behavior extends to functions like `now()` and `extract()` on `TIMESTAMPTZ` values.
 
+<span class="version-tag">New in v19.2:</span> You can use the [`timezone()`](functions-and-operators.html#date-and-time-functions) and [`AT TIME ZONE`](functions-and-operators.html#special-syntax-forms) functions to convert a `TIMESTAMPTZ` into a `TIMESTAMP` at a specified timezone, or to convert a `TIMESTAMP` into a `TIMESTAMPTZ` at a specified timezone.
+
 ## Best practices
 
 We recommend always using the `TIMESTAMPTZ` variant because the `TIMESTAMP` variant can sometimes lead to unexpected behaviors when it ignores a session offset. However, we also recommend you avoid setting a session time for your database.


### PR DESCRIPTION
Fixes #5286.

- Added `AT TIME ZONE` to special syntax table
- Added note to `TIMESTAMP` page about converting between `TIMESTAMP` and `TIMESTAMPTZ`