### PR TITLE
Disallow column references in ROWS/RANGE 

### DIFF
--- a/v19.2/window-functions.md
+++ b/v19.2/window-functions.md
@@ -68,6 +68,11 @@ Parameter | Description
 
 </div>
 
+
+{{site.data.alerts.callout_danger}}
+<span class="version-tag">New in v19.2:</span> For PostgreSQL compatibility, variables are no longer valid arguments in window frame `ROW`/`RANGE` clauses.
+{{site.data.alerts.end}}
+
 ## How window functions work
 
 At a high level, window functions work by:


### PR DESCRIPTION
Fixes #5514.

Added warning to [Window Function Syntax section](https://www.cockroachlabs.com/docs/dev/window-functions#parameters) stating that variables are no longer valid in ROW/RANGE clauses.

Do we want an example too? Not sure how much attention we want to bring to this, as our behavior before this change was undocumented and not postgres-like.