### PR TITLE
cmd to delete cockroachdb-client-secure is missing

### DIFF
--- a/v19.2/training/orchestration-with-kubernetes.md
+++ b/v19.2/training/orchestration-with-kubernetes.md
@@ -500,6 +500,11 @@ $ kubectl delete job.batch/cluster-init-secure
 
 {% include copy-clipboard.html %}
 ~~~ shell
+$ kubectl delete pod cockroachdb-client-secure
+~~~
+
+{% include copy-clipboard.html %}
+~~~ shell
 $ minikube delete
 ~~~
 

--- a/v20.1/training/orchestration-with-kubernetes.md
+++ b/v20.1/training/orchestration-with-kubernetes.md
@@ -500,6 +500,10 @@ $ kubectl delete job.batch/cluster-init-secure
 
 {% include copy-clipboard.html %}
 ~~~ shell
+$ kubectl delete pod cockroachdb-client-secure
+
+{% include copy-clipboard.html %}
+~~~ shell
 $ minikube delete
 ~~~
 


### PR DESCRIPTION
Instructions mention an option to delete client pod but if one chooses to skip the step, there's an additional pod lingering in the clean up step. This adds an explicit step to delete the pod.