### PR TITLE
link upgrades doc to Kubernetes instructions

### DIFF
--- a/v19.1/upgrade-cockroach-version.md
+++ b/v19.1/upgrade-cockroach-version.md
@@ -72,6 +72,10 @@ When upgrading from v2.1 to v19.1, certain features and performance improvements
 
 For each node in your cluster, complete the following steps.
 
+{{site.data.alerts.callout_info}}
+These steps apply to manual deployments. If you are running CockroachDB on Kubernetes, read our documentation on [single-cluster](orchestrate-cockroachdb-with-kubernetes.html#upgrade-the-cluster) and/or [multi-cluster](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html#upgrade-the-cluster) orchestrated deployments of CockroachDB.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}
 We recommend creating scripts to perform these steps instead of performing them manually.
 {{site.data.alerts.end}}

--- a/v19.2/upgrade-cockroach-version.md
+++ b/v19.2/upgrade-cockroach-version.md
@@ -73,6 +73,10 @@ When upgrading from v19.1 to v19.2, certain features and performance improvement
 
 For each node in your cluster, complete the following steps.
 
+{{site.data.alerts.callout_info}}
+These steps apply to manual deployments. If you are running CockroachDB on Kubernetes, read our documentation on [single-cluster](orchestrate-cockroachdb-with-kubernetes.html#upgrade-the-cluster) and/or [multi-cluster](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html#upgrade-the-cluster) orchestrated deployments of CockroachDB.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}
 We recommend creating scripts to perform these steps instead of performing them manually.
 {{site.data.alerts.end}}

--- a/v20.1/upgrade-cockroach-version.md
+++ b/v20.1/upgrade-cockroach-version.md
@@ -70,6 +70,10 @@ TBD
 
 For each node in your cluster, complete the following steps.
 
+{{site.data.alerts.callout_info}}
+These steps apply to manual deployments. If you are running CockroachDB on Kubernetes, read our documentation on [single-cluster](orchestrate-cockroachdb-with-kubernetes.html#upgrade-the-cluster) and/or [multi-cluster](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html#upgrade-the-cluster) orchestrated deployments of CockroachDB.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}
 We recommend creating scripts to perform these steps instead of performing them manually.
 {{site.data.alerts.end}}


### PR DESCRIPTION
Made the Kubernetes instructions easier to discover & access in our upgrade docs.

Relates to #5780.