### PR TITLE
Remove ␤ characters from example outputs

### DIFF
--- a/v1.0/add-constraint.md
+++ b/v1.0/add-constraint.md
@@ -62,12 +62,12 @@ For example, let's say you have two simple tables, `orders` and `customers`:
 +-----------+-------------------------------------------------+
 |   Table   |                   CreateTable                   |
 +-----------+-------------------------------------------------+
-| customers | CREATE TABLE customers (␤                       |
-|           |     id INT NOT NULL,␤                           |
-|           |     "name" STRING NOT NULL,␤                    |
-|           |     address STRING NULL,␤                       |
-|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤ |
-|           |     FAMILY "primary" (id, "name", address)␤     |
+| customers | CREATE TABLE customers (                        |
+|           |     id INT NOT NULL,                            |
+|           |     "name" STRING NOT NULL,                     |
+|           |     address STRING NULL,                        |
+|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),  |
+|           |     FAMILY "primary" (id, "name", address)      |
 |           | )                                               |
 +-----------+-------------------------------------------------+
 (1 row)
@@ -81,13 +81,13 @@ For example, let's say you have two simple tables, `orders` and `customers`:
 +--------+-------------------------------------------------------------------------------------------------------------+
 | Table  |                                                 CreateTable                                                 |
 +--------+-------------------------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                                      |
-|        |     id INT NOT NULL,␤                                                                                       |
-|        |     customer_id INT NULL,␤                                                                                  |
-|        |     status STRING NOT NULL,␤                                                                                |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                                             |
-|        |     FAMILY "primary" (id, customer_id, status),␤                                                            |
-|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))␤ |
+| orders | CREATE TABLE orders (                                                                                       |
+|        |     id INT NOT NULL,                                                                                        |
+|        |     customer_id INT NULL,                                                                                   |
+|        |     status STRING NOT NULL,                                                                                 |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                                              |
+|        |     FAMILY "primary" (id, customer_id, status),                                                             |
+|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))  |
 |        | )                                                                                                           |
 +--------+-------------------------------------------------------------------------------------------------------------+
 (1 row)

--- a/v1.0/column-families.md
+++ b/v1.0/column-families.md
@@ -39,13 +39,13 @@ For example, let's say we want to create a table to store an immutable blob of d
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
-| test  | CREATE TABLE test (␤                       |
-|       |     id INT NOT NULL,␤                       |
-|       |     last_accessed TIMESTAMP NULL,␤          |
-|       |     data BYTES NULL,␤                       |
-|       |     CONSTRAINT "primary" PRIMARY KEY (id),␤ |
-|       |     FAMILY f1 (id, last_accessed),␤         |
-|       |     FAMILY f2 (data)␤                       |
+| test  | CREATE TABLE test (                         |
+|       |     id INT NOT NULL,                        |
+|       |     last_accessed TIMESTAMP NULL,           |
+|       |     data BYTES NULL,                        |
+|       |     CONSTRAINT "primary" PRIMARY KEY (id),  |
+|       |     FAMILY f1 (id, last_accessed),          |
+|       |     FAMILY f2 (data)                        |
 |       | )                                           |
 +-------+---------------------------------------------+
 (1 row)

--- a/v1.0/create-table-as.md
+++ b/v1.0/create-table-as.md
@@ -74,11 +74,11 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)
@@ -101,12 +101,12 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     INDEX logoff_copy_id_idx (user_id ASC),␤                    |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     INDEX logoff_copy_id_idx (user_id ASC),                     |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)

--- a/v1.0/create-table.md
+++ b/v1.0/create-table.md
@@ -289,13 +289,13 @@ To show the definition of a table, use the [`SHOW CREATE TABLE`](show-create-tab
 +--------+----------------------------------------------------------+
 | Table  |                       CreateTable                        |
 +--------+----------------------------------------------------------+
-| logoff | CREATE TABLE logoff (␤                                   |
-|        |     user_id INT NOT NULL,␤                               |
-|        |     user_email STRING(50) NULL,␤                         |
-|        |     logoff_date DATE NULL,␤                              |
-|        |     CONSTRAINT "primary" PRIMARY KEY (user_id),␤         |
-|        |     UNIQUE INDEX logoff_user_email_key (user_email),␤    |
-|        |     FAMILY "primary" (user_id, user_email, logoff_date)␤ |
+| logoff | CREATE TABLE logoff (                                    |
+|        |     user_id INT NOT NULL,                                |
+|        |     user_email STRING(50) NULL,                          |
+|        |     logoff_date DATE NULL,                               |
+|        |     CONSTRAINT "primary" PRIMARY KEY (user_id),          |
+|        |     UNIQUE INDEX logoff_user_email_key (user_email),     |
+|        |     FAMILY "primary" (user_id, user_email, logoff_date)  |
 |        | )                                                        |
 +--------+----------------------------------------------------------+
 (1 row)

--- a/v1.0/show-create-table.md
+++ b/v1.0/show-create-table.md
@@ -48,17 +48,17 @@ Field | Description
 +--------+--------------------------------------------------------------------------------------------------+
 | Table  |                                           CreateTable                                            |
 +--------+--------------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                           |
-|        |     id INT NOT NULL DEFAULT unique_rowid(),␤                                                     |
-|        |     date TIMESTAMP NOT NULL,␤                                                                    |
-|        |     priority INT NULL DEFAULT 1,␤                                                                |
-|        |     customer_id INT NULL,␤                                                                       |
-|        |     status STRING NULL DEFAULT 'open',␤                                                          |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id),␤                                                      |
-|        |     UNIQUE INDEX orders_customer_id_key (customer_id),␤                                          |
-|        |     FAMILY fam_0_id_date_priority_customer_id_status (id, date, priority, customer_id, status),␤ |
-|        |     CHECK (priority BETWEEN 1 AND 5),␤                                                           |
-|        |     CHECK (status IN ('open', 'in progress', 'done', 'cancelled'))␤                              |
+| orders | CREATE TABLE orders (                                                                            |
+|        |     id INT NOT NULL DEFAULT unique_rowid(),                                                      |
+|        |     date TIMESTAMP NOT NULL,                                                                     |
+|        |     priority INT NULL DEFAULT 1,                                                                 |
+|        |     customer_id INT NULL,                                                                        |
+|        |     status STRING NULL DEFAULT 'open',                                                           |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id),                                                       |
+|        |     UNIQUE INDEX orders_customer_id_key (customer_id),                                           |
+|        |     FAMILY fam_0_id_date_priority_customer_id_status (id, date, priority, customer_id, status),  |
+|        |     CHECK (priority BETWEEN 1 AND 5),                                                            |
+|        |     CHECK (status IN ('open', 'in progress', 'done', 'cancelled'))                               |
 |        | )                                                                                                |
 +--------+--------------------------------------------------------------------------------------------------+
 (1 row)

--- a/v1.1/add-constraint.md
+++ b/v1.1/add-constraint.md
@@ -66,12 +66,12 @@ For example, let's say you have two simple tables, `orders` and `customers`:
 +-----------+-------------------------------------------------+
 |   Table   |                   CreateTable                   |
 +-----------+-------------------------------------------------+
-| customers | CREATE TABLE customers (␤                       |
-|           |     id INT NOT NULL,␤                           |
-|           |     "name" STRING NOT NULL,␤                    |
-|           |     address STRING NULL,␤                       |
-|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤ |
-|           |     FAMILY "primary" (id, "name", address)␤     |
+| customers | CREATE TABLE customers (                        |
+|           |     id INT NOT NULL,                            |
+|           |     "name" STRING NOT NULL,                     |
+|           |     address STRING NULL,                        |
+|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),  |
+|           |     FAMILY "primary" (id, "name", address)      |
 |           | )                                               |
 +-----------+-------------------------------------------------+
 (1 row)
@@ -85,13 +85,13 @@ For example, let's say you have two simple tables, `orders` and `customers`:
 +--------+-------------------------------------------------------------------------------------------------------------+
 | Table  |                                                 CreateTable                                                 |
 +--------+-------------------------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                                      |
-|        |     id INT NOT NULL,␤                                                                                       |
-|        |     customer_id INT NULL,␤                                                                                  |
-|        |     status STRING NOT NULL,␤                                                                                |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                                             |
-|        |     FAMILY "primary" (id, customer_id, status),␤                                                            |
-|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))␤ |
+| orders | CREATE TABLE orders (                                                                                       |
+|        |     id INT NOT NULL,                                                                                        |
+|        |     customer_id INT NULL,                                                                                   |
+|        |     status STRING NOT NULL,                                                                                 |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                                              |
+|        |     FAMILY "primary" (id, customer_id, status),                                                             |
+|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))  |
 |        | )                                                                                                           |
 +--------+-------------------------------------------------------------------------------------------------------------+
 (1 row)

--- a/v1.1/column-families.md
+++ b/v1.1/column-families.md
@@ -39,13 +39,13 @@ For example, let's say we want to create a table to store an immutable blob of d
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
-| test  | CREATE TABLE test (␤                       |
-|       |     id INT NOT NULL,␤                       |
-|       |     last_accessed TIMESTAMP NULL,␤          |
-|       |     data BYTES NULL,␤                       |
-|       |     CONSTRAINT "primary" PRIMARY KEY (id),␤ |
-|       |     FAMILY f1 (id, last_accessed),␤         |
-|       |     FAMILY f2 (data)␤                       |
+| test  | CREATE TABLE test (                         |
+|       |     id INT NOT NULL,                        |
+|       |     last_accessed TIMESTAMP NULL,           |
+|       |     data BYTES NULL,                        |
+|       |     CONSTRAINT "primary" PRIMARY KEY (id),  |
+|       |     FAMILY f1 (id, last_accessed),          |
+|       |     FAMILY f2 (data)                        |
 |       | )                                           |
 +-------+---------------------------------------------+
 (1 row)

--- a/v1.1/create-table-as.md
+++ b/v1.1/create-table-as.md
@@ -74,11 +74,11 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)
@@ -101,12 +101,12 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     INDEX logoff_copy_id_idx (user_id ASC),␤                    |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     INDEX logoff_copy_id_idx (user_id ASC),                     |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)

--- a/v1.1/create-table.md
+++ b/v1.1/create-table.md
@@ -289,13 +289,13 @@ To show the definition of a table, use the [`SHOW CREATE TABLE`](show-create-tab
 +--------+----------------------------------------------------------+
 | Table  |                       CreateTable                        |
 +--------+----------------------------------------------------------+
-| logoff | CREATE TABLE logoff (␤                                   |
-|        |     user_id INT NOT NULL,␤                               |
-|        |     user_email STRING(50) NULL,␤                         |
-|        |     logoff_date DATE NULL,␤                              |
-|        |     CONSTRAINT "primary" PRIMARY KEY (user_id),␤         |
-|        |     UNIQUE INDEX logoff_user_email_key (user_email),␤    |
-|        |     FAMILY "primary" (user_id, user_email, logoff_date)␤ |
+| logoff | CREATE TABLE logoff (                                    |
+|        |     user_id INT NOT NULL,                                |
+|        |     user_email STRING(50) NULL,                          |
+|        |     logoff_date DATE NULL,                               |
+|        |     CONSTRAINT "primary" PRIMARY KEY (user_id),          |
+|        |     UNIQUE INDEX logoff_user_email_key (user_email),     |
+|        |     FAMILY "primary" (user_id, user_email, logoff_date)  |
 |        | )                                                        |
 +--------+----------------------------------------------------------+
 (1 row)

--- a/v1.1/show-create-table.md
+++ b/v1.1/show-create-table.md
@@ -59,12 +59,12 @@ Field | Description
 +-----------+----------------------------------------------------+
 |   Table   |                    CreateTable                     |
 +-----------+----------------------------------------------------+
-| customers | CREATE TABLE customers (␤                          |
-|           |     id INT NOT NULL,␤                              |
-|           |     email STRING NULL,␤                            |
-|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤    |
-|           |     UNIQUE INDEX customers_email_key (email ASC),␤ |
-|           |     FAMILY "primary" (id, email)␤                  |
+| customers | CREATE TABLE customers (                           |
+|           |     id INT NOT NULL,                               |
+|           |     email STRING NULL,                             |
+|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),     |
+|           |     UNIQUE INDEX customers_email_key (email ASC),  |
+|           |     FAMILY "primary" (id, email)                   |
 |           | )                                                  |
 +-----------+----------------------------------------------------+
 (1 row)
@@ -78,11 +78,11 @@ Field | Description
 +----------+--------------------------------------------------+
 |  Table   |                   CreateTable                    |
 +----------+--------------------------------------------------+
-| products | CREATE TABLE products (␤                         |
-|          |     sku STRING NOT NULL,␤                        |
-|          |     price DECIMAL(9,2) NULL,␤                    |
-|          |     CONSTRAINT "primary" PRIMARY KEY (sku ASC),␤ |
-|          |     FAMILY "primary" (sku, price)␤               |
+| products | CREATE TABLE products (                          |
+|          |     sku STRING NOT NULL,                         |
+|          |     price DECIMAL(9,2) NULL,                     |
+|          |     CONSTRAINT "primary" PRIMARY KEY (sku ASC),  |
+|          |     FAMILY "primary" (sku, price)                |
 |          | )                                                |
 +----------+--------------------------------------------------+
 (1 row)
@@ -96,18 +96,18 @@ Field | Description
 +--------+------------------------------------------------------------------------------------------+
 | Table  |                                       CreateTable                                        |
 +--------+------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                   |
-|        |     id INT NOT NULL,␤                                                                    |
-|        |     product STRING NOT NULL,␤                                                            |
-|        |     quantity INT NULL,␤                                                                  |
-|        |     customer INT NOT NULL,␤                                                              |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                          |
-|        |     UNIQUE INDEX id_customer_unique (id ASC, customer ASC),␤                             |
-|        |     CONSTRAINT fk_product_ref_products FOREIGN KEY (product) REFERENCES products (sku),␤ |
-|        |     INDEX orders_product_idx (product ASC),␤                                             |
-|        |     CONSTRAINT valid_customer FOREIGN KEY (customer) REFERENCES customers (id),␤         |
-|        |     INDEX orders_customer_idx (customer ASC),␤                                           |
-|        |     FAMILY "primary" (id, product, quantity, customer)␤                                  |
+| orders | CREATE TABLE orders (                                                                    |
+|        |     id INT NOT NULL,                                                                     |
+|        |     product STRING NOT NULL,                                                             |
+|        |     quantity INT NULL,                                                                   |
+|        |     customer INT NOT NULL,                                                               |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                           |
+|        |     UNIQUE INDEX id_customer_unique (id ASC, customer ASC),                              |
+|        |     CONSTRAINT fk_product_ref_products FOREIGN KEY (product) REFERENCES products (sku),  |
+|        |     INDEX orders_product_idx (product ASC),                                              |
+|        |     CONSTRAINT valid_customer FOREIGN KEY (customer) REFERENCES customers (id),          |
+|        |     INDEX orders_customer_idx (customer ASC),                                            |
+|        |     FAMILY "primary" (id, product, quantity, customer)                                   |
 |        | )                                                                                        |
 +--------+------------------------------------------------------------------------------------------+
 (1 row)

--- a/v1.1/show-trace.md
+++ b/v1.1/show-trace.md
@@ -318,13 +318,13 @@ In this example, we use session tracing to show an [automatic transaction retry]
 	|        age         |        message                                                                                                |
 	+--------------------+---------------------------------------------------------------------------------------------------------------+
 	| 0s                 | === SPAN START: sql txn implicit ===                                                                          |
-	| 123µs317ns         | AutoCommit. err: <nil>␤                                                                                       |
+	| 123µs317ns         | AutoCommit. err: <nil>                                                                                        |
 	|                    | txn: "sql txn implicit" id=64d34fbc key=/Min rw=false pri=0.02500536 iso=SERIALIZABLE stat=COMMITTED ...      |
 	| 1s767ms959µs448ns  | === SPAN START: sql txn ===                                                                                   |
 	| 1s767ms989µs448ns  | executing 1/1: BEGIN TRANSACTION                                                                              |
 	| # Annotation: First execution of INSERT.                                                                                           |
 	| 13s536ms79µs67ns   | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>                                                                         |
 	|                    | txn: "unnamed" id=329e7307 key=/Min rw=false pri=0.01354772 iso=SERIALIZABLE stat=COMMITTED epo=0 ...         |
 	| 13s536ms143µs145ns | added table 't' to table collection                                                                           |
 	| 13s536ms305µs103ns | query not supported for distSQL: mutations not supported                                                      |
@@ -348,7 +348,7 @@ In this example, we use session tracing to show an [automatic transaction retry]
 	|                      HandledRetryableTxnError: serializable transaction timestamp pushed (detected by SQL Executor)                |
 	| # Annotation: Second execution of INSERT.                                                                                          |
 	| 13s537ms83µs369ns  | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>                                                                         |
 	|                    | txn: "unnamed" id=1228171b key=/Min rw=false pri=0.02917782 iso=SERIALIZABLE stat=COMMITTED epo=0             |
 	|                      ts=1507321556.991937203,0 orig=1507321556.991937203,0 max=1507321557.491937203,0 wto=false rop=false          |
 	| 13s537ms111µs738ns | releasing 1 tables                                                                                            |

--- a/v19.1/column-families.md
+++ b/v19.1/column-families.md
@@ -43,13 +43,13 @@ For example, let's say we want to create a table to store an immutable blob of d
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
-| test  | CREATE TABLE test (␤                       |
-|       |     id INT NOT NULL,␤                       |
-|       |     last_accessed TIMESTAMP NULL,␤          |
-|       |     data BYTES NULL,␤                       |
-|       |     CONSTRAINT "primary" PRIMARY KEY (id),␤ |
-|       |     FAMILY f1 (id, last_accessed),␤         |
-|       |     FAMILY f2 (data)␤                       |
+| test  | CREATE TABLE test (                         |
+|       |     id INT NOT NULL,                        |
+|       |     last_accessed TIMESTAMP NULL,           |
+|       |     data BYTES NULL,                        |
+|       |     CONSTRAINT "primary" PRIMARY KEY (id),  |
+|       |     FAMILY f1 (id, last_accessed),          |
+|       |     FAMILY f2 (data)                        |
 |       | )                                           |
 +-------+---------------------------------------------+
 (1 row)

--- a/v19.1/create-table-as.md
+++ b/v19.1/create-table-as.md
@@ -83,11 +83,11 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)
@@ -115,12 +115,12 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     INDEX logoff_copy_id_idx (user_id ASC),␤                    |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     INDEX logoff_copy_id_idx (user_id ASC),                     |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)

--- a/v19.1/show-trace.md
+++ b/v19.1/show-trace.md
@@ -402,13 +402,13 @@ In this example, we use session tracing to show an [automatic transaction retry]
   	|        age         |        message                                                                                                |
   	+--------------------+---------------------------------------------------------------------------------------------------------------+
   	| 0s                 | === SPAN START: sql txn implicit ===                                                                          |
-  	| 123µs317ns         | AutoCommit. err: <nil>␤                                                                                       |
+  	| 123µs317ns         | AutoCommit. err: <nil>                                                                                        |
   	|                    | txn: "sql txn implicit" id=64d34fbc key=/Min rw=false pri=0.02500536 iso=SERIALIZABLE stat=COMMITTED ...      |
   	| 1s767ms959µs448ns  | === SPAN START: sql txn ===                                                                                   |
   	| 1s767ms989µs448ns  | executing 1/1: BEGIN TRANSACTION                                                                              |
   	| # Annotation: First execution of INSERT.                                                                                           |
   	| 13s536ms79µs67ns   | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-  	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+  	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>                                                                         |
   	|                    | txn: "unnamed" id=329e7307 key=/Min rw=false pri=0.01354772 iso=SERIALIZABLE stat=COMMITTED epo=0 ...         |
   	| 13s536ms143µs145ns | added table 't' to table collection                                                                           |
   	| 13s536ms305µs103ns | query not supported for distSQL: mutations not supported                                                      |
@@ -432,7 +432,7 @@ In this example, we use session tracing to show an [automatic transaction retry]
   	|                      HandledRetryableTxnError: serializable transaction timestamp pushed (detected by SQL Executor)                |
   	| # Annotation: Second execution of INSERT.                                                                                          |
   	| 13s537ms83µs369ns  | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-  	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+  	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>                                                                         |
   	|                    | txn: "unnamed" id=1228171b key=/Min rw=false pri=0.02917782 iso=SERIALIZABLE stat=COMMITTED epo=0             |
   	|                      ts=1507321556.991937203,0 orig=1507321556.991937203,0 max=1507321557.491937203,0 wto=false rop=false          |
   	| 13s537ms111µs738ns | releasing 1 tables                                                                                            |

--- a/v19.2/column-families.md
+++ b/v19.2/column-families.md
@@ -43,13 +43,13 @@ For example, let's say we want to create a table to store an immutable blob of d
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
-| test  | CREATE TABLE test (␤                       |
-|       |     id INT NOT NULL,␤                       |
-|       |     last_accessed TIMESTAMP NULL,␤          |
-|       |     data BYTES NULL,␤                       |
-|       |     CONSTRAINT "primary" PRIMARY KEY (id),␤ |
-|       |     FAMILY f1 (id, last_accessed),␤         |
-|       |     FAMILY f2 (data)␤                       |
+| test  | CREATE TABLE test (                         |
+|       |     id INT NOT NULL,                        |
+|       |     last_accessed TIMESTAMP NULL,           |
+|       |     data BYTES NULL,                        |
+|       |     CONSTRAINT "primary" PRIMARY KEY (id),  |
+|       |     FAMILY f1 (id, last_accessed),          |
+|       |     FAMILY f2 (data)                        |
 |       | )                                           |
 +-------+---------------------------------------------+
 (1 row)

--- a/v19.2/show-trace.md
+++ b/v19.2/show-trace.md
@@ -402,13 +402,13 @@ In this example, we use session tracing to show an [automatic transaction retry]
   	|        age         |        message                                                                                                |
   	+--------------------+---------------------------------------------------------------------------------------------------------------+
   	| 0s                 | === SPAN START: sql txn implicit ===                                                                          |
-  	| 123µs317ns         | AutoCommit. err: <nil>␤                                                                                       |
+  	| 123µs317ns         | AutoCommit. err: <nil>                                                                                        |
   	|                    | txn: "sql txn implicit" id=64d34fbc key=/Min rw=false pri=0.02500536 iso=SERIALIZABLE stat=COMMITTED ...      |
   	| 1s767ms959µs448ns  | === SPAN START: sql txn ===                                                                                   |
   	| 1s767ms989µs448ns  | executing 1/1: BEGIN TRANSACTION                                                                              |
   	| # Annotation: First execution of INSERT.                                                                                           |
   	| 13s536ms79µs67ns   | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-  	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+  	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>                                                                         |
   	|                    | txn: "unnamed" id=329e7307 key=/Min rw=false pri=0.01354772 iso=SERIALIZABLE stat=COMMITTED epo=0 ...         |
   	| 13s536ms143µs145ns | added table 't' to table collection                                                                           |
   	| 13s536ms305µs103ns | query not supported for distSQL: mutations not supported                                                      |
@@ -432,7 +432,7 @@ In this example, we use session tracing to show an [automatic transaction retry]
   	|                      HandledRetryableTxnError: serializable transaction timestamp pushed (detected by SQL Executor)                |
   	| # Annotation: Second execution of INSERT.                                                                                          |
   	| 13s537ms83µs369ns  | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-  	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+  	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>                                                                         |
   	|                    | txn: "unnamed" id=1228171b key=/Min rw=false pri=0.02917782 iso=SERIALIZABLE stat=COMMITTED epo=0             |
   	|                      ts=1507321556.991937203,0 orig=1507321556.991937203,0 max=1507321557.491937203,0 wto=false rop=false          |
   	| 13s537ms111µs738ns | releasing 1 tables                                                                                            |

--- a/v2.0/add-constraint.md
+++ b/v2.0/add-constraint.md
@@ -71,12 +71,12 @@ For example, let's say you have two simple tables, `orders` and `customers`:
 +-----------+-------------------------------------------------+
 |   Table   |                   CreateTable                   |
 +-----------+-------------------------------------------------+
-| customers | CREATE TABLE customers (␤                       |
-|           |     id INT NOT NULL,␤                           |
-|           |     "name" STRING NOT NULL,␤                    |
-|           |     address STRING NULL,␤                       |
-|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤ |
-|           |     FAMILY "primary" (id, "name", address)␤     |
+| customers | CREATE TABLE customers (                        |
+|           |     id INT NOT NULL,                            |
+|           |     "name" STRING NOT NULL,                     |
+|           |     address STRING NULL,                        |
+|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),  |
+|           |     FAMILY "primary" (id, "name", address)      |
 |           | )                                               |
 +-----------+-------------------------------------------------+
 (1 row)
@@ -91,13 +91,13 @@ For example, let's say you have two simple tables, `orders` and `customers`:
 +--------+-------------------------------------------------------------------------------------------------------------+
 | Table  |                                                 CreateTable                                                 |
 +--------+-------------------------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                                      |
-|        |     id INT NOT NULL,␤                                                                                       |
-|        |     customer_id INT NULL,␤                                                                                  |
-|        |     status STRING NOT NULL,␤                                                                                |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                                             |
-|        |     FAMILY "primary" (id, customer_id, status),␤                                                            |
-|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))␤ |
+| orders | CREATE TABLE orders (                                                                                       |
+|        |     id INT NOT NULL,                                                                                        |
+|        |     customer_id INT NULL,                                                                                   |
+|        |     status STRING NOT NULL,                                                                                 |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                                              |
+|        |     FAMILY "primary" (id, customer_id, status),                                                             |
+|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))  |
 |        | )                                                                                                           |
 +--------+-------------------------------------------------------------------------------------------------------------+
 (1 row)

--- a/v2.0/column-families.md
+++ b/v2.0/column-families.md
@@ -39,13 +39,13 @@ For example, let's say we want to create a table to store an immutable blob of d
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
-| test  | CREATE TABLE test (␤                       |
-|       |     id INT NOT NULL,␤                       |
-|       |     last_accessed TIMESTAMP NULL,␤          |
-|       |     data BYTES NULL,␤                       |
-|       |     CONSTRAINT "primary" PRIMARY KEY (id),␤ |
-|       |     FAMILY f1 (id, last_accessed),␤         |
-|       |     FAMILY f2 (data)␤                       |
+| test  | CREATE TABLE test (                         |
+|       |     id INT NOT NULL,                        |
+|       |     last_accessed TIMESTAMP NULL,           |
+|       |     data BYTES NULL,                        |
+|       |     CONSTRAINT "primary" PRIMARY KEY (id),  |
+|       |     FAMILY f1 (id, last_accessed),          |
+|       |     FAMILY f2 (data)                        |
 |       | )                                           |
 +-------+---------------------------------------------+
 (1 row)

--- a/v2.0/create-table-as.md
+++ b/v2.0/create-table-as.md
@@ -76,11 +76,11 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)
@@ -103,12 +103,12 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     INDEX logoff_copy_id_idx (user_id ASC),␤                    |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     INDEX logoff_copy_id_idx (user_id ASC),                     |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)

--- a/v2.0/create-table.md
+++ b/v2.0/create-table.md
@@ -272,13 +272,13 @@ In this example, we use `ON DELETE CASCADE` (i.e., when row referenced by a fore
 +--------+---------------------------------------------------------------------------------------------------------------------+
 | Table  |                                                     CreateTable                                                     |
 +--------+---------------------------------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                                              |
-|        |     id INT NOT NULL,␤                                                                                               |
-|        |     customer_id INT NULL,␤                                                                                          |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                                                     |
-|        |     CONSTRAINT fk_customer_id_ref_customers FOREIGN KEY (customer_id) REFERENCES customers (id) ON DELETE CASCADE,␤ |
-|        |     INDEX orders_auto_index_fk_customer_id_ref_customers (customer_id ASC),␤                                        |
-|        |     FAMILY "primary" (id, customer_id)␤                                                                             |
+| orders | CREATE TABLE orders (                                                                                               |
+|        |     id INT NOT NULL,                                                                                                |
+|        |     customer_id INT NULL,                                                                                           |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                                                      |
+|        |     CONSTRAINT fk_customer_id_ref_customers FOREIGN KEY (customer_id) REFERENCES customers (id) ON DELETE CASCADE,  |
+|        |     INDEX orders_auto_index_fk_customer_id_ref_customers (customer_id ASC),                                         |
+|        |     FAMILY "primary" (id, customer_id)                                                                              |
 |        | )                                                                                                                   |
 +--------+---------------------------------------------------------------------------------------------------------------------+
 ```
@@ -403,13 +403,13 @@ To show the definition of a table, use the [`SHOW CREATE TABLE`](show-create-tab
 +--------+----------------------------------------------------------+
 | Table  |                       CreateTable                        |
 +--------+----------------------------------------------------------+
-| logoff | CREATE TABLE logoff (␤                                   |
-|        |     user_id INT NOT NULL,␤                               |
-|        |     user_email STRING(50) NULL,␤                         |
-|        |     logoff_date DATE NULL,␤                              |
-|        |     CONSTRAINT "primary" PRIMARY KEY (user_id),␤         |
-|        |     UNIQUE INDEX logoff_user_email_key (user_email),␤    |
-|        |     FAMILY "primary" (user_id, user_email, logoff_date)␤ |
+| logoff | CREATE TABLE logoff (                                    |
+|        |     user_id INT NOT NULL,                                |
+|        |     user_email STRING(50) NULL,                          |
+|        |     logoff_date DATE NULL,                               |
+|        |     CONSTRAINT "primary" PRIMARY KEY (user_id),          |
+|        |     UNIQUE INDEX logoff_user_email_key (user_email),     |
+|        |     FAMILY "primary" (user_id, user_email, logoff_date)  |
 |        | )                                                        |
 +--------+----------------------------------------------------------+
 (1 row)

--- a/v2.0/show-create-table.md
+++ b/v2.0/show-create-table.md
@@ -61,12 +61,12 @@ Field | Description
 +-----------+----------------------------------------------------+
 |   Table   |                    CreateTable                     |
 +-----------+----------------------------------------------------+
-| customers | CREATE TABLE customers (␤                          |
-|           |     id INT NOT NULL,␤                              |
-|           |     email STRING NULL,␤                            |
-|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤    |
-|           |     UNIQUE INDEX customers_email_key (email ASC),␤ |
-|           |     FAMILY "primary" (id, email)␤                  |
+| customers | CREATE TABLE customers (                           |
+|           |     id INT NOT NULL,                               |
+|           |     email STRING NULL,                             |
+|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),     |
+|           |     UNIQUE INDEX customers_email_key (email ASC),  |
+|           |     FAMILY "primary" (id, email)                   |
 |           | )                                                  |
 +-----------+----------------------------------------------------+
 (1 row)
@@ -80,11 +80,11 @@ Field | Description
 +----------+--------------------------------------------------+
 |  Table   |                   CreateTable                    |
 +----------+--------------------------------------------------+
-| products | CREATE TABLE products (␤                         |
-|          |     sku STRING NOT NULL,␤                        |
-|          |     price DECIMAL(9,2) NULL,␤                    |
-|          |     CONSTRAINT "primary" PRIMARY KEY (sku ASC),␤ |
-|          |     FAMILY "primary" (sku, price)␤               |
+| products | CREATE TABLE products (                          |
+|          |     sku STRING NOT NULL,                         |
+|          |     price DECIMAL(9,2) NULL,                     |
+|          |     CONSTRAINT "primary" PRIMARY KEY (sku ASC),  |
+|          |     FAMILY "primary" (sku, price)                |
 |          | )                                                |
 +----------+--------------------------------------------------+
 (1 row)
@@ -98,18 +98,18 @@ Field | Description
 +--------+------------------------------------------------------------------------------------------+
 | Table  |                                       CreateTable                                        |
 +--------+------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                   |
-|        |     id INT NOT NULL,␤                                                                    |
-|        |     product STRING NOT NULL,␤                                                            |
-|        |     quantity INT NULL,␤                                                                  |
-|        |     customer INT NOT NULL,␤                                                              |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                          |
-|        |     UNIQUE INDEX id_customer_unique (id ASC, customer ASC),␤                             |
-|        |     CONSTRAINT fk_product_ref_products FOREIGN KEY (product) REFERENCES products (sku),␤ |
-|        |     INDEX orders_product_idx (product ASC),␤                                             |
-|        |     CONSTRAINT valid_customer FOREIGN KEY (customer) REFERENCES customers (id),␤         |
-|        |     INDEX orders_customer_idx (customer ASC),␤                                           |
-|        |     FAMILY "primary" (id, product, quantity, customer)␤                                  |
+| orders | CREATE TABLE orders (                                                                    |
+|        |     id INT NOT NULL,                                                                     |
+|        |     product STRING NOT NULL,                                                             |
+|        |     quantity INT NULL,                                                                   |
+|        |     customer INT NOT NULL,                                                               |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                           |
+|        |     UNIQUE INDEX id_customer_unique (id ASC, customer ASC),                              |
+|        |     CONSTRAINT fk_product_ref_products FOREIGN KEY (product) REFERENCES products (sku),  |
+|        |     INDEX orders_product_idx (product ASC),                                              |
+|        |     CONSTRAINT valid_customer FOREIGN KEY (customer) REFERENCES customers (id),          |
+|        |     INDEX orders_customer_idx (customer ASC),                                            |
+|        |     FAMILY "primary" (id, product, quantity, customer)                                   |
 |        | )                                                                                        |
 +--------+------------------------------------------------------------------------------------------+
 (1 row)

--- a/v2.0/show-trace.md
+++ b/v2.0/show-trace.md
@@ -331,13 +331,13 @@ In this example, we use session tracing to show an [automatic transaction retry]
 	|        age         |        message                                                                                                |
 	+--------------------+---------------------------------------------------------------------------------------------------------------+
 	| 0s                 | === SPAN START: sql txn implicit ===                                                                          |
-	| 123µs317ns         | AutoCommit. err: <nil>␤                                                                                       |
+	| 123µs317ns         | AutoCommit. err: <nil>                                                                                        |
 	|                    | txn: "sql txn implicit" id=64d34fbc key=/Min rw=false pri=0.02500536 iso=SERIALIZABLE stat=COMMITTED ...      |
 	| 1s767ms959µs448ns  | === SPAN START: sql txn ===                                                                                   |
 	| 1s767ms989µs448ns  | executing 1/1: BEGIN TRANSACTION                                                                              |
 	| # Annotation: First execution of INSERT.                                                                                           |
 	| 13s536ms79µs67ns   | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>                                                                         |
 	|                    | txn: "unnamed" id=329e7307 key=/Min rw=false pri=0.01354772 iso=SERIALIZABLE stat=COMMITTED epo=0 ...         |
 	| 13s536ms143µs145ns | added table 't' to table collection                                                                           |
 	| 13s536ms305µs103ns | query not supported for distSQL: mutations not supported                                                      |
@@ -361,7 +361,7 @@ In this example, we use session tracing to show an [automatic transaction retry]
 	|                      HandledRetryableTxnError: serializable transaction timestamp pushed (detected by SQL Executor)                |
 	| # Annotation: Second execution of INSERT.                                                                                          |
 	| 13s537ms83µs369ns  | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>                                                                         |
 	|                    | txn: "unnamed" id=1228171b key=/Min rw=false pri=0.02917782 iso=SERIALIZABLE stat=COMMITTED epo=0             |
 	|                      ts=1507321556.991937203,0 orig=1507321556.991937203,0 max=1507321557.491937203,0 wto=false rop=false          |
 	| 13s537ms111µs738ns | releasing 1 tables                                                                                            |

--- a/v2.1/add-constraint.md
+++ b/v2.1/add-constraint.md
@@ -72,12 +72,12 @@ For example, let's say you have two tables, `orders` and `customers`:
 +-----------+-------------------------------------------------+
 |   Table   |                   CreateTable                   |
 +-----------+-------------------------------------------------+
-| customers | CREATE TABLE customers (␤                       |
-|           |     id INT NOT NULL,␤                           |
-|           |     "name" STRING NOT NULL,␤                    |
-|           |     address STRING NULL,␤                       |
-|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤ |
-|           |     FAMILY "primary" (id, "name", address)␤     |
+| customers | CREATE TABLE customers (                        |
+|           |     id INT NOT NULL,                            |
+|           |     "name" STRING NOT NULL,                     |
+|           |     address STRING NULL,                        |
+|           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),  |
+|           |     FAMILY "primary" (id, "name", address)      |
 |           | )                                               |
 +-----------+-------------------------------------------------+
 (1 row)
@@ -92,13 +92,13 @@ For example, let's say you have two tables, `orders` and `customers`:
 +--------+-------------------------------------------------------------------------------------------------------------+
 | Table  |                                                 CreateTable                                                 |
 +--------+-------------------------------------------------------------------------------------------------------------+
-| orders | CREATE TABLE orders (␤                                                                                      |
-|        |     id INT NOT NULL,␤                                                                                       |
-|        |     customer_id INT NULL,␤                                                                                  |
-|        |     status STRING NOT NULL,␤                                                                                |
-|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),␤                                                             |
-|        |     FAMILY "primary" (id, customer_id, status),␤                                                            |
-|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))␤ |
+| orders | CREATE TABLE orders (                                                                                       |
+|        |     id INT NOT NULL,                                                                                        |
+|        |     customer_id INT NULL,                                                                                   |
+|        |     status STRING NOT NULL,                                                                                 |
+|        |     CONSTRAINT "primary" PRIMARY KEY (id ASC),                                                              |
+|        |     FAMILY "primary" (id, customer_id, status),                                                             |
+|        |     CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))  |
 |        | )                                                                                                           |
 +--------+-------------------------------------------------------------------------------------------------------------+
 (1 row)

--- a/v2.1/column-families.md
+++ b/v2.1/column-families.md
@@ -43,13 +43,13 @@ For example, let's say we want to create a table to store an immutable blob of d
 +-------+---------------------------------------------+
 | Table |                 CreateTable                 |
 +-------+---------------------------------------------+
-| test  | CREATE TABLE test (␤                       |
-|       |     id INT NOT NULL,␤                       |
-|       |     last_accessed TIMESTAMP NULL,␤          |
-|       |     data BYTES NULL,␤                       |
-|       |     CONSTRAINT "primary" PRIMARY KEY (id),␤ |
-|       |     FAMILY f1 (id, last_accessed),␤         |
-|       |     FAMILY f2 (data)␤                       |
+| test  | CREATE TABLE test (                         |
+|       |     id INT NOT NULL,                        |
+|       |     last_accessed TIMESTAMP NULL,           |
+|       |     data BYTES NULL,                        |
+|       |     CONSTRAINT "primary" PRIMARY KEY (id),  |
+|       |     FAMILY f1 (id, last_accessed),          |
+|       |     FAMILY f2 (data)                        |
 |       | )                                           |
 +-------+---------------------------------------------+
 (1 row)

--- a/v2.1/create-table-as.md
+++ b/v2.1/create-table-as.md
@@ -83,11 +83,11 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)
@@ -115,12 +115,12 @@ For example:
 +-------------+-----------------------------------------------------------------+
 |    Table    |                           CreateTable                           |
 +-------------+-----------------------------------------------------------------+
-| logoff_copy | CREATE TABLE logoff_copy (␤                                     |
-|             |     user_id INT NULL,␤                                          |
-|             |     user_email STRING NULL,␤                                    |
-|             |     logoff_date DATE NULL,␤                                     |
-|             |     INDEX logoff_copy_id_idx (user_id ASC),␤                    |
-|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)␤ |
+| logoff_copy | CREATE TABLE logoff_copy (                                      |
+|             |     user_id INT NULL,                                           |
+|             |     user_email STRING NULL,                                     |
+|             |     logoff_date DATE NULL,                                      |
+|             |     INDEX logoff_copy_id_idx (user_id ASC),                     |
+|             |     FAMILY "primary" (user_id, user_email, logoff_date, rowid)  |
 |             | )                                                               |
 +-------------+-----------------------------------------------------------------+
 (1 row)

--- a/v2.1/show-trace.md
+++ b/v2.1/show-trace.md
@@ -402,13 +402,13 @@ In this example, we use session tracing to show an [automatic transaction retry]
   	|        age         |        message                                                                                                |
   	+--------------------+---------------------------------------------------------------------------------------------------------------+
   	| 0s                 | === SPAN START: sql txn implicit ===                                                                          |
-  	| 123µs317ns         | AutoCommit. err: <nil>␤                                                                                       |
+  	| 123µs317ns         | AutoCommit. err: <nil>                                                                                        |
   	|                    | txn: "sql txn implicit" id=64d34fbc key=/Min rw=false pri=0.02500536 iso=SERIALIZABLE stat=COMMITTED ...      |
   	| 1s767ms959µs448ns  | === SPAN START: sql txn ===                                                                                   |
   	| 1s767ms989µs448ns  | executing 1/1: BEGIN TRANSACTION                                                                              |
   	| # Annotation: First execution of INSERT.                                                                                           |
   	| 13s536ms79µs67ns   | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-  	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+  	| 13s536ms134µs682ns | client.Txn did AutoCommit. err: <nil>                                                                         |
   	|                    | txn: "unnamed" id=329e7307 key=/Min rw=false pri=0.01354772 iso=SERIALIZABLE stat=COMMITTED epo=0 ...         |
   	| 13s536ms143µs145ns | added table 't' to table collection                                                                           |
   	| 13s536ms305µs103ns | query not supported for distSQL: mutations not supported                                                      |
@@ -432,7 +432,7 @@ In this example, we use session tracing to show an [automatic transaction retry]
   	|                      HandledRetryableTxnError: serializable transaction timestamp pushed (detected by SQL Executor)                |
   	| # Annotation: Second execution of INSERT.                                                                                          |
   	| 13s537ms83µs369ns  | executing 1/1: INSERT INTO t VALUES (1)                                                                       |
-  	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>␤                                                                        |
+  	| 13s537ms109µs516ns | client.Txn did AutoCommit. err: <nil>                                                                         |
   	|                    | txn: "unnamed" id=1228171b key=/Min rw=false pri=0.02917782 iso=SERIALIZABLE stat=COMMITTED epo=0             |
   	|                      ts=1507321556.991937203,0 orig=1507321556.991937203,0 max=1507321557.491937203,0 wto=false rop=false          |
   	| 13s537ms111µs738ns | releasing 1 tables                                                                                            |


### PR DESCRIPTION
I noticed that a few of our example CLI outputs had ␤ characters at the
end of each line. I think this is a just display artifact from an older
version of the Cockroach CLI, so I removed them.