### PR TITLE
Add a new 'Developer Guide' to the docs

### DIFF
--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -47,16 +47,75 @@
             "urls": [
               "/${VERSION}/learn-cockroachdb-sql.html"
             ]
+          }
+        ]
+      },
+      {
+        "title": "Develop",
+        "items": [
+          {
+            "title": "Overview",
+            "urls": [
+              "/${VERSION}/developer-guide-overview.html"
+            ]
           },
           {
-            "title": "Build an App",
-            "items": [
-              {
-                "title": "Overview",
-                "urls": [
-                  "/${VERSION}/build-an-app-with-cockroachdb.html"
-                ]
-              },
+            "title": "Connect to the Database",
+            "urls": [
+              "/${VERSION}/connect-to-the-database.html"
+            ]
+          },
+          {
+            "title": "Insert Data",
+            "urls": [
+              "/${VERSION}/insert-data.html"
+            ]
+          },
+          {
+            "title": "Query Data",
+            "urls": [
+              "/${VERSION}/query-data.html"
+            ]
+          },
+          {
+            "title": "Update Data",
+            "urls": [
+              "/${VERSION}/update-data.html"
+            ]
+          },
+          {
+            "title": "Delete Data",
+            "urls": [
+              "/${VERSION}/delete-data.html"
+            ]
+          },
+          {
+            "title": "Run Multi-Statement Transactions",
+            "urls": [
+              "/${VERSION}/run-multi-statement-transactions.html"
+            ]
+          },
+          {
+            "title": "Error Handling & Troubleshooting",
+            "urls": [
+              "/${VERSION}/error-handling-and-troubleshooting.html"
+            ]
+          },
+          {
+            "title": "Make Queries Fast",
+            "urls": [
+              "/${VERSION}/make-queries-fast.html"
+            ]
+          },
+          {
+            "title": "'Hello World' Example Apps",
+              "items": [
+                  {
+                      "title": "Overview",
+                      "urls": [
+                          "/${VERSION}/hello-world-example-apps.html"
+                      ]
+                  },
               {
                 "title": "Go",
                 "urls": [

--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -47,16 +47,75 @@
             "urls": [
               "/${VERSION}/learn-cockroachdb-sql.html"
             ]
+          }
+        ]
+      },
+      {
+        "title": "Develop",
+        "items": [
+          {
+            "title": "Overview",
+            "urls": [
+              "/${VERSION}/developer-guide-overview.html"
+            ]
           },
           {
-            "title": "Build an App",
-            "items": [
-              {
-                "title": "Overview",
-                "urls": [
-                  "/${VERSION}/build-an-app-with-cockroachdb.html"
-                ]
-              },
+            "title": "Connect to the Database",
+            "urls": [
+              "/${VERSION}/connect-to-the-database.html"
+            ]
+          },
+          {
+            "title": "Insert Data",
+            "urls": [
+              "/${VERSION}/insert-data.html"
+            ]
+          },
+          {
+            "title": "Query Data",
+            "urls": [
+              "/${VERSION}/query-data.html"
+            ]
+          },
+          {
+            "title": "Update Data",
+            "urls": [
+              "/${VERSION}/update-data.html"
+            ]
+          },
+          {
+            "title": "Delete Data",
+            "urls": [
+              "/${VERSION}/delete-data.html"
+            ]
+          },
+          {
+            "title": "Run Multi-Statement Transactions",
+            "urls": [
+              "/${VERSION}/run-multi-statement-transactions.html"
+            ]
+          },
+          {
+            "title": "Error Handling & Troubleshooting",
+            "urls": [
+              "/${VERSION}/error-handling-and-troubleshooting.html"
+            ]
+          },
+          {
+            "title": "Make Queries Fast",
+            "urls": [
+              "/${VERSION}/make-queries-fast.html"
+            ]
+          },
+          {
+            "title": "'Hello World' Example Apps",
+              "items": [
+                  {
+                      "title": "Overview",
+                      "urls": [
+                          "/${VERSION}/hello-world-example-apps.html"
+                      ]
+                  },
               {
                 "title": "Go",
                 "urls": [

--- a/_includes/v19.2/app/for-a-complete-example-go.md
+++ b/_includes/v19.2/app/for-a-complete-example-go.md
@@ -1,0 +1,4 @@
+For complete examples, see:
+
+- [Build a Go App with CockroachDB](build-a-go-app-with-cockroachdb.html) (pq)
+- [Build a Go App with CockroachDB and GORM](build-a-go-app-with-cockroachdb.html)

--- a/_includes/v19.2/app/for-a-complete-example-java.md
+++ b/_includes/v19.2/app/for-a-complete-example-java.md
@@ -1,0 +1,4 @@
+For complete examples, see:
+
+- [Build a Java App with CockroachDB](build-a-java-app-with-cockroachdb.html) (JDBC)
+- [Build a Java App with CockroachDB and Hibernate](build-a-java-app-with-cockroachdb-hibernate.html)

--- a/_includes/v19.2/app/for-a-complete-example-python.md
+++ b/_includes/v19.2/app/for-a-complete-example-python.md
@@ -1,0 +1,5 @@
+For complete examples, see:
+
+- [Build a Python App with CockroachDB](build-a-python-app-with-cockroachdb.html) (psycopg2)
+- [Build a Python App with CockroachDB and SQLAlchemy](build-a-python-app-with-cockroachdb-sqlalchemy.html)
+- [Build a Python App with CockroachDB and Django](build-a-python-app-with-cockroachdb-django.html)

--- a/_includes/v19.2/app/retry-errors.md
+++ b/_includes/v19.2/app/retry-errors.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+Your application should use a retry loop to handle the transaction retry errors that [can occur under contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).  For more information, see [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html).
+{{site.data.alerts.end}}

--- a/_includes/v19.2/misc/client-side-intervention-example.md
+++ b/_includes/v19.2/misc/client-side-intervention-example.md
@@ -1,0 +1,27 @@
+The Python-like pseudocode below shows how to implement an application-level retry loop; it does not require your driver or ORM to implement [advanced retry handling logic](advanced-client-side-transaction-retries.html), so it can be used from any programming language or environment. In particular, your retry loop must:
+
+- Raise an error if the `max_retries` limit is reached
+- Retry on `40001` error codes
+- [`COMMIT`](commit-transaction.html) at the end of the `try` block
+- Implement [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) logic as shown below for best performance
+
+~~~ python
+while true:
+    n++
+    if n == max_retries:
+        throw Error("did not succeed within N retries")
+    try:
+        # add logic here to run all your statements
+        conn.exec('COMMIT')
+    catch error:
+        if error.code != "40001":
+            throw error
+        else:
+            # This is a retry error, so we roll back the current transaction
+            # and sleep for a bit before retrying. The sleep time increases
+            # for each failed transaction.  Adapted from
+            # https://colintemple.com/2017/03/java-exponential-backoff/
+            conn.exec('ROLLBACK');
+            sleep_ms = int(((2**n) * 100) + rand( 100 - 1 ) + 1)
+            sleep(sleep_ms) # Assumes your sleep() takes milliseconds
+~~~

--- a/_includes/v19.2/sql/unsupported-postgres-features.md
+++ b/_includes/v19.2/sql/unsupported-postgres-features.md
@@ -1,0 +1,12 @@
+- Stored procedures and functions
+- Triggers
+- Events
+- User-defined functions
+- FULLTEXT functions and indexes
+- GEOSPATIAL functions and indexes
+- Drop primary key
+- XML Functions
+- Savepoints
+- Column-level privileges
+- CREATE TEMPORARY TABLE syntax
+- XA syntax

--- a/_includes/v20.1/app/for-a-complete-example-go.md
+++ b/_includes/v20.1/app/for-a-complete-example-go.md
@@ -1,0 +1,4 @@
+For complete examples, see:
+
+- [Build a Go App with CockroachDB](build-a-go-app-with-cockroachdb.html) (pq)
+- [Build a Go App with CockroachDB and GORM](build-a-go-app-with-cockroachdb.html)

--- a/_includes/v20.1/app/for-a-complete-example-java.md
+++ b/_includes/v20.1/app/for-a-complete-example-java.md
@@ -1,0 +1,4 @@
+For complete examples, see:
+
+- [Build a Java App with CockroachDB](build-a-java-app-with-cockroachdb.html) (JDBC)
+- [Build a Java App with CockroachDB and Hibernate](build-a-java-app-with-cockroachdb-hibernate.html)

--- a/_includes/v20.1/app/for-a-complete-example-python.md
+++ b/_includes/v20.1/app/for-a-complete-example-python.md
@@ -1,0 +1,5 @@
+For complete examples, see:
+
+- [Build a Python App with CockroachDB](build-a-python-app-with-cockroachdb.html) (psycopg2)
+- [Build a Python App with CockroachDB and SQLAlchemy](build-a-python-app-with-cockroachdb-sqlalchemy.html)
+- [Build a Python App with CockroachDB and Django](build-a-python-app-with-cockroachdb-django.html)

--- a/_includes/v20.1/app/retry-errors.md
+++ b/_includes/v20.1/app/retry-errors.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+Your application should use a retry loop to handle the transaction retry errors that [can occur under contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).  For more information, see [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html).
+{{site.data.alerts.end}}

--- a/_includes/v20.1/misc/client-side-intervention-example.md
+++ b/_includes/v20.1/misc/client-side-intervention-example.md
@@ -1,0 +1,27 @@
+The Python-like pseudocode below shows how to implement an application-level retry loop; it does not require your driver or ORM to implement [advanced retry handling logic](advanced-client-side-transaction-retries.html), so it can be used from any programming language or environment. In particular, your retry loop must:
+
+- Raise an error if the `max_retries` limit is reached
+- Retry on `40001` error codes
+- [`COMMIT`](commit-transaction.html) at the end of the `try` block
+- Implement [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) logic as shown below for best performance
+
+~~~ python
+while true:
+    n++
+    if n == max_retries:
+        throw Error("did not succeed within N retries")
+    try:
+        # add logic here to run all your statements
+        conn.exec('COMMIT')
+    catch error:
+        if error.code != "40001":
+            throw error
+        else:
+            # This is a retry error, so we roll back the current transaction
+            # and sleep for a bit before retrying. The sleep time increases
+            # for each failed transaction.  Adapted from
+            # https://colintemple.com/2017/03/java-exponential-backoff/
+            conn.exec('ROLLBACK');
+            sleep_ms = int(((2**n) * 100) + rand( 100 - 1 ) + 1)
+            sleep(sleep_ms) # Assumes your sleep() takes milliseconds
+~~~

--- a/_includes/v20.1/sql/unsupported-postgres-features.md
+++ b/_includes/v20.1/sql/unsupported-postgres-features.md
@@ -1,0 +1,12 @@
+- Stored procedures and functions
+- Triggers
+- Events
+- User-defined functions
+- FULLTEXT functions and indexes
+- GEOSPATIAL functions and indexes
+- Drop primary key
+- XML Functions
+- Savepoints
+- Column-level privileges
+- CREATE TEMPORARY TABLE syntax
+- XA syntax

--- a/v19.2/connect-to-the-database.md
+++ b/v19.2/connect-to-the-database.md
@@ -1,0 +1,138 @@
+---
+title: Connect to the Database
+summary: How to connect to a CockroachDB cluster from your application
+toc: true
+---
+
+This page has instructions for connecting to a CockroachDB cluster from your application using various programming languages.
+
+The instructions assume that you already have a [local cluster](secure-a-cluster.html) up and running.
+
+Each example shows a [connection string][connection_params] for a [secure local cluster][local_secure] to a `bank` database by a user named `maxroach`.  Depending on your cluster's configuration, you may need to edit this connection string.
+
+For a reference that lists all of the supported cluster connection parameters, see [Connection Parameters][connection_params].
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --certs-dir=certs --host=localhost:26257
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+import (
+    "database/sql"
+    "fmt"
+    "log"
+    _ "github.com/lib/pq"
+)
+
+db, err := sql.Open("postgres",
+        "postgresql://maxroach@localhost:26257/bank?ssl=true&sslmode=require&sslrootcert=certs/ca.crt&sslkey=certs/client.maxroach.key&sslcert=certs/client.maxroach.crt")
+if err != nil {
+    log.Fatal("error connecting to the database: ", err)
+}
+defer db.Close()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+import java.sql.*;
+import javax.sql.DataSource;
+
+PGSimpleDataSource ds = new PGSimpleDataSource();
+ds.setServerName("localhost");
+ds.setPortNumber(26257);
+ds.setDatabaseName("bank");
+ds.setUser("maxroach");
+ds.setPassword(null);
+ds.setSsl(true);
+ds.setSslMode("require");
+ds.setSslCert("certs/client.maxroach.crt");
+ds.setSslKey("certs/client.maxroach.key.pk8");
+ds.setReWriteBatchedInserts(true); // add `rewriteBatchedInserts=true` to pg connection string
+ds.setApplicationName("BasicExample");
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+import psycopg2
+
+conn = psycopg2.connect(
+    database='bank',
+    user='maxroach',
+    sslmode='require',
+    sslrootcert='certs/ca.crt',
+    sslkey='certs/client.maxroach.key',
+    sslcert='certs/client.maxroach.crt',
+    port=26257,
+    host='localhost'
+)
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [Connection parameters][connection_params]
+- [Manual deployments][manual]
+- [Orchestrated deployments][orchestrated]
+- [Start a local cluster (secure)][local_secure]
+
+<a name="tasks"></a>
+
+Other common tasks:
+
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast](make-queries-fast.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[local_secure]: secure-a-cluster.html
+[connection_params]: connection-parameters.html

--- a/v19.2/delete-data.md
+++ b/v19.2/delete-data.md
@@ -1,0 +1,162 @@
+---
+title: Delete Data
+summary: How to delete data from CockroachDB during application development
+toc: true
+---
+
+This page has instructions for deleting data from CockroachDB (using the [`DELETE`](update.html) statement) using various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to delete.
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+{{site.data.alerts.callout_success}}
+For [`DELETE`](delete.html) statements, a single statement that deletes multiple rows (using a `WHERE` clause) is faster than multiple single-row statements.  Whenever possible, use a multi-row statement.  For more information, see [Delete Multiple Rows](delete.html#delete-specific-rows).
+{{site.data.alerts.end}}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ sql
+DELETE from accounts WHERE id = 1;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ go
+// 'db' is an open database connection
+
+if _, err := db.Exec("DELETE FROM accounts WHERE id = 1"); err != nil {
+    return err
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+try (Connection connection = ds.getConnection()) {
+    connection.createStatement().executeUpdate("DELETE FROM accounts WHERE id = 1");
+
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+with conn.cursor() as cur:
+    cur.execute("DELETE FROM accounts WHERE id = 1",
+conn.commit()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## Delete multiple rows
+
+You can delete multiple rows from a table in several ways:
+
+- Using a `WHERE` clause to limit the number of rows based on one or more predicates:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    DELETE FROM student_loan_accounts WHERE loan_amount < 30000;
+    ~~~
+
+- Using a `WHERE` clause to specify multiple records by a specific column's value (in this case, `id`):
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    DELETE FROM accounts WHERE id IN (1, 2, 3, 4, 5);
+    ~~~
+
+- Using [`TRUNCATE`](truncate.html) instead of [`DELETE`](delete.html) to delete all of the rows from a table, as recommended in our [performance best practices](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
+
+{{site.data.alerts.callout_info}}
+Before deleting large amounts of data, see [Performance considerations](#performance-considerations).
+{{site.data.alerts.end}}
+
+## Performance considerations
+
+Because of the way CockroachDB works under the hood, deleting data from the database does not immediately reduce disk usage.  Instead, records are marked as "deleted" and processed asynchronously by a background garbage collection process.  This process runs every 25 hours by default to allow sufficient time for running [backups](backup-and-restore.html) and running [time travel queries using `AS OF SYSTEM TIME`](as-of-system-time.html).  The garbage collection interval is controlled by the [`gc.ttlseconds`](configure-replication-zones.html#replication-zone-variables) setting.
+
+The practical implications of the above are:
+
+- Deleting data will not immediately decrease disk usage.
+- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly, for reasons [explained in this FAQ entry](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+- To delete all of the rows in a table, [it's faster to use `TRUNCATE` instead of `DELETE`](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
+
+For more information about how the storage layer of CockroachDB works, see the [storage layer reference documentation](architecture/storage-layer.html).
+
+## See also
+
+Reference information related to this task:
+
+- [`DELETE`](delete.html)
+- [Disk space usage after deletes](delete.html#disk-space-usage-after-deletes)
+- [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time)
+- [`TRUNCATE`](truncate.html)
+- [`DROP TABLE`](drop-table.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Delete Multiple Rows](delete.html#delete-specific-rows)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast][fast]
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[selection]: selection-queries.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[fast]: make-queries-fast.html
+[paginate]: selection-queries.html#paginate-through-limited-results
+[joins]: joins.html

--- a/v19.2/developer-guide-overview.md
+++ b/v19.2/developer-guide-overview.md
@@ -1,0 +1,29 @@
+---
+title: Developer Guide Overview
+summary: An overview of common tasks that come up when you build an application using CockroachDB
+toc: true
+---
+
+This guide shows you how to do common tasks that come up when you build an application using CockroachDB.
+
+For instructions showing how to do a specific task, see the links below.
+
+## Common Tasks
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast](make-queries-fast.html)
+- ['Hello World' Example Apps](hello-world-example-apps.html)
+
+## See also
+
+- [Migrate to CockroachDB](migration-overview.html)
+- [Connection parameters](connection-parameters.html)
+- [Selection queries](selection-queries.html)
+- [Joins](joins.html)
+- [Transactions](transactions.html)

--- a/v19.2/error-handling-and-troubleshooting.md
+++ b/v19.2/error-handling-and-troubleshooting.md
@@ -1,0 +1,91 @@
+---
+title: Error Handling and Troubleshooting
+summary: How to troubleshoot problems and handle transaction retry errors during application development
+toc: true
+---
+
+This page has instructions for handling errors and troubleshooting problems that may arise during application development.
+
+## Troubleshooting query problems
+
+If you are not satisfied with your SQL query performance, follow the instructions in [Make Queries Fast][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
+
+If you have already optimized your SQL queries as described in [Make Queries Fast][fast] and are still having issues such as
+
+- Hanging or "stuck" queries
+- Queries that are slow some of the time (but not always)
+- Low throughput of queries
+
+take a look at [Query Behavior Troubleshooting](query-behavior-troubleshooting.html).
+
+## Transaction retry errors
+
+Messages with the Postgres error code `40001` indicate that a transaction failed because it conflicted with another concurrent or recent transaction accessing the same data. The transaction needs to be retried by the client.
+
+If your language's client driver or ORM implements transaction retry logic internally (e.g., if you are using Python and [SQLAlchemy with the CockroachDB dialect](build-a-python-app-with-cockroachdb-sqlalchemy.html)), then you don't need to handle this logic from your application.
+
+If your driver or ORM does not implement this logic, then you will need to implement a retry loop in your application.
+
+{% include {{page.version.version}}/misc/client-side-intervention-example.md %}
+
+{{site.data.alerts.callout_info}}
+If a consistently high percentage of your transactions are resulting in transaction retry errors, then you may need to evaluate your schema design and data access patterns to find and remove sources of contention. For more information, see [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
+{{site.data.alerts.end}}
+
+For more information about transaction retry errors, see [Transaction retries](transactions.html#client-side-intervention).
+
+## Unsupported SQL features
+
+CockroachDB has support for [most SQL features](sql-feature-support.html).
+
+Additionally, CockroachDB supports [the PostgreSQL wire protocol and the majority of its syntax](postgresql-compatibility.html). This means that existing applications can often be migrated to CockroachDB without changing application code.
+
+However, you may encounter features of SQL or the Postgres dialect that are not supported by CockroachDB. For example, the following Postgres features are not supported:
+
+{% include {{page.version.version}}/sql/unsupported-postgres-features.md %}
+
+For more information about the differences between CockroachDB and Postgres feature support, see [PostgreSQL Compatibility](postgresql-compatibility.html).
+
+For more information about the SQL standard features supported by CockroachDB, see [SQL Feature Support](sql-feature-support.html)
+
+## Troubleshooting cluster problems
+
+As a developer, you will mostly be working with the CockroachDB [SQL API](sql-statements.html).
+
+However, you may need to access the underlying cluster to troubleshoot issues where the root cause is not your SQL, but something happening at the cluster level. Symptoms of cluster-level issues can include:
+
+- Cannot join a node to an existing cluster
+- Networking, client connection, or authentication issues
+- Clock sync, replication, or node liveness issues
+- Capacity planning, storage, or memory issues
+- Node decommissioning failures
+
+For more information about how to troubleshoot cluster-level issues, see [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html).
+
+## See also
+
+Reference information related to this page:
+
+- [Troubleshoot Query Behavior](query-behavior-troubleshooting.html)
+- [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html)
+- [Common errors](common-errors.html)
+- [Transactions](transactions.html)
+- [Transaction retries](transactions.html#client-side-intervention)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [SQL Layer][sql]
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Make Queries Fast][fast]
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[sql]: architecture/sql-layer.html
+[fast]: make-queries-fast.html

--- a/v19.2/hello-world-example-apps.md
+++ b/v19.2/hello-world-example-apps.md
@@ -1,0 +1,40 @@
+---
+title: Hello World Example Apps
+summary: Examples that show you how to build a simple "Hello World" application with CockroachDB
+tags: golang, python, java
+toc: true
+redirect_from: build-an-app-with-cockroachdb.html
+---
+
+The examples in this section show you how to build simple "Hello World" applications using CockroachDB.
+
+## Apps
+
+Click the links in the table below to see simple but complete example applications for each supported language and library combination.
+
+If you are looking to do a specific task such as connect to the database, insert data, or run multi-statement transactions, see [this list of tasks](#tasks).
+
+{% include {{page.version.version}}/misc/drivers.md %}
+
+## See also
+
+Reference information:
+
+- [Client drivers](install-client-drivers.html)
+- [Third-party database tools](third-party-database-tools.html)
+- [Connection parameters](connection-parameters.html)
+- [Transactions](transactions.html)
+- [Performance best practices](performance-best-practices-overview.html)
+
+<a name="tasks"></a>
+
+Specific tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Make Queries Fast](make-queries-fast.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)

--- a/v19.2/insert-data.md
+++ b/v19.2/insert-data.md
@@ -1,0 +1,138 @@
+---
+title: Insert Data
+summary: How to insert data into CockroachDB during application development
+toc: true
+---
+
+This page has instructions for getting data into CockroachDB with various programming languages, using the [`INSERT`](insert.html) SQL statement.
+
+The instructions assume that you already have a [local cluster](secure-a-cluster.html) up and running.
+
+The instructions assume you are already [connected to the database](connect-to-the-database.html).
+
+{{site.data.alerts.callout_success}}
+If you need to get a lot of data into a CockroachDB cluster quickly, use the [`IMPORT`](import.html) statement instead of sending SQL [`INSERT`s](insert.html) from application code. It will be much faster because it bypasses the SQL layer altogether and writes directly to the data store using low-level commands. For instructions, see the [Migration Overview](migration-overview.html).
+{{site.data.alerts.end}}
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+{{site.data.alerts.callout_success}}
+For [`INSERT`](insert.html) statements, a single multi-row statement is faster than multiple single-row statements.  Whenever possible, use a multi-row statement.  For more information, see [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table).
+{{site.data.alerts.end}}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT);
+INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250);
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+// 'db' is an open database connection
+
+// Insert two rows into the "accounts" table.
+if _, err := db.Exec(
+    "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)"); err != nil {
+    log.Fatal(err)
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+try (Connection connection = ds.getConnection()) {
+    connection.setAutoCommit(false);
+    PreparedStatement pstmt = connection.prepareStatement("INSERT INTO accounts (id, balance) VALUES (?, ?)");
+
+    pstmt.setInt(1, 1);
+    pstmt.setInt(2, 1000);
+    pstmt.addBatch();
+
+    pstmt.executeBatch();
+    connection.commit();
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+with conn.cursor() as cur:
+    cur.execute('INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)')
+
+conn.commit()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [Migration Overview](migration-overview.html)
+- [`IMPORT`](import.html)
+- [Import performance](import.html#performance)
+- [`INSERT`](insert.html)
+- [`UPSERT`](upsert.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Multi-row DML best practices](performance-best-practices-overview.html#multi-row-dml-best-practices)
+- [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast](make-queries-fast.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[local_secure]: secure-a-cluster.html
+[connection_params]: connection-parameters.html

--- a/v19.2/make-queries-fast.md
+++ b/v19.2/make-queries-fast.md
@@ -1,0 +1,466 @@
+---
+title: Make Queries Fast
+summary: How to make your queries run faster during application development
+toc: true
+---
+
+This page describes how to get good SQL query performance from CockroachDB. To get good performance, you need to look at how you're accessing the database through several lenses:
+
+- [SQL query performance](#sql-query-performance): This is the most common cause of performance problems, and where most developers should start.
+- [Schema design](#schema-design): Depending on your SQL schema and the data access patterns of your workload, you may need to make changes to avoid creating "hotspots".
+- [Cluster topology](#cluster-topology): As a distributed system, CockroachDB requires you to trade off latency vs. resiliency. This requires choosing the right cluster topology for your needs.
+
+## SQL query performance
+
+To get good SQL query performance, follow the rules below (in approximate order of importance):
+
+{{site.data.alerts.callout_info}}
+These rules apply to an environment where thousands of [OLTP](https://en.wikipedia.org/wiki/Online_transaction_processing) queries are being run per second, and each query needs to run in milliseconds. These rules are not intended to apply to analytical queries.
+{{site.data.alerts.end}}
+
+- [Rule 1. Scan as few rows as possible](#rule-1-scan-as-few-rows-as-possible). If your application is scanning more rows than necessary for a given query, it's going to be difficult to scale.
+- [Rule 2. Use the right index](#rule-2-use-the-right-index): Your query should use an index on the columns in the `WHERE` clause. You want to avoid the performance hit of a full table scan.
+- [Rule 3. Use the right join type](#rule-3-use-the-right-join-type): Depending on the relative sizes of the tables you are querying, the type of [join][joins] may be important. This should rarely be necessary because the [cost-based optimizer](cost-based-optimizer.html) should pick the best-performing join type if you add the right indexes as described in Rule 2.
+
+To show each of these rules in action, we will optimize a query against the [MovR data set](movr.html) as follows:
+
+1. Start a [local cluster](start-a-local-cluster.html).
+
+2. Populate the cluster with data by running the following [`cockroach workload`](cockroach-workload.html) command:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    cockroach workload init movr --num-histories 250000 --num-promo-codes 250000 --num-rides 125000 --num-users 12500 --num-vehicles 3750 'postgresql://root@localhost:26257?sslmode=disable'
+    ~~~
+
+It's common to offer users promo codes to increase usage and customer loyalty. In this scenario, we want to find the 10 users who have taken the highest number of rides on a given date, and offer them promo codes that provide a 10% discount.
+
+To phrase it in the form of a question: "Who are the top 10 users by number of rides on a given date?"
+
+### Rule 1. Scan as few rows as possible
+
+First, let's study the schema so we understand the relationships between the tables.
+
+Start a SQL shell:
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach sql --insecure
+~~~
+
+Next, set `movr` as the current database and run [`SHOW TABLES`](show-tables.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+USE movr;
+SHOW TABLES;
+~~~
+
+~~~
+          table_name
++----------------------------+
+  promo_codes
+  rides
+  user_promo_codes
+  users
+  vehicle_location_histories
+  vehicles
+(6 rows)
+~~~
+
+Let's look at the schema for the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW CREATE TABLE users;
+~~~
+
+~~~
+  table_name |                      create_statement
++------------+-------------------------------------------------------------+
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | )
+~~~
+
+There's no information about the number of rides taken here, nor anything about the days on which rides occurred. Luckily, there is also a `rides` table. Let's look at it:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW CREATE TABLE rides;
+~~~
+
+~~~
+  table_name |                                                        create_statement
++------------+---------------------------------------------------------------------------------------------------------------------------------+
+  rides      | CREATE TABLE rides (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     vehicle_city VARCHAR NULL,
+             |     rider_id UUID NULL,
+             |     vehicle_id UUID NULL,
+             |     start_address VARCHAR NULL,
+             |     end_address VARCHAR NULL,
+             |     start_time TIMESTAMP NULL,
+             |     end_time TIMESTAMP NULL,
+             |     revenue DECIMAL(10,2) NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),
+             |     INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),
+             |     FAMILY "primary" (id, city, vehicle_city, rider_id, vehicle_id, start_address, end_address, start_time, end_time, revenue),
+             |     CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)
+             | )
+~~~
+
+There is a `rider_id` field that we can use to match each ride to a user. There is also a `start_time` field that we can use to filter the rides by date.
+
+This means that to get the information we want, we'll need to do a [join][joins] on the `users` and `rides` tables.
+
+Next, let's get the row counts for the tables that we'll be using in this query. We need to understand which tables are large, and which are small by comparison. We will need this later if we need to verify we are [using the right join type](#rule-3-use-the-right-join-type).
+
+As specified above by our [`cockroach workload`](cockroach-workload.html) command, the `users` table has 12,500 records, and the `rides` table has 125,000 records. Because it's so large, we want to avoid scanning the entire `rides` table in our query. In this case, we can avoid scanning `rides` using an index, as shown in the next section.
+
+### Rule 2. Use the right index
+
+Below is a query that fetches the right answer to our question: "Who are the top 10 users by number of rides on a given date?"
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name        | sum
++-------------------+-----+
+  William Brown     |   6
+  Joseph Smith      |   5
+  Laura Marsh       |   5
+  Arthur Nielsen    |   4
+  Elizabeth Miller  |   4
+  Christopher Allen |   4
+  David Martinez    |   4
+  Donald Young      |   4
+  Michael Garcia    |   4
+  Jennifer Johnson  |   4
+(10 rows)
+
+Time: 162.217ms
+~~~
+
+Unfortunately, this query is a bit slow. 160 milliseconds puts us [over the limit where a user feels the system is reacting instantaneously](https://www.nngroup.com/articles/response-times-3-important-limits/), and we're still down in the database layer. This data still needs to be shipped back out to your application and displayed to the user.
+
+We can see why if we look at the output of [`EXPLAIN`](explain.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+EXPLAIN SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+              tree              |    field    |                                         description
++-------------------------------+-------------+---------------------------------------------------------------------------------------------+
+                                | distributed | true
+                                | vectorized  | false
+  limit                         |             |
+   │                            | count       | 10
+   └── sort                     |             |
+        │                       | order       | -sum
+        └── group               |             |
+             │                  | aggregate 0 | name
+             │                  | aggregate 1 | count(id)
+             │                  | group by    | name
+             └── render         |             |
+                  └── hash-join |             |
+                       │        | type        | inner
+                       │        | equality    | (rider_id) = (id)
+                       ├── scan |             |
+                       │        | table       | rides@primary
+                       │        | spans       | ALL
+                       │        | filter      | (start_time >= '2018-12-31 00:00:00+00:00') AND (start_time <= '2019-01-01 00:00:00+00:00')
+                       └── scan |             |
+                                | table       | users@primary
+                                | spans       | ALL
+~~~
+
+The main problem is that we are doing full table scans on both the `users` and `rides` tables (see `spans | ALL`). This tells us that we don't have indexes on the columns in our `WHERE` clause, which is [an indexing best practice](indexes.html#best-practices).
+
+Therefore, we need to create an index on the column in our `WHERE` clause, in this case: `rides.start_time`.
+
+It's also possible that there is not an index on the `rider_id` column that we are doing a join against, which will also hurt performance.
+
+Before creating any more indexes, let's see what indexes already exist on the `rides` table by running [`SHOW INDEXES`](show-index.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW INDEXES FROM rides;
+~~~
+
+~~~
+  table_name |                  index_name                   | non_unique | seq_in_index | column_name  | direction | storing | implicit
++------------+-----------------------------------------------+------------+--------------+--------------+-----------+---------+----------+
+  rides      | primary                                       |   false    |            1 | city         | ASC       |  false  |  false
+  rides      | primary                                       |   false    |            2 | id           | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_city_ref_users            |    true    |            1 | city         | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_city_ref_users            |    true    |            2 | rider_id     | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_city_ref_users            |    true    |            3 | id           | ASC       |  false  |   true
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            1 | vehicle_city | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            2 | vehicle_id   | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            3 | city         | ASC       |  false  |   true
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            4 | id           | ASC       |  false  |   true
+~~~
+
+As we suspected, there are no indexes on `start_time` or `rider_id`, so we'll need to create indexes on those columns.
+
+Because another performance best practice is to [create an index on the `WHERE` condition storing the join key](sql-tuning-with-explain.html#solution-create-a-secondary-index-on-the-where-condition-storing-the-join-key), we will create an index on `start_time` that stores the join key `rider_id`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE INDEX ON rides (start_time) storing (rider_id);
+~~~
+
+Now that we have an index on the column in our `WHERE` clause that stores the join key, let's run the query again:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name       | sum
++------------------+-----+
+  William Brown    |   6
+  Joseph Smith     |   5
+  Laura Marsh      |   5
+  Donald Young     |   4
+  Elizabeth Miller |   4
+  William Mitchell |   4
+  David Mitchell   |   4
+  Veronica Lindsey |   4
+  Michael Garcia   |   4
+  Jennifer Ford    |   4
+(10 rows)
+
+Time: 23.354ms
+~~~
+
+This query is now running about 7x faster than it was before we added the indexes (160ms vs. 25ms). This means we have an extra 135 milliseconds we can budget towards other areas of our application.
+
+To see what changed, let's look at the [`EXPLAIN`](explain.html) output:
+
+{% include copy-clipboard.html %}
+~~~ sql
+EXPLAIN SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+As you can see, this query is no longer scanning the entire (larger) `rides` table. Instead, it is now doing a much smaller range scan against only the values in `rides` that match the index we just created on the `start_time` column.
+
+~~~
+              tree              |    field    |                      description
++-------------------------------+-------------+-------------------------------------------------------+
+                                | distributed | true
+                                | vectorized  | false
+  limit                         |             |
+   │                            | count       | 10
+   └── sort                     |             |
+        │                       | order       | -sum
+        └── group               |             |
+             │                  | aggregate 0 | name
+             │                  | aggregate 1 | count(id)
+             │                  | group by    | name
+             └── render         |             |
+                  └── hash-join |             |
+                       │        | type        | inner
+                       │        | equality    | (id) = (rider_id)
+                       ├── scan |             |
+                       │        | table       | users@primary
+                       │        | spans       | ALL
+                       └── scan |             |
+                                | table       | rides@rides_start_time_idx
+                                | spans       | /2018-12-31T00:00:00Z-/2019-01-01T00:00:00.000000001Z
+~~~
+
+
+### Rule 3. Use the right join type
+
+Out of the box, the [cost-based optimizer](cost-based-optimizer.html) will select the right join type for your query in the majority of cases. This statement becomes more and more true with every new release of CockroachDB. Therefore, you should only provide [join hints](cost-based-optimizer.html#join-hints) in your query if you can **prove** to yourself through experimentation that the optimizer should be using a different [join type](joins.html#join-algorithms) than it is selecting.
+
+We can confirm that in this case the optimizer has already found the right join type for this query by using a hint to force another join type.
+
+For example, we might think that a [lookup join](joins.html#lookup-joins) could perform better in this instance, since one of the tables in the join is 10x smaller than the other.
+
+In order to get CockroachDB to plan a lookup join in this case, we will need to add an explicit index on the join key for the right-hand-side table, in this case, `rides`.
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE INDEX ON rides (rider_id);
+~~~
+
+Next, we can specify the lookup join with a join hint:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users INNER LOOKUP JOIN rides ON users.id = rides.rider_id
+WHERE
+	(rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00')
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name        | sum
++-------------------+-----+
+  William Brown     |   6
+  Laura Marsh       |   5
+  Joseph Smith      |   5
+  Christopher Allen |   4
+  Veronica Lindsey  |   4
+  David Martinez    |   4
+  David Mitchell    |   4
+  Jennifer Ford     |   4
+  Donald Young      |   4
+  Michael Bradford  |   4
+(10 rows)
+
+Time: 2.071285s
+~~~
+
+The results, however, are not good. The query is much slower using a lookup join than what CockroachDB planned for us earlier. It takes about 2 seconds to run.
+
+The query is also not faster when we force CockroachDB to use a merge join:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users INNER MERGE JOIN rides ON users.id = rides.rider_id
+WHERE
+	(rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00')
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name        | sum
++-------------------+-----+
+  William Brown     |   6
+  Laura Marsh       |   5
+  Joseph Smith      |   5
+  Jennifer Ford     |   4
+  David Mitchell    |   4
+  William Mitchell  |   4
+  Christopher Allen |   4
+  Michael Bradford  |   4
+  Michael Garcia    |   4
+  Jennifer Johnson  |   4
+(10 rows)
+
+Time: 31.31ms
+~~~
+
+The results are consistently about 31-35ms with merge join vs. 25-27ms when we let CockroachDB choose the join type as shown in the previous section. In other words, forcing the merge join is slightly slower than if we had done nothing.
+
+## Schema design
+
+If you are following the instructions in [the SQL performance section](#sql-query-performance) and still not getting the performance you want, you may need to look at your schema design and data access patterns to make sure you are not creating "hotspots" in your cluster that will lead to performance problems due to transaction contention.
+
+You can avoid contention with the following strategies:
+
+- Use index keys with a more random distribution of values, as described in [Unique ID best practices](performance-best-practices-overview.html#unique-id-best-practices).
+- Make transactions smaller by operating on less data per transaction. This will offer fewer opportunities for transactions' data access to overlap.
+- [Split the table across multiple ranges](split-at.html) to distribute its data across multiple nodes for better load balancing of some write-heavy workloads.
+
+For more information about how to avoid performance problems caused by contention, see [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
+
+## Cluster topology
+
+It's very important to make sure that the cluster topology you are using is the right one for your use case. Because CockroachDB is a distributed system that involves nodes communicating over the network, you need to choose the cluster topology that results in the right latency vs. resiliency tradeoff.
+
+For more information about how to choose the cluster topology that is right for your application, see [this list of topology patterns](topology-patterns.html).
+
+## See also
+
+Reference information:
+
+- [SQL Tuning with `EXPLAIN`](sql-tuning-with-explain.html)
+- [SQL Performance Best Practices](performance-best-practices-overview.html)
+- [Joins](joins.html)
+- [CockroachDB Performance](performance.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Topology Patterns](topology-patterns.html)
+
+Specific tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[joins]: joins.html

--- a/v19.2/postgresql-compatibility.md
+++ b/v19.2/postgresql-compatibility.md
@@ -13,18 +13,8 @@ However, CockroachDB does not support some of the PostgreSQL features or behaves
 {{site.data.alerts.callout_info}}This document currently only covers unsupported SQL and how to rewrite SQL expressions. It does not discuss strategies for porting applications that use <a href="sql-feature-support.html">SQL features CockroachDB does not currently support</a>, such as the <code>ENUM</code> type.{{site.data.alerts.end}}
 
 ## Unsupported Features
-- Stored procedures and functions
-- Triggers
-- Events
-- User-defined functions
-- FULLTEXT functions and indexes
-- GEOSPATIAL functions and indexes
-- Drop primary key
-- XML Functions
-- Savepoints
-- Column-level privileges
-- CREATE TEMPORARY TABLE syntax
-- XA syntax
+
+{% include {{page.version.version}}/sql/unsupported-postgres-features.md %}
 
 ##Features that differ from PostgreSQL
 Note, some of these differences below only apply to rare inputs, and so no change will be needed, even if the listed feature is being used. In these cases, it is safe to ignore the porting instructions.

--- a/v19.2/query-data.md
+++ b/v19.2/query-data.md
@@ -1,0 +1,182 @@
+---
+title: Query Data
+summary: How to send SQL queries to CockroachDB from various programming languages
+toc: true
+---
+
+This page has instructions for making SQL [selection queries][selection] against CockroachDB from various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to run queries against.
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT id, balance from accounts;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+// 'db' is an open database connection
+
+rows, err := db.Query("SELECT id, balance FROM accounts")
+if err != nil {
+    log.Fatal(err)
+}
+defer rows.Close()
+fmt.Println("Initial balances:")
+for rows.Next() {
+    var id, balance int
+    if err := rows.Scan(&id, &balance); err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("%d %d\n", id, balance)
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+try (Connection connection = ds.getConnection()) {
+    Statement stmt = connection.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT id, balance FROM accounts");
+
+    while (rs.next()) {
+        int id = rs.getInt(1);
+        int bal = rs.getInt(2);
+        System.out.printf("ID: %10s\nBalance: %5s\n", id, bal);
+    }
+    rs.close();
+
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+with conn.cursor() as cur:
+    cur.execute("SELECT id, balance FROM accounts")
+    rows = cur.fetchall()
+    for row in rows:
+        print([str(cell) for cell in row])
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## Joins
+
+The syntax for a [selection query][selection] with a two-way [join][joins] is shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	a.col1, b.col1
+FROM
+	some_table AS a
+	JOIN
+    some_other_table AS b
+    ON
+    a.id = b.id
+WHERE
+	a.col2 > 100 AND a.col3 > now()
+ORDER BY
+	a.col2 DESC
+LIMIT
+	25;
+~~~
+
+Join performance can be a big factor in your application's performance.  For more information about how to make sure your SQL performs well, see [Make queries fast][fast].
+
+## Pagination
+
+For pagination queries, we strongly recommend keyset pagination (also known as "the seek method").  The syntax for a keyset pagination query is shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT * FROM t AS OF SYSTEM TIME ${time}
+  WHERE key > ${value}
+  ORDER BY key
+  LIMIT ${amount};
+~~~
+
+For a tutorial explaining keyset pagination queries and showing how to write them, see [Paginate through limited results][paginate].
+
+## Query optimization
+
+For instructions showing how to optimize your SQL queries, see [Make queries fast][fast].
+
+## See also
+
+Reference information related to this task:
+
+- [Selection queries][selection]
+- [`SELECT`](select-clause.html)
+- [Joins][joins]
+- [Paginate through limited results][paginate]
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast][fast]
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[selection]: selection-queries.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[fast]: make-queries-fast.html
+[paginate]: selection-queries.html#paginate-through-limited-results
+[joins]: joins.html

--- a/v19.2/run-multi-statement-transactions.md
+++ b/v19.2/run-multi-statement-transactions.md
@@ -1,0 +1,103 @@
+---
+title: Run Multi-Statement Transactions
+summary: How to use multi-statement transactions during application development
+toc: true
+---
+
+This page has instructions for running [multi-statement transactions](transactions.html#batched-statements) against CockroachDB from various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to run queries against.
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+BEGIN;
+DELETE FROM customers WHERE id = 1;
+DELETE orders WHERE customer = 1;
+COMMIT;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+The best way to run a multi-statement transaction from Go code is to use one of the following approaches:
+
+- Use the [`crdb` transaction wrapper](https://github.com/cockroachdb/cockroach-go/tree/master/crdb) which automatically handles transaction retry errors if they occur, as shown in [Build a Go App with CockroachDB](build-a-go-app-with-cockroachdb.html).
+
+- Write your own retry loop wrapper, as shown in [Build a Go App with CockroachDB and GORM](build-a-go-app-with-cockroachdb-gorm.html)
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+The best way to run a multi-statement transaction from Java is to write a wrapper method that automatically handles transaction retry errors.
+
+For complete examples showing how to write and use such wrapper methods, see [Build a Java App with CockroachDB](build-a-java-app-with-cockroachdb.html).
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+The best way to run a multi-statement transaction from Python code is to use one of the following approaches:
+
+- Use the [cockroachdb-python](https://github.com/cockroachdb/cockroachdb-python) SQLAlchemy dialect, which automatically handles transaction retry errors if they occur, as shown in [Build a Python App with CockroachDB and SQLAlchemy](build-a-python-app-with-cockroachdb-sqlalchemy.html).
+
+- Write your own retry loop wrapper, as shown in [Build a Python App with CockroachDB](build-a-python-app-with-cockroachdb.html).
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [Transactions](transactions.html)
+- [Transaction retries](transactions.html#client-side-intervention)
+- [Batched statements](transactions.html#batched-statements)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [`BEGIN`](begin-transaction.html)
+- [`COMMIT`](commit-transaction.html)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Make Queries Fast][fast]
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[selection]: selection-queries.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[fast]: make-queries-fast.html
+[paginate]: selection-queries.html#paginate-through-limited-results
+[joins]: joins.html

--- a/v19.2/transactions.md
+++ b/v19.2/transactions.md
@@ -158,33 +158,7 @@ To handle these types of errors you have the following options:
 
 #### Client-side intervention example
 
-The Python-like pseudocode below shows how to implement an application-level retry loop; it does not require your driver or ORM to implement [advanced retry handling logic](advanced-client-side-transaction-retries.html), so it can be used from any programming language or environment. In particular, your retry loop must:
-
-- Raise an error if the `max_retries` limit is reached
-- Retry on `40001` error codes
-- [`COMMIT`](commit-transaction.html) at the end of the `try` block
-- Implement [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) logic as shown below for best performance
-
-~~~ python
-while true:
-    n++
-    if n == max_retries:
-        throw Error("did not succeed within N retries")
-    try:
-        # add logic here to run all your statements
-        conn.exec('COMMIT')
-    catch error:
-        if error.code != "40001":
-            throw error
-        else:
-            # This is a retry error, so we roll back the current transaction
-            # and sleep for a bit before retrying. The sleep time increases
-            # for each failed transaction.  Adapted from
-            # https://colintemple.com/2017/03/java-exponential-backoff/
-            conn.exec('ROLLBACK');
-            sleep_ms = int(((2**n) * 100) + rand( 100 - 1 ) + 1)
-            sleep(sleep_ms) # Assumes your sleep() takes milliseconds
-~~~
+{% include {{page.version.version}}/misc/client-side-intervention-example.md %}
 
 ## Transaction contention
 

--- a/v19.2/update-data.md
+++ b/v19.2/update-data.md
@@ -1,0 +1,127 @@
+---
+title: Update Data
+summary: How to update the data in CockroachDB from various programming languages
+toc: true
+---
+
+This page has instructions for updating rows of data (using the [`UPDATE`](update.html) statement) in CockroachDB from various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to update.
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+UPDATE accounts SET balance = 900 WHERE id = 1;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+// tx is a *sql.Tx from "database/sql"
+
+transferAmount := 100
+fromID := 1
+
+if _, err := tx.Exec("UPDATE accounts SET balance = balance - $1 WHERE id = $2", transferAmount, fromID); err != nil {
+    return err
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+int transferAmount = 100;
+int fromID = 1;
+
+try (Connection connection = ds.getConnection()) {
+    connection.createStatement().executeUpdate("UPDATE accounts SET balance = balance - "
+                                               + transferAmount + " where id = " + fromID);
+
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+transferAmount = 100
+fromID = 1
+
+with conn.cursor() as cur:
+    cur.execute("UPDATE accounts SET balance = balance - %s WHERE id = %s",
+                (transferAmount, fromID));
+conn.commit()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [`UPDATE`](update.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Selection queries][selection]
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting][error_handling]
+- [Make Queries Fast](make-queries-fast.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[error_handling]: error-handling-and-troubleshooting.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[selection]: selection-queries.html

--- a/v20.1/connect-to-the-database.md
+++ b/v20.1/connect-to-the-database.md
@@ -1,0 +1,138 @@
+---
+title: Connect to the Database
+summary: How to connect to a CockroachDB cluster from your application
+toc: true
+---
+
+This page has instructions for connecting to a CockroachDB cluster from your application using various programming languages.
+
+The instructions assume that you already have a [local cluster](secure-a-cluster.html) up and running.
+
+Each example shows a [connection string][connection_params] for a [secure local cluster][local_secure] to a `bank` database by a user named `maxroach`.  Depending on your cluster's configuration, you may need to edit this connection string.
+
+For a reference that lists all of the supported cluster connection parameters, see [Connection Parameters][connection_params].
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --certs-dir=certs --host=localhost:26257
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+import (
+    "database/sql"
+    "fmt"
+    "log"
+    _ "github.com/lib/pq"
+)
+
+db, err := sql.Open("postgres",
+        "postgresql://maxroach@localhost:26257/bank?ssl=true&sslmode=require&sslrootcert=certs/ca.crt&sslkey=certs/client.maxroach.key&sslcert=certs/client.maxroach.crt")
+if err != nil {
+    log.Fatal("error connecting to the database: ", err)
+}
+defer db.Close()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+import java.sql.*;
+import javax.sql.DataSource;
+
+PGSimpleDataSource ds = new PGSimpleDataSource();
+ds.setServerName("localhost");
+ds.setPortNumber(26257);
+ds.setDatabaseName("bank");
+ds.setUser("maxroach");
+ds.setPassword(null);
+ds.setSsl(true);
+ds.setSslMode("require");
+ds.setSslCert("certs/client.maxroach.crt");
+ds.setSslKey("certs/client.maxroach.key.pk8");
+ds.setReWriteBatchedInserts(true); // add `rewriteBatchedInserts=true` to pg connection string
+ds.setApplicationName("BasicExample");
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+import psycopg2
+
+conn = psycopg2.connect(
+    database='bank',
+    user='maxroach',
+    sslmode='require',
+    sslrootcert='certs/ca.crt',
+    sslkey='certs/client.maxroach.key',
+    sslcert='certs/client.maxroach.crt',
+    port=26257,
+    host='localhost'
+)
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [Connection parameters][connection_params]
+- [Manual deployments][manual]
+- [Orchestrated deployments][orchestrated]
+- [Start a local cluster (secure)][local_secure]
+
+<a name="tasks"></a>
+
+Other common tasks:
+
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast](make-queries-fast.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[local_secure]: secure-a-cluster.html
+[connection_params]: connection-parameters.html

--- a/v20.1/delete-data.md
+++ b/v20.1/delete-data.md
@@ -1,0 +1,162 @@
+---
+title: Delete Data
+summary: How to delete data from CockroachDB during application development
+toc: true
+---
+
+This page has instructions for deleting data from CockroachDB (using the [`DELETE`](update.html) statement) using various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to delete.
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+{{site.data.alerts.callout_success}}
+For [`DELETE`](delete.html) statements, a single statement that deletes multiple rows (using a `WHERE` clause) is faster than multiple single-row statements.  Whenever possible, use a multi-row statement.  For more information, see [Delete Multiple Rows](delete.html#delete-specific-rows).
+{{site.data.alerts.end}}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ sql
+DELETE from accounts WHERE id = 1;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ go
+// 'db' is an open database connection
+
+if _, err := db.Exec("DELETE FROM accounts WHERE id = 1"); err != nil {
+    return err
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+try (Connection connection = ds.getConnection()) {
+    connection.createStatement().executeUpdate("DELETE FROM accounts WHERE id = 1");
+
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Delete a single row
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+with conn.cursor() as cur:
+    cur.execute("DELETE FROM accounts WHERE id = 1",
+conn.commit()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## Delete multiple rows
+
+You can delete multiple rows from a table in several ways:
+
+- Using a `WHERE` clause to limit the number of rows based on one or more predicates:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    DELETE FROM student_loan_accounts WHERE loan_amount < 30000;
+    ~~~
+
+- Using a `WHERE` clause to specify multiple records by a specific column's value (in this case, `id`):
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    DELETE FROM accounts WHERE id IN (1, 2, 3, 4, 5);
+    ~~~
+
+- Using [`TRUNCATE`](truncate.html) instead of [`DELETE`](delete.html) to delete all of the rows from a table, as recommended in our [performance best practices](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
+
+{{site.data.alerts.callout_info}}
+Before deleting large amounts of data, see [Performance considerations](#performance-considerations).
+{{site.data.alerts.end}}
+
+## Performance considerations
+
+Because of the way CockroachDB works under the hood, deleting data from the database does not immediately reduce disk usage.  Instead, records are marked as "deleted" and processed asynchronously by a background garbage collection process.  This process runs every 25 hours by default to allow sufficient time for running [backups](backup-and-restore.html) and running [time travel queries using `AS OF SYSTEM TIME`](as-of-system-time.html).  The garbage collection interval is controlled by the [`gc.ttlseconds`](configure-replication-zones.html#replication-zone-variables) setting.
+
+The practical implications of the above are:
+
+- Deleting data will not immediately decrease disk usage.
+- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly, for reasons [explained in this FAQ entry](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+- To delete all of the rows in a table, [it's faster to use `TRUNCATE` instead of `DELETE`](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
+
+For more information about how the storage layer of CockroachDB works, see the [storage layer reference documentation](architecture/storage-layer.html).
+
+## See also
+
+Reference information related to this task:
+
+- [`DELETE`](delete.html)
+- [Disk space usage after deletes](delete.html#disk-space-usage-after-deletes)
+- [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time)
+- [`TRUNCATE`](truncate.html)
+- [`DROP TABLE`](drop-table.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Delete Multiple Rows](delete.html#delete-specific-rows)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast][fast]
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[selection]: selection-queries.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[fast]: make-queries-fast.html
+[paginate]: selection-queries.html#paginate-through-limited-results
+[joins]: joins.html

--- a/v20.1/developer-guide-overview.md
+++ b/v20.1/developer-guide-overview.md
@@ -1,0 +1,29 @@
+---
+title: Developer Guide Overview
+summary: An overview of common tasks that come up when you build an application using CockroachDB
+toc: true
+---
+
+This guide shows you how to do common tasks that come up when you build an application using CockroachDB.
+
+For instructions showing how to do a specific task, see the links below.
+
+## Common Tasks
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast](make-queries-fast.html)
+- ['Hello World' Example Apps](hello-world-example-apps.html)
+
+## See also
+
+- [Migrate to CockroachDB](migration-overview.html)
+- [Connection parameters](connection-parameters.html)
+- [Selection queries](selection-queries.html)
+- [Joins](joins.html)
+- [Transactions](transactions.html)

--- a/v20.1/error-handling-and-troubleshooting.md
+++ b/v20.1/error-handling-and-troubleshooting.md
@@ -1,0 +1,91 @@
+---
+title: Error Handling and Troubleshooting
+summary: How to troubleshoot problems and handle transaction retry errors during application development
+toc: true
+---
+
+This page has instructions for handling errors and troubleshooting problems that may arise during application development.
+
+## Troubleshooting query problems
+
+If you are not satisfied with your SQL query performance, follow the instructions in [Make Queries Fast][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
+
+If you have already optimized your SQL queries as described in [Make Queries Fast][fast] and are still having issues such as
+
+- Hanging or "stuck" queries
+- Queries that are slow some of the time (but not always)
+- Low throughput of queries
+
+take a look at [Query Behavior Troubleshooting](query-behavior-troubleshooting.html).
+
+## Transaction retry errors
+
+Messages with the Postgres error code `40001` indicate that a transaction failed because it conflicted with another concurrent or recent transaction accessing the same data. The transaction needs to be retried by the client.
+
+If your language's client driver or ORM implements transaction retry logic internally (e.g., if you are using Python and [SQLAlchemy with the CockroachDB dialect](build-a-python-app-with-cockroachdb-sqlalchemy.html)), then you don't need to handle this logic from your application.
+
+If your driver or ORM does not implement this logic, then you will need to implement a retry loop in your application.
+
+{% include {{page.version.version}}/misc/client-side-intervention-example.md %}
+
+{{site.data.alerts.callout_info}}
+If a consistently high percentage of your transactions are resulting in transaction retry errors, then you may need to evaluate your schema design and data access patterns to find and remove sources of contention. For more information, see [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
+{{site.data.alerts.end}}
+
+For more information about transaction retry errors, see [Transaction retries](transactions.html#client-side-intervention).
+
+## Unsupported SQL features
+
+CockroachDB has support for [most SQL features](sql-feature-support.html).
+
+Additionally, CockroachDB supports [the PostgreSQL wire protocol and the majority of its syntax](postgresql-compatibility.html). This means that existing applications can often be migrated to CockroachDB without changing application code.
+
+However, you may encounter features of SQL or the Postgres dialect that are not supported by CockroachDB. For example, the following Postgres features are not supported:
+
+{% include {{page.version.version}}/sql/unsupported-postgres-features.md %}
+
+For more information about the differences between CockroachDB and Postgres feature support, see [PostgreSQL Compatibility](postgresql-compatibility.html).
+
+For more information about the SQL standard features supported by CockroachDB, see [SQL Feature Support](sql-feature-support.html)
+
+## Troubleshooting cluster problems
+
+As a developer, you will mostly be working with the CockroachDB [SQL API](sql-statements.html).
+
+However, you may need to access the underlying cluster to troubleshoot issues where the root cause is not your SQL, but something happening at the cluster level. Symptoms of cluster-level issues can include:
+
+- Cannot join a node to an existing cluster
+- Networking, client connection, or authentication issues
+- Clock sync, replication, or node liveness issues
+- Capacity planning, storage, or memory issues
+- Node decommissioning failures
+
+For more information about how to troubleshoot cluster-level issues, see [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html).
+
+## See also
+
+Reference information related to this page:
+
+- [Troubleshoot Query Behavior](query-behavior-troubleshooting.html)
+- [Troubleshoot Cluster Setup](cluster-setup-troubleshooting.html)
+- [Common errors](common-errors.html)
+- [Transactions](transactions.html)
+- [Transaction retries](transactions.html#client-side-intervention)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [SQL Layer][sql]
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Make Queries Fast][fast]
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[sql]: architecture/sql-layer.html
+[fast]: make-queries-fast.html

--- a/v20.1/hello-world-example-apps.md
+++ b/v20.1/hello-world-example-apps.md
@@ -1,0 +1,40 @@
+---
+title: Hello World Example Apps
+summary: Examples that show you how to build a simple "Hello World" application with CockroachDB
+tags: golang, python, java
+toc: true
+redirect_from: build-an-app-with-cockroachdb.html
+---
+
+The examples in this section show you how to build simple "Hello World" applications using CockroachDB.
+
+## Apps
+
+Click the links in the table below to see simple but complete example applications for each supported language and library combination.
+
+If you are looking to do a specific task such as connect to the database, insert data, or run multi-statement transactions, see [this list of tasks](#tasks).
+
+{% include {{page.version.version}}/misc/drivers.md %}
+
+## See also
+
+Reference information:
+
+- [Client drivers](install-client-drivers.html)
+- [Third-party database tools](third-party-database-tools.html)
+- [Connection parameters](connection-parameters.html)
+- [Transactions](transactions.html)
+- [Performance best practices](performance-best-practices-overview.html)
+
+<a name="tasks"></a>
+
+Specific tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Make Queries Fast](make-queries-fast.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)

--- a/v20.1/insert-data.md
+++ b/v20.1/insert-data.md
@@ -1,0 +1,138 @@
+---
+title: Insert Data
+summary: How to insert data into CockroachDB during application development
+toc: true
+---
+
+This page has instructions for getting data into CockroachDB with various programming languages, using the [`INSERT`](insert.html) SQL statement.
+
+The instructions assume that you already have a [local cluster](secure-a-cluster.html) up and running.
+
+The instructions assume you are already [connected to the database](connect-to-the-database.html).
+
+{{site.data.alerts.callout_success}}
+If you need to get a lot of data into a CockroachDB cluster quickly, use the [`IMPORT`](import.html) statement instead of sending SQL [`INSERT`s](insert.html) from application code. It will be much faster because it bypasses the SQL layer altogether and writes directly to the data store using low-level commands. For instructions, see the [Migration Overview](migration-overview.html).
+{{site.data.alerts.end}}
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+{{site.data.alerts.callout_success}}
+For [`INSERT`](insert.html) statements, a single multi-row statement is faster than multiple single-row statements.  Whenever possible, use a multi-row statement.  For more information, see [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table).
+{{site.data.alerts.end}}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT);
+INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250);
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+// 'db' is an open database connection
+
+// Insert two rows into the "accounts" table.
+if _, err := db.Exec(
+    "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)"); err != nil {
+    log.Fatal(err)
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+try (Connection connection = ds.getConnection()) {
+    connection.setAutoCommit(false);
+    PreparedStatement pstmt = connection.prepareStatement("INSERT INTO accounts (id, balance) VALUES (?, ?)");
+
+    pstmt.setInt(1, 1);
+    pstmt.setInt(2, 1000);
+    pstmt.addBatch();
+
+    pstmt.executeBatch();
+    connection.commit();
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+with conn.cursor() as cur:
+    cur.execute('INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)')
+
+conn.commit()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [Migration Overview](migration-overview.html)
+- [`IMPORT`](import.html)
+- [Import performance](import.html#performance)
+- [`INSERT`](insert.html)
+- [`UPSERT`](upsert.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Multi-row DML best practices](performance-best-practices-overview.html#multi-row-dml-best-practices)
+- [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast](make-queries-fast.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[local_secure]: secure-a-cluster.html
+[connection_params]: connection-parameters.html

--- a/v20.1/make-queries-fast.md
+++ b/v20.1/make-queries-fast.md
@@ -1,0 +1,466 @@
+---
+title: Make Queries Fast
+summary: How to make your queries run faster during application development
+toc: true
+---
+
+This page describes how to get good SQL query performance from CockroachDB. To get good performance, you need to look at how you're accessing the database through several lenses:
+
+- [SQL query performance](#sql-query-performance): This is the most common cause of performance problems, and where most developers should start.
+- [Schema design](#schema-design): Depending on your SQL schema and the data access patterns of your workload, you may need to make changes to avoid creating "hotspots".
+- [Cluster topology](#cluster-topology): As a distributed system, CockroachDB requires you to trade off latency vs. resiliency. This requires choosing the right cluster topology for your needs.
+
+## SQL query performance
+
+To get good SQL query performance, follow the rules below (in approximate order of importance):
+
+{{site.data.alerts.callout_info}}
+These rules apply to an environment where thousands of [OLTP](https://en.wikipedia.org/wiki/Online_transaction_processing) queries are being run per second, and each query needs to run in milliseconds. These rules are not intended to apply to analytical queries.
+{{site.data.alerts.end}}
+
+- [Rule 1. Scan as few rows as possible](#rule-1-scan-as-few-rows-as-possible). If your application is scanning more rows than necessary for a given query, it's going to be difficult to scale.
+- [Rule 2. Use the right index](#rule-2-use-the-right-index): Your query should use an index on the columns in the `WHERE` clause. You want to avoid the performance hit of a full table scan.
+- [Rule 3. Use the right join type](#rule-3-use-the-right-join-type): Depending on the relative sizes of the tables you are querying, the type of [join][joins] may be important. This should rarely be necessary because the [cost-based optimizer](cost-based-optimizer.html) should pick the best-performing join type if you add the right indexes as described in Rule 2.
+
+To show each of these rules in action, we will optimize a query against the [MovR data set](movr.html) as follows:
+
+1. Start a [local cluster](start-a-local-cluster.html).
+
+2. Populate the cluster with data by running the following [`cockroach workload`](cockroach-workload.html) command:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    cockroach workload init movr --num-histories 250000 --num-promo-codes 250000 --num-rides 125000 --num-users 12500 --num-vehicles 3750 'postgresql://root@localhost:26257?sslmode=disable'
+    ~~~
+
+It's common to offer users promo codes to increase usage and customer loyalty. In this scenario, we want to find the 10 users who have taken the highest number of rides on a given date, and offer them promo codes that provide a 10% discount.
+
+To phrase it in the form of a question: "Who are the top 10 users by number of rides on a given date?"
+
+### Rule 1. Scan as few rows as possible
+
+First, let's study the schema so we understand the relationships between the tables.
+
+Start a SQL shell:
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach sql --insecure
+~~~
+
+Next, set `movr` as the current database and run [`SHOW TABLES`](show-tables.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+USE movr;
+SHOW TABLES;
+~~~
+
+~~~
+          table_name
++----------------------------+
+  promo_codes
+  rides
+  user_promo_codes
+  users
+  vehicle_location_histories
+  vehicles
+(6 rows)
+~~~
+
+Let's look at the schema for the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW CREATE TABLE users;
+~~~
+
+~~~
+  table_name |                      create_statement
++------------+-------------------------------------------------------------+
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | )
+~~~
+
+There's no information about the number of rides taken here, nor anything about the days on which rides occurred. Luckily, there is also a `rides` table. Let's look at it:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW CREATE TABLE rides;
+~~~
+
+~~~
+  table_name |                                                        create_statement
++------------+---------------------------------------------------------------------------------------------------------------------------------+
+  rides      | CREATE TABLE rides (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     vehicle_city VARCHAR NULL,
+             |     rider_id UUID NULL,
+             |     vehicle_id UUID NULL,
+             |     start_address VARCHAR NULL,
+             |     end_address VARCHAR NULL,
+             |     start_time TIMESTAMP NULL,
+             |     end_time TIMESTAMP NULL,
+             |     revenue DECIMAL(10,2) NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC),
+             |     INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC),
+             |     FAMILY "primary" (id, city, vehicle_city, rider_id, vehicle_id, start_address, end_address, start_time, end_time, revenue),
+             |     CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city)
+             | )
+~~~
+
+There is a `rider_id` field that we can use to match each ride to a user. There is also a `start_time` field that we can use to filter the rides by date.
+
+This means that to get the information we want, we'll need to do a [join][joins] on the `users` and `rides` tables.
+
+Next, let's get the row counts for the tables that we'll be using in this query. We need to understand which tables are large, and which are small by comparison. We will need this later if we need to verify we are [using the right join type](#rule-3-use-the-right-join-type).
+
+As specified above by our [`cockroach workload`](cockroach-workload.html) command, the `users` table has 12,500 records, and the `rides` table has 125,000 records. Because it's so large, we want to avoid scanning the entire `rides` table in our query. In this case, we can avoid scanning `rides` using an index, as shown in the next section.
+
+### Rule 2. Use the right index
+
+Below is a query that fetches the right answer to our question: "Who are the top 10 users by number of rides on a given date?"
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name        | sum
++-------------------+-----+
+  William Brown     |   6
+  Joseph Smith      |   5
+  Laura Marsh       |   5
+  Arthur Nielsen    |   4
+  Elizabeth Miller  |   4
+  Christopher Allen |   4
+  David Martinez    |   4
+  Donald Young      |   4
+  Michael Garcia    |   4
+  Jennifer Johnson  |   4
+(10 rows)
+
+Time: 162.217ms
+~~~
+
+Unfortunately, this query is a bit slow. 160 milliseconds puts us [over the limit where a user feels the system is reacting instantaneously](https://www.nngroup.com/articles/response-times-3-important-limits/), and we're still down in the database layer. This data still needs to be shipped back out to your application and displayed to the user.
+
+We can see why if we look at the output of [`EXPLAIN`](explain.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+EXPLAIN SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+              tree              |    field    |                                         description
++-------------------------------+-------------+---------------------------------------------------------------------------------------------+
+                                | distributed | true
+                                | vectorized  | false
+  limit                         |             |
+   │                            | count       | 10
+   └── sort                     |             |
+        │                       | order       | -sum
+        └── group               |             |
+             │                  | aggregate 0 | name
+             │                  | aggregate 1 | count(id)
+             │                  | group by    | name
+             └── render         |             |
+                  └── hash-join |             |
+                       │        | type        | inner
+                       │        | equality    | (rider_id) = (id)
+                       ├── scan |             |
+                       │        | table       | rides@primary
+                       │        | spans       | ALL
+                       │        | filter      | (start_time >= '2018-12-31 00:00:00+00:00') AND (start_time <= '2019-01-01 00:00:00+00:00')
+                       └── scan |             |
+                                | table       | users@primary
+                                | spans       | ALL
+~~~
+
+The main problem is that we are doing full table scans on both the `users` and `rides` tables (see `spans | ALL`). This tells us that we don't have indexes on the columns in our `WHERE` clause, which is [an indexing best practice](indexes.html#best-practices).
+
+Therefore, we need to create an index on the column in our `WHERE` clause, in this case: `rides.start_time`.
+
+It's also possible that there is not an index on the `rider_id` column that we are doing a join against, which will also hurt performance.
+
+Before creating any more indexes, let's see what indexes already exist on the `rides` table by running [`SHOW INDEXES`](show-index.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+SHOW INDEXES FROM rides;
+~~~
+
+~~~
+  table_name |                  index_name                   | non_unique | seq_in_index | column_name  | direction | storing | implicit
++------------+-----------------------------------------------+------------+--------------+--------------+-----------+---------+----------+
+  rides      | primary                                       |   false    |            1 | city         | ASC       |  false  |  false
+  rides      | primary                                       |   false    |            2 | id           | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_city_ref_users            |    true    |            1 | city         | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_city_ref_users            |    true    |            2 | rider_id     | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_city_ref_users            |    true    |            3 | id           | ASC       |  false  |   true
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            1 | vehicle_city | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            2 | vehicle_id   | ASC       |  false  |  false
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            3 | city         | ASC       |  false  |   true
+  rides      | rides_auto_index_fk_vehicle_city_ref_vehicles |    true    |            4 | id           | ASC       |  false  |   true
+~~~
+
+As we suspected, there are no indexes on `start_time` or `rider_id`, so we'll need to create indexes on those columns.
+
+Because another performance best practice is to [create an index on the `WHERE` condition storing the join key](sql-tuning-with-explain.html#solution-create-a-secondary-index-on-the-where-condition-storing-the-join-key), we will create an index on `start_time` that stores the join key `rider_id`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE INDEX ON rides (start_time) storing (rider_id);
+~~~
+
+Now that we have an index on the column in our `WHERE` clause that stores the join key, let's run the query again:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name       | sum
++------------------+-----+
+  William Brown    |   6
+  Joseph Smith     |   5
+  Laura Marsh      |   5
+  Donald Young     |   4
+  Elizabeth Miller |   4
+  William Mitchell |   4
+  David Mitchell   |   4
+  Veronica Lindsey |   4
+  Michael Garcia   |   4
+  Jennifer Ford    |   4
+(10 rows)
+
+Time: 23.354ms
+~~~
+
+This query is now running about 7x faster than it was before we added the indexes (160ms vs. 25ms). This means we have an extra 135 milliseconds we can budget towards other areas of our application.
+
+To see what changed, let's look at the [`EXPLAIN`](explain.html) output:
+
+{% include copy-clipboard.html %}
+~~~ sql
+EXPLAIN SELECT
+	name, count(rides.id) AS sum
+FROM
+	users JOIN rides ON users.id = rides.rider_id
+WHERE
+	rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00'
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+As you can see, this query is no longer scanning the entire (larger) `rides` table. Instead, it is now doing a much smaller range scan against only the values in `rides` that match the index we just created on the `start_time` column.
+
+~~~
+              tree              |    field    |                      description
++-------------------------------+-------------+-------------------------------------------------------+
+                                | distributed | true
+                                | vectorized  | false
+  limit                         |             |
+   │                            | count       | 10
+   └── sort                     |             |
+        │                       | order       | -sum
+        └── group               |             |
+             │                  | aggregate 0 | name
+             │                  | aggregate 1 | count(id)
+             │                  | group by    | name
+             └── render         |             |
+                  └── hash-join |             |
+                       │        | type        | inner
+                       │        | equality    | (id) = (rider_id)
+                       ├── scan |             |
+                       │        | table       | users@primary
+                       │        | spans       | ALL
+                       └── scan |             |
+                                | table       | rides@rides_start_time_idx
+                                | spans       | /2018-12-31T00:00:00Z-/2019-01-01T00:00:00.000000001Z
+~~~
+
+
+### Rule 3. Use the right join type
+
+Out of the box, the [cost-based optimizer](cost-based-optimizer.html) will select the right join type for your query in the majority of cases. This statement becomes more and more true with every new release of CockroachDB. Therefore, you should only provide [join hints](cost-based-optimizer.html#join-hints) in your query if you can **prove** to yourself through experimentation that the optimizer should be using a different [join type](joins.html#join-algorithms) than it is selecting.
+
+We can confirm that in this case the optimizer has already found the right join type for this query by using a hint to force another join type.
+
+For example, we might think that a [lookup join](joins.html#lookup-joins) could perform better in this instance, since one of the tables in the join is 10x smaller than the other.
+
+In order to get CockroachDB to plan a lookup join in this case, we will need to add an explicit index on the join key for the right-hand-side table, in this case, `rides`.
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE INDEX ON rides (rider_id);
+~~~
+
+Next, we can specify the lookup join with a join hint:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users INNER LOOKUP JOIN rides ON users.id = rides.rider_id
+WHERE
+	(rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00')
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name        | sum
++-------------------+-----+
+  William Brown     |   6
+  Laura Marsh       |   5
+  Joseph Smith      |   5
+  Christopher Allen |   4
+  Veronica Lindsey  |   4
+  David Martinez    |   4
+  David Mitchell    |   4
+  Jennifer Ford     |   4
+  Donald Young      |   4
+  Michael Bradford  |   4
+(10 rows)
+
+Time: 2.071285s
+~~~
+
+The results, however, are not good. The query is much slower using a lookup join than what CockroachDB planned for us earlier. It takes about 2 seconds to run.
+
+The query is also not faster when we force CockroachDB to use a merge join:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	name, count(rides.id) AS sum
+FROM
+	users INNER MERGE JOIN rides ON users.id = rides.rider_id
+WHERE
+	(rides.start_time BETWEEN '2018-12-31 00:00:00' AND '2019-01-01 00:00:00')
+GROUP BY
+	name
+ORDER BY
+	sum DESC
+LIMIT
+	10;
+~~~
+
+~~~
+        name        | sum
++-------------------+-----+
+  William Brown     |   6
+  Laura Marsh       |   5
+  Joseph Smith      |   5
+  Jennifer Ford     |   4
+  David Mitchell    |   4
+  William Mitchell  |   4
+  Christopher Allen |   4
+  Michael Bradford  |   4
+  Michael Garcia    |   4
+  Jennifer Johnson  |   4
+(10 rows)
+
+Time: 31.31ms
+~~~
+
+The results are consistently about 31-35ms with merge join vs. 25-27ms when we let CockroachDB choose the join type as shown in the previous section. In other words, forcing the merge join is slightly slower than if we had done nothing.
+
+## Schema design
+
+If you are following the instructions in [the SQL performance section](#sql-query-performance) and still not getting the performance you want, you may need to look at your schema design and data access patterns to make sure you are not creating "hotspots" in your cluster that will lead to performance problems due to transaction contention.
+
+You can avoid contention with the following strategies:
+
+- Use index keys with a more random distribution of values, as described in [Unique ID best practices](performance-best-practices-overview.html#unique-id-best-practices).
+- Make transactions smaller by operating on less data per transaction. This will offer fewer opportunities for transactions' data access to overlap.
+- [Split the table across multiple ranges](split-at.html) to distribute its data across multiple nodes for better load balancing of some write-heavy workloads.
+
+For more information about how to avoid performance problems caused by contention, see [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention).
+
+## Cluster topology
+
+It's very important to make sure that the cluster topology you are using is the right one for your use case. Because CockroachDB is a distributed system that involves nodes communicating over the network, you need to choose the cluster topology that results in the right latency vs. resiliency tradeoff.
+
+For more information about how to choose the cluster topology that is right for your application, see [this list of topology patterns](topology-patterns.html).
+
+## See also
+
+Reference information:
+
+- [SQL Tuning with `EXPLAIN`](sql-tuning-with-explain.html)
+- [SQL Performance Best Practices](performance-best-practices-overview.html)
+- [Joins](joins.html)
+- [CockroachDB Performance](performance.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Topology Patterns](topology-patterns.html)
+
+Specific tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[joins]: joins.html

--- a/v20.1/postgresql-compatibility.md
+++ b/v20.1/postgresql-compatibility.md
@@ -14,18 +14,8 @@ However, CockroachDB does not support some of the PostgreSQL features or behaves
 {{site.data.alerts.callout_info}}This document currently only covers unsupported SQL and how to rewrite SQL expressions. It does not discuss strategies for porting applications that use <a href="sql-feature-support.html">SQL features CockroachDB does not currently support</a>, such as the <code>ENUM</code> type.{{site.data.alerts.end}}
 
 ## Unsupported Features
-- Stored procedures and functions
-- Triggers
-- Events
-- User-defined functions
-- FULLTEXT functions and indexes
-- GEOSPATIAL functions and indexes
-- Drop primary key
-- XML Functions
-- Savepoints
-- Column-level privileges
-- CREATE TEMPORARY TABLE syntax
-- XA syntax
+
+{% include {{page.version.version}}/sql/unsupported-postgres-features.md %}
 
 ##Features that differ from PostgreSQL
 Note, some of these differences below only apply to rare inputs, and so no change will be needed, even if the listed feature is being used. In these cases, it is safe to ignore the porting instructions.

--- a/v20.1/query-data.md
+++ b/v20.1/query-data.md
@@ -1,0 +1,182 @@
+---
+title: Query Data
+summary: How to send SQL queries to CockroachDB from various programming languages
+toc: true
+---
+
+This page has instructions for making SQL [selection queries][selection] against CockroachDB from various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to run queries against.
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT id, balance from accounts;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+// 'db' is an open database connection
+
+rows, err := db.Query("SELECT id, balance FROM accounts")
+if err != nil {
+    log.Fatal(err)
+}
+defer rows.Close()
+fmt.Println("Initial balances:")
+for rows.Next() {
+    var id, balance int
+    if err := rows.Scan(&id, &balance); err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("%d %d\n", id, balance)
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+try (Connection connection = ds.getConnection()) {
+    Statement stmt = connection.createStatement();
+    ResultSet rs = stmt.executeQuery("SELECT id, balance FROM accounts");
+
+    while (rs.next()) {
+        int id = rs.getInt(1);
+        int bal = rs.getInt(2);
+        System.out.printf("ID: %10s\nBalance: %5s\n", id, bal);
+    }
+    rs.close();
+
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+with conn.cursor() as cur:
+    cur.execute("SELECT id, balance FROM accounts")
+    rows = cur.fetchall()
+    for row in rows:
+        print([str(cell) for cell in row])
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## Joins
+
+The syntax for a [selection query][selection] with a two-way [join][joins] is shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT
+	a.col1, b.col1
+FROM
+	some_table AS a
+	JOIN
+    some_other_table AS b
+    ON
+    a.id = b.id
+WHERE
+	a.col2 > 100 AND a.col3 > now()
+ORDER BY
+	a.col2 DESC
+LIMIT
+	25;
+~~~
+
+Join performance can be a big factor in your application's performance.  For more information about how to make sure your SQL performs well, see [Make queries fast][fast].
+
+## Pagination
+
+For pagination queries, we strongly recommend keyset pagination (also known as "the seek method").  The syntax for a keyset pagination query is shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT * FROM t AS OF SYSTEM TIME ${time}
+  WHERE key > ${value}
+  ORDER BY key
+  LIMIT ${amount};
+~~~
+
+For a tutorial explaining keyset pagination queries and showing how to write them, see [Paginate through limited results][paginate].
+
+## Query optimization
+
+For instructions showing how to optimize your SQL queries, see [Make queries fast][fast].
+
+## See also
+
+Reference information related to this task:
+
+- [Selection queries][selection]
+- [`SELECT`](select-clause.html)
+- [Joins][joins]
+- [Paginate through limited results][paginate]
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Make Queries Fast][fast]
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[selection]: selection-queries.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[fast]: make-queries-fast.html
+[paginate]: selection-queries.html#paginate-through-limited-results
+[joins]: joins.html

--- a/v20.1/run-multi-statement-transactions.md
+++ b/v20.1/run-multi-statement-transactions.md
@@ -1,0 +1,103 @@
+---
+title: Run Multi-Statement Transactions
+summary: How to use multi-statement transactions during application development
+toc: true
+---
+
+This page has instructions for running [multi-statement transactions](transactions.html#batched-statements) against CockroachDB from various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to run queries against.
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+BEGIN;
+DELETE FROM customers WHERE id = 1;
+DELETE orders WHERE customer = 1;
+COMMIT;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+The best way to run a multi-statement transaction from Go code is to use one of the following approaches:
+
+- Use the [`crdb` transaction wrapper](https://github.com/cockroachdb/cockroach-go/tree/master/crdb) which automatically handles transaction retry errors if they occur, as shown in [Build a Go App with CockroachDB](build-a-go-app-with-cockroachdb.html).
+
+- Write your own retry loop wrapper, as shown in [Build a Go App with CockroachDB and GORM](build-a-go-app-with-cockroachdb-gorm.html)
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+The best way to run a multi-statement transaction from Java is to write a wrapper method that automatically handles transaction retry errors.
+
+For complete examples showing how to write and use such wrapper methods, see [Build a Java App with CockroachDB](build-a-java-app-with-cockroachdb.html).
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+The best way to run a multi-statement transaction from Python code is to use one of the following approaches:
+
+- Use the [cockroachdb-python](https://github.com/cockroachdb/cockroachdb-python) SQLAlchemy dialect, which automatically handles transaction retry errors if they occur, as shown in [Build a Python App with CockroachDB and SQLAlchemy](build-a-python-app-with-cockroachdb-sqlalchemy.html).
+
+- Write your own retry loop wrapper, as shown in [Build a Python App with CockroachDB](build-a-python-app-with-cockroachdb.html).
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [Transactions](transactions.html)
+- [Transaction retries](transactions.html#client-side-intervention)
+- [Batched statements](transactions.html#batched-statements)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [`BEGIN`](begin-transaction.html)
+- [`COMMIT`](commit-transaction.html)
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Update Data](update-data.html)
+- [Delete Data](delete-data.html)
+- [Make Queries Fast][fast]
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[selection]: selection-queries.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[fast]: make-queries-fast.html
+[paginate]: selection-queries.html#paginate-through-limited-results
+[joins]: joins.html

--- a/v20.1/transactions.md
+++ b/v20.1/transactions.md
@@ -158,33 +158,7 @@ To handle these types of errors you have the following options:
 
 #### Client-side intervention example
 
-The Python-like pseudocode below shows how to implement an application-level retry loop; it does not require your driver or ORM to implement [advanced retry handling logic](advanced-client-side-transaction-retries.html), so it can be used from any programming language or environment. In particular, your retry loop must:
-
-- Raise an error if the `max_retries` limit is reached
-- Retry on `40001` error codes
-- [`COMMIT`](commit-transaction.html) at the end of the `try` block
-- Implement [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) logic as shown below for best performance
-
-~~~ python
-while true:
-    n++
-    if n == max_retries:
-        throw Error("did not succeed within N retries")
-    try:
-        # add logic here to run all your statements
-        conn.exec('COMMIT')
-    catch error:
-        if error.code != "40001":
-            throw error
-        else:
-            # This is a retry error, so we roll back the current transaction
-            # and sleep for a bit before retrying. The sleep time increases
-            # for each failed transaction.  Adapted from
-            # https://colintemple.com/2017/03/java-exponential-backoff/
-            conn.exec('ROLLBACK');
-            sleep_ms = int(((2**n) * 100) + rand( 100 - 1 ) + 1)
-            sleep(sleep_ms) # Assumes your sleep() takes milliseconds
-~~~
+{% include {{page.version.version}}/misc/client-side-intervention-example.md %}
 
 ## Transaction contention
 

--- a/v20.1/update-data.md
+++ b/v20.1/update-data.md
@@ -1,0 +1,127 @@
+---
+title: Update Data
+summary: How to update the data in CockroachDB from various programming languages
+toc: true
+---
+
+This page has instructions for updating rows of data (using the [`UPDATE`](update.html) statement) in CockroachDB from various programming languages.
+
+The instructions assume that you have already:
+
+- Set up a [local cluster](secure-a-cluster.html).
+- [Connected to the database](connect-to-the-database.html).
+- [Inserted data](insert-data.html) that you now want to update.
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="sql">SQL</button>
+  <button class="filter-button" data-scope="go">Go</button>
+  <button class="filter-button" data-scope="java">Java</button>
+  <button class="filter-button" data-scope="python">Python</button>
+</div>
+
+{% include {{page.version.version}}/app/retry-errors.md %}
+
+<section class="filter-content" markdown="1" data-scope="sql">
+
+## SQL
+
+{% include copy-clipboard.html %}
+~~~ sql
+UPDATE accounts SET balance = 900 WHERE id = 1;
+~~~
+
+For more information about how to use the built-in SQL client, see the [`cockroach sql`](cockroach-sql.html) reference docs.
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="go">
+
+## Go
+
+{% include copy-clipboard.html %}
+~~~ go
+// tx is a *sql.Tx from "database/sql"
+
+transferAmount := 100
+fromID := 1
+
+if _, err := tx.Exec("UPDATE accounts SET balance = balance - $1 WHERE id = $2", transferAmount, fromID); err != nil {
+    return err
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-go.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="java">
+
+## Java
+
+{% include copy-clipboard.html %}
+~~~ java
+// ds is an org.postgresql.ds.PGSimpleDataSource
+
+int transferAmount = 100;
+int fromID = 1;
+
+try (Connection connection = ds.getConnection()) {
+    connection.createStatement().executeUpdate("UPDATE accounts SET balance = balance - "
+                                               + transferAmount + " where id = " + fromID);
+
+} catch (SQLException e) {
+    System.out.printf("sql state = [%s]\ncause = [%s]\nmessage = [%s]\n",
+                      e.getSQLState(), e.getCause(), e.getMessage());
+}
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-java.md %}
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="python">
+
+## Python
+
+{% include copy-clipboard.html %}
+~~~ python
+# conn is a psycopg2 connection
+
+transferAmount = 100
+fromID = 1
+
+with conn.cursor() as cur:
+    cur.execute("UPDATE accounts SET balance = balance - %s WHERE id = %s",
+                (transferAmount, fromID));
+conn.commit()
+~~~
+
+{% include {{page.version.version}}/app/for-a-complete-example-python.md %}
+
+</section>
+
+## See also
+
+Reference information related to this task:
+
+- [`UPDATE`](update.html)
+- [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
+- [Selection queries][selection]
+
+Other common tasks:
+
+- [Connect to the Database](connect-to-the-database.html)
+- [Insert Data](insert-data.html)
+- [Query Data](query-data.html)
+- [Delete Data](delete-data.html)
+- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+- [Error Handling and Troubleshooting][error_handling]
+- [Make Queries Fast](make-queries-fast.html)
+- [Hello World Example apps](hello-world-example-apps.html)
+
+<!-- Reference Links -->
+
+[error_handling]: error-handling-and-troubleshooting.html
+[manual]: manual-deployment.html
+[orchestrated]: orchestration.html
+[selection]: selection-queries.html


### PR DESCRIPTION
Summary of changes:

- Add a new 'Develop' section to the TOC that shows how to do common
  application development tasks in several langs (SQL, Go, Python, Java)

- E.g., connect to the database, run queries, handle errors, optimize
  your SQL

- Also, we pull all of the example "apps" that used to live under
  'Build an App' into a new section called "'Hello World' Example Apps"

Fixes #5865.