### PR TITLE
Fix diagrams for 'table_name @ index_name' syntax

### DIFF
--- a/_includes/v19.1/sql/diagrams/drop_index.html
+++ b/_includes/v19.1/sql/diagrams/drop_index.html
@@ -1,34 +1,31 @@
-<div><svg width="686" height="198">
+<div><svg width="705" height="199">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">DROP</text>
-<rect x="109" y="3" width="62" height="32" rx="10"></rect>
-<rect x="107" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<rect x="109" y="3" width="64" height="32" rx="10"></rect>
+<rect x="107" y="1" width="64" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="117" y="21">INDEX</text>
-<rect x="211" y="35" width="34" height="32" rx="10"></rect>
-<rect x="209" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="219" y="53">IF</text>
-<rect x="265" y="35" width="68" height="32" rx="10"></rect>
-<rect x="263" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="273" y="53">EXISTS</text>
-<rect x="373" y="3" width="90" height="32"></rect>
-<rect x="371" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="21">table_name</text>
-<rect x="503" y="35" width="30" height="32" rx="10"></rect>
-<rect x="501" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="511" y="53">@</text>
-<rect x="553" y="35" width="92" height="32"></rect>
-<rect x="551" y="33" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="561" y="53">index_name</text>
-<rect x="553" y="121" width="82" height="32" rx="10"></rect>
-<rect x="551" y="119" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="139">CASCADE</text>
-<rect x="553" y="165" width="86" height="32" rx="10"></rect>
-<rect x="551" y="163" width="86" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="183">RESTRICT</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-<polygon points="677 103 685 99 685 107"></polygon>
-<polygon points="677 103 669 99 669 107"></polygon>
-</svg></div>
+<rect x="213" y="35" width="34" height="32" rx="10"></rect>
+<rect x="211" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="221" y="53">IF</text>
+<rect x="267" y="35" width="70" height="32" rx="10"></rect>
+<rect x="265" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="275" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="397" y="35" width="96" height="32"></rect>
+<rect x="395" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="405" y="53">table_name</text></a><rect x="513" y="35" width="32" height="32" rx="10"></rect>
+<rect x="511" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="521" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="585" y="3" width="98" height="32"></rect>
+<rect x="583" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="21">index_name</text></a><rect x="569" y="121" width="84" height="32" rx="10"></rect>
+<rect x="567" y="119" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="139">CASCADE</text>
+<rect x="569" y="165" width="88" height="32" rx="10"></rect>
+<rect x="567" y="163" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="183">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="695 103 703 99 703 107"></polygon>
+<polygon points="695 103 687 99 687 107"></polygon></svg></div>

--- a/_includes/v19.1/sql/diagrams/rename_index.html
+++ b/_includes/v19.1/sql/diagrams/rename_index.html
@@ -1,44 +1,33 @@
-<div><svg width="700" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="53">IF</text>
-         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="277" y="53">EXISTS</text>
-         
-            <rect x="377" y="3" width="94" height="32"></rect>
-            <rect x="375" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="385" y="21">table_name</text>
-         
-         <rect x="511" y="35" width="32" height="32" rx="10"></rect>
-         <rect x="509" y="33" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="53">@</text>
-         
-            <rect x="563" y="35" width="96" height="32"></rect>
-            <rect x="561" y="33" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="571" y="53">index_name</text>
-         
-         <rect x="467" y="101" width="74" height="32" rx="10"></rect>
-         <rect x="465" y="99" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="475" y="119">RENAME</text>
-         <rect x="561" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="559" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="569" y="119">TO</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="619" y="101" width="54" height="32"></rect>
-            <rect x="617" y="99" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="627" y="119">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m32 0 h10 m0 0 h10 m96 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-256 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="691 115 699 111 699 119"></polygon>
-         <polygon points="691 115 683 111 683 119"></polygon>
-      </svg></div>
+<div><svg width="709" height="135">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="35" width="34" height="32" rx="10"></rect>
+<rect x="215" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="225" y="53">IF</text>
+<rect x="271" y="35" width="70" height="32" rx="10"></rect>
+<rect x="269" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="279" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="401" y="35" width="96" height="32"></rect>
+<rect x="399" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="409" y="53">table_name</text></a><rect x="517" y="35" width="32" height="32" rx="10"></rect>
+<rect x="515" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="589" y="3" width="98" height="32"></rect>
+<rect x="587" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="597" y="21">index_name</text></a><rect x="429" y="101" width="76" height="32" rx="10"></rect>
+<rect x="427" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="437" y="119">RENAME</text>
+<rect x="525" y="101" width="38" height="32" rx="10"></rect>
+<rect x="523" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="533" y="119">TO</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="583" y="101" width="98" height="32"></rect>
+<rect x="581" y="99" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="591" y="119">index_name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-302 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m98 0 h10 m3 0 h-3"></path>
+<polygon points="699 115 707 111 707 119"></polygon>
+<polygon points="699 115 691 111 691 119"></polygon></svg></div>

--- a/_includes/v19.1/sql/diagrams/split_index_at.html
+++ b/_includes/v19.1/sql/diagrams/split_index_at.html
@@ -1,38 +1,35 @@
-<div><svg width="646" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         
-            <rect x="195" y="3" width="90" height="32"></rect>
-            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="21">table_name</text>
-         
-         <rect x="325" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="323" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="53">@</text>
-         
-            <rect x="375" y="35" width="92" height="32"></rect>
-            <rect x="373" y="33" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="383" y="53">index_name</text>
-         
-         <rect x="507" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="505" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="515" y="21">SPLIT</text>
-         <rect x="587" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="585" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="595" y="21">AT</text>
-         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-            <rect x="529" y="101" width="90" height="32"></rect>
-            <rect x="527" y="99" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="119">select_stmt</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="637 115 645 111 645 119"></polygon>
-         <polygon points="637 115 629 111 629 119"></polygon>
-      </svg></div>
+<div><svg width="663" height="167">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
+<rect x="521" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="531" y="21">SPLIT</text>
+<rect x="603" y="3" width="38" height="32" rx="10"></rect>
+<rect x="601" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="611" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="213" y="101" width="94" height="32"></rect>
+<rect x="211" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="221" y="119">select_stmt</text></a><rect x="347" y="133" width="58" height="32" rx="10"></rect>
+<rect x="345" y="131" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="151">WITH</text>
+<rect x="425" y="133" width="106" height="32" rx="10"></rect>
+<rect x="423" y="131" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="151">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="551" y="133" width="64" height="32"></rect>
+<rect x="549" y="131" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="151">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="653 115 661 111 661 119"></polygon>
+<polygon points="653 115 645 111 645 119"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/alter_index_partition_by.html
+++ b/_includes/v19.2/sql/diagrams/alter_index_partition_by.html
@@ -13,14 +13,14 @@
 <rect x="273" y="35" width="70" height="32" rx="10"></rect>
 <rect x="271" y="33" width="70" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="281" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="383" y="3" width="96" height="32"></rect>
-<rect x="381" y="1" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="391" y="21">table_name</text></a><rect x="499" y="3" width="32" height="32" rx="10"></rect>
-<rect x="497" y="1" width="32" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="507" y="21">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
-<rect x="551" y="3" width="98" height="32"></rect>
-<rect x="549" y="1" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="559" y="21">index_name</text></a><rect x="45" y="145" width="98" height="32" rx="10"></rect>
+<rect x="403" y="35" width="96" height="32"></rect>
+<rect x="401" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="411" y="53">table_name</text></a><rect x="519" y="35" width="32" height="32" rx="10"></rect>
+<rect x="517" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="527" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="591" y="3" width="98" height="32"></rect>
+<rect x="589" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="599" y="21">index_name</text></a><rect x="45" y="145" width="98" height="32" rx="10"></rect>
 <rect x="43" y="143" width="98" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="53" y="163">PARTITION</text>
 <rect x="163" y="145" width="38" height="32" rx="10"></rect>
@@ -67,6 +67,6 @@
 <rect x="45" y="101" width="24" height="32" rx="10"></rect>
 <rect x="43" y="99" width="24" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="53" y="119">,</text>
-<path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-668 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m0 0 h10 m38 0 h10 m40 0 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-492 0 h20 m472 0 h20 m-512 0 q10 0 10 10 m492 0 q0 -10 10 -10 m-502 10 v24 m492 0 v-24 m-492 24 q0 10 10 10 m472 0 q10 0 10 -10 m-482 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 -44 h10 m26 0 h10 m-578 0 h20 m558 0 h20 m-598 0 q10 0 10 10 m578 0 q0 -10 10 -10 m-588 10 v68 m578 0 v-68 m-578 68 q0 10 10 10 m558 0 q10 0 10 -10 m-568 10 h10 m86 0 h10 m0 0 h452 m-774 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m774 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-774 0 h10 m24 0 h10 m0 0 h730 m23 44 h-3"></path>
+<path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-708 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m0 0 h10 m38 0 h10 m40 0 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-492 0 h20 m472 0 h20 m-512 0 q10 0 10 10 m492 0 q0 -10 10 -10 m-502 10 v24 m492 0 v-24 m-492 24 q0 10 10 10 m472 0 q10 0 10 -10 m-482 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 -44 h10 m26 0 h10 m-578 0 h20 m558 0 h20 m-598 0 q10 0 10 10 m578 0 q0 -10 10 -10 m-588 10 v68 m578 0 v-68 m-578 68 q0 10 10 10 m558 0 q10 0 10 -10 m-568 10 h10 m86 0 h10 m0 0 h452 m-774 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m774 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-774 0 h10 m24 0 h10 m0 0 h730 m23 44 h-3"></path>
 <polygon points="837 159 845 155 845 163"></polygon>
 <polygon points="837 159 829 155 829 163"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/drop_index.html
+++ b/_includes/v19.2/sql/diagrams/drop_index.html
@@ -1,34 +1,31 @@
-<div><svg width="686" height="198">
+<div><svg width="705" height="199">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">DROP</text>
-<rect x="109" y="3" width="62" height="32" rx="10"></rect>
-<rect x="107" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<rect x="109" y="3" width="64" height="32" rx="10"></rect>
+<rect x="107" y="1" width="64" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="117" y="21">INDEX</text>
-<rect x="211" y="35" width="34" height="32" rx="10"></rect>
-<rect x="209" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="219" y="53">IF</text>
-<rect x="265" y="35" width="68" height="32" rx="10"></rect>
-<rect x="263" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="273" y="53">EXISTS</text>
-<rect x="373" y="3" width="90" height="32"></rect>
-<rect x="371" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="21">table_name</text>
-<rect x="503" y="35" width="30" height="32" rx="10"></rect>
-<rect x="501" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="511" y="53">@</text>
-<rect x="553" y="35" width="92" height="32"></rect>
-<rect x="551" y="33" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="561" y="53">index_name</text>
-<rect x="553" y="121" width="82" height="32" rx="10"></rect>
-<rect x="551" y="119" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="139">CASCADE</text>
-<rect x="553" y="165" width="86" height="32" rx="10"></rect>
-<rect x="551" y="163" width="86" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="183">RESTRICT</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-<polygon points="677 103 685 99 685 107"></polygon>
-<polygon points="677 103 669 99 669 107"></polygon>
-</svg></div>
+<rect x="213" y="35" width="34" height="32" rx="10"></rect>
+<rect x="211" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="221" y="53">IF</text>
+<rect x="267" y="35" width="70" height="32" rx="10"></rect>
+<rect x="265" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="275" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="397" y="35" width="96" height="32"></rect>
+<rect x="395" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="405" y="53">table_name</text></a><rect x="513" y="35" width="32" height="32" rx="10"></rect>
+<rect x="511" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="521" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="585" y="3" width="98" height="32"></rect>
+<rect x="583" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="21">index_name</text></a><rect x="569" y="121" width="84" height="32" rx="10"></rect>
+<rect x="567" y="119" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="139">CASCADE</text>
+<rect x="569" y="165" width="88" height="32" rx="10"></rect>
+<rect x="567" y="163" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="183">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="695 103 703 99 703 107"></polygon>
+<polygon points="695 103 687 99 687 107"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/rename_index.html
+++ b/_includes/v19.2/sql/diagrams/rename_index.html
@@ -1,44 +1,33 @@
-<div><svg width="700" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="53">IF</text>
-         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="277" y="53">EXISTS</text>
-         
-            <rect x="377" y="3" width="94" height="32"></rect>
-            <rect x="375" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="385" y="21">table_name</text>
-         
-         <rect x="511" y="35" width="32" height="32" rx="10"></rect>
-         <rect x="509" y="33" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="53">@</text>
-         
-            <rect x="563" y="35" width="96" height="32"></rect>
-            <rect x="561" y="33" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="571" y="53">index_name</text>
-         
-         <rect x="467" y="101" width="74" height="32" rx="10"></rect>
-         <rect x="465" y="99" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="475" y="119">RENAME</text>
-         <rect x="561" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="559" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="569" y="119">TO</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="619" y="101" width="54" height="32"></rect>
-            <rect x="617" y="99" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="627" y="119">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m32 0 h10 m0 0 h10 m96 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-256 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="691 115 699 111 699 119"></polygon>
-         <polygon points="691 115 683 111 683 119"></polygon>
-      </svg></div>
+<div><svg width="709" height="135">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="35" width="34" height="32" rx="10"></rect>
+<rect x="215" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="225" y="53">IF</text>
+<rect x="271" y="35" width="70" height="32" rx="10"></rect>
+<rect x="269" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="279" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="401" y="35" width="96" height="32"></rect>
+<rect x="399" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="409" y="53">table_name</text></a><rect x="517" y="35" width="32" height="32" rx="10"></rect>
+<rect x="515" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="589" y="3" width="98" height="32"></rect>
+<rect x="587" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="597" y="21">index_name</text></a><rect x="429" y="101" width="76" height="32" rx="10"></rect>
+<rect x="427" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="437" y="119">RENAME</text>
+<rect x="525" y="101" width="38" height="32" rx="10"></rect>
+<rect x="523" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="533" y="119">TO</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="583" y="101" width="98" height="32"></rect>
+<rect x="581" y="99" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="591" y="119">index_name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-302 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m98 0 h10 m3 0 h-3"></path>
+<polygon points="699 115 707 111 707 119"></polygon>
+<polygon points="699 115 691 111 691 119"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/split_index_at.html
+++ b/_includes/v19.2/sql/diagrams/split_index_at.html
@@ -1,4 +1,4 @@
-<div><svg width="663" height="179">
+<div><svg width="663" height="167">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="62" height="32" rx="10"></rect>
@@ -6,33 +6,30 @@
 <text class="terminal" x="39" y="21">ALTER</text>
 <rect x="113" y="3" width="64" height="32" rx="10"></rect>
 <rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="121" y="21">INDEX</text>
-<rect x="217" y="3" width="96" height="32"></rect>
-<rect x="215" y="1" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="21">table_name</text><rect x="333" y="3" width="32" height="32" rx="10"></rect>
-<rect x="331" y="1" width="32" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="341" y="21">@</text>
-<rect x="385" y="3" width="98" height="32"></rect>
-<rect x="383" y="1" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="393" y="21">index_name</text><a xlink:href="sql-grammar.html#standalone_index_name" xlink:title="standalone_index_name">
-<rect x="217" y="47" width="176" height="32"></rect>
-<rect x="215" y="45" width="176" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="65">standalone_index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
 <rect x="521" y="1" width="60" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="531" y="21">SPLIT</text>
 <rect x="603" y="3" width="38" height="32" rx="10"></rect>
 <rect x="601" y="1" width="38" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="611" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="213" y="113" width="94" height="32"></rect>
-<rect x="211" y="111" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="221" y="131">select_stmt</text></a><rect x="347" y="145" width="58" height="32" rx="10"></rect>
-<rect x="345" y="143" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="355" y="163">WITH</text>
-<rect x="425" y="145" width="106" height="32" rx="10"></rect>
-<rect x="423" y="143" width="106" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="163">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-<rect x="551" y="145" width="64" height="32"></rect>
-<rect x="549" y="143" width="64" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="559" y="163">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m176 0 h10 m0 0 h90 m20 -44 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
-<polygon points="653 127 661 123 661 131"></polygon>
-<polygon points="653 127 645 123 645 131"></polygon></svg></div>
+<rect x="213" y="101" width="94" height="32"></rect>
+<rect x="211" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="221" y="119">select_stmt</text></a><rect x="347" y="133" width="58" height="32" rx="10"></rect>
+<rect x="345" y="131" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="151">WITH</text>
+<rect x="425" y="133" width="106" height="32" rx="10"></rect>
+<rect x="423" y="131" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="151">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="551" y="133" width="64" height="32"></rect>
+<rect x="549" y="131" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="151">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="653 115 661 111 661 119"></polygon>
+<polygon points="653 115 645 111 645 119"></polygon></svg></div>

--- a/_includes/v19.2/sql/diagrams/unsplit_index_at.html
+++ b/_includes/v19.2/sql/diagrams/unsplit_index_at.html
@@ -1,4 +1,4 @@
-<div><svg width="625" height="191">
+<div><svg width="625" height="179">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="62" height="32" rx="10"></rect>
@@ -6,28 +6,25 @@
 <text class="terminal" x="39" y="21">ALTER</text>
 <rect x="113" y="3" width="64" height="32" rx="10"></rect>
 <rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="121" y="21">INDEX</text>
-<rect x="217" y="3" width="96" height="32"></rect>
-<rect x="215" y="1" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="21">table_name</text><rect x="333" y="3" width="32" height="32" rx="10"></rect>
-<rect x="331" y="1" width="32" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="341" y="21">@</text>
-<rect x="385" y="3" width="98" height="32"></rect>
-<rect x="383" y="1" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="393" y="21">index_name</text><a xlink:href="sql-grammar.html#standalone_index_name" xlink:title="standalone_index_name">
-<rect x="217" y="47" width="176" height="32"></rect>
-<rect x="215" y="45" width="176" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="65">standalone_index_name</text></a><rect x="523" y="3" width="80" height="32" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="80" height="32" rx="10"></rect>
 <rect x="521" y="1" width="80" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="531" y="21">UNSPLIT</text>
-<rect x="425" y="113" width="38" height="32" rx="10"></rect>
-<rect x="423" y="111" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="131">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="483" y="113" width="94" height="32"></rect>
-<rect x="481" y="111" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="491" y="131">select_stmt</text></a><rect x="425" y="157" width="44" height="32" rx="10"></rect>
-<rect x="423" y="155" width="44" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="175">ALL</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m176 0 h10 m0 0 h90 m20 -44 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-242 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m44 0 h10 m0 0 h108 m23 -44 h-3"></path>
-<polygon points="615 127 623 123 623 131"></polygon>
-<polygon points="615 127 607 123 607 131"></polygon></svg></div>
+<rect x="425" y="101" width="38" height="32" rx="10"></rect>
+<rect x="423" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="119">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="483" y="101" width="94" height="32"></rect>
+<rect x="481" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="491" y="119">select_stmt</text></a><rect x="425" y="145" width="44" height="32" rx="10"></rect>
+<rect x="423" y="143" width="44" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="163">ALL</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-242 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m44 0 h10 m0 0 h108 m23 -44 h-3"></path>
+<polygon points="615 115 623 111 623 119"></polygon>
+<polygon points="615 115 607 111 607 119"></polygon></svg></div>

--- a/_includes/v2.0/sql/diagrams/drop_index.html
+++ b/_includes/v2.0/sql/diagrams/drop_index.html
@@ -1,34 +1,31 @@
-<div><svg width="686" height="198">
+<div><svg width="705" height="199">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">DROP</text>
-<rect x="109" y="3" width="62" height="32" rx="10"></rect>
-<rect x="107" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<rect x="109" y="3" width="64" height="32" rx="10"></rect>
+<rect x="107" y="1" width="64" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="117" y="21">INDEX</text>
-<rect x="211" y="35" width="34" height="32" rx="10"></rect>
-<rect x="209" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="219" y="53">IF</text>
-<rect x="265" y="35" width="68" height="32" rx="10"></rect>
-<rect x="263" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="273" y="53">EXISTS</text>
-<rect x="373" y="3" width="90" height="32"></rect>
-<rect x="371" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="21">table_name</text>
-<rect x="503" y="35" width="30" height="32" rx="10"></rect>
-<rect x="501" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="511" y="53">@</text>
-<rect x="553" y="35" width="92" height="32"></rect>
-<rect x="551" y="33" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="561" y="53">index_name</text>
-<rect x="553" y="121" width="82" height="32" rx="10"></rect>
-<rect x="551" y="119" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="139">CASCADE</text>
-<rect x="553" y="165" width="86" height="32" rx="10"></rect>
-<rect x="551" y="163" width="86" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="183">RESTRICT</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-<polygon points="677 103 685 99 685 107"></polygon>
-<polygon points="677 103 669 99 669 107"></polygon>
-</svg></div>
+<rect x="213" y="35" width="34" height="32" rx="10"></rect>
+<rect x="211" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="221" y="53">IF</text>
+<rect x="267" y="35" width="70" height="32" rx="10"></rect>
+<rect x="265" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="275" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="397" y="35" width="96" height="32"></rect>
+<rect x="395" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="405" y="53">table_name</text></a><rect x="513" y="35" width="32" height="32" rx="10"></rect>
+<rect x="511" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="521" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="585" y="3" width="98" height="32"></rect>
+<rect x="583" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="21">index_name</text></a><rect x="569" y="121" width="84" height="32" rx="10"></rect>
+<rect x="567" y="119" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="139">CASCADE</text>
+<rect x="569" y="165" width="88" height="32" rx="10"></rect>
+<rect x="567" y="163" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="183">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="695 103 703 99 703 107"></polygon>
+<polygon points="695 103 687 99 687 107"></polygon></svg></div>

--- a/_includes/v2.0/sql/diagrams/rename_index.html
+++ b/_includes/v2.0/sql/diagrams/rename_index.html
@@ -1,44 +1,33 @@
-<div><svg width="700" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="53">IF</text>
-         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="277" y="53">EXISTS</text>
-         
-            <rect x="377" y="3" width="94" height="32"></rect>
-            <rect x="375" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="385" y="21">table_name</text>
-         
-         <rect x="511" y="35" width="32" height="32" rx="10"></rect>
-         <rect x="509" y="33" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="53">@</text>
-         
-            <rect x="563" y="35" width="96" height="32"></rect>
-            <rect x="561" y="33" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="571" y="53">index_name</text>
-         
-         <rect x="467" y="101" width="74" height="32" rx="10"></rect>
-         <rect x="465" y="99" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="475" y="119">RENAME</text>
-         <rect x="561" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="559" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="569" y="119">TO</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="619" y="101" width="54" height="32"></rect>
-            <rect x="617" y="99" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="627" y="119">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m32 0 h10 m0 0 h10 m96 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-256 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="691 115 699 111 699 119"></polygon>
-         <polygon points="691 115 683 111 683 119"></polygon>
-      </svg></div>
+<div><svg width="709" height="135">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="35" width="34" height="32" rx="10"></rect>
+<rect x="215" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="225" y="53">IF</text>
+<rect x="271" y="35" width="70" height="32" rx="10"></rect>
+<rect x="269" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="279" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="401" y="35" width="96" height="32"></rect>
+<rect x="399" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="409" y="53">table_name</text></a><rect x="517" y="35" width="32" height="32" rx="10"></rect>
+<rect x="515" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="589" y="3" width="98" height="32"></rect>
+<rect x="587" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="597" y="21">index_name</text></a><rect x="429" y="101" width="76" height="32" rx="10"></rect>
+<rect x="427" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="437" y="119">RENAME</text>
+<rect x="525" y="101" width="38" height="32" rx="10"></rect>
+<rect x="523" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="533" y="119">TO</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="583" y="101" width="98" height="32"></rect>
+<rect x="581" y="99" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="591" y="119">index_name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-302 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m98 0 h10 m3 0 h-3"></path>
+<polygon points="699 115 707 111 707 119"></polygon>
+<polygon points="699 115 691 111 691 119"></polygon></svg></div>

--- a/_includes/v2.0/sql/diagrams/split_index_at.html
+++ b/_includes/v2.0/sql/diagrams/split_index_at.html
@@ -1,38 +1,35 @@
-<div><svg width="646" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         
-            <rect x="195" y="3" width="90" height="32"></rect>
-            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="21">table_name</text>
-         
-         <rect x="325" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="323" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="53">@</text>
-         
-            <rect x="375" y="35" width="92" height="32"></rect>
-            <rect x="373" y="33" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="383" y="53">index_name</text>
-         
-         <rect x="507" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="505" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="515" y="21">SPLIT</text>
-         <rect x="587" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="585" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="595" y="21">AT</text>
-         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-            <rect x="529" y="101" width="90" height="32"></rect>
-            <rect x="527" y="99" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="119">select_stmt</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="637 115 645 111 645 119"></polygon>
-         <polygon points="637 115 629 111 629 119"></polygon>
-      </svg></div>
+<div><svg width="663" height="167">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
+<rect x="521" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="531" y="21">SPLIT</text>
+<rect x="603" y="3" width="38" height="32" rx="10"></rect>
+<rect x="601" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="611" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="213" y="101" width="94" height="32"></rect>
+<rect x="211" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="221" y="119">select_stmt</text></a><rect x="347" y="133" width="58" height="32" rx="10"></rect>
+<rect x="345" y="131" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="151">WITH</text>
+<rect x="425" y="133" width="106" height="32" rx="10"></rect>
+<rect x="423" y="131" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="151">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="551" y="133" width="64" height="32"></rect>
+<rect x="549" y="131" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="151">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="653 115 661 111 661 119"></polygon>
+<polygon points="653 115 645 111 645 119"></polygon></svg></div>

--- a/_includes/v2.1/sql/diagrams/drop_index.html
+++ b/_includes/v2.1/sql/diagrams/drop_index.html
@@ -1,34 +1,31 @@
-<div><svg width="686" height="198">
+<div><svg width="705" height="199">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">DROP</text>
-<rect x="109" y="3" width="62" height="32" rx="10"></rect>
-<rect x="107" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<rect x="109" y="3" width="64" height="32" rx="10"></rect>
+<rect x="107" y="1" width="64" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="117" y="21">INDEX</text>
-<rect x="211" y="35" width="34" height="32" rx="10"></rect>
-<rect x="209" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="219" y="53">IF</text>
-<rect x="265" y="35" width="68" height="32" rx="10"></rect>
-<rect x="263" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="273" y="53">EXISTS</text>
-<rect x="373" y="3" width="90" height="32"></rect>
-<rect x="371" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="21">table_name</text>
-<rect x="503" y="35" width="30" height="32" rx="10"></rect>
-<rect x="501" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="511" y="53">@</text>
-<rect x="553" y="35" width="92" height="32"></rect>
-<rect x="551" y="33" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="561" y="53">index_name</text>
-<rect x="553" y="121" width="82" height="32" rx="10"></rect>
-<rect x="551" y="119" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="139">CASCADE</text>
-<rect x="553" y="165" width="86" height="32" rx="10"></rect>
-<rect x="551" y="163" width="86" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="183">RESTRICT</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-<polygon points="677 103 685 99 685 107"></polygon>
-<polygon points="677 103 669 99 669 107"></polygon>
-</svg></div>
+<rect x="213" y="35" width="34" height="32" rx="10"></rect>
+<rect x="211" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="221" y="53">IF</text>
+<rect x="267" y="35" width="70" height="32" rx="10"></rect>
+<rect x="265" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="275" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="397" y="35" width="96" height="32"></rect>
+<rect x="395" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="405" y="53">table_name</text></a><rect x="513" y="35" width="32" height="32" rx="10"></rect>
+<rect x="511" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="521" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="585" y="3" width="98" height="32"></rect>
+<rect x="583" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="21">index_name</text></a><rect x="569" y="121" width="84" height="32" rx="10"></rect>
+<rect x="567" y="119" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="139">CASCADE</text>
+<rect x="569" y="165" width="88" height="32" rx="10"></rect>
+<rect x="567" y="163" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="183">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="695 103 703 99 703 107"></polygon>
+<polygon points="695 103 687 99 687 107"></polygon></svg></div>

--- a/_includes/v2.1/sql/diagrams/rename_index.html
+++ b/_includes/v2.1/sql/diagrams/rename_index.html
@@ -1,44 +1,33 @@
-<div><svg width="700" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="53">IF</text>
-         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="277" y="53">EXISTS</text>
-         
-            <rect x="377" y="3" width="94" height="32"></rect>
-            <rect x="375" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="385" y="21">table_name</text>
-         
-         <rect x="511" y="35" width="32" height="32" rx="10"></rect>
-         <rect x="509" y="33" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="53">@</text>
-         
-            <rect x="563" y="35" width="96" height="32"></rect>
-            <rect x="561" y="33" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="571" y="53">index_name</text>
-         
-         <rect x="467" y="101" width="74" height="32" rx="10"></rect>
-         <rect x="465" y="99" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="475" y="119">RENAME</text>
-         <rect x="561" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="559" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="569" y="119">TO</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="619" y="101" width="54" height="32"></rect>
-            <rect x="617" y="99" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="627" y="119">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m32 0 h10 m0 0 h10 m96 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-256 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="691 115 699 111 699 119"></polygon>
-         <polygon points="691 115 683 111 683 119"></polygon>
-      </svg></div>
+<div><svg width="709" height="135">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="35" width="34" height="32" rx="10"></rect>
+<rect x="215" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="225" y="53">IF</text>
+<rect x="271" y="35" width="70" height="32" rx="10"></rect>
+<rect x="269" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="279" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="401" y="35" width="96" height="32"></rect>
+<rect x="399" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="409" y="53">table_name</text></a><rect x="517" y="35" width="32" height="32" rx="10"></rect>
+<rect x="515" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="589" y="3" width="98" height="32"></rect>
+<rect x="587" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="597" y="21">index_name</text></a><rect x="429" y="101" width="76" height="32" rx="10"></rect>
+<rect x="427" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="437" y="119">RENAME</text>
+<rect x="525" y="101" width="38" height="32" rx="10"></rect>
+<rect x="523" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="533" y="119">TO</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="583" y="101" width="98" height="32"></rect>
+<rect x="581" y="99" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="591" y="119">index_name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-302 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m98 0 h10 m3 0 h-3"></path>
+<polygon points="699 115 707 111 707 119"></polygon>
+<polygon points="699 115 691 111 691 119"></polygon></svg></div>

--- a/_includes/v2.1/sql/diagrams/split_index_at.html
+++ b/_includes/v2.1/sql/diagrams/split_index_at.html
@@ -1,38 +1,35 @@
-<div><svg width="646" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         
-            <rect x="195" y="3" width="90" height="32"></rect>
-            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="21">table_name</text>
-         
-         <rect x="325" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="323" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="53">@</text>
-         
-            <rect x="375" y="35" width="92" height="32"></rect>
-            <rect x="373" y="33" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="383" y="53">index_name</text>
-         
-         <rect x="507" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="505" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="515" y="21">SPLIT</text>
-         <rect x="587" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="585" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="595" y="21">AT</text>
-         <a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-            <rect x="529" y="101" width="90" height="32"></rect>
-            <rect x="527" y="99" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="119">select_stmt</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"></path>
-         <polygon points="637 115 645 111 645 119"></polygon>
-         <polygon points="637 115 629 111 629 119"></polygon>
-      </svg></div>
+<div><svg width="663" height="167">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
+<rect x="521" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="531" y="21">SPLIT</text>
+<rect x="603" y="3" width="38" height="32" rx="10"></rect>
+<rect x="601" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="611" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="213" y="101" width="94" height="32"></rect>
+<rect x="211" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="221" y="119">select_stmt</text></a><rect x="347" y="133" width="58" height="32" rx="10"></rect>
+<rect x="345" y="131" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="151">WITH</text>
+<rect x="425" y="133" width="106" height="32" rx="10"></rect>
+<rect x="423" y="131" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="151">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="551" y="133" width="64" height="32"></rect>
+<rect x="549" y="131" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="151">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="653 115 661 111 661 119"></polygon>
+<polygon points="653 115 645 111 645 119"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/alter_index_partition_by.html
+++ b/_includes/v20.1/sql/diagrams/alter_index_partition_by.html
@@ -13,14 +13,14 @@
 <rect x="273" y="35" width="70" height="32" rx="10"></rect>
 <rect x="271" y="33" width="70" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="281" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="383" y="3" width="96" height="32"></rect>
-<rect x="381" y="1" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="391" y="21">table_name</text></a><rect x="499" y="3" width="32" height="32" rx="10"></rect>
-<rect x="497" y="1" width="32" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="507" y="21">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
-<rect x="551" y="3" width="98" height="32"></rect>
-<rect x="549" y="1" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="559" y="21">index_name</text></a><rect x="45" y="145" width="98" height="32" rx="10"></rect>
+<rect x="403" y="35" width="96" height="32"></rect>
+<rect x="401" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="411" y="53">table_name</text></a><rect x="519" y="35" width="32" height="32" rx="10"></rect>
+<rect x="517" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="527" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="591" y="3" width="98" height="32"></rect>
+<rect x="589" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="599" y="21">index_name</text></a><rect x="45" y="145" width="98" height="32" rx="10"></rect>
 <rect x="43" y="143" width="98" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="53" y="163">PARTITION</text>
 <rect x="163" y="145" width="38" height="32" rx="10"></rect>
@@ -67,6 +67,6 @@
 <rect x="45" y="101" width="24" height="32" rx="10"></rect>
 <rect x="43" y="99" width="24" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="53" y="119">,</text>
-<path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-668 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m0 0 h10 m38 0 h10 m40 0 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-492 0 h20 m472 0 h20 m-512 0 q10 0 10 10 m492 0 q0 -10 10 -10 m-502 10 v24 m492 0 v-24 m-492 24 q0 10 10 10 m472 0 q10 0 10 -10 m-482 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 -44 h10 m26 0 h10 m-578 0 h20 m558 0 h20 m-598 0 q10 0 10 10 m578 0 q0 -10 10 -10 m-588 10 v68 m578 0 v-68 m-578 68 q0 10 10 10 m558 0 q10 0 10 -10 m-568 10 h10 m86 0 h10 m0 0 h452 m-774 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m774 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-774 0 h10 m24 0 h10 m0 0 h730 m23 44 h-3"></path>
+<path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-708 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m0 0 h10 m38 0 h10 m40 0 h10 m52 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-492 0 h20 m472 0 h20 m-512 0 q10 0 10 10 m492 0 q0 -10 10 -10 m-502 10 v24 m492 0 v-24 m-492 24 q0 10 10 10 m472 0 q10 0 10 -10 m-482 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 -44 h10 m26 0 h10 m-578 0 h20 m558 0 h20 m-598 0 q10 0 10 10 m578 0 q0 -10 10 -10 m-588 10 v68 m578 0 v-68 m-578 68 q0 10 10 10 m558 0 q10 0 10 -10 m-568 10 h10 m86 0 h10 m0 0 h452 m-774 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m774 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-774 0 h10 m24 0 h10 m0 0 h730 m23 44 h-3"></path>
 <polygon points="837 159 845 155 845 163"></polygon>
 <polygon points="837 159 829 155 829 163"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/drop_index.html
+++ b/_includes/v20.1/sql/diagrams/drop_index.html
@@ -1,34 +1,31 @@
-<div><svg width="686" height="198">
+<div><svg width="705" height="199">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">DROP</text>
-<rect x="109" y="3" width="62" height="32" rx="10"></rect>
-<rect x="107" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<rect x="109" y="3" width="64" height="32" rx="10"></rect>
+<rect x="107" y="1" width="64" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="117" y="21">INDEX</text>
-<rect x="211" y="35" width="34" height="32" rx="10"></rect>
-<rect x="209" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="219" y="53">IF</text>
-<rect x="265" y="35" width="68" height="32" rx="10"></rect>
-<rect x="263" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="273" y="53">EXISTS</text>
-<rect x="373" y="3" width="90" height="32"></rect>
-<rect x="371" y="1" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="21">table_name</text>
-<rect x="503" y="35" width="30" height="32" rx="10"></rect>
-<rect x="501" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="511" y="53">@</text>
-<rect x="553" y="35" width="92" height="32"></rect>
-<rect x="551" y="33" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="561" y="53">index_name</text>
-<rect x="553" y="121" width="82" height="32" rx="10"></rect>
-<rect x="551" y="119" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="139">CASCADE</text>
-<rect x="553" y="165" width="86" height="32" rx="10"></rect>
-<rect x="551" y="163" width="86" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="561" y="183">RESTRICT</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m20 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m30 0 h10 m0 0 h10 m92 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-<polygon points="677 103 685 99 685 107"></polygon>
-<polygon points="677 103 669 99 669 107"></polygon>
-</svg></div>
+<rect x="213" y="35" width="34" height="32" rx="10"></rect>
+<rect x="211" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="221" y="53">IF</text>
+<rect x="267" y="35" width="70" height="32" rx="10"></rect>
+<rect x="265" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="275" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="397" y="35" width="96" height="32"></rect>
+<rect x="395" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="405" y="53">table_name</text></a><rect x="513" y="35" width="32" height="32" rx="10"></rect>
+<rect x="511" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="521" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="585" y="3" width="98" height="32"></rect>
+<rect x="583" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="21">index_name</text></a><rect x="569" y="121" width="84" height="32" rx="10"></rect>
+<rect x="567" y="119" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="139">CASCADE</text>
+<rect x="569" y="165" width="88" height="32" rx="10"></rect>
+<rect x="567" y="163" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="577" y="183">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-178 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="695 103 703 99 703 107"></polygon>
+<polygon points="695 103 687 99 687 107"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/rename_index.html
+++ b/_includes/v20.1/sql/diagrams/rename_index.html
@@ -1,44 +1,33 @@
-<div><svg width="700" height="134">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">INDEX</text>
-         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="53">IF</text>
-         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="277" y="53">EXISTS</text>
-         
-            <rect x="377" y="3" width="94" height="32"></rect>
-            <rect x="375" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="385" y="21">table_name</text>
-         
-         <rect x="511" y="35" width="32" height="32" rx="10"></rect>
-         <rect x="509" y="33" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="53">@</text>
-         
-            <rect x="563" y="35" width="96" height="32"></rect>
-            <rect x="561" y="33" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="571" y="53">index_name</text>
-         
-         <rect x="467" y="101" width="74" height="32" rx="10"></rect>
-         <rect x="465" y="99" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="475" y="119">RENAME</text>
-         <rect x="561" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="559" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="569" y="119">TO</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="619" y="101" width="54" height="32"></rect>
-            <rect x="617" y="99" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="627" y="119">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m32 0 h10 m0 0 h10 m96 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-256 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="691 115 699 111 699 119"></polygon>
-         <polygon points="691 115 683 111 683 119"></polygon>
-      </svg></div>
+<div><svg width="709" height="135">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="64" height="32" rx="10"></rect>
+<rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text>
+<rect x="217" y="35" width="34" height="32" rx="10"></rect>
+<rect x="215" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="225" y="53">IF</text>
+<rect x="271" y="35" width="70" height="32" rx="10"></rect>
+<rect x="269" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="279" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="401" y="35" width="96" height="32"></rect>
+<rect x="399" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="409" y="53">table_name</text></a><rect x="517" y="35" width="32" height="32" rx="10"></rect>
+<rect x="515" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="589" y="3" width="98" height="32"></rect>
+<rect x="587" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="597" y="21">index_name</text></a><rect x="429" y="101" width="76" height="32" rx="10"></rect>
+<rect x="427" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="437" y="119">RENAME</text>
+<rect x="525" y="101" width="38" height="32" rx="10"></rect>
+<rect x="523" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="533" y="119">TO</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="583" y="101" width="98" height="32"></rect>
+<rect x="581" y="99" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="591" y="119">index_name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m40 -32 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-302 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m98 0 h10 m3 0 h-3"></path>
+<polygon points="699 115 707 111 707 119"></polygon>
+<polygon points="699 115 691 111 691 119"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/split_index_at.html
+++ b/_includes/v20.1/sql/diagrams/split_index_at.html
@@ -1,4 +1,4 @@
-<div><svg width="663" height="179">
+<div><svg width="663" height="167">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="62" height="32" rx="10"></rect>
@@ -6,33 +6,30 @@
 <text class="terminal" x="39" y="21">ALTER</text>
 <rect x="113" y="3" width="64" height="32" rx="10"></rect>
 <rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="121" y="21">INDEX</text>
-<rect x="217" y="3" width="96" height="32"></rect>
-<rect x="215" y="1" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="21">table_name</text><rect x="333" y="3" width="32" height="32" rx="10"></rect>
-<rect x="331" y="1" width="32" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="341" y="21">@</text>
-<rect x="385" y="3" width="98" height="32"></rect>
-<rect x="383" y="1" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="393" y="21">index_name</text><a xlink:href="sql-grammar.html#standalone_index_name" xlink:title="standalone_index_name">
-<rect x="217" y="47" width="176" height="32"></rect>
-<rect x="215" y="45" width="176" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="65">standalone_index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="60" height="32" rx="10"></rect>
 <rect x="521" y="1" width="60" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="531" y="21">SPLIT</text>
 <rect x="603" y="3" width="38" height="32" rx="10"></rect>
 <rect x="601" y="1" width="38" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="611" y="21">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="213" y="113" width="94" height="32"></rect>
-<rect x="211" y="111" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="221" y="131">select_stmt</text></a><rect x="347" y="145" width="58" height="32" rx="10"></rect>
-<rect x="345" y="143" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="355" y="163">WITH</text>
-<rect x="425" y="145" width="106" height="32" rx="10"></rect>
-<rect x="423" y="143" width="106" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="163">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-<rect x="551" y="145" width="64" height="32"></rect>
-<rect x="549" y="143" width="64" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="559" y="163">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m176 0 h10 m0 0 h90 m20 -44 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
-<polygon points="653 127 661 123 661 131"></polygon>
-<polygon points="653 127 645 123 645 131"></polygon></svg></div>
+<rect x="213" y="101" width="94" height="32"></rect>
+<rect x="211" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="221" y="119">select_stmt</text></a><rect x="347" y="133" width="58" height="32" rx="10"></rect>
+<rect x="345" y="131" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="151">WITH</text>
+<rect x="425" y="133" width="106" height="32" rx="10"></rect>
+<rect x="423" y="131" width="106" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="151">EXPIRATION</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="551" y="133" width="64" height="32"></rect>
+<rect x="549" y="131" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="151">a_expr</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m20 0 h10 m0 0 h278 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v12 m308 0 v-12 m-308 12 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m58 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+<polygon points="653 115 661 111 661 119"></polygon>
+<polygon points="653 115 645 111 645 119"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/unsplit_index_at.html
+++ b/_includes/v20.1/sql/diagrams/unsplit_index_at.html
@@ -1,4 +1,4 @@
-<div><svg width="625" height="191">
+<div><svg width="625" height="179">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="62" height="32" rx="10"></rect>
@@ -6,28 +6,25 @@
 <text class="terminal" x="39" y="21">ALTER</text>
 <rect x="113" y="3" width="64" height="32" rx="10"></rect>
 <rect x="111" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="121" y="21">INDEX</text>
-<rect x="217" y="3" width="96" height="32"></rect>
-<rect x="215" y="1" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="21">table_name</text><rect x="333" y="3" width="32" height="32" rx="10"></rect>
-<rect x="331" y="1" width="32" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="341" y="21">@</text>
-<rect x="385" y="3" width="98" height="32"></rect>
-<rect x="383" y="1" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="393" y="21">index_name</text><a xlink:href="sql-grammar.html#standalone_index_name" xlink:title="standalone_index_name">
-<rect x="217" y="47" width="176" height="32"></rect>
-<rect x="215" y="45" width="176" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="65">standalone_index_name</text></a><rect x="523" y="3" width="80" height="32" rx="10"></rect>
+<text class="terminal" x="121" y="21">INDEX</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="217" y="35" width="96" height="32"></rect>
+<rect x="215" y="33" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="53">table_name</text></a><rect x="333" y="35" width="32" height="32" rx="10"></rect>
+<rect x="331" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="341" y="53">@</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="405" y="3" width="98" height="32"></rect>
+<rect x="403" y="1" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="413" y="21">index_name</text></a><rect x="523" y="3" width="80" height="32" rx="10"></rect>
 <rect x="521" y="1" width="80" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="531" y="21">UNSPLIT</text>
-<rect x="425" y="113" width="38" height="32" rx="10"></rect>
-<rect x="423" y="111" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="131">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="483" y="113" width="94" height="32"></rect>
-<rect x="481" y="111" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="491" y="131">select_stmt</text></a><rect x="425" y="157" width="44" height="32" rx="10"></rect>
-<rect x="423" y="155" width="44" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="175">ALL</text>
-<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m96 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m98 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m176 0 h10 m0 0 h90 m20 -44 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-242 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m44 0 h10 m0 0 h108 m23 -44 h-3"></path>
-<polygon points="615 127 623 123 623 131"></polygon>
-<polygon points="615 127 607 123 607 131"></polygon></svg></div>
+<rect x="425" y="101" width="38" height="32" rx="10"></rect>
+<rect x="423" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="119">AT</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="483" y="101" width="94" height="32"></rect>
+<rect x="481" y="99" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="491" y="119">select_stmt</text></a><rect x="425" y="145" width="44" height="32" rx="10"></rect>
+<rect x="423" y="143" width="44" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="433" y="163">ALL</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m96 0 h10 m0 0 h10 m32 0 h10 m20 -32 h10 m98 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-242 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m44 0 h10 m0 0 h108 m23 -44 h-3"></path>
+<polygon points="615 115 623 111 623 119"></polygon>
+<polygon points="615 115 607 111 607 119"></polygon></svg></div>


### PR DESCRIPTION
Previously, some of the syntax diagrams would indicate that table_name
was required, and index_name was optional. However, the opposite is true.

fixes #5948