### PR TITLE
Added app tutorial to sidebar nav

### DIFF
--- a/_includes/sidebar-data-v19.2.cockroachcloud.json
+++ b/_includes/sidebar-data-v19.2.cockroachcloud.json
@@ -106,6 +106,17 @@
     ]
   },
   {
+    "title": "Tutorials",
+    "items": [
+      {
+        "title": "Build a Python app with Kubernetes on CockroachCloud",
+        "urls": [
+          "/${VERSION}/cockroachcloud-build-a-python-app-with-kubernetes.html"
+        ]
+      }
+    ]
+  },
+  {
     "title": "FAQs",
     "urls": [
       "/${VERSION}/cockroachcloud-frequently-asked-questions.html"


### PR DESCRIPTION
Closes https://github.com/cockroachdb/docs/issues/5598

The tutorial was already ported but wasn't added to the sidebar nav. Adding it in this PR.