### PR TITLE
teach make test to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,10 @@ cockroachcloud: jekyll-action := serve --port 4001
 cockroachcloud: cockroachcloud-build
 
 .PHONY: test
-test: bootstrap
+test:
 	go get -u github.com/cockroachdb/htmltest
+	# Docker must be running locally for this to work.
+	./netlify/local
 	htmltest
 
 vendor:


### PR DESCRIPTION
htmltest assumes the _site directory has a working site layout. When building with just jekyll (i.e., not using netlify/build or netlify/local), the cloud directory is not in the expected place, so things break.

Add this make target so people can just type "make htmltest" which uses the docker builder to simulate exactly what happens on netlify, which htmltest can then check since things are in the expected locations.

Fixes #4093
Closes #6157