### PR TITLE
Update redirects to use correct YAML var name

### DIFF
--- a/v19.2/cockroach-cert.md
+++ b/v19.2/cockroach-cert.md
@@ -2,7 +2,7 @@
 title: cockroach cert
 summary: A secure CockroachDB cluster uses TLS for encrypted inter-node and client-node communication.
 toc: true
-redirect-from: create-security-certificates.html
+redirect_from: create-security-certificates.html
 key: create-security-certificates.html
 ---
 

--- a/v19.2/cockroach-debug-ballast.md
+++ b/v19.2/cockroach-debug-ballast.md
@@ -2,7 +2,7 @@
 title: cockroach debug ballast
 summary: Create a large, unused file in a node's storage directory that you can delete if the node runs out of disk space.
 toc: true
-redirect-from: debug-ballast.html
+redirect_from: debug-ballast.html
 key: debug-ballast.html
 ---
 

--- a/v19.2/cockroach-debug-encryption-active-key.md
+++ b/v19.2/cockroach-debug-encryption-active-key.md
@@ -2,7 +2,7 @@
 title: cockroach debug encryption-active-key
 summary: Learn the command for viewing the algorithm and store key for an encrypted store.
 toc: true
-redirect-from: debug-encryption-active-key.html
+redirect_from: debug-encryption-active-key.html
 key: debug-encryption-active-key.html
 ---
 

--- a/v19.2/cockroach-debug-merge-logs.md
+++ b/v19.2/cockroach-debug-merge-logs.md
@@ -2,7 +2,7 @@
 title: cockroach debug merge-logs
 summary: Learn the command for merging the collected debug logs from all nodes in your cluster.
 toc: true
-redirect-from: debug-merge-logs.html
+redirect_from: debug-merge-logs.html
 key: debug-merge-logs.html
 ---
 

--- a/v19.2/cockroach-debug-zip.md
+++ b/v19.2/cockroach-debug-zip.md
@@ -2,7 +2,7 @@
 title: cockroach debug zip
 summary: Learn the commands for collecting debug information from all nodes in your cluster.
 toc: true
-redirect-from: debug-zip.html
+redirect_from: debug-zip.html
 key: debug-zip.html
 ---
 

--- a/v19.2/cockroach-dump.md
+++ b/v19.2/cockroach-dump.md
@@ -2,7 +2,7 @@
 title: cockroach dump
 summary: Learn how to dump schemas and data from a CockroachDB cluster.
 toc: true
-redirect-from: sql-dump.html
+redirect_from: sql-dump.html
 key: sql-dump.html
 ---
 

--- a/v19.2/cockroach-gen.md
+++ b/v19.2/cockroach-gen.md
@@ -2,7 +2,7 @@
 title: cockroach gen
 summary: Use cockroach gen to generate command-line interface utlities, such as man pages, and example data.
 toc: true
-redirect-from: generate-cockroachdb-resources.html
+redirect_from: generate-cockroachdb-resources.html
 key: generate-cockroachdb-resources.html
 ---
 

--- a/v19.2/cockroach-node.md
+++ b/v19.2/cockroach-node.md
@@ -2,7 +2,7 @@
 title: cockroach node
 summary: To view details for each node in the cluster, use the cockroach node command with the appropriate subcommands and flags.
 toc: true
-redirect-from: view-node-details.html
+redirect_from: view-node-details.html
 key: view-node-details.html
 ---
 

--- a/v19.2/cockroach-quit.md
+++ b/v19.2/cockroach-quit.md
@@ -2,7 +2,7 @@
 title: cockroach quit
 summary: Learn how to temporarily stop a CockroachDB node.
 toc: true
-redirect-from: stop-a-node.html
+redirect_from: stop-a-node.html
 key: stop-a-node.html
 ---
 

--- a/v19.2/cockroach-sql.md
+++ b/v19.2/cockroach-sql.md
@@ -2,7 +2,7 @@
 title: cockroach sql
 summary: CockroachDB comes with a built-in client for executing SQL statements from an interactive shell or directly from the command line.
 toc: true
-redirect-from: use-the-built-in-sql-client.html
+redirect_from: use-the-built-in-sql-client.html
 key: use-the-built-in-sql-client.html
 ---
 

--- a/v19.2/cockroach-sqlfmt.md
+++ b/v19.2/cockroach-sqlfmt.md
@@ -2,7 +2,7 @@
 title: cockroach sqlfmt
 summary: Use cockroach sqlfmt to enhance the text layout of a SQL query.
 toc: true
-redirect-from: use-the-query-formatter.html
+redirect_from: use-the-query-formatter.html
 key: use-the-query-formatter.html
 ---
 

--- a/v19.2/cockroach-start.md
+++ b/v19.2/cockroach-start.md
@@ -2,7 +2,7 @@
 title: cockroach start
 summary: Start a new multi-node cluster or add nodes to an existing multi-node cluster.
 toc: true
-redirect-form: start-a-node.html
+redirect_from: start-a-node.html
 key: start-a-node.html
 ---
 

--- a/v19.2/cockroach-version.md
+++ b/v19.2/cockroach-version.md
@@ -2,7 +2,7 @@
 title: cockroach version
 summary: To view version details for a specific cockroach binary, run the cockroach version command.
 toc: false
-redirect-from: view-version-details.html
+redirect_from: view-version-details.html
 key: view-version-details.html
 ---
 

--- a/v19.2/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.md
+++ b/v19.2/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy a sample Python web app with Flask, Kubernetes, and
 toc: true
 toc_not_nested: true
 build_for: [cockroachcloud]
-redirect-from:
+redirect_from:
 - managed-build-a-python-app-with-kubernetes.html
 - cockroachcloud-build-a-python-app-with-kubernetes.html
 ---

--- a/v19.2/performance-benchmarking-with-tpc-c-100k-warehouses.md
+++ b/v19.2/performance-benchmarking-with-tpc-c-100k-warehouses.md
@@ -3,7 +3,7 @@ title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C 100k.
 toc: true
 toc_not_nested: true
-redirect-from: performance-benchmarking-with-tpc-c.html
+redirect_from: performance-benchmarking-with-tpc-c.html
 ---
 
 This page shows you how to reproduce [CockroachDB's TPC-C performance benchmarking results](performance.html#scale) on commodity AWS hardware. Across all scales, CockroachDB can process tpmC (new order transactions per minute) at near maximum efficiency. Start by choosing the scale you're interested in:

--- a/v19.2/postgresql-compatibility.md
+++ b/v19.2/postgresql-compatibility.md
@@ -2,7 +2,7 @@
 title: PostgreSQL Compatibility
 summary: A summary of CockroachDB's compatibility with PostgreSQL
 toc: true
-redirect-from: porting-postgres.html
+redirect_from: porting-postgres.html
 ---
 CockroachDB supports the PostgreSQL wire protocol and the majority of its syntax. This means that your existing applications can often be migrated to CockroachDB without changing application code.
 

--- a/v20.1/cockroach-cert.md
+++ b/v20.1/cockroach-cert.md
@@ -2,7 +2,7 @@
 title: cockroach cert
 summary: A secure CockroachDB cluster uses TLS for encrypted inter-node and client-node communication.
 toc: true
-redirect-from: create-security-certificates.html
+redirect_from: create-security-certificates.html
 key: create-security-certificates.html
 ---
 

--- a/v20.1/cockroach-debug-ballast.md
+++ b/v20.1/cockroach-debug-ballast.md
@@ -2,7 +2,7 @@
 title: cockroach debug ballast
 summary: Create a large, unused file in a node's storage directory that you can delete if the node runs out of disk space.
 toc: true
-redirect-from: cockroach-debug-ballast.html
+redirect_from: cockroach-debug-ballast.html
 key: cockroach-debug-ballast.html
 ---
 

--- a/v20.1/cockroach-debug-encryption-active-key.md
+++ b/v20.1/cockroach-debug-encryption-active-key.md
@@ -2,7 +2,7 @@
 title: cockroach debug encryption-active-key
 summary: Learn the command for viewing the algorithm and store key for an encrypted store.
 toc: true
-redirect-from: debug-encryption-active-key.html
+redirect_from: debug-encryption-active-key.html
 key: debug-encryption-active-key.html
 ---
 

--- a/v20.1/cockroach-debug-merge-logs.md
+++ b/v20.1/cockroach-debug-merge-logs.md
@@ -2,7 +2,7 @@
 title: cockroach debug merge-logs
 summary: Learn the command for merging the collected debug logs from all nodes in your cluster.
 toc: true
-redirect-from: debug-merge-logs.html
+redirect_from: debug-merge-logs.html
 key: debug-merge-logs.html
 ---
 

--- a/v20.1/cockroach-debug-zip.md
+++ b/v20.1/cockroach-debug-zip.md
@@ -2,7 +2,7 @@
 title: cockroach debug zip
 summary: Learn the commands for collecting debug information from all nodes in your cluster.
 toc: true
-redirect-from: debug-zip.html
+redirect_from: debug-zip.html
 key: debug-zip.html
 ---
 

--- a/v20.1/cockroach-dump.md
+++ b/v20.1/cockroach-dump.md
@@ -2,7 +2,7 @@
 title: cockroach dump
 summary: Learn how to dump schemas and data from a CockroachDB cluster.
 toc: true
-redirect-from: sql-dump.html
+redirect_from: sql-dump.html
 key: sql-dump.html
 ---
 

--- a/v20.1/cockroach-gen.md
+++ b/v20.1/cockroach-gen.md
@@ -2,7 +2,7 @@
 title: cockroach gen
 summary: Use cockroach gen to generate command-line interface utlities, such as man pages, and example data.
 toc: true
-redirect-from: generate-cockroachdb-resources.html
+redirect_from: generate-cockroachdb-resources.html
 key: generate-cockroachdb-resources.html
 ---
 

--- a/v20.1/cockroach-node.md
+++ b/v20.1/cockroach-node.md
@@ -2,7 +2,7 @@
 title: cockroach node
 summary: To view details for each node in the cluster, use the cockroach node command with the appropriate subcommands and flags.
 toc: true
-redirect-from: view-node-details.html
+redirect_from: view-node-details.html
 key: view-node-details.html
 ---
 

--- a/v20.1/cockroach-quit.md
+++ b/v20.1/cockroach-quit.md
@@ -2,7 +2,7 @@
 title: cockroach quit
 summary: Learn how to temporarily stop a CockroachDB node.
 toc: true
-redirect-from: stop-a-node.html
+redirect_from: stop-a-node.html
 key: stop-a-node.html
 ---
 

--- a/v20.1/cockroach-sql.md
+++ b/v20.1/cockroach-sql.md
@@ -2,7 +2,7 @@
 title: cockroach sql
 summary: CockroachDB comes with a built-in client for executing SQL statements from an interactive shell or directly from the command line.
 toc: true
-redirect-from: use-the-built-in-sql-client.html
+redirect_from: use-the-built-in-sql-client.html
 key: use-the-built-in-sql-client.html
 ---
 

--- a/v20.1/cockroach-sqlfmt.md
+++ b/v20.1/cockroach-sqlfmt.md
@@ -2,7 +2,7 @@
 title: cockroach sqlfmt
 summary: Use cockroach sqlfmt to enhance the text layout of a SQL query.
 toc: true
-redirect-from: use-the-query-formatter.html
+redirect_from: use-the-query-formatter.html
 key: use-the-query-formatter.html
 ---
 

--- a/v20.1/cockroach-start.md
+++ b/v20.1/cockroach-start.md
@@ -2,7 +2,7 @@
 title: cockroach start
 summary: Start a new multi-node cluster or add nodes to an existing multi-node cluster.
 toc: true
-redirect-form: start-a-node.html
+redirect_from: start-a-node.html
 key: start-a-node.html
 ---
 

--- a/v20.1/cockroach-version.md
+++ b/v20.1/cockroach-version.md
@@ -2,7 +2,7 @@
 title: cockroach version
 summary: To view version details for a specific cockroach binary, run the cockroach version command.
 toc: false
-redirect-from: view-version-details.html
+redirect_from: view-version-details.html
 key: view-version-details.html
 ---
 

--- a/v20.1/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.md
+++ b/v20.1/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.md
@@ -4,7 +4,7 @@ summary: Learn how to deploy a sample Python web app with Flask, Kubernetes, and
 toc: true
 toc_not_nested: true
 build_for: [cockroachcloud]
-redirect-from:
+redirect_from:
 - managed-build-a-python-app-with-kubernetes.html
 - cockroachcloud-build-a-python-app-with-kubernetes.html
 ---

--- a/v20.1/performance-benchmarking-with-tpc-c-100k-warehouses.md
+++ b/v20.1/performance-benchmarking-with-tpc-c-100k-warehouses.md
@@ -3,7 +3,7 @@ title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C 100k.
 toc: true
 toc_not_nested: true
-redirect-from: performance-benchmarking-with-tpc-c.html
+redirect_from: performance-benchmarking-with-tpc-c.html
 ---
 
 This page shows you how to reproduce [CockroachDB's TPC-C performance benchmarking results](performance.html#scale) on commodity AWS hardware. Across all scales, CockroachDB can process tpmC (new order transactions per minute) at near maximum efficiency. Start by choosing the scale you're interested in:

--- a/v20.1/postgresql-compatibility.md
+++ b/v20.1/postgresql-compatibility.md
@@ -2,7 +2,7 @@
 title: PostgreSQL Compatibility
 summary: A summary of CockroachDB's compatibility with PostgreSQL
 toc: true
-redirect-from: porting-postgres.html
+redirect_from: porting-postgres.html
 ---
 
 CockroachDB supports the PostgreSQL wire protocol and the majority of its syntax. This means that your existing applications can often be migrated to CockroachDB without changing application code.


### PR DESCRIPTION
According to the documentation for the Jekyll redirect
plugin (https://github.com/jekyll/jekyll-redirect-from) we are using,
the variable name to use in the YAML header is

  `redirect_from`

Prior to this change, we had used the variable name

  `redirect-from`

which is apparently not understood by the Jekyll plugin.

This was causing our redirects to break.

Note: Unfortunately, this redirection plugin does not work for anchors
to specific locations on the page, so that visiting e.g.,

https://www.cockroachlabs.com/docs/stable/create-security-certificates.html#create-the-certificate-and-key-pair-for-a-client

redirects to the top-level page URL

https://www.cockroachlabs.com/docs/v19.2/cockroach-cert.html

which means the user is not directed to the specific location implied by
the anchor.