### PR TITLE
Clarify changefeeds on sql statement list

### DIFF
--- a/v19.1/sql-statements.md
+++ b/v19.1/sql-statements.md
@@ -169,13 +169,9 @@ Statement | Usage
 
 ## Changefeed statements (Enterprise)
 
-[Change data capture](change-data-capture.html) (CDC) provides row-level change feeds into Apache Kafka for downstream processing.
-
-{{site.data.alerts.callout_info}}
-CDC is an enterprise feature. There will be a core version in a future release.
-{{site.data.alerts.end}}
+[Change data capture](change-data-capture.html) (CDC) provides an enterprise and core version of row-level change subscriptions for downstream processing.
 
 Statement | Usage
 ----------|------------
-[`CREATE CHANGEFEED`](create-changefeed.html) | _(Enterprise)_ Create a new changefeed, which provides row-level change subscriptions.
-[`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html) | _(Core)_ Create a new core changefeed, which provides row-level change subscriptions.
+[`CREATE CHANGEFEED`](create-changefeed.html) | _(Enterprise)_ Create a new changefeed to stream row-level changes in a configurable format to a configurable sink (Kafka or a cloud storage sink).
+[`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html) | _(Core)_ Create a new changefeed to stream row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.

--- a/v19.2/sql-statements.md
+++ b/v19.2/sql-statements.md
@@ -10,7 +10,6 @@ CockroachDB supports the following SQL statements. Click a statement for more de
 In the [built-in SQL shell](use-the-built-in-sql-client.html#help), use `\h [statement]` to get inline help about a specific statement.
 {{site.data.alerts.end}}
 
-
 ## Data manipulation statements
 
 Statement | Usage
@@ -173,13 +172,9 @@ Statement | Usage
 
 ## Changefeed statements (Enterprise)
 
-[Change data capture](change-data-capture.html) (CDC) provides row-level change feeds into Apache Kafka for downstream processing.
-
-{{site.data.alerts.callout_info}}
-CDC is an enterprise feature. There will be a core version in a future release.
-{{site.data.alerts.end}}
+[Change data capture](change-data-capture.html) (CDC) provides an enterprise and core version of row-level change subscriptions for downstream processing.
 
 Statement | Usage
 ----------|------------
-[`CREATE CHANGEFEED`](create-changefeed.html) | _(Enterprise)_ Create a new changefeed, which provides row-level change subscriptions.
-[`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html) | _(Core)_ Create a new core changefeed, which provides row-level change subscriptions.
+[`CREATE CHANGEFEED`](create-changefeed.html) | _(Enterprise)_ Create a new changefeed to stream row-level changes in a configurable format to a configurable sink (Kafka or a cloud storage sink).
+[`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html) | _(Core)_ Create a new changefeed to stream row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. 


### PR DESCRIPTION
@lhirata, in addition to this, I think we need to make sure it's clear on the CDC overview and other related docs how the enterprise and core versions differ. 

Fixes #5718 