### PR TITLE
CC SEO fix

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {% if site.cockroachcloud %}
-<meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 | replace: "CockroachDB", "CockroachCloud" }}{% endif %}">
+<meta name="description" content="{% if page.summary %}{% if page.homepage == true %}CockroachCloud is a fully hosted and fully managed service created and owned by Cockroach Labs that makes deploying, scaling, and managing CockroachDB effortless.{% else %}{{ page.summary | strip_html | strip_newlines | truncate: 160 | replace: "CockroachDB", "CockroachCloud" }}{% endif %}{% endif %}">
 {% else %}
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,11 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+{% if site.cockroachcloud %}
+<meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 | replace: "CockroachDB", "CockroachCloud" }}{% endif %}">
+{% else %}
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
+{% endif %}
 <meta name="keywords" content="{% if page.tags %}{{ page.tags | join: ', ' | escape }}{% endif %}">
 {% if page.block_search %}
 <meta name="robots" content="noindex">
@@ -9,7 +13,11 @@
 <meta name="robots" content="noarchive">
 <meta name="robots" content="nocache">
 {% endif %}
+{% if site.cockroachcloud %}
+<title>{{ page.title | replace: "CockroachDB", "CockroachCloud" }} | {{ site.site_title | replace: "CockroachDB", "CockroachCloud" }}</title>
+{% else %}
 <title>{{ page.title }} | {{ site.site_title }}</title>
+{% endif %}
 <link rel="canonical" href="{{ page.canonical | absolute_url }}">
 <link rel="shortcut icon" href="{{ 'images/favicon.png' | relative_url }}" type="image/png">
 

--- a/v19.1/index.md
+++ b/v19.1/index.md
@@ -1,6 +1,6 @@
 ---
 title: CockroachDB Docs
-summary: CockroachDB user documentation.
+summary: CockroachDB is the SQL database for building global, scalable cloud services that survive disasters.
 toc: true
 homepage: true
 contribute: false

--- a/v19.2/index.md
+++ b/v19.2/index.md
@@ -1,6 +1,6 @@
 ---
 title: CockroachDB Docs
-summary: CockroachDB user documentation.
+summary: CockroachDB is the SQL database for building global, scalable cloud services that survive disasters.
 toc: true
 homepage: true
 contribute: false

--- a/v2.1/index.md
+++ b/v2.1/index.md
@@ -1,6 +1,6 @@
 ---
 title: CockroachDB Docs
-summary: CockroachDB user documentation.
+summary: CockroachDB is the SQL database for building global, scalable cloud services that survive disasters.
 toc: true
 homepage: true
 contribute: false

--- a/v20.1/index.md
+++ b/v20.1/index.md
@@ -1,6 +1,6 @@
 ---
 title: CockroachDB Docs
-summary: CockroachDB user documentation.
+summary: CockroachDB is the SQL database for building global, scalable cloud services that survive disasters.
 toc: true
 homepage: true
 contribute: false


### PR DESCRIPTION
Previously, the title and description tags on CC docs pages
were referencing CockroachDB, which we think was negatively
effective SEO. This PR adds logic to replace "CockroachDB"
with "CockroachCloud" in the meta title and desciption fields
on pages with the site.cockroachcloud variable, which gets
added to pages built with _config_cockroachcloud.yml. It
also adds customer, and more descriptive, meta descriptions
for CC and CRDB docs landing pages.

Fixes #5876.