### PR TITLE
PG-compatible dates

### DIFF
--- a/v19.2/date.md
+++ b/v19.2/date.md
@@ -23,9 +23,13 @@ CockroachDB also supports using uninterpreted
 [string literals](sql-constants.html#string-literals) in contexts
 where a `DATE` value is otherwise expected.
 
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v19.2:</span> `DATE` values in CockroachDB are fully [PostgreSQL-compatible](https://www.postgresql.org/docs/current/datatype-datetime.html), including support for special values (e.g. `+/- infinity`). Existing dates outside of the PostgreSQL date range (`4714-11-24 BC` to `5874897-12-31`) are converted to `+/- infinity` dates.
+{{site.data.alerts.end}}
+
 ## Size
 
-A `DATE` column supports values up to 8 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
+A `DATE` column supports values up to 16 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
 
 ## Examples
 
@@ -83,7 +87,7 @@ Type | Details
 -----|--------
 `DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
 `FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`TIMESTAMP` | Sets the time to 00:00 (midnight) in the resulting timestamp
+`TIMESTAMP` | Sets the time to 00:00 (midnight) in the resulting timestamp.
 `INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
 `STRING` | ––
 

--- a/v19.2/known-limitations.md
+++ b/v19.2/known-limitations.md
@@ -151,14 +151,6 @@ This limitation will be lifted when the cost-based optimizer covers all queries.
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/22418)
 
-### Conversion of integers to date/time values
-
-CockroachDB supports an experimental extension to the SQL standard where an integer value can be converted to a `DATE`/`TIME`/`TIMESTAMP` value, taking the number as a number of seconds since the Unix epoch.
-
-This conversion is currently only well defined for a small range of integers, i.e., large absolute values are not properly converted. For example, `(-9223372036854775808):::int64::date` converts to `1970-01-01 00:00:00+00:00`.
-
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/20136)
-
 ### Cannot decommission nodes
 
 The [`cockroach node decommission`](https://www.cockroachlabs.com/docs/stable/view-node-details.html#subcommands) command will hang when used to target a set of nodes that cannot be removed without breaking the configured replication rules.

--- a/v19.2/migrate-from-oracle.md
+++ b/v19.2/migrate-from-oracle.md
@@ -223,7 +223,6 @@ Use the table below for data type mappings:
 
 When moving from Oracle to CockroachDB data types, consider the following:
 
-- [Conversion of integers to `DATE` / `TIME` values](known-limitations.html#conversion-of-integers-to-date-time-values)
 - [Silent validation error with `DECIMAL` values](known-limitations.html#silent-validation-error-with-decimal-values)
 - [Schema changes within transactions](known-limitations.html#schema-changes-within-transactions)
 - [Schema changes between executions of prepared statements](online-schema-changes.html#no-schema-changes-between-executions-of-prepared-statements)


### PR DESCRIPTION
Fixes #4887.

- Removed known limitation "Conversion of integers to date/time values". The tracking issue (cockroachdb/cockroach/issues/20136) has been resolved.
- Updated size of supported `DATE` column values from 8 bytes to 16 bytes.
- Added note about PG-compatible dates.

Please review for technical accuracy, and please advise if we need to update the documentation in other places to reflect this change.