### PR TITLE
Fix links to geo-partitioning tutorial

### DIFF
--- a/v19.2/create-table-as.md
+++ b/v19.2/create-table-as.md
@@ -292,7 +292,7 @@ original table.
 
 <span class="version-tag">New in v19.2:</span> If you are [partitioning](partitioning.html) a table based on a [primary key](primary-key.html), you must correctly define the primary key at table creation. It is not possible to add or change primary keys after table creation. To work around this limitation, you can create a new table from an existing one, with the correct primary keys specified in your `CREATE TABLE ... AS` statement.
 
-Suppose that you want to [geo-partition](demo-geo-partitioning.html) the `drivers` table that you created with the following statement:
+Suppose that you want to [geo-partition](demo-low-latency-multi-region-deployment.html) the `drivers` table that you created with the following statement:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -421,4 +421,4 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v19.2/show-locality.md
+++ b/v19.2/show-locality.md
@@ -82,7 +82,7 @@ For a more extensive example, see [Create a table with node locality information
 
 ## See also
 
-- [Geo-Partitioning](demo-geo-partitioning.html)
+- [Geo-Partitioning](demo-low-latency-multi-region-deployment.html)
 - [Locality](cockroach-start.html#locality)
 - [Orchestrated Deployment](orchestration.html)
 - [Manual Deployment](manual-deployment.html)

--- a/v19.2/show-partitions.md
+++ b/v19.2/show-partitions.md
@@ -236,4 +236,4 @@ If a partitioned table has no zones configured, the `SHOW CREATE TABLE` output i
 
 - [Define Table Partitions](partitioning.html)
 - [SQL Statements](sql-statements.html)
-- [Geo-Partitioning](demo-geo-partitioning.html)
+- [Geo-Partitioning](demo-low-latency-multi-region-deployment.html)

--- a/v19.2/start-a-local-cluster-in-docker-linux.md
+++ b/v19.2/start-a-local-cluster-in-docker-linux.md
@@ -35,4 +35,4 @@ Also, feel free to watch this process in action before going through the steps y
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v19.2/start-a-local-cluster-in-docker-mac.md
+++ b/v19.2/start-a-local-cluster-in-docker-mac.md
@@ -36,4 +36,4 @@ Also, feel free to watch this process in action before going through the steps y
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v19.2/start-a-local-cluster-in-docker-windows.md
+++ b/v19.2/start-a-local-cluster-in-docker-windows.md
@@ -237,4 +237,4 @@ Remove-Item C:\Users\username> cockroach-data -recurse
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v19.2/start-a-local-cluster.md
+++ b/v19.2/start-a-local-cluster.md
@@ -375,4 +375,4 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v20.1/create-table-as.md
+++ b/v20.1/create-table-as.md
@@ -292,7 +292,7 @@ You can define the [column families](column-families.html) of a new table create
 
 If you are [partitioning](partitioning.html) a table based on a [primary key](primary-key.html), you must correctly define the primary key at table creation. It is not possible to add or change primary keys after table creation. To work around this limitation, you can create a new table from an existing one, with the correct primary keys specified in your `CREATE TABLE ... AS` statement.
 
-Suppose that you want to [geo-partition](demo-geo-partitioning.html) the `drivers` table that you created with the following statement:
+Suppose that you want to [geo-partition](demo-low-latency-multi-region-deployment.html) the `drivers` table that you created with the following statement:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -421,4 +421,4 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v20.1/show-locality.md
+++ b/v20.1/show-locality.md
@@ -78,7 +78,7 @@ For a more extensive example, see [Create a table with node locality information
 
 ## See also
 
-- [Geo-Partitioning](demo-geo-partitioning.html)
+- [Geo-Partitioning](demo-low-latency-multi-region-deployment.html)
 - [Locality](cockroach-start.html#locality)
 - [Orchestrated Deployment](orchestration.html)
 - [Manual Deployment](manual-deployment.html)

--- a/v20.1/show-partitions.md
+++ b/v20.1/show-partitions.md
@@ -236,4 +236,4 @@ If a partitioned table has no zones configured, the `SHOW CREATE TABLE` output i
 
 - [Define Table Partitions](partitioning.html)
 - [SQL Statements](sql-statements.html)
-- [Geo-Partitioning](demo-geo-partitioning.html)
+- [Geo-Partitioning](demo-low-latency-multi-region-deployment.html)

--- a/v20.1/start-a-local-cluster-in-docker-linux.md
+++ b/v20.1/start-a-local-cluster-in-docker-linux.md
@@ -35,4 +35,4 @@ Also, feel free to watch this process in action before going through the steps y
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v20.1/start-a-local-cluster-in-docker-mac.md
+++ b/v20.1/start-a-local-cluster-in-docker-mac.md
@@ -36,4 +36,4 @@ Also, feel free to watch this process in action before going through the steps y
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v20.1/start-a-local-cluster-in-docker-windows.md
+++ b/v20.1/start-a-local-cluster-in-docker-windows.md
@@ -237,4 +237,4 @@ Remove-Item C:\Users\username> cockroach-data -recurse
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v20.1/start-a-local-cluster.md
+++ b/v20.1/start-a-local-cluster.md
@@ -375,4 +375,4 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
-- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), geo-partitioning](demo-geo-partitioning.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+- Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)


### PR DESCRIPTION
Follow-up to https://github.com/cockroachdb/docs/pull/6239.