### PR TITLE
K8s prod requirements

### DIFF
--- a/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
@@ -85,7 +85,7 @@ You can expand certain [types of persistent volumes](https://kubernetes.io/docs/
     ~~~
 	</section>
 
-4. If the volume contains a file system, its capacity will not have changed. Confirm this by viewing the persistent volume claim:
+4. Check the capacity of the persistent volume claim:
 
 	<section class="filter-content" markdown="1" data-scope="helm">
     {% include copy-clipboard.html %}
@@ -111,11 +111,13 @@ datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100G
     ~~~
 	</section>
 
+    You may need to start or restart a pod before the new PVC capacity is made available. This is necessary if `AllowVolumeExpansion` was initially set to `false` or if the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded.
+
     {{site.data.alerts.callout_success}}
     Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
-	{{site.data.alerts.end}}    
+	{{site.data.alerts.end}}
 
-5. Examine the persistent volume claim, and you will see that it has a `FileSystemResizePending` condition with an accompanying message:
+5. Examine the persistent volume claim. You may see a `FileSystemResizePending` condition with an accompanying message:
 
 	<section class="filter-content" markdown="1" data-scope="helm">
 	{% include copy-clipboard.html %}
@@ -134,8 +136,6 @@ datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100G
     ~~~
     Waiting for user to (re-)start a pod to finish file system resize of volume on node.
     ~~~
-
-    Expanding the file system on the volume is an additional step that only occurs when a pod is started or restarted. See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) for more details.
 
 6.  Delete the corresponding pod to restart it:
 

--- a/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
@@ -180,3 +180,5 @@ datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e
 datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
     ~~~
 	</section>
+
+8. The CockroachDB cluster needs to be expanded one node at a time. Repeat steps 3 - 6 to increase the capacities of the remaining volumes by the same amount.

--- a/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
@@ -1,0 +1,182 @@
+You can expand certain [types of persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes
+) (including GCE Persistent Disk and Amazon Elastic Block Store) by editing their persistent volume claims. Increasing disk size is often beneficial for CockroachDB performance. Read our [Kubernetes performance guide](kubernetes-performance.html#disk-size) for guidance on disks.
+
+1. Get the persistent volume claims for the volumes:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc
+    ~~~
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-my-release-cockroachdb-1   Bound    pvc-75e143ca-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-my-release-cockroachdb-2   Bound    pvc-75ef409a-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+    ~~~
+    </section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-cockroachdb-1   Bound    pvc-75e143ca-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-cockroachdb-2   Bound    pvc-75ef409a-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+    ~~~
+	</section>
+
+2. In order to expand a persistent volume claim, `AllowVolumeExpansion` in its storage class must be `true`. Examine the storage class:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe storageclass standard
+    ~~~
+
+	~~~
+	Name:                  standard
+	IsDefaultClass:        Yes
+	Annotations:           storageclass.kubernetes.io/is-default-class=true
+	Provisioner:           kubernetes.io/gce-pd
+	Parameters:            type=pd-standard
+	AllowVolumeExpansion:  False
+	MountOptions:          <none>
+	ReclaimPolicy:         Delete
+	VolumeBindingMode:     Immediate
+	Events:                <none>
+	~~~
+
+	If necessary, edit the storage class:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
+    ~~~
+
+    ~~~
+    storageclass.storage.k8s.io/standard patched
+    ~~~
+
+3. Edit one of the persistent volume claims to request more space:
+
+    {{site.data.alerts.callout_info}}
+    The requested `storage` value must be larger than the previous value. You cannot use this method to decrease the disk size.
+	{{site.data.alerts.end}}
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch pvc datadir-my-release-cockroachdb-0 -p '{"spec": {"resources": {"requests": {"storage": "200Gi"}}}}'
+    ~~~
+
+    ~~~
+    persistentvolumeclaim/datadir-my-release-cockroachdb-0 patched
+    ~~~		
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch pvc datadir-cockroachdb-0 -p '{"spec": {"resources": {"requests": {"storage": "200Gi"}}}}'
+    ~~~
+
+    ~~~
+    persistentvolumeclaim/datadir-cockroachdb-0 patched
+    ~~~
+	</section>
+
+4. If the volume contains a file system, its capacity will not have changed. Confirm this by viewing the persistent volume claim:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-my-release-cockroachdb-0
+    ~~~	
+
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    ~~~		
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-cockroachdb-0
+    ~~~	
+
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    ~~~
+	</section>
+
+    {{site.data.alerts.callout_success}}
+    Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
+	{{site.data.alerts.end}}    
+
+5. Examine the persistent volume claim, and you will see that it has a `FileSystemResizePending` condition with an accompanying message:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe pvc datadir-my-release-cockroachdb-0
+    ~~~
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe pvc datadir-cockroachdb-0
+    ~~~
+	</section>
+
+    ~~~
+    Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+    ~~~
+
+    Expanding the file system on the volume is an additional step that only occurs when a pod is started or restarted. See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) for more details.
+
+6.  Delete the corresponding pod to restart it:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod my-release-cockroachdb-0
+    ~~~
+   	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod cockroachdb-0
+    ~~~
+	</section>
+
+    The `FileSystemResizePending` condition and message will be removed.
+
+7. View the updated persistent volume claim:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-my-release-cockroachdb-0
+    ~~~
+
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
+    ~~~	
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-cockroachdb-0
+    ~~~
+
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
+    ~~~
+	</section>

--- a/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.1/orchestration/kubernetes-expand-disk-size.md
@@ -95,7 +95,7 @@ You can expand certain [types of persistent volumes](https://kubernetes.io/docs/
 
     ~~~
 	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
     ~~~		
 	</section>
 
@@ -107,17 +107,17 @@ datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e
 
     ~~~
 	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
     ~~~
 	</section>
 
-    You may need to start or restart a pod before the new PVC capacity is made available. This is necessary if `AllowVolumeExpansion` was initially set to `false` or if the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded.
+    If the PVC capacity has not changed, this may be because `AllowVolumeExpansion` was initially set to `false` or because the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded. You will need to start or restart a pod in order to have it reflect the new capacity.
 
     {{site.data.alerts.callout_success}}
     Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
-	{{site.data.alerts.end}}
+    {{site.data.alerts.end}}
 
-5. Examine the persistent volume claim. You may see a `FileSystemResizePending` condition with an accompanying message:
+5. Examine the persistent volume claim. If the volume has a file system, you will see a `FileSystemResizePending` condition with an accompanying message:
 
 	<section class="filter-content" markdown="1" data-scope="helm">
 	{% include copy-clipboard.html %}

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -67,20 +67,20 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
+    $ helm install --name my-release --set Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
 
     {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    CacheSize="2GB",MaxSQLMemory="2GB"
+    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -75,7 +75,7 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -67,10 +67,21 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release stable/cockroachdb
+    $ helm install --name my-release --set CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    CacheSize="2GB",MaxSQLMemory="2GB"
+    ~~~
 
     {{site.data.alerts.callout_info}}
     You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
@@ -65,10 +65,21 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true stable/cockroachdb
+    $ helm install --name my-release --set Secure.Enabled=true,CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    CacheSize="2GB",MaxSQLMemory="2GB"
+    ~~~
 
     {{site.data.alerts.callout_info}}
     You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
@@ -65,20 +65,20 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true,CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
+    $ helm install --name my-release --set Secure.Enabled=true,Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
 
     {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    CacheSize="2GB",MaxSQLMemory="2GB"
+    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
@@ -73,7 +73,7 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.1/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-insecure.md
@@ -1,9 +1,28 @@
-1. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
+1. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it.
+
+    Download [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create \
-    -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    --cache 2GB --max-sql-memory 2GB
+    ~~~
+
+    Use the file to create the StatefulSet and start the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f cockroachdb-statefulset.yaml
     ~~~
 
     ~~~

--- a/_includes/v19.1/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-insecure.md
@@ -7,24 +7,15 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
 
-    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ resources:
-          requests:
-            memory: "<your memory allocation>"
-    ~~~    
-
     {{site.data.alerts.callout_danger}}
-    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset.yaml`. Their values should be identical.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of `cockroachdb-statefulset.yaml`:
+    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L146):
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GiB --max-sql-memory 2GiB
+    --cache 2Gi --max-sql-memory 2Gi
     ~~~
 
     Use the file to create the StatefulSet and start the cluster:

--- a/_includes/v19.1/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-insecure.md
@@ -7,15 +7,24 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
 
-    {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ resources:
+          requests:
+            memory: "<your memory allocation>"
+    ~~~    
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of `cockroachdb-statefulset.yaml`:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GB --max-sql-memory 2GB
+    --cache 2GiB --max-sql-memory 2GiB
     ~~~
 
     Use the file to create the StatefulSet and start the cluster:

--- a/_includes/v19.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-secure.md
@@ -7,26 +7,17 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
     ~~~
 
-    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ resources:
-          requests:
-            memory: "<your memory allocation>"
-    ~~~    
-
     {{site.data.alerts.callout_danger}}
-    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset-secure.yaml`. Their values should be identical.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of `cockroachdb-statefulset-secure.yaml`:
+    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L247):
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GiB --max-sql-memory 2GiB
+    --cache 2Gi --max-sql-memory 2Gi
     ~~~
-
+    
     Use the file to create the StatefulSet and start the cluster:
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-secure.md
@@ -7,15 +7,24 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
     ~~~
 
-    {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ resources:
+          requests:
+            memory: "<your memory allocation>"
+    ~~~    
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of `cockroachdb-statefulset-secure.yaml`:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GB --max-sql-memory 2GB
+    --cache 2GiB --max-sql-memory 2GiB
     ~~~
 
     Use the file to create the StatefulSet and start the cluster:

--- a/_includes/v19.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-secure.md
@@ -1,9 +1,28 @@
-1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
+1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it.
+
+    Download [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create \
-    -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    --cache 2GB --max-sql-memory 2GB
+    ~~~
+
+    Use the file to create the StatefulSet and start the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f cockroachdb-statefulset-secure.yaml
     ~~~
 
     ~~~

--- a/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
@@ -95,7 +95,7 @@ You can expand certain [types of persistent volumes](https://kubernetes.io/docs/
 
     ~~~
     NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
     ~~~     
     </section>
 
@@ -107,17 +107,17 @@ datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e
 
     ~~~
     NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
     ~~~
     </section>
 
-    You may need to start or restart a pod before the new PVC capacity is made available. This is necessary if `AllowVolumeExpansion` was initially set to `false` or if the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded.
+    If the PVC capacity has not changed, this may be because `AllowVolumeExpansion` was initially set to `false` or because the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded. You will need to start or restart a pod in order to have it reflect the new capacity.
 
     {{site.data.alerts.callout_success}}
     Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
     {{site.data.alerts.end}}
 
-5. Examine the persistent volume claim. You may see a `FileSystemResizePending` condition with an accompanying message:
+5. Examine the persistent volume claim. If the volume has a file system, you will see a `FileSystemResizePending` condition with an accompanying message:
 
 	<section class="filter-content" markdown="1" data-scope="helm">
 	{% include copy-clipboard.html %}

--- a/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
@@ -85,37 +85,39 @@ You can expand certain [types of persistent volumes](https://kubernetes.io/docs/
     ~~~
 	</section>
 
-4. If the volume contains a file system, its capacity will not have changed. Confirm this by viewing the persistent volume claim:
+4. Check the capacity of the persistent volume claim:
 
-	<section class="filter-content" markdown="1" data-scope="helm">
+    <section class="filter-content" markdown="1" data-scope="helm">
     {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pvc datadir-my-release-cockroachdb-0
-    ~~~	
+    ~~~ 
 
     ~~~
-	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
 datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
-    ~~~		
-	</section>
+    ~~~     
+    </section>
 
-	<section class="filter-content" markdown="1" data-scope="manual">
+    <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pvc datadir-cockroachdb-0
-    ~~~	
+    ~~~ 
 
     ~~~
-	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
 datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
     ~~~
-	</section>
+    </section>
+
+    You may need to start or restart a pod before the new PVC capacity is made available. This is necessary if `AllowVolumeExpansion` was initially set to `false` or if the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded.
 
     {{site.data.alerts.callout_success}}
     Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
-	{{site.data.alerts.end}}    
+    {{site.data.alerts.end}}
 
-5. Examine the persistent volume claim, and you will see that it has a `FileSystemResizePending` condition with an accompanying message:
+5. Examine the persistent volume claim. You may see a `FileSystemResizePending` condition with an accompanying message:
 
 	<section class="filter-content" markdown="1" data-scope="helm">
 	{% include copy-clipboard.html %}
@@ -134,8 +136,6 @@ datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100G
     ~~~
     Waiting for user to (re-)start a pod to finish file system resize of volume on node.
     ~~~
-
-    Expanding the file system on the volume is an additional step that only occurs when a pod is started or restarted. See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) for more details.
 
 6.  Delete the corresponding pod to restart it:
 

--- a/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
@@ -180,3 +180,5 @@ datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e
 datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
     ~~~
 	</section>
+
+8. The CockroachDB cluster needs to be expanded one node at a time. Repeat steps 3 - 6 to increase the capacities of the remaining volumes by the same amount.

--- a/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v19.2/orchestration/kubernetes-expand-disk-size.md
@@ -1,0 +1,182 @@
+You can expand certain [types of persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes
+) (including GCE Persistent Disk and Amazon Elastic Block Store) by editing their persistent volume claims. Increasing disk size is often beneficial for CockroachDB performance. Read our [Kubernetes performance guide](kubernetes-performance.html#disk-size) for guidance on disks.
+
+1. Get the persistent volume claims for the volumes:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc
+    ~~~
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-my-release-cockroachdb-1   Bound    pvc-75e143ca-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-my-release-cockroachdb-2   Bound    pvc-75ef409a-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+    ~~~
+    </section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-cockroachdb-1   Bound    pvc-75e143ca-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-cockroachdb-2   Bound    pvc-75ef409a-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+    ~~~
+	</section>
+
+2. In order to expand a persistent volume claim, `AllowVolumeExpansion` in its storage class must be `true`. Examine the storage class:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe storageclass standard
+    ~~~
+
+	~~~
+	Name:                  standard
+	IsDefaultClass:        Yes
+	Annotations:           storageclass.kubernetes.io/is-default-class=true
+	Provisioner:           kubernetes.io/gce-pd
+	Parameters:            type=pd-standard
+	AllowVolumeExpansion:  False
+	MountOptions:          <none>
+	ReclaimPolicy:         Delete
+	VolumeBindingMode:     Immediate
+	Events:                <none>
+	~~~
+
+	If necessary, edit the storage class:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
+    ~~~
+
+    ~~~
+    storageclass.storage.k8s.io/standard patched
+    ~~~
+
+3. Edit one of the persistent volume claims to request more space:
+
+    {{site.data.alerts.callout_info}}
+    The requested `storage` value must be larger than the previous value. You cannot use this method to decrease the disk size.
+	{{site.data.alerts.end}}
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch pvc datadir-my-release-cockroachdb-0 -p '{"spec": {"resources": {"requests": {"storage": "200Gi"}}}}'
+    ~~~
+
+    ~~~
+    persistentvolumeclaim/datadir-my-release-cockroachdb-0 patched
+    ~~~		
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch pvc datadir-cockroachdb-0 -p '{"spec": {"resources": {"requests": {"storage": "200Gi"}}}}'
+    ~~~
+
+    ~~~
+    persistentvolumeclaim/datadir-cockroachdb-0 patched
+    ~~~
+	</section>
+
+4. If the volume contains a file system, its capacity will not have changed. Confirm this by viewing the persistent volume claim:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-my-release-cockroachdb-0
+    ~~~	
+
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    ~~~		
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-cockroachdb-0
+    ~~~	
+
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    ~~~
+	</section>
+
+    {{site.data.alerts.callout_success}}
+    Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
+	{{site.data.alerts.end}}    
+
+5. Examine the persistent volume claim, and you will see that it has a `FileSystemResizePending` condition with an accompanying message:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe pvc datadir-my-release-cockroachdb-0
+    ~~~
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe pvc datadir-cockroachdb-0
+    ~~~
+	</section>
+
+    ~~~
+    Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+    ~~~
+
+    Expanding the file system on the volume is an additional step that only occurs when a pod is started or restarted. See the [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) for more details.
+
+6.  Delete the corresponding pod to restart it:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod my-release-cockroachdb-0
+    ~~~
+   	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod cockroachdb-0
+    ~~~
+	</section>
+
+    The `FileSystemResizePending` condition and message will be removed.
+
+7. View the updated persistent volume claim:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-my-release-cockroachdb-0
+    ~~~
+
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
+    ~~~	
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-cockroachdb-0
+    ~~~
+
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
+    ~~~
+	</section>

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -67,20 +67,20 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
+    $ helm install --name my-release --set Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
 
     {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    CacheSize="2GB",MaxSQLMemory="2GB"
+    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -75,7 +75,7 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -67,10 +67,21 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release stable/cockroachdb
+    $ helm install --name my-release --set CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    CacheSize="2GB",MaxSQLMemory="2GB"
+    ~~~
 
     {{site.data.alerts.callout_info}}
     You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
@@ -65,10 +65,21 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true stable/cockroachdb
+    $ helm install --name my-release --set Secure.Enabled=true,CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    CacheSize="2GB",MaxSQLMemory="2GB"
+    ~~~
 
     {{site.data.alerts.callout_info}}
     You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
@@ -65,20 +65,20 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true,CacheSize=<your cache size>,MaxSQLMemory=<your SQL memory size> stable/cockroachdb
+    $ helm install --name my-release --set Secure.Enabled=true,Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
 
     {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and specify an appropriate cache size and SQL memory size for each CockroachDB node using the `--set` flag in the `helm install` comand. For example, if you are allocating 8GB memory to each Kubernetes node, use the following values.
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    CacheSize="2GB",MaxSQLMemory="2GB"
+    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
@@ -73,7 +73,7 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/_includes/v19.2/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-insecure.md
@@ -1,9 +1,21 @@
-1. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
+1. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it.
+
+    Download [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create \
-    -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    --cache 2GB --max-sql-memory 2GB
     ~~~
 
     ~~~

--- a/_includes/v19.2/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-insecure.md
@@ -7,24 +7,22 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
 
-    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ resources:
-          requests:
-            memory: "<your memory allocation>"
-    ~~~    
-
     {{site.data.alerts.callout_danger}}
-    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset.yaml`. Their values should be identical.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of `cockroachdb-statefulset.yaml`:
+    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L146):
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GiB --max-sql-memory 2GiB
+    --cache 2Gi --max-sql-memory 2Gi
+    ~~~
+
+    Use the file to create the StatefulSet and start the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f cockroachdb-statefulset.yaml
     ~~~
 
     ~~~

--- a/_includes/v19.2/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-insecure.md
@@ -7,15 +7,24 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
     ~~~
 
-    {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ resources:
+          requests:
+            memory: "<your memory allocation>"
+    ~~~    
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L131) of `cockroachdb-statefulset.yaml`:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GB --max-sql-memory 2GB
+    --cache 2GiB --max-sql-memory 2GiB
     ~~~
 
     ~~~

--- a/_includes/v19.2/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-secure.md
@@ -7,15 +7,24 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
     ~~~
 
-    {{site.data.alerts.callout_danger}}
-    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
 
-    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ resources:
+          requests:
+            memory: "<your memory allocation>"
+    ~~~    
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of `cockroachdb-statefulset-secure.yaml`:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GB --max-sql-memory 2GB
+    --cache 2GiB --max-sql-memory 2GiB
     ~~~
 
     Use the file to create the StatefulSet and start the cluster:

--- a/_includes/v19.2/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-secure.md
@@ -7,24 +7,15 @@
     $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
     ~~~
 
-    Specify the amount of memory to allocate to each CockroachDB node. Add a `resources.requests.memory` parameter inside the `containers` object in the config file:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ resources:
-          requests:
-            memory: "<your memory allocation>"
-    ~~~    
-
     {{site.data.alerts.callout_danger}}
-    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset-secure.yaml`. Their values should be identical.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of `cockroachdb-statefulset-secure.yaml`:
+    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L247):
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    --cache 2GiB --max-sql-memory 2GiB
+    --cache 2Gi --max-sql-memory 2Gi
     ~~~
 
     Use the file to create the StatefulSet and start the cluster:

--- a/_includes/v19.2/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-secure.md
@@ -1,9 +1,28 @@
-1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
+1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it.
+
+    Download [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create \
-    -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    To avoid OOM issues, you need to define memory limits for each CockroachDB node as an absolute value and not a percentage. This is due to how Kubernetes handles memory allocation.
+
+    Review our [Production Checklist](recommended-production-settings.html#cache-and-sql-memory-size) guidelines and define an appropriate cache size and SQL memory size for each CockroachDB node in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L232) of the above file. For example, if you are allocating 8GB memory to each Kubernetes node, substitute the following values.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    --cache 2GB --max-sql-memory 2GB
+    ~~~
+
+    Use the file to create the StatefulSet and start the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f cockroachdb-statefulset-secure.yaml
     ~~~
 
     ~~~

--- a/_includes/v20.1/orchestration/kubernetes-expand-disk-size.md
+++ b/_includes/v20.1/orchestration/kubernetes-expand-disk-size.md
@@ -1,0 +1,184 @@
+You can expand certain [types of persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes
+) (including GCE Persistent Disk and Amazon Elastic Block Store) by editing their persistent volume claims. Increasing disk size is often beneficial for CockroachDB performance. Read our [Kubernetes performance guide](kubernetes-performance.html#disk-size) for guidance on disks.
+
+1. Get the persistent volume claims for the volumes:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc
+    ~~~
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-my-release-cockroachdb-1   Bound    pvc-75e143ca-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-my-release-cockroachdb-2   Bound    pvc-75ef409a-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+    ~~~
+    </section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-cockroachdb-1   Bound    pvc-75e143ca-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+	datadir-cockroachdb-2   Bound    pvc-75ef409a-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       17m
+    ~~~
+	</section>
+
+2. In order to expand a persistent volume claim, `AllowVolumeExpansion` in its storage class must be `true`. Examine the storage class:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe storageclass standard
+    ~~~
+
+	~~~
+	Name:                  standard
+	IsDefaultClass:        Yes
+	Annotations:           storageclass.kubernetes.io/is-default-class=true
+	Provisioner:           kubernetes.io/gce-pd
+	Parameters:            type=pd-standard
+	AllowVolumeExpansion:  False
+	MountOptions:          <none>
+	ReclaimPolicy:         Delete
+	VolumeBindingMode:     Immediate
+	Events:                <none>
+	~~~
+
+	If necessary, edit the storage class:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch storageclass standard -p '{"allowVolumeExpansion": true}'
+    ~~~
+
+    ~~~
+    storageclass.storage.k8s.io/standard patched
+    ~~~
+
+3. Edit one of the persistent volume claims to request more space:
+
+    {{site.data.alerts.callout_info}}
+    The requested `storage` value must be larger than the previous value. You cannot use this method to decrease the disk size.
+	{{site.data.alerts.end}}
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch pvc datadir-my-release-cockroachdb-0 -p '{"spec": {"resources": {"requests": {"storage": "200Gi"}}}}'
+    ~~~
+
+    ~~~
+    persistentvolumeclaim/datadir-my-release-cockroachdb-0 patched
+    ~~~		
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch pvc datadir-cockroachdb-0 -p '{"spec": {"resources": {"requests": {"storage": "200Gi"}}}}'
+    ~~~
+
+    ~~~
+    persistentvolumeclaim/datadir-cockroachdb-0 patched
+    ~~~
+	</section>
+
+4. Check the capacity of the persistent volume claim:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-my-release-cockroachdb-0
+    ~~~	
+
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    ~~~		
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-cockroachdb-0
+    ~~~	
+
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+    datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   100Gi      RWO            standard       18m
+    ~~~
+	</section>
+
+    If the PVC capacity has not changed, this may be because `AllowVolumeExpansion` was initially set to `false` or because the [volume has a file system](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim) that has to be expanded. You will need to start or restart a pod in order to have it reflect the new capacity.
+
+    {{site.data.alerts.callout_success}}
+    Running `kubectl get pv` will display the persistent volumes with their *requested* capacity and not their actual capacity. This can be misleading, so it's best to use `kubectl get pvc`.
+    {{site.data.alerts.end}}
+
+5. Examine the persistent volume claim. If the volume has a file system, you will see a `FileSystemResizePending` condition with an accompanying message:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe pvc datadir-my-release-cockroachdb-0
+    ~~~
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl describe pvc datadir-cockroachdb-0
+    ~~~
+	</section>
+
+    ~~~
+    Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+    ~~~
+
+6.  Delete the corresponding pod to restart it:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod my-release-cockroachdb-0
+    ~~~
+   	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod cockroachdb-0
+    ~~~
+	</section>
+
+    The `FileSystemResizePending` condition and message will be removed.
+
+7. View the updated persistent volume claim:
+
+	<section class="filter-content" markdown="1" data-scope="helm">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-my-release-cockroachdb-0
+    ~~~
+
+    ~~~
+	NAME                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-my-release-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
+    ~~~	
+	</section>
+
+	<section class="filter-content" markdown="1" data-scope="manual">
+	{% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pvc datadir-cockroachdb-0
+    ~~~
+
+    ~~~
+	NAME                    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+datadir-cockroachdb-0   Bound    pvc-75dadd4c-01a1-11ea-b065-42010a8e00cb   200Gi      RWO            standard       20m
+    ~~~
+	</section>
+
+8. The CockroachDB cluster needs to be expanded one node at a time. Repeat steps 3 - 6 to increase the capacities of the remaining volumes by the same amount.

--- a/_includes/v20.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -67,10 +67,21 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release stable/cockroachdb
+    $ helm install --name my-release --set Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
+    ~~~
 
     {{site.data.alerts.callout_info}}
     You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).

--- a/_includes/v20.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-helm-secure.md
@@ -65,10 +65,21 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true stable/cockroachdb
+    $ helm install --name my-release --set Secure.Enabled=true,Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
+
+    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
+    ~~~
 
     {{site.data.alerts.callout_info}}
     You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).

--- a/_includes/v20.1/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-insecure.md
@@ -1,9 +1,28 @@
-1. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
+1. From your local workstation, use our [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it.
+
+    Download [`cockroachdb-statefulset.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create \
-    -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset.yaml
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset.yaml`. Their values should be identical.
+
+    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L146):
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    --cache 2Gi --max-sql-memory 2Gi
+    ~~~
+
+    Use the file to create the StatefulSet and start the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f cockroachdb-statefulset.yaml
     ~~~
 
     ~~~

--- a/_includes/v20.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-secure.md
@@ -1,9 +1,28 @@
-1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it:
+1. From your local workstation, use our [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml) file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it.
+
+    Download [`cockroachdb-statefulset-secure.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create \
-    -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset-secure.yaml`. Their values should be identical.
+
+    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset-secure.yaml#L247):
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    --cache 2Gi --max-sql-memory 2Gi
+    ~~~
+
+    Use the file to create the StatefulSet and start the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f cockroachdb-statefulset-secure.yaml
     ~~~
 
     ~~~

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -90,6 +90,7 @@ Note that when running on Amazon EKS, certificates signed by Kubernetes' built-i
 
 - [Add nodes](#add-nodes)
 - [Remove nodes](#remove-nodes)
+- [Expand disk size](#expand-disk-size)
 - [Upgrade the cluster](#upgrade-the-cluster)
 - [Stop the cluster](#stop-the-cluster)
 
@@ -255,6 +256,10 @@ Note that when running on Amazon EKS, certificates signed by Kubernetes' built-i
 ### Remove nodes
 
 {% include {{ page.version.version }}/orchestration/kubernetes-remove-nodes-secure.md %}
+
+### Expand disk size
+
+{% include {{ page.version.version }}/orchestration/kubernetes-expand-disk-size.md %}
 
 ### Upgrade the cluster
 

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -90,6 +90,7 @@ Note that when running on Amazon EKS, certificates signed by Kubernetes' built-i
 
 - [Add nodes](#add-nodes)
 - [Remove nodes](#remove-nodes)
+- [Expand disk size](#expand-disk-size)
 - [Upgrade the cluster](#upgrade-the-cluster)
 - [Stop the cluster](#stop-the-cluster)
 
@@ -255,6 +256,10 @@ Note that when running on Amazon EKS, certificates signed by Kubernetes' built-i
 ### Remove nodes
 
 {% include {{ page.version.version }}/orchestration/kubernetes-remove-nodes-secure.md %}
+
+### Expand disk size
+
+{% include {{ page.version.version }}/orchestration/kubernetes-expand-disk-size.md %}
 
 ### Upgrade the cluster
 

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -90,6 +90,7 @@ Note that when running on Amazon EKS, certificates signed by Kubernetes' built-i
 
 - [Add nodes](#add-nodes)
 - [Remove nodes](#remove-nodes)
+- [Expand disk size](#expand-disk-size)
 - [Upgrade the cluster](#upgrade-the-cluster)
 - [Stop the cluster](#stop-the-cluster)
 
@@ -255,6 +256,10 @@ Note that when running on Amazon EKS, certificates signed by Kubernetes' built-i
 ### Remove nodes
 
 {% include {{ page.version.version }}/orchestration/kubernetes-remove-nodes-secure.md %}
+
+### Expand disk size
+
+{% include {{ page.version.version }}/orchestration/kubernetes-expand-disk-size.md %}
 
 ### Upgrade the cluster
 


### PR DESCRIPTION
Fixes #5459

- For the memory adjustments, I documented the second workaround that was listed in the issue. I was able to execute the steps for both Helm and config, but wasn't sure how to verify that the new cache and SQL memory size values were actually in effect (the Admin UI doesn't appear to reflect these limits). Will possibly need a technical review. If we also want to describe the first workaround, I will need some more technical context on this.
- For expanding the persistent volume claims, I was able to increase the disk sizes in production (GKE) even after manually setting `allowVolumeExpansion` to `false`. I documented the requirement to set this to `true` anyway, but could use clarity from an engineer on why that might have happened. Also, because I wasn't able to test this by changing the boolean, it's not clear to me whether the value has to be `true` before the pod is created, or only before the PVC is resized. The official k8s docs imply the former, but an OpenShift doc explicitly states that the pod has to have been created from a `StorageClass` where this value is `true`. I thought I should go with the first-party docs.