### PR TITLE
config: make htmltest -s work locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ cockroachcloud-build: bootstrap
 cockroachcloud: jekyll-action := serve --port 4001
 cockroachcloud: cockroachcloud-build
 
+.PHONY: htmltest
+htmltest: cockroachdb-build cockroachcloud-build
+	htmltest -s
+
 .PHONY: test
 test: bootstrap
 	go get -u github.com/cockroachdb/htmltest

--- a/_config_cockroachcloud.yml
+++ b/_config_cockroachcloud.yml
@@ -1,6 +1,6 @@
 homepage_title: CockroachCloud Docs
 
-baseurl: "/docs/cockroachcloud"
+baseurl: "/cockroachcloud"
 destination: _site/cockroachcloud
 
 versions:

--- a/_config_cockroachdb.yml
+++ b/_config_cockroachdb.yml
@@ -1,7 +1,7 @@
 homepage_title: CockroachDB Docs
 
-baseurl: "/docs"
-destination: _site/docs
+baseurl: "/"
+destination: _site/
 
 versions:
   stable: v19.2

--- a/netlify/build
+++ b/netlify/build
@@ -8,7 +8,3 @@ gem install bundler
 bundle install
 build _config_cockroachdb.yml
 build _config_cockroachcloud.yml
-mv _site/cockroachcloud _site/docs/cockroachcloud
-
-cp _site/docs/_redirects _site/_redirects
-cat _site/docs/cockroachcloud/_redirects >> _site/_redirects


### PR DESCRIPTION
Potentially resolves https://github.com/cockroachdb/docs/issues/4093.

Make htmltest -s work locally by removing the /docs prefix.

Also add a make command for executing htmltest (`make htmltest`)

Not sure how to test if this breaks building locally though - please pull and see if it works!