### PR TITLE
Fix inaccurate TIMESTAMPTZ description

### DIFF
--- a/v1.0/timestamp.md
+++ b/v1.0/timestamp.md
@@ -1,6 +1,6 @@
 ---
 title: TIMESTAMP
-summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIMESTAMPTZ stores a date and time pair with a time zone offset from UTC.
+summary: The TIMESTAMP data type stores a date and time pair in UTC.
 toc: true
 ---
 

--- a/v1.1/timestamp.md
+++ b/v1.1/timestamp.md
@@ -1,6 +1,6 @@
 ---
 title: TIMESTAMP
-summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIMESTAMPTZ stores a date and time pair with a time zone offset from UTC.
+summary: The TIMESTAMP data type stores a date and time pair in UTC.
 toc: true
 ---
 

--- a/v19.1/timestamp.md
+++ b/v19.1/timestamp.md
@@ -1,10 +1,10 @@
 ---
 title: TIMESTAMP
-summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIMESTAMPTZ stores a date and time pair with a time zone offset from UTC.
+summary: The TIMESTAMP data type stores a date and time pair in UTC.
 toc: true
 ---
 
-The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC, whereas `TIMESTAMPTZ` stores a date and time pair with a time zone offset from UTC.
+The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC.
 
 
 ## Variants

--- a/v19.2/timestamp.md
+++ b/v19.2/timestamp.md
@@ -1,10 +1,10 @@
 ---
 title: TIMESTAMP
-summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIMESTAMPTZ stores a date and time pair with a time zone offset from UTC.
+summary: The TIMESTAMP data type stores a date and time pair in UTC.
 toc: true
 ---
 
-The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC, whereas `TIMESTAMPTZ` stores a date and time pair with a time zone offset from UTC.
+The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC.
 
 
 ## Variants

--- a/v2.0/timestamp.md
+++ b/v2.0/timestamp.md
@@ -1,6 +1,6 @@
 ---
 title: TIMESTAMP
-summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIMESTAMPTZ stores a date and time pair with a time zone offset from UTC.
+summary: The TIMESTAMP data type stores a date and time pair in UTC.
 toc: true
 ---
 

--- a/v2.1/timestamp.md
+++ b/v2.1/timestamp.md
@@ -1,10 +1,10 @@
 ---
 title: TIMESTAMP
-summary: The TIMESTAMP data type stores a date and time pair in UTC, whereas TIMESTAMPTZ stores a date and time pair with a time zone offset from UTC.
+summary: The TIMESTAMP data type stores a date and time pair in UTC.
 toc: true
 ---
 
-The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC, whereas `TIMESTAMPTZ` stores a date and time pair with a time zone offset from UTC.
+The `TIMESTAMP` [data type](data-types.html) stores a date and time pair in UTC.
 
 
 ## Variants


### PR DESCRIPTION
The timestamp docs specified that our TIMESTAMPTZ datatype stores a time
zone offset. This is not true. It always stores the timestamp in UTC.
This is explicitly stated further down on the same page: "However, it is
conceptually important to note that TIMESTAMPTZ does not store any time
zone data."

For some reason this was correct in the v2.0 docs and earlier but
incorrect in later docs.