### PR TITLE
fix link to geo-partitioning

### DIFF
--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -421,4 +421,4 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)


### PR DESCRIPTION
Noticed this link wasn't rendering properly in the "secure a cluster" section:

![image](https://user-images.githubusercontent.com/836375/71388773-90142d00-25ae-11ea-8507-6280f5be9234.png)

Single missing `[` to fix it up. 😄 