### PR TITLE
No import rolling upgrade

### DIFF
--- a/_includes/v19.2/known-limitations/import-high-disk-contention.md
+++ b/_includes/v19.2/known-limitations/import-high-disk-contention.md
@@ -1,0 +1,6 @@
+[`IMPORT`](import.html) can sometimes fail with a "context canceled" error, or can restart itself many times without ever finishing. If this is happening, it is likely due to a high amount of disk contention. This can be mitigated by setting the `kv.bulk_io_write.max_rate` [cluster setting](cluster-settings.html) to a value below your max disk write speed. For example, to set it to 10MB/s, execute:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SET CLUSTER SETTING kv.bulk_io_write.max_rate = '10MB';
+~~~

--- a/v19.2/import.md
+++ b/v19.2/import.md
@@ -16,7 +16,7 @@ This page has reference information about the `IMPORT` statement.  For instructi
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_danger}}
-`IMPORT` only works for creating new tables. For information on how to add CSV data to existing tables, see [`IMPORT INTO`](import-into.html). Also, `IMPORT` cannot be used within a [transaction](transactions.html).
+`IMPORT` only works for creating new tables. For information on how to add CSV data to existing tables, see [`IMPORT INTO`](import-into.html). Also, `IMPORT` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
 {{site.data.alerts.end}}
 
 ## Required privileges
@@ -699,12 +699,7 @@ For more detailed information about importing data from MySQL, see [Migrate from
 
 ## Known limitation
 
-`IMPORT` can sometimes fail with a "context canceled" error, or can restart itself many times without ever finishing. If this is happening, it is likely due to a high amount of disk contention. This can be mitigated by setting the `kv.bulk_io_write.max_rate` [cluster setting](cluster-settings.html) to a value below your max disk write speed. For example, to set it to 10MB/s, execute:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET CLUSTER SETTING kv.bulk_io_write.max_rate = '10MB';
-~~~
+{% include {{ page.version.version }}/known-limitations/import-high-disk-contention.md %}
 
 ## See also
 

--- a/v19.2/known-limitations.md
+++ b/v19.2/known-limitations.md
@@ -197,12 +197,7 @@ Most client drivers and frameworks use the text format to pass placeholder value
 
 ### Import with a high amount of disk contention
 
-[`IMPORT`](import.html) can sometimes fail with a "context canceled" error, or can restart itself many times without ever finishing. If this is happening, it is likely due to a high amount of disk contention. This can be mitigated by setting the `kv.bulk_io_write.max_rate` [cluster setting](cluster-settings.html) to a value below your max disk write speed. For example, to set it to 10MB/s, execute:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET CLUSTER SETTING kv.bulk_io_write.max_rate = '10MB';
-~~~
+{% include {{ page.version.version }}/known-limitations/import-high-disk-contention.md %}
 
 ### Assigning latitude/longitude for the Node Map
 

--- a/v19.2/upgrade-cockroach-version.md
+++ b/v19.2/upgrade-cockroach-version.md
@@ -25,8 +25,8 @@ Before starting the upgrade, complete the following steps.
 
 1. Make sure your cluster is behind a [load balancer](recommended-production-settings.html#load-balancing), or your clients are configured to talk to multiple nodes. If your application communicates with a single node, stopping that node to upgrade its CockroachDB binary will cause your application to fail.
 
-2. Make sure there are no [schema changes](online-schema-changes.html) in progress. Schema changes are complex operations that involve coordination across nodes and can increase the potential for unexpected behavior during an upgrade.
-    - To check for ongoing schema changes, use [`SHOW JOBS`](show-jobs.html#show-schema-changes) or check the [**Jobs** page](admin-ui-jobs-page.html) in the Admin UI.
+2. Make sure there are no [bulk imports](import.html) or [schema changes](online-schema-changes.html) in progress. These are complex operations that involve coordination across nodes and can increase the potential for unexpected behavior during an upgrade.
+    - To check for ongoing imports or schema changes, use [`SHOW JOBS`](show-jobs.html#show-schema-changes) or check the [**Jobs** page](admin-ui-jobs-page.html) in the Admin UI.
 
 3. Verify the overall health of your cluster using the [Admin UI](admin-ui-access-and-navigate.html). On the **Cluster Overview**:
     - Under **Node Status**, make sure all nodes that should be live are listed as such. If any nodes are unexpectedly listed as suspect or dead, identify why the nodes are offline and either restart them or [decommission](remove-nodes.html) them before beginning your upgrade. If there are dead and non-decommissioned nodes in your cluster, it will not be possible to finalize the upgrade (either automatically or manually).


### PR DESCRIPTION
- Call out that it's not allowed in import docs.
- Mention that imports should've be in progress when starting
  a rolling upgrade.

Fixes #5703.