### PR TITLE
Add note about when BACKUP, etc. commands return

### DIFF
--- a/v19.1/backup.md
+++ b/v19.1/backup.md
@@ -99,6 +99,10 @@ After CockroachDB successfully initiates a backup, it registers the backup as a 
 
 After the backup has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the backup is finished or if it encounters an error. In some cases, the backup can continue after an error has been returned (the error message will tell you that the backup has resumed in background).
+{{site.data.alerts.end}}
+
 ## Synopsis
 
 <div>

--- a/v19.1/import.md
+++ b/v19.1/import.md
@@ -148,6 +148,10 @@ After CockroachDB successfully initiates an import, it registers the import as a
 
 After the import has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the import is finished or if it encounters an error. In some cases, the import can continue after an error has been returned (the error message will tell you that the import has resumed in background).
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_danger}}Pausing and then resuming an <code>IMPORT</code> job will cause it to restart from the beginning.{{site.data.alerts.end}}
 
 ## Examples

--- a/v19.1/restore.md
+++ b/v19.1/restore.md
@@ -82,6 +82,10 @@ After CockroachDB successfully initiates a restore, it registers the restore as 
 
 After the restore has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the restore is finished or if it encounters an error. In some cases, the restore can continue after an error has been returned (the error message will tell you that the restore has resumed in background).
+{{site.data.alerts.end}}
+
 ## Synopsis
 
 <div>

--- a/v19.2/backup.md
+++ b/v19.2/backup.md
@@ -99,6 +99,10 @@ After CockroachDB successfully initiates a backup, it registers the backup as a 
 
 After the backup has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the backup is finished or if it encounters an error. In some cases, the backup can continue after an error has been returned (the error message will tell you that the backup has resumed in background).
+{{site.data.alerts.end}}
+
 ## Synopsis
 
 <div>

--- a/v19.2/import-into.md
+++ b/v19.2/import-into.md
@@ -99,6 +99,10 @@ After CockroachDB successfully initiates an import into an existing table, it re
 
 After the import has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the import is finished or if it encounters an error. In some cases, the import can continue after an error has been returned (the error message will tell you that the import has resumed in background).
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_danger}}
 Pausing and then resuming an `IMPORT INTO` job will cause it to restart from the beginning.
 {{site.data.alerts.end}}

--- a/v19.2/import.md
+++ b/v19.2/import.md
@@ -150,6 +150,10 @@ After CockroachDB successfully initiates an import, it registers the import as a
 
 After the import has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the import is finished or if it encounters an error. In some cases, the import can continue after an error has been returned (the error message will tell you that the import has resumed in background).
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_danger}}Pausing and then resuming an <code>IMPORT</code> job will cause it to restart from the beginning.{{site.data.alerts.end}}
 
 ## Examples

--- a/v19.2/restore.md
+++ b/v19.2/restore.md
@@ -82,6 +82,10 @@ After CockroachDB successfully initiates a restore, it registers the restore as 
 
 After the restore has been initiated, you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
 
+{{site.data.alerts.callout_info}}
+If initiated correctly, the statement returns when the restore is finished or if it encounters an error. In some cases, the restore can continue after an error has been returned (the error message will tell you that the restore has resumed in background).
+{{site.data.alerts.end}}
+
 ## Synopsis
 
 <div>


### PR DESCRIPTION
Add note to BACKUP, RESTORE, IMPORT, IMPORT INTO that the statement returns when the job is finished or if it encounters an error.

Closes #5240.
