### PR TITLE
crdb_internal.partitions tip

### DIFF
--- a/_includes/v19.2/sql/crdb-internal-partitions-example.md
+++ b/_includes/v19.2/sql/crdb-internal-partitions-example.md
@@ -1,0 +1,43 @@
+## Querying partitions programmatically
+
+The `crdb_internal.partitions` internal table contains information about the partitions in your database. In testing, scripting, and other programmatic environments, we recommend querying this table for partition information instead of using the `SHOW PARTITIONS` statement. For example, to get all `us_west` partitions of in your database, you can run the following query:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM crdb_internal.partitions WHERE name='us_west';
+~~~
+
+~~~
+  table_id | index_id | parent_name |  name   | columns | column_names |                   list_value                    | range_value | zone_id | subzone_id
++----------+----------+-------------+---------+---------+--------------+-------------------------------------------------+-------------+---------+------------+
+        53 |        1 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |       0 |          0
+        54 |        1 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      54 |          1
+        54 |        2 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      54 |          2
+        55 |        1 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      55 |          1
+        55 |        2 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      55 |          2
+        55 |        3 | NULL        | us_west |       1 | vehicle_city | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      55 |          3
+        56 |        1 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      56 |          1
+        58 |        1 | NULL        | us_west |       1 | city         | ('seattle'), ('san francisco'), ('los angeles') | NULL        |      58 |          1
+(8 rows)
+~~~
+
+Other internal tables, like `crdb_internal.tables`, include information that could be useful in conjunction with `crdb_internal.partitions`.
+
+For example, if you want the output for your partitions to include the name of the table and database, you can perform a join of the two tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT
+  partitions.name AS partition_name, column_names, list_value, tables.name AS table_name, database_name
+  FROM crdb_internal.partitions JOIN crdb_internal.tables ON partitions.table_id=tables.table_id
+  WHERE tables.name='users';
+~~~
+
+~~~
+  partition_name | column_names |                   list_value                    | table_name | database_name
++----------------+--------------+-------------------------------------------------+------------+---------------+
+  us_west        | city         | ('seattle'), ('san francisco'), ('los angeles') | users      | movr
+  us_east        | city         | ('new york'), ('boston'), ('washington dc')     | users      | movr
+  europe_west    | city         | ('amsterdam'), ('paris'), ('rome')              | users      | movr
+(3 rows)
+~~~

--- a/_includes/v19.2/sql/crdb-internal-partitions.md
+++ b/_includes/v19.2/sql/crdb-internal-partitions.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_success}}
+In testing, scripting, and other programmatic environments, we recommend querying the `crdb_internal.partitions` internal table for partition information instead of using the `SHOW PARTITIONS` statement. For more information, see [Querying partitions programmatically](show-partitions.html#querying-partitions-programmatically).
+{{site.data.alerts.end}}

--- a/v19.2/configure-replication-zones.md
+++ b/v19.2/configure-replication-zones.md
@@ -136,6 +136,8 @@ Use the [`SHOW ZONE CONFIGURATIONS`](#view-all-replication-zones) statement to v
 
 You can also use the [`SHOW PARTITIONS`](show-partitions.html) statement to view the zone constraints on existing table partitions, or [`SHOW CREATE TABLE`](show-create.html) to view zone configurations for a table.
 
+{% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
+
 ## Basic examples
 
 {% include {{ page.version.version }}/sql/movr-statements-geo-partitioned-replicas.md %}

--- a/v19.2/demo-low-latency-multi-region-deployment.md
+++ b/v19.2/demo-low-latency-multi-region-deployment.md
@@ -898,6 +898,8 @@ As mentioned earlier, all of the tables except `promo_codes` are geographically 
     (6 rows)
     ~~~
 
+      {% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
+
 ### Duplicate the reference table
 
 In contrast to the other tables, the `promo_codes` table is not tied to geography, and its data is read frequently but rarely updated. This type of table is often referred to as a "reference table" or "lookup table". For this table, you'll keep read latency low by applying the [Duplicate Indexes](topology-duplicate-indexes.html) data topology. In practice, you will put the leaseholder for the table itself (also called the primary index) in one region, create two secondary indexes on the table, and tell CockroachDB to put the leaseholder for each secondary index in one of the other regions. CockroachDB's [cost-based optimizer](cost-based-optimizer.html) will then make sure that reads from `promo_codes` access the local leaseholder (either for the table itself or for one of the secondary indexes). Writes, however, will still leave the region to get consensus for the table and its secondary indexes, but writes are so rare that this won't impact overall performance.

--- a/v19.2/partitioning.md
+++ b/v19.2/partitioning.md
@@ -442,6 +442,8 @@ To retrieve table partitions, you can use the [`SHOW PARTITIONS`](show-partition
 
 You can also view partitions by [database](show-partitions.html#show-partitions-by-database) and [index](show-partitions.html#show-partitions-by-index).
 
+{% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
+
 ### Define table partitions by range
 
 Suppose we want to store the data of current students on fast and expensive storage devices (e.g., SSD) and store the data of the graduated students on slower, cheaper storage devices (e.g., HDD).

--- a/v19.2/topology-geo-partitioned-leaseholders.md
+++ b/v19.2/topology-geo-partitioned-leaseholders.md
@@ -195,6 +195,8 @@ Assuming you have a [cluster deployed across three regions](#cluster-setup) and 
 As you scale and add more cities, you can repeat steps 2 and 3 with the new complete list of cities to re-partition the table and its secondary indexes, and then repeat step 4 to create replication zones for the new partitions.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
+
 ## Characteristics
 
 ### Latency

--- a/v19.2/topology-geo-partitioned-replicas.md
+++ b/v19.2/topology-geo-partitioned-replicas.md
@@ -169,6 +169,8 @@ A geo-partitioned table does not require a secondary index. However, if the tabl
 As you scale and add more cities, you can repeat steps 2 and 3 with the new complete list of cities to re-partition the table and its secondary indexes, and then repeat step 4 to create replication zones for the new partitions.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
+
 ## Characteristics
 
 ### Latency


### PR DESCRIPTION
Fixes #4796.

Include files created:
- Tip
- Details and examples

Tip include added to:
- SHOW PARTITIONS page
- Define Table Partitions page
- Geo-partitioning Demo

Details and examples include added to:
- SHOW PARTITIONS page

**Note**: This table, and others, will be documented in more detail in a forthcoming `crdb_internal` PR (see #2957).