### PR TITLE
Improve SQL reference on partitioning

### DIFF
--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -749,6 +749,12 @@
                 ]
               },
               {
+                "title": "<code>ALTER PARTITION</code> (Enterprise)",
+                "urls": [
+                  "/${VERSION}/alter-partition.html"
+                ]
+              },
+              {
                 "title": "<code>ALTER RANGE</code>",
                 "urls": [
                   "/${VERSION}/alter-range.html"

--- a/_includes/v19.2/sql/diagrams/alter_index_partition_by.html
+++ b/_includes/v19.2/sql/diagrams/alter_index_partition_by.html
@@ -1,0 +1,72 @@
+<div><svg width="847" height="267">
+<polygon points="11 17 3 13 3 21"></polygon>
+<polygon points="19 17 11 13 11 21"></polygon>
+<rect x="33" y="3" width="62" height="32" rx="10"></rect>
+<rect x="31" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="41" y="21">ALTER</text>
+<rect x="115" y="3" width="64" height="32" rx="10"></rect>
+<rect x="113" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="123" y="21">INDEX</text>
+<rect x="219" y="35" width="34" height="32" rx="10"></rect>
+<rect x="217" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="227" y="53">IF</text>
+<rect x="273" y="35" width="70" height="32" rx="10"></rect>
+<rect x="271" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="281" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="383" y="3" width="96" height="32"></rect>
+<rect x="381" y="1" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="391" y="21">table_name</text></a><rect x="499" y="3" width="32" height="32" rx="10"></rect>
+<rect x="497" y="1" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="507" y="21">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="551" y="3" width="98" height="32"></rect>
+<rect x="549" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="21">index_name</text></a><rect x="45" y="145" width="98" height="32" rx="10"></rect>
+<rect x="43" y="143" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="163">PARTITION</text>
+<rect x="163" y="145" width="38" height="32" rx="10"></rect>
+<rect x="161" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="171" y="163">BY</text>
+<rect x="261" y="145" width="52" height="32" rx="10"></rect>
+<rect x="259" y="143" width="52" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="269" y="163">LIST</text>
+<rect x="333" y="145" width="26" height="32" rx="10"></rect>
+<rect x="331" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="163">(</text><a xlink:href="sql-grammar.html#name_list" xlink:title="name_list">
+<rect x="379" y="145" width="82" height="32"></rect>
+<rect x="377" y="143" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="387" y="163">name_list</text></a><rect x="481" y="145" width="26" height="32" rx="10"></rect>
+<rect x="479" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="489" y="163">)</text>
+<rect x="527" y="145" width="26" height="32" rx="10"></rect>
+<rect x="525" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="535" y="163">(</text><a xlink:href="sql-grammar.html#list_partitions" xlink:title="list_partitions">
+<rect x="573" y="145" width="106" height="32"></rect>
+<rect x="571" y="143" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="581" y="163">list_partitions</text></a><rect x="261" y="189" width="66" height="32" rx="10"></rect>
+<rect x="259" y="187" width="66" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="269" y="207">RANGE</text>
+<rect x="347" y="189" width="26" height="32" rx="10"></rect>
+<rect x="345" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="207">(</text><a xlink:href="sql-grammar.html#name_list" xlink:title="name_list">
+<rect x="393" y="189" width="82" height="32"></rect>
+<rect x="391" y="187" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="401" y="207">name_list</text></a><rect x="495" y="189" width="26" height="32" rx="10"></rect>
+<rect x="493" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="503" y="207">)</text>
+<rect x="541" y="189" width="26" height="32" rx="10"></rect>
+<rect x="539" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="549" y="207">(</text><a xlink:href="sql-grammar.html#range_partitions" xlink:title="range_partitions">
+<rect x="587" y="189" width="126" height="32"></rect>
+<rect x="585" y="187" width="126" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="595" y="207">range_partitions</text></a><rect x="753" y="145" width="26" height="32" rx="10"></rect>
+<rect x="751" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="761" y="163">)</text>
+<rect x="241" y="233" width="86" height="32" rx="10"></rect>
+<rect x="239" y="231" width="86" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="249" y="251">NOTHING</text>
+<rect x="45" y="101" width="24" height="32" rx="10"></rect>
+<rect x="43" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="119">,</text>
+<path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-668 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m0 0 h10 m38 0 h10 m40 0 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-492 0 h20 m472 0 h20 m-512 0 q10 0 10 10 m492 0 q0 -10 10 -10 m-502 10 v24 m492 0 v-24 m-492 24 q0 10 10 10 m472 0 q10 0 10 -10 m-482 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 -44 h10 m26 0 h10 m-578 0 h20 m558 0 h20 m-598 0 q10 0 10 10 m578 0 q0 -10 10 -10 m-588 10 v68 m578 0 v-68 m-578 68 q0 10 10 10 m558 0 q10 0 10 -10 m-568 10 h10 m86 0 h10 m0 0 h452 m-774 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m774 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-774 0 h10 m24 0 h10 m0 0 h730 m23 44 h-3"></path>
+<polygon points="837 159 845 155 845 163"></polygon>
+<polygon points="837 159 829 155 829 163"></polygon></svg></div>

--- a/v19.2/alter-database.md
+++ b/v19.2/alter-database.md
@@ -4,13 +4,17 @@ summary: Use the ALTER DATABASE statement to change an existing database.
 toc: false
 ---
 
-The `ALTER DATABASE` [statement](sql-statements.html) applies a schema change to a database.
+The `ALTER DATABASE` [statement](sql-statements.html) applies a schema change to a database. For information on using `ALTER DATABASE`, see the pages for its relevant [subcommands](#subcommands).
 
 {% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
-For information on using `ALTER DATABASE`, see the documents for its relevant subcommands.
+## Subcommands
 
 Subcommand | Description
 -----------|------------
 [`CONFIGURE ZONE`](configure-zone.html) | [Configure replication zones](configure-replication-zones.html) for a database.
 [`RENAME`](rename-database.html) | Change the name of a database.
+
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}

--- a/v19.2/alter-index.md
+++ b/v19.2/alter-index.md
@@ -1,20 +1,23 @@
 ---
 title: ALTER INDEX
 summary: Use the ALTER INDEX statement to change an existing index.
-toc: false
+toc: true
 ---
 
-The `ALTER INDEX` [statement](sql-statements.html) applies a schema change to an index.
+The `ALTER INDEX` [statement](sql-statements.html) applies a schema change to an index. For information on using `ALTER INDEX`, see the pages for its relevant [subcommands](#subcommands).
 
 {% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
-For information on using `ALTER INDEX`, see the documents for its relevant subcommands.
-
-{% include {{{ page.version.version }}/misc/schema-change-view-job.md %}
+## Subcommands
 
 Subcommand | Description
 -----------|------------
 [`CONFIGURE ZONE`](configure-zone.html) | [Configure replication zones](configure-replication-zones.html) for an index.
+[`PARTITION BY`](partition-by.html)  | Partition, re-partition, or un-partition an index. ([Enterprise-only](enterprise-licensing.html)).
 [`RENAME`](rename-index.html) | Change the name of an index.
 [`SPLIT AT`](split-at.html) | Force a range split at the specified row in the index.
 [`UNSPLIT AT`](unsplit-at.html) | <span class="version-tag">New in v19.2:</span> Remove a range split enforcement at a specified row in the index.
+
+## Viewing schema changes
+
+{% include {{ page.version.version }}/misc/schema-change-view-job.md %}

--- a/v19.2/alter-partition.md
+++ b/v19.2/alter-partition.md
@@ -1,0 +1,11 @@
+---
+title: ALTER PARTITION
+summary: Use the ALTER PARTITION statement to configure the replication zone for a partition.
+toc: true
+---
+
+The `ALTER PARTITION` [statement](sql-statements.html) is used to configure replication zones for partitions. See the [`CONFIGURE ZONE`](configure-zone.html) subcommand for more details.
+
+{{site.data.alerts.callout_info}}
+[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
+{{site.data.alerts.end}}

--- a/v19.2/alter-range.md
+++ b/v19.2/alter-range.md
@@ -1,15 +1,7 @@
 ---
 title: ALTER RANGE
-summary: Use the ALTER RANGE statement to change an existing system range.
-toc: false
+summary: Use the ALTER RANGE statement to configure the replication zone for a system range.
+toc: true
 ---
 
-The `ALTER RANGE` [statement](sql-statements.html) applies a schema change to a system range.
-
-{% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
-
-For information on using `ALTER RANGE`, see the documents for its relevant subcommands.
-
-Subcommand | Description
------------|------------
-[`CONFIGURE ZONE`](configure-zone.html) | [Configure replication zones](configure-replication-zones.html) for a system range.
+The `ALTER RANGE` [statement](sql-statements.html) is used to configure replication zones for system ranges. See the [`CONFIGURE ZONE`](configure-zone.html) subcommand for more details.

--- a/v19.2/alter-table.md
+++ b/v19.2/alter-table.md
@@ -4,17 +4,11 @@ summary: Use the ALTER TABLE statement to change the schema of a table.
 toc: true
 ---
 
-The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table.
+The `ALTER TABLE` [statement](sql-statements.html) applies a schema change to a table. For information on using `ALTER TABLE`, see the pages for its relevant [subcommands](#subcommands).
 
 {% include {{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
-## Viewing schema changes
-
-{% include {{ page.version.version }}/misc/schema-change-view-job.md %}
-
 ## Subcommands
-
-For information on using `ALTER TABLE`, see the documents for its relevant subcommands.
 
 {{site.data.alerts.callout_success}}
 Some subcommands can be used in combination in a single `ALTER TABLE` statement. For example, you can [atomically rename a column and add a new column with the old name of the existing column](rename-column.html#add-and-rename-columns-atomically).
@@ -30,7 +24,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`DROP COLUMN`](drop-column.html) | Remove columns from tables. | Yes
 [`DROP CONSTRAINT`](drop-constraint.html) | Remove constraints from columns. | Yes
 [`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Enable per-table audit logs. | Yes
-[`PARTITION BY`](partition-by.html)  | Repartition or unpartition a table with partitions ([Enterprise-only](enterprise-licensing.html)). | Yes
+[`PARTITION BY`](partition-by.html)  | Partition, re-partition, or un-partition a table ([Enterprise-only](enterprise-licensing.html)). | Yes
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns. | Yes
 [`RENAME CONSTRAINT`](rename-constraint.html) | Change constraints columns. | Yes
 [`RENAME TABLE`](rename-table.html) | Change the names of tables. | No

--- a/v19.2/configure-zone.md
+++ b/v19.2/configure-zone.md
@@ -4,21 +4,15 @@ summary: Use the CONFIGURE ZONE statement to add, modify, reset, and remove repl
 toc: true
 ---
 
-Use `CONFIGURE ZONE` to add, modify, reset, and remove [replication zones](configure-replication-zones.html). To view details about existing replication zones, see [`SHOW ZONE CONFIGURATIONS`](show-zone-configurations.html).
+`CONFIGURE ZONE` is a subcommand of the `ALTER DATABASE`, `ALTER TABLE`, `ALTER INDEX`, `ALTER PARTITION`, and `ALTER RANGE` statements and is used to add, modify, reset, or remove [replication zones](configure-replication-zones.html) for those objects. To view details about existing replication zones, see [`SHOW ZONE CONFIGURATIONS`](show-zone-configurations.html).
 
 In CockroachDB, you can use **replication zones** to control the number and location of replicas for specific sets of data, both when replicas are first added and when they are rebalanced to maintain cluster equilibrium.
 
 {{site.data.alerts.callout_info}}
-Adding replication zones for rows and secondary indexes is an [enterprise-only](enterprise-licensing.html) feature.
+Adding replication zones for secondary indexes and partitions is an [enterprise-only](enterprise-licensing.html) feature.
 {{site.data.alerts.end}}
 
 ## Synopsis
-
-**alter_zone_range_stmt ::=**
-
-<div>
-  {% include {{ page.version.version }}/sql/diagrams/alter_zone_range.html %}
-</div>
 
 **alter_zone_database_stmt ::=**
 
@@ -44,6 +38,12 @@ Adding replication zones for rows and secondary indexes is an [enterprise-only](
   {% include {{ page.version.version }}/sql/diagrams/alter_zone_partition.html %}
 </div>
 
+**alter_zone_range_stmt ::=**
+
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/alter_zone_range.html %}
+</div>
+
 ## Required privileges
 
 If the target is a [`system` range](#create-a-replication-zone-for-a-system-range), the [`system` database](show-databases.html#preloaded-databases), or a table in the `system` database, the user must be an [`admin`](authorization.html#create-and-manage-roles). For all other databases and tables, the user must have the [CREATE](grant.html#supported-privileges) privilege on the target database or table.
@@ -51,7 +51,6 @@ If the target is a [`system` range](#create-a-replication-zone-for-a-system-rang
 {{site.data.alerts.callout_danger}}
 Required privileges for `CONFIGURE ZONE` statements in CockroachDB v19.2 may be backward-incompatible for users running scripted statements with restricted permissions in v19.1 and earlier.<br>To add the necessary permissions, use [`GRANT` &lt;privileges&gt;](../v19.2/grant.html) or [`GRANT` &lt;roles&gt;](../v19.2/grant-roles.html) as a user with an admin role. <br>For example, to grant a user the admin role, run `GRANT admin TO <user>`.<br>To grant the `CREATE` privilege on a database or table, run `GRANT CREATE ON [DATABASE | TABLE] <name> TO <user>`.
 {{site.data.alerts.end}}
-
 
 ## Parameters
 
@@ -124,10 +123,12 @@ CONFIGURE ZONE 1
 ## See also
 
 - [Configure Replication Zones](configure-replication-zones.html)
+- [`PARTITION BY`](partition-by.html)
 - [`SHOW ZONE CONFIGURATIONS`](show-zone-configurations.html)
 - [`ALTER DATABASE`](alter-database.html)
 - [`ALTER TABLE`](alter-table.html)
 - [`ALTER INDEX`](alter-index.html)
+- [`ALTER PARTITION`](alter-partition.html)
 - [`ALTER RANGE`](alter-range.html)
 - [`SHOW JOBS`](show-jobs.html)
 - [Table Partitioning](partitioning.html)

--- a/v19.2/online-schema-changes.md
+++ b/v19.2/online-schema-changes.md
@@ -203,6 +203,7 @@ ROLLBACK
 + [How online schema changes are possible in CockroachDB][blog]: Blog post with more technical details about how our schema change engine works.
 + [`ALTER DATABASE`](alter-database.html)
 + [`ALTER INDEX`](alter-index.html)
++ [`ALTER PARTITION`](alter-partition.html)
 + [`ALTER RANGE`](alter-range.html)
 + [`ALTER SEQUENCE`](alter-sequence.html)
 + [`ALTER TABLE`][alter-table]

--- a/v19.2/partition-by.md
+++ b/v19.2/partition-by.md
@@ -1,35 +1,44 @@
 ---
 title: PARTITION BY
-summary: Use the ALTER TABLE statement to define partitions and subpartitions, repartition, or unpartition a table.
+summary: Use the PARTITION BY statement to partition, re-partition, or un-partition a table or secondary index.
 toc: true
 ---
 
-`PARTITION BY` is a subcommand of [`ALTER TABLE`](alter-table.html) that is used to define partitions and subpartitions on a table, and repartition or unpartition a table.
+`PARTITION BY` is a subcommand of [`ALTER TABLE`](alter-table.html) and [`ALTER INDEX`](alter-index.html) that is used to partition, re-partition, or un-partition a table or secondary index. After defining partitions, [`CONFIGURE ZONE`](configure-zone.html) is used to control the replication and placement of partitions.
 
 {{site.data.alerts.callout_info}}
-[Defining table partitions](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature. If you are looking for the `PARTITION BY` used in SQL window functions, see [Window Functions](window-functions.html).
+[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature. If you are looking for the `PARTITION BY` used in SQL window functions, see [Window Functions](window-functions.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
 
 ## Primary key requirements
 
-The [primary key required for partitioning](partitioning.html#partition-using-primary-key) is different from the conventional primary key: The unique identifier in the primary key requires to be prefixed with all columns you want to partition and subpartition the table on, in the order in which you want to nest your subpartitions.
+The [primary key required for partitioning](partitioning.html#partition-using-primary-key) is different from the conventional primary key: The unique identifier in the primary key must be prefixed with all columns you want to partition and subpartition the table on, in the order in which you want to nest your subpartitions.
 
-As of CockroachDB v2.0, you cannot alter the primary key after it has been defined while [creating the table](create-table.html#create-a-table-with-partitions). If the primary key in your existing table does not meet the requirements, you will not be able to use the `ALTER TABLE` statement to define partitions or subpartitions on the existing table.
+You cannot alter the primary key after it has been defined while [creating the table](create-table.html#create-a-table-with-partitions). If the primary key in your existing table does not meet the requirements, you will not be able to use the `ALTER TABLE` or `ALTER INDEX` statement to define partitions or subpartitions on the existing table or index.
 
 ## Synopsis
 
-<div>
+**alter_table_partition_by_stmt ::=**
+
+<section>
 {% include {{ page.version.version }}/sql/diagrams/alter_table_partition_by.html %}
-</div>
+</section>
+
+**alter_index_partition_by_stmt ::=**
+
+<section>
+{% include {{ page.version.version }}/sql/diagrams/alter_index_partition_by.html %}
+</section>
 
 ## Parameters
 
 Parameter | Description |
 -----------|-------------|
-`table_name` | The name of the table you want to define partitions for. |
-`name_list` | List of columns you want to define partitions on (in the order they are defined in the primary key).|
+`table_name` | The name of the table you want to define partitions for.
+`index_name` | The name of the index you want to define partitions for.
+`name_list` | List of columns you want to define partitions on (in the order they are defined in the primary key).
 `list_partitions` | Name of list partition followed by the list of values to be included in the partition.
 `range_partitions` | Name of range partition followed by the range of values to be included in the partition.
 
@@ -46,61 +55,115 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
 ## Examples
 
-### Define a list partition on an existing table
+### Define a list partition on a table or secondary index
 
-Suppose we have an existing table named `students_by_list` in a global online learning portal, and the primary key of the table is defined as `(country, id)`. We can define partitions on the table by list:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> ALTER TABLE students_by_list PARTITION BY LIST (country)
-      (PARTITION north_america VALUES IN ('CA','US'),
-      PARTITION australia VALUES IN ('AU','NZ'),
-      PARTITION DEFAULT VALUES IN (default));
-~~~
-
-### Define a range partition on an existing table
-
-Suppose we have an another existing table named `students_by_range` and the primary key of the table is defined as `(expected_graduation_date, id)`. We can define partitions on the table by range:
+Suppose we have a table called `students_by_list`, and secondary index on the table called `name_idx`, in a global online learning portal, and the primary key of the table is defined as `(country, id)`. We can define partitions on the table and index by list:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> ALTER TABLE students_by_range PARTITION BY RANGE (expected_graduation_date)
-      (PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
-      PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE));
+> ALTER TABLE students_by_list PARTITION BY LIST (country) (
+    PARTITION north_america VALUES IN ('CA','US'),
+    PARTITION australia VALUES IN ('AU','NZ'),
+    PARTITION DEFAULT VALUES IN (default)
+  );
 ~~~
-
-### Define a subpartitions on an existing table
-
-Suppose we have an yet another existing table named `students` with the primary key defined as `(country, expected_graduation_date, id)`. We can define partitions and subpartitions on the table:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> ALTER TABLE students PARTITION BY LIST (country)(
-        PARTITION australia VALUES IN ('AU','NZ') PARTITION BY RANGE (expected_graduation_date)(PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)),
-        PARTITION north_america VALUES IN ('US','CA') PARTITION BY RANGE (expected_graduation_date)(PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'), PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE))
-    );
+> ALTER INDEX students_by_list@name_idx PARTITION BY LIST (country) (
+    PARTITION north_america VALUES IN ('CA','US'),
+    PARTITION australia VALUES IN ('AU','NZ'),
+    PARTITION DEFAULT VALUES IN (default)
+  );
 ~~~
 
-### Repartition a table
+### Define a range partition on a table or secondary index
+
+Suppose we have another table called `students_by_range`, also with a secondary index called `name_idx`, and the primary key of the table is defined as `(expected_graduation_date, id)`. We can define partitions on the table and index by range:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE students_by_range PARTITION BY RANGE (expected_graduation_date) (
+    PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
+    PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+  );
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX students_by_range@name_idx PARTITION BY RANGE (expected_graduation_date) (
+    PARTITION graduated VALUES FROM (MINVALUE) TO ('2017-08-15'),
+    PARTITION current VALUES FROM ('2017-08-15') TO (MAXVALUE)
+  );
+~~~
+
+### Define subpartitions on a table or secondary index
+
+Suppose we have an yet another table named `students`, again with a secondary index called `name_idx`, and the primary key is defined as `(country, expected_graduation_date, id)`. We can define partitions and subpartitions on the table and index:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE students PARTITION BY LIST (country) (
+    PARTITION australia VALUES IN ('AU','NZ') PARTITION BY RANGE (expected_graduation_date) (
+      PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
+      PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+    ),
+    PARTITION north_america VALUES IN ('US','CA') PARTITION BY RANGE (expected_graduation_date) (
+      PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
+      PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+    )
+  );
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX students@name_idx PARTITION BY LIST (country) (
+    PARTITION australia VALUES IN ('AU','NZ') PARTITION BY RANGE (expected_graduation_date) (
+      PARTITION graduated_au VALUES FROM (MINVALUE) TO ('2017-08-15'),
+      PARTITION current_au VALUES FROM ('2017-08-15') TO (MAXVALUE)
+    ),
+    PARTITION north_america VALUES IN ('US','CA') PARTITION BY RANGE (expected_graduation_date) (
+      PARTITION graduated_us VALUES FROM (MINVALUE) TO ('2017-08-15'),
+      PARTITION current_us VALUES FROM ('2017-08-15') TO (MAXVALUE)
+    )
+  );
+~~~
+
+### Repartition a table or secondary index
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > ALTER TABLE students_by_range PARTITION BY RANGE (expected_graduation_date) (
     PARTITION graduated VALUES FROM (MINVALUE) TO ('2018-08-15'),
-    PARTITION current VALUES FROM ('2018-08-15') TO (MAXVALUE));
+    PARTITION current VALUES FROM ('2018-08-15') TO (MAXVALUE)
+  );
 ~~~
 
-### Unpartition a table
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX students_by_range@name_idx PARTITION BY RANGE (expected_graduation_date) (
+    PARTITION graduated VALUES FROM (MINVALUE) TO ('2018-08-15'),
+    PARTITION current VALUES FROM ('2018-08-15') TO (MAXVALUE)
+  );
+~~~
+
+### Unpartition a table or secondary index
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > ALTER TABLE students PARTITION BY NOTHING;
 ~~~
 
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER INDEX students@name_idx PARTITION BY NOTHING;
+~~~
+
 ## See also
 
 - [`CREATE TABLE`](create-table.html)
 - [`ALTER TABLE`](alter-table.html)
+- [`ALTER INDEX`](alter-index.html)
 - [Define Table Partitions](partitioning.html)
 - [`SHOW JOBS`](show-jobs.html)
 - [`SHOW PARTITIONS`](show-partitions.html)

--- a/v19.2/show-partitions.md
+++ b/v19.2/show-partitions.md
@@ -7,7 +7,7 @@ toc: true
 <span class="version-tag">New in v19.2:</span> Use the `SHOW PARTITIONS` [statement](sql-statements.html) to view details about existing [partitions](partitioning.html).
 
 {{site.data.alerts.callout_info}}
-[Defining table partitions](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
+[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/sql/crdb-internal-partitions.md %}

--- a/v19.2/sql-statements.md
+++ b/v19.2/sql-statements.md
@@ -16,7 +16,7 @@ Statement | Usage
 ----------|------------
 [`CREATE TABLE AS`](create-table-as.html) | Create a new table in a database using the results from a [selection query](selection-queries.html).
 [`DELETE`](delete.html) | Delete specific rows from a table.
-[`EXPORT`](export.html) | Export an entire table's data, or the results of a `SELECT` statement, to CSV files. This statement is available only to [enterprise](https://www.cockroachlabs.com/product/cockroachdb/) users.
+[`EXPORT`](export.html) | Export an entire table's data, or the results of a `SELECT` statement, to CSV files. Note that this statement requires an [enterprise license](enterprise-licensing.html).
 [`IMPORT`](import.html) | Bulk-insert CSV data into a new table.
 [`IMPORT INTO`](import-into.html) | <span class="version-tag">New in v19.2:</span> Bulk-insert CSV data into an existing table.
 [`INSERT`](insert.html) | Insert rows into a table.
@@ -36,14 +36,15 @@ Statement | Usage
 [`ALTER COLUMN`](alter-column.html) | Change a column's [Default constraint](default-value.html) or [`NOT NULL` constraint](not-null.html).
 [`ALTER DATABASE`](alter-database.html) | Apply a schema change to a database.
 [`ALTER INDEX`](alter-index.html) | Apply a schema change to an index.
-[`ALTER RANGE`](alter-range.html) | Change an existing system range.
+[`ALTER PARTITION`](alter-partition.html) | Configure the replication zone for a partition. Note that [partitioning](partitioning.html) requires an [enterprise license](enterprise-licensing.html).
+[`ALTER RANGE`](alter-range.html) | Configure the replication zone for a system range.
 [`ALTER SEQUENCE`](alter-sequence.html) | Apply a schema change to a sequence.
 [`ALTER TABLE`](alter-table.html) | Apply a schema change to a table.
 [`ALTER TYPE`](alter-type.html) | Change a column's [data type](data-types.html).
 [`ALTER USER`](alter-user.html) | Add or change a user's password.
 [`ALTER VIEW`](alter-view.html) | Rename a view.
 [`COMMENT ON`](comment-on.html) | Associate a comment to a database, table, or column.
-[`CONFIGURE ZONE`](configure-zone.html) | Add, modify, reset, and remove [replication zones](configure-replication-zones.html).
+[`CONFIGURE ZONE`](configure-zone.html) | Add, modify, reset, or remove a [replication zone](configure-replication-zones.html) for a database, table, index, partition, or system range.
 [`CREATE DATABASE`](create-database.html) | Create a new database.
 [`CREATE INDEX`](create-index.html) | Create an index for a table.
 [`CREATE SEQUENCE`](create-sequence.html) | Create a new sequence.
@@ -58,6 +59,7 @@ Statement | Usage
 [`DROP TABLE`](drop-table.html) | Remove a table.
 [`DROP VIEW`](drop-view.html)| Remove a view.
 [`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Turn SQL audit logging on or off for a table.
+[`PARTITION BY`](partition-by.html) | Partition, re-partition, or un-partition a table or secondary index. Note that [partitioning](partitioning.html) requires an [enterprise license](enterprise-licensing.html).
 [`RENAME COLUMN`](rename-column.html) | Rename a column in a table.
 [`RENAME CONSTRAINT`](rename-constraint.html) | Rename a constraint on a column.
 [`RENAME DATABASE`](rename-database.html) | Rename a database.
@@ -68,7 +70,7 @@ Statement | Usage
 [`SHOW CONSTRAINTS`](show-constraints.html) | List constraints on a table.
 [`SHOW CREATE`](show-create.html) | View the `CREATE` statement for a table, view, or sequence.
 [`SHOW DATABASES`](show-databases.html) | List databases in the cluster.
-[`SHOW PARTITIONS`](show-partitions.html) | <span class="version-tag">New in v19.2:</span> List table partitions in a database.
+[`SHOW PARTITIONS`](show-partitions.html) | <span class="version-tag">New in v19.2:</span> List partitions in a database. Note that [partitioning](partitioning.html) requires an [enterprise license](enterprise-licensing.html).
 [`SHOW INDEX`](show-index.html) | View index information for a table or database.
 [`SHOW LOCALITY`](show-locality.html) | <span class="version-tag">New in v19.2:</span> View the locality of the current node.
 [`SHOW SCHEMAS`](show-schemas.html) | List the schemas in a database.
@@ -158,7 +160,7 @@ Statement | Usage
 
 ## Backup and restore statements (Enterprise)
 
-The following statements are available only to [enterprise](https://www.cockroachlabs.com/product/cockroachdb/) users.
+The following statements require an [enterprise license](enterprise-licensing.html).
 
 {{site.data.alerts.callout_info}}
 For non-enterprise users, see [Back up Data](backup.html) and [Restore Data](restore.html).


### PR DESCRIPTION
- Add landing page for ALTER PARTITION that references the only
  relevant subcommand, CONFIGURE ZONE.
- Update PARTITION BY to cover by tables and indexes. Also add
  this statement to the SQL statements list and cross-reference
  it more.
- Update other ALTER landing pages for usability and consistency.

Fixes #5869.
Fixes #5868.