### PR TITLE
Add homepage front-matter field

### DIFF
--- a/v19.1/index.md
+++ b/v19.1/index.md
@@ -2,6 +2,7 @@
 title: CockroachDB Docs
 summary: CockroachDB user documentation.
 toc: true
+homepage: true
 contribute: false
 build_for: [cockroachdb, cockroachcloud]
 cta: false

--- a/v19.2/index.md
+++ b/v19.2/index.md
@@ -2,6 +2,7 @@
 title: CockroachDB Docs
 summary: CockroachDB user documentation.
 toc: true
+homepage: true
 contribute: false
 build_for: [cockroachdb, cockroachcloud]
 cta: false

--- a/v2.1/index.md
+++ b/v2.1/index.md
@@ -2,6 +2,7 @@
 title: CockroachDB Docs
 summary: CockroachDB user documentation.
 toc: true
+homepage: true
 contribute: false
 build_for: [cockroachdb, cockroachcloud]
 cta: false


### PR DESCRIPTION
This uses the homepage_title field from the relevant
config as the index.html h1. CockroachCloud Docs for
CockroachCloud, and CockroachDB Docs for CockroachDB.

Fixes #5651.