### PR TITLE
Fix Jekyll plugin ordering

### DIFF
--- a/_includes/version-nav.html
+++ b/_includes/version-nav.html
@@ -32,9 +32,7 @@
       <span class="version-nav__link-text version-nav__link-text--managed"></span>
     </a>
     {% if page.version %}
-      {% unless page.cockroachcloud == true}
-        {% include version-switcher.html %}
-      {% endunless %}
+      {% include version-switcher.html %}
     {% endif %}
   </div>
 </div>

--- a/_plugins/flavor_selector.rb
+++ b/_plugins/flavor_selector.rb
@@ -8,9 +8,12 @@ require 'addressable/uri'
 # open in a new window.
 module FlavorSelector
   class Generator < Jekyll::Generator
-    # Ensure we run after JekyllRedirectFrom, so that if cockroachcloud links to
-    # a page that *redirects* to the cockroachdb docs, we rewrite that link.
-    priority :lowest
+    # Ordering requirements:
+    #   - Run after JekyllRedirectFrom, so that if cockroachcloud links to
+    #     a page that *redirects* to the cockroachdb docs, we rewrite that link.
+    #   - Run before JekyllVersions, so that it doesn't see pages that don't
+    #     apply to this flavor.
+    priority :low
 
     def initialize(config)
       @config = config

--- a/_plugins/versions/generator.rb
+++ b/_plugins/versions/generator.rb
@@ -1,7 +1,10 @@
 module JekyllVersions
  class JekyllGenerator < Jekyll::Generator
-    # Ensure we run after JekyllRedirectFrom so we can apply version aliases
-    # (e.g. stable) to redirects.
+    # Ordering requirements:
+    #   - Run after JekyllRedirectFrom so we can apply version aliases
+    #     (e.g. stable) to redirects.
+    #   - Run after FlavorSelector, so that we don't see pages that don't
+    #     apply to this flavor.
     priority :lowest
 
     def initialize(config)


### PR DESCRIPTION
The FlavorSelector plugin needs to run before the JekyllVersions plugin.
We were getting lucky previously with the right order, but For some
reason enabling the sitemap plugin caused us to get unlucky.

Use more granular plugin priorities to enforce exactly the right
ordering.