### PR TITLE
Update locality-and-replication-zones.md

### DIFF
--- a/v19.2/training/locality-and-replication-zones.md
+++ b/v19.2/training/locality-and-replication-zones.md
@@ -355,7 +355,7 @@ Now verify that the data for the table in the `intro` database is located on US-
     ~~~ shell
     $ cockroach sql \
     --insecure \
-    --host=127.0.0.1:54942 \
+    --host=localhost:26257 \
     --execute="SHOW RANGES FROM TABLE intro.mytable;" \
     --execute="SHOW RANGES FROM TABLE startrek.episodes;" \
     --execute="SHOW RANGES FROM TABLE startrek.quotes;"    


### PR DESCRIPTION
There's no node in the tutorial with port `54942` making the query fail
```
cockroach sql --insecure --host=127.0.0.1:54942 --execute="SHOW RANGES FROM TABLE intro.mytable;" --execute="SHOW RANGES FROM TABLE startrek.episodes;" --execute="SHOW RANGES FROM TABLE startrek.quotes;"
Error: cannot dial server.
Is the server running?
If the server is running, check --host client-side and --advertise server-side.

dial tcp 127.0.0.1:54942: connect: connection refused
Failed running "sql"
```