### PR TITLE
Clarify go compiler version requirements for all releases.

### DIFF
--- a/v19.1/install-cockroachdb-linux.html
+++ b/v19.1/install-cockroachdb-linux.html
@@ -130,7 +130,10 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.11.6 or higher is required.</td>
+          <td>Version 1.11.6+. Older go versions might work by doing
+            <code>make build IGNORE_GOVERS=1</code>,
+            but you're on your own. 1.12 and above is not recommended.
+          </td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v19.1/install-cockroachdb-mac.html
+++ b/v19.1/install-cockroachdb-mac.html
@@ -119,7 +119,10 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.11.6.</td>
+          <td>Version 1.11.6+. Older go versions might work by doing
+            <code>make build IGNORE_GOVERS=1</code>,
+            but you're on your own. 1.12 and above is not recommended.
+          </td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v19.2/install-cockroachdb-linux.html
+++ b/v19.2/install-cockroachdb-linux.html
@@ -130,7 +130,10 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.12.12 or higher is required.</td>
+          <td>Version 1.12.12+. Older go versions might work by doing
+            <code>make build IGNORE_GOVERS=1</code>,
+            but you're on your own. 1.13 and above is not recommended.
+          </td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v19.2/install-cockroachdb-mac.html
+++ b/v19.2/install-cockroachdb-mac.html
@@ -156,7 +156,10 @@ If you previously installed CockroachDB via Homebrew before version v19.2.0, run
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.12.12 or higher is required.</td>
+          <td>Version 1.12.12+. Older go versions might work by doing
+            <code>make build IGNORE_GOVERS=1</code>,
+            but you're on your own. 1.13 and above is not recommended.
+          </td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v2.0/install-cockroachdb.html
+++ b/v2.0/install-cockroachdb.html
@@ -149,7 +149,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>Go</td>
-        <td>Version 1.10 or higher is required.</td>
+        <td>Version 1.10.*. 1.11+ is known to not work reliably.</td>
       </tr>
       <tr>
         <td>Bash</td>
@@ -337,7 +337,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>Go</td>
-        <td>Version 1.10 or higher is required.</td>
+        <td>Version 1.10.*. 1.11+ is known to not work reliably.</td>
       </tr>
       <tr>
         <td>Bash</td>

--- a/v2.1/install-cockroachdb-linux.html
+++ b/v2.1/install-cockroachdb-linux.html
@@ -130,7 +130,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.10 or higher is required.</td>
+          <td>Version 1.10.*. 1.11+ is not recommended.</td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v2.1/install-cockroachdb-mac.html
+++ b/v2.1/install-cockroachdb-mac.html
@@ -158,7 +158,7 @@ If you previously installed CockroachDB using a different method, you may need t
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.10 or higher is required.</td>
+          <td>Version 1.10.*. 1.11+ is not recommended.</td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v20.1/install-cockroachdb-linux.html
+++ b/v20.1/install-cockroachdb-linux.html
@@ -130,7 +130,10 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.12.12 or higher is required.</td>
+          <td>Version 1.12.12+ or 1.13.4+. Older go versions might work by doing
+            <code>make build IGNORE_GOVERS=1</code>,
+            but you're on your own. 1.14 and above is not recommended.
+          </td>
         </tr>
         <tr>
           <td>Bash</td>

--- a/v20.1/install-cockroachdb-mac.html
+++ b/v20.1/install-cockroachdb-mac.html
@@ -156,7 +156,10 @@ If you previously installed CockroachDB using a different method, you may need t
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.12.12 or higher is required.</td>
+          <td>Version 1.12.12+ or 1.13.4+. Older go versions might work by doing
+            <code>make build IGNORE_GOVERS=1</code>,
+            but you're on your own. 1.14 and above is not recommended.
+          </td>
         </tr>
         <tr>
           <td>Bash</td>


### PR DESCRIPTION
Fixes #6097