### PR TITLE
Improved vectorized support docs

### DIFF
--- a/_includes/v19.2/sql/vectorized-support.md
+++ b/_includes/v19.2/sql/vectorized-support.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+[Vectorized execution](vectorized-execution.html) is currently not supported for this data type.
+{{site.data.alerts.end}}

--- a/_includes/v20.1/sql/vectorized-support.md
+++ b/_includes/v20.1/sql/vectorized-support.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+[Vectorized execution](vectorized-execution.html) is currently not supported for this data type.
+{{site.data.alerts.end}}

--- a/v19.2/array.md
+++ b/v19.2/array.md
@@ -8,10 +8,11 @@ The `ARRAY` data type stores one-dimensional, 1-indexed, homogeneous arrays of a
 
 The `ARRAY` data type is useful for ensuring compatibility with ORMs and other tools. However, if such compatibility is not a concern, it's more flexible to design your schema with normalized tables.
 
-
 {{site.data.alerts.callout_info}}
 CockroachDB does not support nested arrays, creating database indexes on arrays, and ordering by arrays.
 {{site.data.alerts.end}}
+
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Syntax
 

--- a/v19.2/bit.md
+++ b/v19.2/bit.md
@@ -7,6 +7,8 @@ toc: true
 The `BIT` and `VARBIT` [data types](data-types.html) stores bit arrays.
 With `BIT`, the length is fixed; with `VARBIT`, the length can be variable.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Aliases
 
 The name `BIT VARYING` is an alias for `VARBIT`.

--- a/v19.2/collate.md
+++ b/v19.2/collate.md
@@ -9,6 +9,7 @@ The `COLLATE` feature lets you sort [`STRING`](string.html) values according to 
 
 Collated strings are important because different languages have [different rules for alphabetic order](https://en.wikipedia.org/wiki/Alphabetical_order#Language-specific_conventions), especially with respect to accented letters. For example, in German accented letters are sorted with their unaccented counterparts, while in Swedish they are placed at the end of the alphabet. A collation is a set of rules used for ordering and usually corresponds to a language, though some languages have multiple collations with different rules for sorting; for example Portuguese has separate collations for Brazilian and European dialects (`pt-BR` and `pt-PT` respectively).
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Details
 

--- a/v19.2/data-types.md
+++ b/v19.2/data-types.md
@@ -15,8 +15,8 @@ Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
 [`BOOL`](bool.html) | A Boolean value. | `true` | Supported
 [`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'` | Supported
 [`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.  | `'a1b2c3' COLLATE en` | Not supported
-[`DATE`](date.html) | A date.  | `DATE '2016-01-25'` | Not supported
-[`DECIMAL`](decimal.html) | An exact, fixed-point number.  | `1.2345` | Not supported
+[`DATE`](date.html) | A date.  | `DATE '2016-01-25'` | Supported
+[`DECIMAL`](decimal.html) | An exact, fixed-point number.  | `1.2345` | Partially supported
 [`FLOAT`](float.html) | A 64-bit, inexact, floating-point number.  | `1.2345` | Supported
 [`INET`](inet.html) | An IPv4 or IPv6 address.  | `192.168.0.1` | Not supported
 [`INT`](int.html) | A signed integer, up to 64 bits. | `12345` | Supported
@@ -25,7 +25,7 @@ Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
 [`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html).  | `148591304110702593` | Not supported
 [`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'` | Supported
 [`TIME`](time.html) | A time of day in UTC.  | `TIME '01:23:45.123456'` | Not supported
-[`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'` | Supported
+[`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'` | `TIMESTAMP` supported <br> `TIMESTAMPTZ` not supported
 [`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec` | Supported
 
 ## Data type conversions and casts

--- a/v19.2/data-types.md
+++ b/v19.2/data-types.md
@@ -8,25 +8,25 @@ toc: true
 
 CockroachDB supports the following data types. Click a type for more details.
 
-Type | Description | Example
------|-------------|--------
-[`ARRAY`](array.html) | A 1-dimensional, 1-indexed, homogeneous array of any non-array data type. | `{"sky","road","car"}`
-[`BIT`](bit.html) | A string of binary digits (bits). | `B'10010101'`
-[`BOOL`](bool.html) | A Boolean value. | `true`
-[`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'`
-[`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations. | `'a1b2c3' COLLATE en`
-[`DATE`](date.html) | A date. | `DATE '2016-01-25'`
-[`DECIMAL`](decimal.html) | An exact, fixed-point number. | `1.2345`
-[`FLOAT`](float.html) | A 64-bit, inexact, floating-point number. | `1.2345`
-[`INET`](inet.html) | An IPv4 or IPv6 address. | `192.168.0.1`
-[`INT`](int.html) | A signed integer, up to 64 bits. | `12345`
-[`INTERVAL`](interval.html) | A span of time. | `INTERVAL '2h30m30s'`
-[`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data. | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'`
-[`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html). | `148591304110702593`
-[`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'`
-[`TIME`](time.html) | A time of day in UTC. | `TIME '01:23:45.123456'`
-[`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'`
-[`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec`
+Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
+-----|-------------|---------|----------
+[`ARRAY`](array.html) | A 1-dimensional, 1-indexed, homogeneous array of any non-array data type. | `{"sky","road","car"}` | Not supported
+[`BIT`](bit.html) | A string of binary digits (bits).  | `B'10010101'` | Not supported
+[`BOOL`](bool.html) | A Boolean value. | `true` | Supported
+[`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'` | Supported
+[`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.  | `'a1b2c3' COLLATE en` | Not supported
+[`DATE`](date.html) | A date.  | `DATE '2016-01-25'` | Not supported
+[`DECIMAL`](decimal.html) | An exact, fixed-point number.  | `1.2345` | Not supported
+[`FLOAT`](float.html) | A 64-bit, inexact, floating-point number.  | `1.2345` | Supported
+[`INET`](inet.html) | An IPv4 or IPv6 address.  | `192.168.0.1` | Not supported
+[`INT`](int.html) | A signed integer, up to 64 bits. | `12345` | Supported
+[`INTERVAL`](interval.html) | A span of time.  | `INTERVAL '2h30m30s'` | Not supported
+[`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data.  | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'` | Not supported
+[`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html).  | `148591304110702593` | Not supported
+[`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'` | Supported
+[`TIME`](time.html) | A time of day in UTC.  | `TIME '01:23:45.123456'` | Not supported
+[`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'` | Supported
+[`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec` | Supported
 
 ## Data type conversions and casts
 

--- a/v19.2/date.md
+++ b/v19.2/date.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DATE` [data type](data-types.html) stores a year, month, and day.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Syntax
 

--- a/v19.2/date.md
+++ b/v19.2/date.md
@@ -6,8 +6,6 @@ toc: true
 
 The `DATE` [data type](data-types.html) stores a year, month, and day.
 
-{% include {{page.version.version}}/sql/vectorized-support.md %}
-
 ## Syntax
 
 A constant value of type `DATE` can be expressed using an

--- a/v19.2/decimal.md
+++ b/v19.2/decimal.md
@@ -6,7 +6,9 @@ toc: true
 
 The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers. This type is used when it is important to preserve exact precision, for example, with monetary data.
 
-{% include {{page.version.version}}/sql/vectorized-support.md %}
+{{site.data.alerts.callout_info}}
+The [vectorized execution](vectorized-execution.html) engine does not support the serialization of `DECIMAL` data types in CockroachDB v19.2. As such, vectorized execution is not supported for `DECIMAL` data types that must be sent over a network.
+{{site.data.alerts.end}}
 
 ## Aliases
 

--- a/v19.2/decimal.md
+++ b/v19.2/decimal.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers. This type is used when it is important to preserve exact precision, for example, with monetary data.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Aliases
 

--- a/v19.2/inet.md
+++ b/v19.2/inet.md
@@ -5,6 +5,7 @@ toc: true
 ---
 The `INET` [data type](data-types.html) stores an IPv4 or IPv6 address.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Syntax
 

--- a/v19.2/interval.md
+++ b/v19.2/interval.md
@@ -6,6 +6,8 @@ toc: true
 
 The `INTERVAL` [data type](data-types.html) stores a value that represents a span of time.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Aliases
 
 - `INTERVAL(6)`

--- a/v19.2/jsonb.md
+++ b/v19.2/jsonb.md
@@ -8,6 +8,7 @@ The `JSONB` [data type](data-types.html) stores JSON (JavaScript Object Notation
 
 {{site.data.alerts.callout_success}}For a hands-on demonstration of storing and querying JSON data from a third-party API, see the <a href="demo-json-support.html">JSON tutorial</a>.{{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Alias
 

--- a/v19.2/serial.md
+++ b/v19.2/serial.md
@@ -20,6 +20,8 @@ In most cases, we recommend using the [`UUID`](uuid.html) data type with the `ge
 See [this FAQ entry](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb) for more details.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Modes of operation
 
 The keyword `SERIAL` is recognized in `CREATE TABLE` and is

--- a/v19.2/time.md
+++ b/v19.2/time.md
@@ -5,6 +5,8 @@ toc: true
 ---
 The `TIME` [data type](data-types.html) stores the time of day in UTC.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Aliases
 
 In CockroachDB, the following are aliases:

--- a/v19.2/timestamp.md
+++ b/v19.2/timestamp.md
@@ -6,6 +6,10 @@ toc: true
 
 The `TIMESTAMP` and `TIMESTAMPTZ` [data types](data-types.html) stores a date and time pair in UTC.
 
+{{site.data.alerts.callout_info}}
+[Vectorized execution](vectorized-execution.html) is not supported for `TIMESTAMPTZ` in CockroachDB v19.2.
+{{site.data.alerts.end}}
+
 ## Variants
 
 `TIMESTAMP` has two variants:

--- a/v19.2/vectorized-execution.md
+++ b/v19.2/vectorized-execution.md
@@ -57,6 +57,7 @@ Vectorized execution is supported for the following [data types](data-types.html
 
 - [`BOOL`](bool.html)
 - [`BYTES`](bytes.html)
+- [`DATE`](date.html)
 - [`FLOAT`](float.html)
 - [`INT`](int.html)
 - [`STRING`](string.html)

--- a/v20.1/array.md
+++ b/v20.1/array.md
@@ -13,6 +13,9 @@ The `ARRAY` data type is useful for ensuring compatibility with ORMs and other t
 CockroachDB does not support nested arrays, creating database indexes on arrays, and ordering by arrays.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
+
 ## Syntax
 
 A value of data type `ARRAY` can be expressed in the following ways:

--- a/v20.1/bit.md
+++ b/v20.1/bit.md
@@ -7,6 +7,8 @@ toc: true
 The `BIT` and `VARBIT` [data types](data-types.html) stores bit arrays.
 With `BIT`, the length is fixed; with `VARBIT`, the length can be variable.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Aliases
 
 The name `BIT VARYING` is an alias for `VARBIT`.

--- a/v20.1/collate.md
+++ b/v20.1/collate.md
@@ -9,6 +9,7 @@ The `COLLATE` feature lets you sort [`STRING`](string.html) values according to 
 
 Collated strings are important because different languages have [different rules for alphabetic order](https://en.wikipedia.org/wiki/Alphabetical_order#Language-specific_conventions), especially with respect to accented letters. For example, in German accented letters are sorted with their unaccented counterparts, while in Swedish they are placed at the end of the alphabet. A collation is a set of rules used for ordering and usually corresponds to a language, though some languages have multiple collations with different rules for sorting; for example Portuguese has separate collations for Brazilian and European dialects (`pt-BR` and `pt-PT` respectively).
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Details
 

--- a/v20.1/data-types.md
+++ b/v20.1/data-types.md
@@ -15,8 +15,8 @@ Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
 [`BOOL`](bool.html) | A Boolean value. | `true` | Supported
 [`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'` | Supported
 [`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.  | `'a1b2c3' COLLATE en` | Not supported
-[`DATE`](date.html) | A date.  | `DATE '2016-01-25'` | Not supported
-[`DECIMAL`](decimal.html) | An exact, fixed-point number.  | `1.2345` | Not supported
+[`DATE`](date.html) | A date.  | `DATE '2016-01-25'` | Supported
+[`DECIMAL`](decimal.html) | An exact, fixed-point number.  | `1.2345` | Supported
 [`FLOAT`](float.html) | A 64-bit, inexact, floating-point number.  | `1.2345` | Supported
 [`INET`](inet.html) | An IPv4 or IPv6 address.  | `192.168.0.1` | Not supported
 [`INT`](int.html) | A signed integer, up to 64 bits. | `12345` | Supported

--- a/v20.1/data-types.md
+++ b/v20.1/data-types.md
@@ -8,25 +8,25 @@ toc: true
 
 CockroachDB supports the following data types. Click a type for more details.
 
-Type | Description | Example
------|-------------|--------
-[`ARRAY`](array.html) | A 1-dimensional, 1-indexed, homogeneous array of any non-array data type. | `{"sky","road","car"}`
-[`BIT`](bit.html) | A string of binary digits (bits). | `B'10010101'`
-[`BOOL`](bool.html) | A Boolean value. | `true`
-[`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'`
-[`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations. | `'a1b2c3' COLLATE en`
-[`DATE`](date.html) | A date. | `DATE '2016-01-25'`
-[`DECIMAL`](decimal.html) | An exact, fixed-point number. | `1.2345`
-[`FLOAT`](float.html) | A 64-bit, inexact, floating-point number. | `1.2345`
-[`INET`](inet.html) | An IPv4 or IPv6 address. | `192.168.0.1`
-[`INT`](int.html) | A signed integer, up to 64 bits. | `12345`
-[`INTERVAL`](interval.html) | A span of time. | `INTERVAL '2h30m30s'`
-[`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data. | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'`
-[`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html). | `148591304110702593`
-[`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'`
-[`TIME`](time.html) | A time of day in UTC. | `TIME '01:23:45.123456'`
-[`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'`
-[`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec`
+Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
+-----|-------------|---------|----------
+[`ARRAY`](array.html) | A 1-dimensional, 1-indexed, homogeneous array of any non-array data type. | `{"sky","road","car"}` | Not supported
+[`BIT`](bit.html) | A string of binary digits (bits).  | `B'10010101'` | Not supported
+[`BOOL`](bool.html) | A Boolean value. | `true` | Supported
+[`BYTES`](bytes.html) | A string of binary characters. | `b'\141\061\142\062\143\063'` | Supported
+[`COLLATE`](collate.html) | The `COLLATE` feature lets you sort [`STRING`](string.html) values according to language- and country-specific rules, known as collations.  | `'a1b2c3' COLLATE en` | Not supported
+[`DATE`](date.html) | A date.  | `DATE '2016-01-25'` | Not supported
+[`DECIMAL`](decimal.html) | An exact, fixed-point number.  | `1.2345` | Not supported
+[`FLOAT`](float.html) | A 64-bit, inexact, floating-point number.  | `1.2345` | Supported
+[`INET`](inet.html) | An IPv4 or IPv6 address.  | `192.168.0.1` | Not supported
+[`INT`](int.html) | A signed integer, up to 64 bits. | `12345` | Supported
+[`INTERVAL`](interval.html) | A span of time.  | `INTERVAL '2h30m30s'` | Not supported
+[`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data.  | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'` | Not supported
+[`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html).  | `148591304110702593` | Not supported
+[`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'` | Supported
+[`TIME`](time.html) | A time of day in UTC.  | `TIME '01:23:45.123456'` | Not supported
+[`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'` | Supported
+[`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec` | Supported
 
 ## Data type conversions and casts
 

--- a/v20.1/date.md
+++ b/v20.1/date.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DATE` [data type](data-types.html) stores a year, month, and day.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Syntax
 

--- a/v20.1/date.md
+++ b/v20.1/date.md
@@ -6,8 +6,6 @@ toc: true
 
 The `DATE` [data type](data-types.html) stores a year, month, and day.
 
-{% include {{page.version.version}}/sql/vectorized-support.md %}
-
 ## Syntax
 
 A constant value of type `DATE` can be expressed using an

--- a/v20.1/decimal.md
+++ b/v20.1/decimal.md
@@ -6,8 +6,6 @@ toc: true
 
 The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers. This type is used when it is important to preserve exact precision, for example, with monetary data.
 
-{% include {{page.version.version}}/sql/vectorized-support.md %}
-
 ## Aliases
 
 In CockroachDB, the following are aliases for `DECIMAL`:

--- a/v20.1/decimal.md
+++ b/v20.1/decimal.md
@@ -6,6 +6,7 @@ toc: true
 
 The `DECIMAL` [data type](data-types.html) stores exact, fixed-point numbers. This type is used when it is important to preserve exact precision, for example, with monetary data.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Aliases
 

--- a/v20.1/inet.md
+++ b/v20.1/inet.md
@@ -5,6 +5,7 @@ toc: true
 ---
 The `INET` [data type](data-types.html) stores an IPv4 or IPv6 address.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Syntax
 

--- a/v20.1/interval.md
+++ b/v20.1/interval.md
@@ -6,6 +6,8 @@ toc: true
 
 The `INTERVAL` [data type](data-types.html) stores a value that represents a span of time.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Aliases
 
 - `INTERVAL(6)`

--- a/v20.1/jsonb.md
+++ b/v20.1/jsonb.md
@@ -8,6 +8,7 @@ The `JSONB` [data type](data-types.html) stores JSON (JavaScript Object Notation
 
 {{site.data.alerts.callout_success}}For a hands-on demonstration of storing and querying JSON data from a third-party API, see the <a href="demo-json-support.html">JSON tutorial</a>.{{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
 
 ## Alias
 

--- a/v20.1/serial.md
+++ b/v20.1/serial.md
@@ -20,6 +20,8 @@ In most cases, we recommend using the [`UUID`](uuid.html) data type with the `ge
 See [this FAQ entry](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb) for more details.
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Modes of operation
 
 The keyword `SERIAL` is recognized in `CREATE TABLE` and is

--- a/v20.1/time.md
+++ b/v20.1/time.md
@@ -5,6 +5,8 @@ toc: true
 ---
 The `TIME` [data type](data-types.html) stores the time of day in UTC.
 
+{% include {{page.version.version}}/sql/vectorized-support.md %}
+
 ## Aliases
 
 In CockroachDB, the following are aliases:

--- a/v20.1/vectorized-execution.md
+++ b/v20.1/vectorized-execution.md
@@ -57,6 +57,8 @@ Vectorized execution is supported for the following [data types](data-types.html
 
 - [`BOOL`](bool.html)
 - [`BYTES`](bytes.html)
+- [`DATE`](date.html)
+- [`DECIMAL`](decimal.html)
 - [`FLOAT`](float.html)
 - [`INT`](int.html)
 - [`STRING`](string.html)


### PR DESCRIPTION
Fixes #5947.

- Added column to data type landing page for vectorized support
- Added note to page for each data type not supported by vectorized execution