### PR TITLE
Temporarily direct `/dev` urls to 19.2

### DIFF
--- a/_config_cockroachcloud.yml
+++ b/_config_cockroachcloud.yml
@@ -5,6 +5,6 @@ destination: _site/cockroachcloud
 
 versions:
   stable: v19.2
-  # dev: v19.2
+  dev: v19.2
 
 cockroachcloud: true

--- a/_config_cockroachdb.yml
+++ b/_config_cockroachdb.yml
@@ -5,4 +5,4 @@ destination: _site/docs
 
 versions:
   stable: v19.2
-  # dev: v19.2
+  dev: v19.2


### PR DESCRIPTION
As soon as we have 20.1 docs, `/dev` will point to them instead.

Fixes #5844.