### PR TITLE
Removed optimizer setting documentation

### DIFF
--- a/_includes/v19.2/misc/session-vars.html
+++ b/_includes/v19.2/misc/session-vars.html
@@ -142,18 +142,6 @@
 
   <tr>
    <td>
-    <code>optimizer</code>
-   </td>
-   <td>The mode in which a query execution plan is generated. If set to <code>on</code>, the <a href="cost-based-optimizer.html">cost-based optimizer</a> is enabled by default and the heuristic planner will only be used if the query is not supported by the cost-based optimizer; if set to <code>off</code>, all queries are run through the legacy heuristic planner.</td>
-   <td>
-    <code>on</code>
-   </td>
-   <td>Yes</td>
-   <td>Yes</td>
-  </tr>
-
-  <tr>
-   <td>
     <code>results_buffer_size</code>
    </td>
    <td>The default size of the buffer that accumulates results for a statement or a batch of statements before they are sent to the client. This can also be set for all connections using the 'sql.defaults.results_buffer_size' <a href="cluster-settings.html">cluster setting</a>. Note that auto-retries generally only happen while no results have been delivered to the client, so reducing this size can increase the number of retriable errors a client receives. On the other hand, increasing the buffer size can increase the delay until the client receives the first result row. Setting to 0 disables any buffering.

--- a/v19.2/cost-based-optimizer.md
+++ b/v19.2/cost-based-optimizer.md
@@ -10,7 +10,6 @@ The cost-based optimizer seeks the lowest cost for a query, usually related to t
 In versions prior to 2.1, a heuristic planner was used to generate query execution plans. The heuristic planner is only used in the following cases:
 
 - If your query uses functionality that is not yet supported by the cost-based optimizer. For more information about the types of queries that are supported, see [Types of statements supported by the cost-based optimizer](#types-of-statements-supported-by-the-cost-based-optimizer).
-- If you explicitly turn off the optimizer. For more information, see [How to turn the optimizer off](#how-to-turn-the-optimizer-off).
 
 ## How is cost calculated?
 
@@ -624,31 +623,9 @@ Time: 619µs
 
 You'll need to make changes to the above configuration to reflect your [production environment](recommended-production-settings.html), but the concepts will be the same.
 
-## How to turn the optimizer off
-
-With the optimizer turned on, the performance of some workloads may change. If your workload performs worse than expected (e.g., lower throughput or higher latency), you can turn off the cost-based optimizer and use the heuristic planner.
-
-To turn the cost-based optimizer off for the current session:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET optimizer = 'off';
-~~~
-
-To turn the cost-based optimizer off for all sessions:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET CLUSTER SETTING sql.defaults.optimizer = 'off';
-~~~
-
-{{site.data.alerts.callout_info}}
-Changing the cluster setting does not immediately turn the optimizer off; instead, it changes the default session setting to `off`. To see the change, restart your session.
-{{site.data.alerts.end}}
-
 ## Known limitations
 
-- Some features are not supported by the cost-based optimizer; however, the optimizer will fall back to the heuristic planner for this functionality. If performance is worse than in previous versions of CockroachDB, you can [turn the optimizer off](#how-to-turn-the-optimizer-off) to manually force it to fallback to the heuristic planner.
+- Some features are not supported by the cost-based optimizer; however, the optimizer will fall back to the heuristic planner for this functionality.
 
 ## See also
 


### PR DESCRIPTION
Fixes #5693. 

The `optimizer` setting is deprecated (i.e. you literally can't change this setting in 19.2, and if you try you get an error).

- Removed "Turn the optimizer off" section.
- Removed "optimizer" session variable.