### PR TITLE
change htmltest DocumentConcurrencyLimit to 16

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -8,3 +8,4 @@ IgnoreURLs:
   - http://localhost:4000
 IgnoreInternalEmptyHash: true
 TestFilesConcurrently: true
+DocumentConcurrencyLimit: 16


### PR DESCRIPTION
Resolves #3833.

The current default of 128 has a tendency to reach "too many files at
once" when attempting to `os.Stat` on local setups. I don't think the
speedup is too important, so setting to a lower setting of 16.