### PR TITLE
Update Helm chart instructions

### DIFF
--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,8 +1,8 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm client](https://v2.helm.sh/docs/using_helm/#installing-the-helm-client).
 
 2. Install the Helm server, known as Tiller.
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
+    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://v2.helm.sh/docs/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
 
     1. Create a `rbac-config.yaml` file to define a role and service account:
 
@@ -40,7 +40,7 @@
         clusterrolebinding.rbac.authorization.k8s.io/tiller created
         ~~~    
 
-    3. Start the Helm server and [install Tiller](https://docs.helm.sh/using_helm/#installing-tiller):
+    3. Start the Helm server and [install Tiller](https://v2.helm.sh/docs/using_helm/#installing-tiller):
 
         {{site.data.alerts.callout_info}}
         Tiller does not currently support [Kubernetes 1.16.0](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). The following command includes a workaround to install Tiller for use with 1.16.0.
@@ -84,7 +84,7 @@
     ~~~
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/fe6c09b96ba882be9a5462e7a420263c1fe567ff/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
 5. Confirm that three pods are `Running` successfully and that the one-time cluster initialization has `Completed`:

--- a/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,8 +1,8 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm client](https://v2.helm.sh/docs/using_helm/#installing-the-helm-client).
 
 2. Install the Helm server, known as Tiller.
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
+    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://v2.helm.sh/docs/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
 
     1. Create a `rbac-config.yaml` file to define a role and service account:
 
@@ -40,7 +40,7 @@
         clusterrolebinding.rbac.authorization.k8s.io/tiller created
         ~~~    
 
-    3. Start the Helm server and [install Tiller](https://docs.helm.sh/using_helm/#installing-tiller):
+    3. Start the Helm server and [install Tiller](https://v2.helm.sh/docs/using_helm/#installing-tiller):
 
         {{site.data.alerts.callout_info}}
         Tiller does not currently support [Kubernetes 1.16.0](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). The following command includes a workaround to install Tiller for use with 1.16.0.
@@ -82,7 +82,7 @@
     ~~~
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/fe6c09b96ba882be9a5462e7a420263c1fe567ff/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
 4. As each pod is created, it issues a Certificate Signing Request, or CSR, to have the CockroachDB node's certificate signed by the Kubernetes CA. You must manually check and approve each node's certificate, at which point the CockroachDB node is started in the pod.

--- a/_includes/v19.2/orchestration/kubernetes-prometheus-alertmanager.md
+++ b/_includes/v19.2/orchestration/kubernetes-prometheus-alertmanager.md
@@ -22,7 +22,7 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     service/cockroachdb labeled
     ~~~
 
-    This ensures that there is a prometheus job and monitoring data only for the `cockroachdb` service, not for the `cockroach-public` service.
+    This ensures that there is a Prometheus job and monitoring data only for the `cockroachdb` service, not for the `cockroach-public` service.
     </section>
 
     <section class="filter-content" markdown="1" data-scope="helm">
@@ -35,7 +35,7 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     service/my-release-cockroachdb labeled
     ~~~
 
-    This ensures that there is a prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
+    This ensures that there is a Prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
     </section>
 
 2. Install [CoreOS's Prometheus Operator](https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.20/bundle.yaml):

--- a/_includes/v19.2/orchestration/kubernetes-remove-nodes-insecure.md
+++ b/_includes/v19.2/orchestration/kubernetes-remove-nodes-insecure.md
@@ -1,4 +1,4 @@
-To safely remove a node from your cluster, you must first decommission the node and only then adjust the `Replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
+To safely remove a node from your cluster, you must first decommission the node and only then adjust the `spec.replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
 
 {{site.data.alerts.callout_danger}}
 If you remove nodes without first telling CockroachDB to decommission them, you may cause data or even cluster unavailability. For more details about how this works and what to consider before removing nodes, see [Decommission Nodes](remove-nodes.html).
@@ -124,7 +124,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=3 \
+    --set statefulset.replicas=3 \
     --reuse-values
     ~~~
     </section>

--- a/_includes/v19.2/orchestration/kubernetes-remove-nodes-secure.md
+++ b/_includes/v19.2/orchestration/kubernetes-remove-nodes-secure.md
@@ -1,4 +1,4 @@
-To safely remove a node from your cluster, you must first decommission the node and only then adjust the `Replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
+To safely remove a node from your cluster, you must first decommission the node and only then adjust the `spec.replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
 
 {{site.data.alerts.callout_danger}}
 If you remove nodes without first telling CockroachDB to decommission them, you may cause data or even cluster unavailability. For more details about how this works and what to consider before removing nodes, see [Decommission Nodes](remove-nodes.html).
@@ -113,7 +113,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=3 \
+    --set statefulset.replicas=3 \
     --reuse-values
     ~~~
     </section>

--- a/_includes/v19.2/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v19.2/orchestration/kubernetes-scale-cluster.md
@@ -28,7 +28,7 @@ To do this, add a new worker node and then edit your StatefulSet configuration t
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=4 \
+    --set statefulset.replicas=4 \
     --reuse-values
     ~~~
 

--- a/_includes/v19.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v19.2/orchestration/kubernetes-upgrade-cluster.md
@@ -113,7 +113,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set ImageTag={{page.release_info.version}} \
+    --set image.tag={{page.release_info.version}} \
     --reuse-values
     ~~~
     </section>

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,65 +1,18 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm](https://helm.sh/docs/intro/install) and add `@stable` chart repository to it.
 
-2. Install the Helm server, known as Tiller.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    ~~~
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
-
-    1. Create a `rbac-config.yaml` file to define a role and service account:
-
-        {% include copy-clipboard.html %}
-        ~~~
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: tiller
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: tiller
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: cluster-admin
-        subjects:
-          - kind: ServiceAccount
-            name: tiller
-            namespace: kube-system
-        ~~~
-
-    2. Create the service account:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl create -f rbac-config.yaml
-        ~~~
-
-        ~~~
-        serviceaccount/tiller created
-        clusterrolebinding.rbac.authorization.k8s.io/tiller created
-        ~~~    
-
-    3. Start the Helm server and [install Tiller](https://docs.helm.sh/using_helm/#installing-tiller):
-
-        {{site.data.alerts.callout_info}}
-        Tiller does not currently support [Kubernetes 1.16.0](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). The following command includes a workaround to install Tiller for use with 1.16.0.
-        {{site.data.alerts.end}}
-
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
-        ~~~
-
-3. Update your Helm chart repositories to ensure that you're using the latest CockroachDB chart:
+2. Update your Helm chart repositories to ensure that you're using the latest CockroachDB chart:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ helm repo update
     ~~~
 
-4. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart:
+3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart:
 
     {{site.data.alerts.callout_info}}
     This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands.
@@ -67,7 +20,7 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
+    $ helm install --name my-release --set statefulset.resources.requests.memory="<your memory allocation>",conf.cache="<your cache size>",conf.max-sql-memory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
@@ -75,19 +28,19 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `conf.cache` and `conf.max-sql-memory` each to 1/4 of the memory allocation specified in your `statefulset.resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
+    statefulset.resources.requests.memory="8GiB",conf.cache="2GiB",conf.max-sql-memory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `storage.persistentVolume.size` and `storage.persistentVolume.storageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `storage.persistentVolume.storageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
-5. Confirm that three pods are `Running` successfully and that the one-time cluster initialization has `Completed`:
+4. Confirm that three pods are `Running` successfully and that the one-time cluster initialization has `Completed`:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -102,7 +55,7 @@
     my-release-cockroachdb-init-k6jcr   0/1       Completed   0          1m
     ~~~
 
-6. Confirm that the persistent volumes and corresponding claims were created successfully for all three pods:
+5. Confirm that the persistent volumes and corresponding claims were created successfully for all three pods:
 
     {% include copy-clipboard.html %}
     ~~~ shell

--- a/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v19.2/orchestration/start-cockroachdb-helm-secure.md
@@ -1,63 +1,18 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm](https://helm.sh/docs/intro/install) and add `@stable` chart repository to it.
 
-2. Install the Helm server, known as Tiller.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    ~~~
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
+2. Update your Helm chart repositories to ensure that you're using the latest CockroachDB chart:
 
-    1. Create a `rbac-config.yaml` file to define a role and service account:
-
-        {% include copy-clipboard.html %}
-        ~~~
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: tiller
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: tiller
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: cluster-admin
-        subjects:
-          - kind: ServiceAccount
-            name: tiller
-            namespace: kube-system
-        ~~~
-
-    2. Create the service account:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl create -f rbac-config.yaml
-        ~~~
-
-        ~~~
-        serviceaccount/tiller created
-        clusterrolebinding.rbac.authorization.k8s.io/tiller created
-        ~~~    
-
-    3. Start the Helm server and [install Tiller](https://docs.helm.sh/using_helm/#installing-tiller):
-
-        {{site.data.alerts.callout_info}}
-        Tiller does not currently support [Kubernetes 1.16.0](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). The following command includes a workaround to install Tiller for use with 1.16.0.
-        {{site.data.alerts.end}}
-
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
-        ~~~
-
-        ~~~
-        deployment.apps/tiller-deploy created
-        service/tiller-deploy created
-        ~~~
-
-3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart and setting the `Secure.Enabled` parameter to `true`:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm repo update
+    ~~~
+   
+3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart and setting the `tls.enabled` parameter to `yes` (or `true`):
 
     {{site.data.alerts.callout_info}}
     This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands. Also be sure to start and end the name with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
@@ -65,7 +20,7 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true,Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
+    $ helm install --name my-release --set tls.enabled=true,statefulset.resources.requests.memory="<your memory allocation>",conf.cache="<your cache size>",conf.max-sql-memory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
@@ -73,16 +28,16 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `conf.cache` and `conf.max-sql-memory` each to 1/4 of the memory allocation specified in your `statefulset.resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
+    statefulset.resources.requests.memory="8GiB",conf.cache="2GiB",conf.max-sql-memory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `storage.persistentVolume.size` and `storage.persistentVolume.storageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `storage.persistentVolume.storageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
 4. As each pod is created, it issues a Certificate Signing Request, or CSR, to have the CockroachDB node's certificate signed by the Kubernetes CA. You must manually check and approve each node's certificate, at which point the CockroachDB node is started in the pod.

--- a/_includes/v2.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v2.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,8 +1,8 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm client](https://v2.helm.sh/docs/using_helm/#installing-the-helm-client).
 
-2. [Install the Helm server, known as Tiller](https://docs.helm.sh/using_helm/#installing-tiller).
+2. [Install the Helm server, known as Tiller](https://v2.helm.sh/docs/using_helm/#installing-tiller).
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
+    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you need to create [RBAC resources](https://v2.helm.sh/docs/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
 
     1. Create a `rbac-config.yaml` file to define a role and service account:
 
@@ -61,7 +61,7 @@
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/fe6c09b96ba882be9a5462e7a420263c1fe567ff/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
 4. Confirm that three pods are `Running` successfully:

--- a/_includes/v2.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v2.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,8 +1,8 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm client](https://v2.helm.sh/docs/using_helm/#installing-the-helm-client).
 
-2. [Install the Helm server, known as Tiller](https://docs.helm.sh/using_helm/#installing-tiller).
+2. [Install the Helm server, known as Tiller](https://v2.helm.sh/docs/using_helm/#installing-tiller).
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
+    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you need to create [RBAC resources](https://v2.helm.sh/docs/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
 
     1. Create a `rbac-config.yaml` file to define a role and service account:
 
@@ -61,7 +61,7 @@
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/fe6c09b96ba882be9a5462e7a420263c1fe567ff/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
 4. As each pod is created, it issues a Certificate Signing Request, or CSR, to have the node's certificate signed by the Kubernetes CA. You must manually check and approve each node's certificates, at which point the CockroachDB node is started in the pod.

--- a/_includes/v20.1/orchestration/kubernetes-prometheus-alertmanager.md
+++ b/_includes/v20.1/orchestration/kubernetes-prometheus-alertmanager.md
@@ -22,7 +22,7 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     service/cockroachdb labeled
     ~~~
 
-    This ensures that there is a prometheus job and monitoring data only for the `cockroachdb` service, not for the `cockroach-public` service.
+    This ensures that there is a Prometheus job and monitoring data only for the `cockroachdb` service, not for the `cockroach-public` service.
     </section>
 
     <section class="filter-content" markdown="1" data-scope="helm">
@@ -35,7 +35,7 @@ If you're on Hosted GKE, before starting, make sure the email address associated
     service/my-release-cockroachdb labeled
     ~~~
 
-    This ensures that there is a prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
+    This ensures that there is a Prometheus job and monitoring data only for the `my-release-cockroachdb` service, not for the `my-release-cockroach-public` service.
     </section>
 
 2. Install [CoreOS's Prometheus Operator](https://raw.githubusercontent.com/coreos/prometheus-operator/release-0.20/bundle.yaml):

--- a/_includes/v20.1/orchestration/kubernetes-remove-nodes-insecure.md
+++ b/_includes/v20.1/orchestration/kubernetes-remove-nodes-insecure.md
@@ -1,4 +1,4 @@
-To safely remove a node from your cluster, you must first decommission the node and only then adjust the `Replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
+To safely remove a node from your cluster, you must first decommission the node and only then adjust the `spec.replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
 
 {{site.data.alerts.callout_danger}}
 If you remove nodes without first telling CockroachDB to decommission them, you may cause data or even cluster unavailability. For more details about how this works and what to consider before removing nodes, see [Decommission Nodes](remove-nodes.html).
@@ -124,7 +124,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=3 \
+    --set statefulset.replicas=3 \
     --reuse-values
     ~~~
     </section>

--- a/_includes/v20.1/orchestration/kubernetes-remove-nodes-secure.md
+++ b/_includes/v20.1/orchestration/kubernetes-remove-nodes-secure.md
@@ -1,4 +1,4 @@
-To safely remove a node from your cluster, you must first decommission the node and only then adjust the `Replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
+To safely remove a node from your cluster, you must first decommission the node and only then adjust the `spec.replicas` value of your StatefulSet configuration to permanently remove it. This sequence is important because the decommissioning process lets a node finish in-flight requests, rejects any new requests, and transfers all range replicas and range leases off the node.
 
 {{site.data.alerts.callout_danger}}
 If you remove nodes without first telling CockroachDB to decommission them, you may cause data or even cluster unavailability. For more details about how this works and what to consider before removing nodes, see [Decommission Nodes](remove-nodes.html).
@@ -113,7 +113,7 @@ If you remove nodes without first telling CockroachDB to decommission them, you 
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=3 \
+    --set statefulset.replicas=3 \
     --reuse-values
     ~~~
     </section>

--- a/_includes/v20.1/orchestration/kubernetes-scale-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-scale-cluster.md
@@ -28,7 +28,7 @@ To do this, add a new worker node and then edit your StatefulSet configuration t
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=4 \
+    --set statefulset.replicas=4 \
     --reuse-values
     ~~~
 

--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -113,7 +113,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set ImageTag={{page.release_info.version}} \
+    --set image.tag={{page.release_info.version}} \
     --reuse-values
     ~~~
     </section>

--- a/_includes/v20.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,65 +1,18 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm](https://helm.sh/docs/intro/install) and add `@stable` chart repository to it.
 
-2. Install the Helm server, known as Tiller.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    ~~~
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
-
-    1. Create a `rbac-config.yaml` file to define a role and service account:
-
-        {% include copy-clipboard.html %}
-        ~~~
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: tiller
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: tiller
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: cluster-admin
-        subjects:
-          - kind: ServiceAccount
-            name: tiller
-            namespace: kube-system
-        ~~~
-
-    2. Create the service account:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl create -f rbac-config.yaml
-        ~~~
-
-        ~~~
-        serviceaccount/tiller created
-        clusterrolebinding.rbac.authorization.k8s.io/tiller created
-        ~~~    
-
-    3. Start the Helm server and [install Tiller](https://docs.helm.sh/using_helm/#installing-tiller):
-
-        {{site.data.alerts.callout_info}}
-        Tiller does not currently support [Kubernetes 1.16.0](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). The following command includes a workaround to install Tiller for use with 1.16.0.
-        {{site.data.alerts.end}}
-
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
-        ~~~
-
-3. Update your Helm chart repositories to ensure that you're using the latest CockroachDB chart:
+2. Update your Helm chart repositories to ensure that you're using the latest CockroachDB chart:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ helm repo update
     ~~~
 
-4. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart:
+3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart:
 
     {{site.data.alerts.callout_info}}
     This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands.
@@ -67,7 +20,7 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
+    $ helm install --name my-release --set statefulset.resources.requests.memory="<your memory allocation>",conf.cache="<your cache size>",conf.max-sql-memory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
@@ -75,19 +28,19 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `conf.cache` and `conf.max-sql-memory` each to 1/4 of the memory specified in your `statefulset.resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
+    statefulset.resources.requests.memory="8GiB",conf.cache="2GiB",conf.max-sql-memory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `storage.persistentVolume.size` and `storage.persistentVolume.storageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `storage.persistentVolume.storageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
-5. Confirm that three pods are `Running` successfully and that the one-time cluster initialization has `Completed`:
+4. Confirm that three pods are `Running` successfully and that the one-time cluster initialization has `Completed`:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -102,7 +55,7 @@
     my-release-cockroachdb-init-k6jcr   0/1       Completed   0          1m
     ~~~
 
-6. Confirm that the persistent volumes and corresponding claims were created successfully for all three pods:
+5. Confirm that the persistent volumes and corresponding claims were created successfully for all three pods:
 
     {% include copy-clipboard.html %}
     ~~~ shell

--- a/_includes/v20.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,63 +1,18 @@
-1. [Install the Helm client](https://docs.helm.sh/using_helm/#installing-the-helm-client).
+1. [Install the Helm](https://helm.sh/docs/intro/install) and add `@stable` chart repository to it.
 
-2. Install the Helm server, known as Tiller.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    ~~~
 
-    In the likely case that your Kubernetes cluster uses RBAC (e.g., if you are using GKE), you first need to create [RBAC resources](https://docs.helm.sh/using_helm/#role-based-access-control) to grant Tiller access to the Kubernetes API:
+2. Update your Helm chart repositories to ensure that you're using the latest CockroachDB chart:
 
-    1. Create a `rbac-config.yaml` file to define a role and service account:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm repo update
+    ~~~
 
-        {% include copy-clipboard.html %}
-        ~~~
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: tiller
-          namespace: kube-system
-        ---
-        apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRoleBinding
-        metadata:
-          name: tiller
-        roleRef:
-          apiGroup: rbac.authorization.k8s.io
-          kind: ClusterRole
-          name: cluster-admin
-        subjects:
-          - kind: ServiceAccount
-            name: tiller
-            namespace: kube-system
-        ~~~
-
-    2. Create the service account:
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl create -f rbac-config.yaml
-        ~~~
-
-        ~~~
-        serviceaccount/tiller created
-        clusterrolebinding.rbac.authorization.k8s.io/tiller created
-        ~~~    
-
-    3. Start the Helm server and [install Tiller](https://docs.helm.sh/using_helm/#installing-tiller):
-
-        {{site.data.alerts.callout_info}}
-        Tiller does not currently support [Kubernetes 1.16.0](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/). The following command includes a workaround to install Tiller for use with 1.16.0.
-        {{site.data.alerts.end}}
-
-
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ helm init --service-account tiller --override spec.selector.matchLabels.'name'='tiller',spec.selector.matchLabels.'app'='helm' --output yaml | sed 's@apiVersion: extensions/v1beta1@apiVersion: apps/v1@' | kubectl apply -f -
-        ~~~
-
-        ~~~
-        deployment.apps/tiller-deploy created
-        service/tiller-deploy created
-        ~~~
-
-3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart and setting the `Secure.Enabled` parameter to `true`:
+3. Install the CockroachDB Helm chart, providing a "release" name to identify and track this particular deployment of the chart and setting the `tls.enabled` parameter to `yes` (or `true`):
 
     {{site.data.alerts.callout_info}}
     This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands. Also be sure to start and end the name with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
@@ -65,7 +20,7 @@
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm install --name my-release --set Secure.Enabled=true,Resources.requests.memory="<your memory allocation>",CacheSize="<your cache size>",MaxSQLMemory="<your SQL memory size>" stable/cockroachdb
+    $ helm install --name my-release --set tls.enabled=true,statefulset.resources.requests.memory="<your memory allocation>",conf.cache="<your cache size>",conf.max-sql-memory="<your SQL memory size>" stable/cockroachdb
     ~~~
 
     Behind the scenes, this command uses our `cockroachdb-statefulset.yaml` file to create the StatefulSet that automatically creates 3 pods, each with a CockroachDB node running inside it, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart.
@@ -73,16 +28,16 @@
     {{site.data.alerts.callout_danger}}
     To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes.
 
-    We recommend setting `CacheSize` and `MaxSQLMemory` each to 1/4 of the memory allocation specified in your `Resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
+    We recommend setting `conf.cache` and `conf.max-sql-memory` each to 1/4 of the memory allocation specified in your `statefulset.resources.requests.memory` parameter. For example, if you are allocating 8GiB of memory to each CockroachDB node, use the following values with the `--set` flag in the `helm install` command:
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    Requests.resources.memory="8GiB",CacheSize="2GiB",MaxSQLMemory="2GiB"
+    statefulset.resources.requests.memory="8GiB",conf.cache="2GiB",conf.max-sql-memory="2GiB"
     ~~~
 
     {{site.data.alerts.callout_info}}
-    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `Storage` and `StorageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `StorageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
+    You can customize your deployment by passing additional [configuration parameters](https://github.com/helm/charts/tree/master/stable/cockroachdb#configuration) to `helm install` using the `--set key=value[,key=value]` flag. For a production cluster, you should consider modifying the `storage.persistentVolume.size` and `storage.persistentVolume.storageClass` parameters. This chart defaults to 100 GiB of disk space per pod, but you may want more or less depending on your use case, and the default persistent volume `storage.persistentVolume.storageClass` in your environment may not be what you want for a database (e.g., on GCE and Azure the default is not SSD).
     {{site.data.alerts.end}}
 
 4. As each pod is created, it issues a Certificate Signing Request, or CSR, to have the CockroachDB node's certificate signed by the Kubernetes CA. You must manually check and approve each node's certificate, at which point the CockroachDB node is started in the pod.

--- a/v19.2/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v19.2/orchestrate-a-local-cluster-with-kubernetes.md
@@ -71,7 +71,7 @@ To start your CockroachDB cluster, you can either use our StatefulSet configurat
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=4 \
+    --set statefulset.replicas=4 \
     --reuse-values
     ~~~
 

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -140,7 +140,7 @@ To shut down the CockroachDB cluster:
     <section class="filter-content" markdown="1" data-scope="helm">
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm delete my-release --purge
+    $ helm uninstall my-release
     ~~~
 
     ~~~

--- a/v20.1/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v20.1/orchestrate-a-local-cluster-with-kubernetes.md
@@ -71,7 +71,7 @@ To start your CockroachDB cluster, you can either use our StatefulSet configurat
     $ helm upgrade \
     my-release \
     stable/cockroachdb \
-    --set Replicas=4 \
+    --set statefulset.replicas=4 \
     --reuse-values
     ~~~
 

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -140,7 +140,7 @@ To shut down the CockroachDB cluster:
     <section class="filter-content" markdown="1" data-scope="helm">
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ helm delete my-release --purge
+    $ helm uninstall my-release
     ~~~
 
     ~~~


### PR DESCRIPTION
Following from https://github.com/helm/charts/pull/18993

- Use values from `^3.0` `stable/cockroachdb` Helm chart for `19.2` and onwards
- Use Helm 3 for `19.2` and onwards
- Set links to `^2.0` `stable/cockroachdb` Helm chart for `19.1` and previous
- Fix links to Helm 2 docs for `19.1` and previous (actually not, as the docs itself are broken and appropriate sections are missing, but now lead to correct site, at least).