### PR TITLE
TIMETZ docs

### DIFF
--- a/v19.2/timestamp.md
+++ b/v19.2/timestamp.md
@@ -83,12 +83,10 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 ~~~
 
 ~~~
-+-------------+--------------------------+-------------+----------------+-----------------------+-------------+
-| column_name |        data_type         | is_nullable | column_default | generation_expression |   indices   |
-+-------------+--------------------------+-------------+----------------+-----------------------+-------------+
-| a           | INT                      |    false    | NULL           |                       | {"primary"} |
-| b           | TIMESTAMP WITH TIME ZONE |    true     | NULL           |                       | {}          |
-+-------------+--------------------------+-------------+----------------+-----------------------+-------------+
+  column_name |  data_type  | is_nullable | column_default | generation_expression |  indices  | is_hidden
++-------------+-------------+-------------+----------------+-----------------------+-----------+-----------+
+  a           | INT8        |    false    | NULL           |                       | {primary} |   false
+  b           | TIMESTAMPTZ |    true     | NULL           |                       | {}        |   false
 (2 rows)
 ~~~
 
@@ -103,13 +101,11 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 ~~~
 
 ~~~
+  a |             b
 +---+---------------------------+
-| a |             b             |
-+---+---------------------------+
-| 1 | 2016-03-26 15:10:10+00:00 |
-| 2 | 2016-03-26 00:00:00+00:00 |
-+---+---------------------------+
-# Note that the first timestamp is UTC-05:00, which is the equivalent of EST.
+  1 | 2016-03-26 15:10:10+00:00
+  2 | 2016-03-26 00:00:00+00:00
+(2 rows)
 ~~~
 
 ## Supported casting and conversion

--- a/v20.1/data-types.md
+++ b/v20.1/data-types.md
@@ -24,7 +24,7 @@ Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
 [`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data.  | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'` | Not supported
 [`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html).  | `148591304110702593` | Not supported
 [`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'` | Supported
-[`TIME`](time.html) | A time of day in UTC.  | `TIME '01:23:45.123456'` | Not supported
+[`TIME`<br>`TIMETZ`](time.html) | A time of day in UTC. | `TIME '01:23:45.123456'`<br> `TIMETZ '01:23:45.123456-5:00'` | Not supported
 [`TIMESTAMP`<br>`TIMESTAMPTZ`](timestamp.html) | A date and time pairing in UTC. | `TIMESTAMP '2016-01-25 10:10:10'`<br>`TIMESTAMPTZ '2016-01-25 10:10:10-05:00'` | Supported
 [`UUID`](uuid.html) | A 128-bit hexadecimal value. | `7f9c24e8-3b12-4fef-91e0-56a2d5a246ec` | Supported
 

--- a/v20.1/set-vars.md
+++ b/v20.1/set-vars.md
@@ -166,7 +166,7 @@ The following demonstrates how to assign a list of values:
 
 {{site.data.alerts.callout_danger}}As a best practice, we recommend not using this setting and avoid setting a session time for your database. We instead recommend converting UTC values to the appropriate time zone on the client side.{{site.data.alerts.end}}
 
-You can control your client's default time zone for the current session with <code>SET TIME ZONE</code>. This will apply a session offset to all [`TIMESTAMP WITH TIME ZONE`](timestamp.html) values.
+You can control your client's default time zone for the current session with <code>SET TIME ZONE</code>. This will apply a session offset to all [`TIMESTAMPTZ`/`TIMESTAMP WITH TIME ZONE`](timestamp.html) and [`TIMETZ`/`TIME WITH TIME ZONE`](time.html) values.
 
 {{site.data.alerts.callout_info}}With setting <code>SET TIME ZONE</code>, CockroachDB uses UTC as the default time zone.{{site.data.alerts.end}}
 
@@ -176,7 +176,7 @@ The time zone value indicates the time zone for the current session.
 
 This value can be a string representation of a local system-defined
 time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or
-negative numeric offset from UTC (e.g., `-7`, `+7`). 
+negative numeric offset from UTC (e.g., `-7`, `+7`).
 All timezone abbreviations are case-sensitive and must be uppercase, with the exception of `UTC`, for which `utc` is an alias.
 
 `DEFAULT`, `LOCAL`, or `0` sets the session time zone to `UTC`.

--- a/v20.1/time.md
+++ b/v20.1/time.md
@@ -1,38 +1,67 @@
 ---
-title: TIME
+title: TIME / TIMETZ
 summary: The TIME data type stores a time of day in UTC.
 toc: true
 ---
+
 The `TIME` [data type](data-types.html) stores the time of day in UTC.
 
+The `TIMETZ` data type stores a time of day with a time zone offset from UTC.
+
 {% include {{page.version.version}}/sql/vectorized-support.md %}
+
+## Variants
+
+`TIME` has two variants:
+
+- `TIME`, which presents all `TIME` values in UTC.
+
+- `TIMETZ`, which converts `TIME` values with a specified time zone offset from UTC.
+
+    Ordering for `TIMETZ` is done in terms of [epoch](https://en.wikipedia.org/wiki/Epoch_(computing)). Time zones with lesser values are ranked higher if times are equal. For example, `'2:00-1' > '2:00+0'` and `'12:00-1' > '1:00+0'`.
+
+    [Like Postgres](https://www.postgresql.org/docs/current/static/datatype-datetime.html), we implement the `TIMETZ` variant for [SQL standards compliance](sql-feature-support.html). We also implement the `TIMETZ` variant for compatibility with ORMs, like [Hibernate](build-a-java-app-with-cockroachdb-hibernate.html).
+
+{{site.data.alerts.callout_success}}
+We recommend always using `TIME` instead of `TIMETZ`. Convert UTC values to the appropriate time zone on the client side.
+{{site.data.alerts.end}}
 
 ## Aliases
 
 In CockroachDB, the following are aliases:
 
-`TIME WITHOUT TIME ZONE`
+Alias    | Long Version
+---------|-------------
+`TIME`   | `TIME WITHOUT TIME ZONE`
+`TIMETZ` | `TIME WITH TIME ZONE`
 
 ## Syntax
 
-A constant value of type `TIME` can be expressed using an
-[interpreted literal](sql-constants.html#interpreted-literals), or a
-string literal
-[annotated with](scalar-expressions.html#explicitly-typed-expressions)
-type `TIME` or
-[coerced to](scalar-expressions.html#explicit-type-coercions) type
-`TIME`.
+### `TIME`
 
-The string format for time is `HH:MM:SS.SSSSSS`. For example: `TIME '05:40:00.000001'`.
+A constant value of type `TIME` can be expressed using an [interpreted literal](sql-constants.html#interpreted-literals), or a string literal [annotated with](scalar-expressions.html#explicitly-typed-expressions) type `TIME` or  [coerced to](scalar-expressions.html#explicit-type-coercions) type `TIME`. When it is unambiguous, a simple unannotated [string literal](sql-constants.html#string-literals) can also be automatically interpreted as type `TIME`.
 
-When it is unambiguous, a simple unannotated [string literal](sql-constants.html#string-literals) can also
-be automatically interpreted as type `TIME`.
+The string format for `TIME` is `HH:MM:SS.SSSSSS`. For example: `TIME '05:40:00.000001'`. The fractional portion is optional and is rounded to microseconds (i.e., six digits after the decimal) for compatibility with the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/static/protocol.html).
 
-Note that the fractional portion of `TIME` is optional and is rounded to microseconds (i.e., six digits after the decimal) for compatibility with the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/static/protocol.html).
+{{site.data.alerts.callout_info}}
+A date of `0000-01-01` is displayed for all `TIME`/`TIMETZ` values, but is not stored in the database. To print without a date, you can cast the type to a `STRING`.
+
+A time zone offset of `+00:00` is also displayed for all `TIME` and [`TIMESTAMP`](timestamp.html) values, but is not stored in the database.
+{{site.data.alerts.end}}
+
+### `TIMETZ`
+
+To express a `TIMETZ` value with a time zone offset from UTC, you can add an offset to a `TIME` value. For example, `TIMETZ '10:10:10.555555-05:00'` offsets from UTC by -5.
+
+If no time zone is specified for a `TIMETZ` value, the `timezone` [session variable](show-vars.html#supported-variables) is used. For example, if you [set the `timezone`](set-vars.html#set-time-zone) for a session using `SET TIME ZONE -2`, and you define the `TIMETZ` as `TIMETZ '10:10:10.55'`, the value will be displayed with an offset of -2 from UTC.
+
+`TIMETZ` is not affected by session-scoped offsets (unlike [`TIMESTAMPTZ`](timestamp.html)). Time zone offsets only apply to values inserted after the offset has been set, and do not affect existing `TIMETZ` values, or `TIMETZ` values with a time zone offset specified.
 
 ## Size
 
 A `TIME` column supports values up to 8 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
+
+A `TIMETZ` column supports values up to 12 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
 
 ## Example
 
@@ -47,12 +76,10 @@ A `TIME` column supports values up to 8 bytes in width, but the total storage si
 ~~~
 
 ~~~
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-| column_name | data_type | is_nullable | column_default | generation_expression |   indices   |
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-| time_id     | INT       |    false    | NULL           |                       | {"primary"} |
-| time_val    | TIME      |    true     | NULL           |                       | {}          |
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
+  column_name | data_type | is_nullable | column_default | generation_expression |  indices  | is_hidden
++-------------+-----------+-------------+----------------+-----------------------+-----------+-----------+
+  time_id     | INT8      |    false    | NULL           |                       | {primary} |   false
+  time_val    | TIME      |    true     | NULL           |                       | {}        |   false
 (2 rows)
 ~~~
 
@@ -67,16 +94,16 @@ A `TIME` column supports values up to 8 bytes in width, but the total storage si
 ~~~
 
 ~~~
+  time_id |         time_val
 +---------+---------------------------+
-| time_id |         time_val          |
-+---------+---------------------------+
-|       1 | 0000-01-01 05:40:00+00:00 |
-|       2 | 0000-01-01 05:41:39+00:00 |
-+---------+---------------------------+
+        1 | 0000-01-01 05:40:00+00:00
+        2 | 0000-01-01 05:41:39+00:00
 (2 rows)
 ~~~
 
-{{site.data.alerts.callout_info}}The <code>cockroach sql</code> shell displays the date and time zone due to the Go SQL driver it uses. Other client drivers may behave similarly. In such cases, however, the date and time zone are not relevant and are not stored in the database.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+The SQL shell displays the date and time zone due to the Go SQL driver it uses. Other client drivers may behave similarly. In such cases, however, the date and time zone are not relevant and are not stored in the database.
+{{site.data.alerts.end}}
 
 Comparing `TIME` values:
 
@@ -86,25 +113,25 @@ Comparing `TIME` values:
 ~~~
 
 ~~~
-+--------------------------------+
-|  (SELECT time_val FROM "time"  |
-|  WHERE time_id = 1) < (SELECT  |
-|   time_val FROM "time" WHERE   |
-|          time_id = 2)          |
-+--------------------------------+
-|              true              |
-+--------------------------------+
+< (SELECT time_val FROM time WHERE time_id = 2);
+  ?column?
++----------+
+    true
 (1 row)
 ~~~
 
 ## Supported casting & conversion
 
-`TIME` values can be [cast](data-types.html#data-type-conversions-and-casts) to any of the following data types:
+`TIME`/`TIMETZ` values can be [cast](data-types.html#data-type-conversions-and-casts) to any of the following data types:
 
 Type | Details
 -----|--------
 `INTERVAL` | Converts to the span of time since midnight (00:00)
 `STRING` | Converts to format `'HH:MM:SS.SSSSSS'` (microsecond precision)
+
+{{site.data.alerts.callout_info}}
+CockroachDB displays `TIME '24:00:00'` and `TIMETZ '24:00:00'` as `0000-01-01 00:00:00`. To display the proper stored value (`24:00:00`), you can [cast the data type to a `STRING`](time.html#supported-casting-conversion).
+{{site.data.alerts.end}}
 
 ## See also
 

--- a/v20.1/timestamp.md
+++ b/v20.1/timestamp.md
@@ -18,7 +18,7 @@ The `TIMESTAMP` and `TIMESTAMPTZ` [data types](data-types.html) stores a date an
     The default session time zone is UTC, which means that by default `TIMESTAMPTZ` values display in UTC.
     {{site.data.alerts.end}}
 
-The difference between these two variants is that `TIMESTAMPTZ` uses the client's session time zone, while the other simply does not. This behavior extends to functions like `now()` and `extract()` on `TIMESTAMPTZ` values.
+The difference between these two variants is that `TIMESTAMPTZ` uses the client's session [time zone](set-vars.html#set-time-zone), while the other simply does not. This behavior extends to functions like `now()` and `extract()` on `TIMESTAMPTZ` values.
 
 You can use the [`timezone()`](functions-and-operators.html#date-and-time-functions) and [`AT TIME ZONE`](functions-and-operators.html#special-syntax-forms) functions to convert a `TIMESTAMPTZ` into a `TIMESTAMP` at a specified timezone, or to convert a `TIMESTAMP` into a `TIMESTAMPTZ` at a specified timezone.
 
@@ -62,6 +62,10 @@ Note that the fractional portion is optional and is rounded to
 microseconds (6 digits after decimal) for compatibility with the
 PostgreSQL wire protocol.
 
+{{site.data.alerts.callout_info}}
+A time zone offset of `+00:00` is displayed for all [`TIME`](time.html) and `TIMESTAMP` values, but is not stored in the database.
+{{site.data.alerts.end}}
+
 ## Size
 
 A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but the total storage size is likely to be larger due to CockroachDB metadata.
@@ -79,12 +83,10 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 ~~~
 
 ~~~
-+-------------+--------------------------+-------------+----------------+-----------------------+-------------+
-| column_name |        data_type         | is_nullable | column_default | generation_expression |   indices   |
-+-------------+--------------------------+-------------+----------------+-----------------------+-------------+
-| a           | INT                      |    false    | NULL           |                       | {"primary"} |
-| b           | TIMESTAMP WITH TIME ZONE |    true     | NULL           |                       | {}          |
-+-------------+--------------------------+-------------+----------------+-----------------------+-------------+
+  column_name |  data_type  | is_nullable | column_default | generation_expression |  indices  | is_hidden
++-------------+-------------+-------------+----------------+-----------------------+-----------+-----------+
+  a           | INT8        |    false    | NULL           |                       | {primary} |   false
+  b           | TIMESTAMPTZ |    true     | NULL           |                       | {}        |   false
 (2 rows)
 ~~~
 
@@ -99,13 +101,11 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 ~~~
 
 ~~~
+  a |             b
 +---+---------------------------+
-| a |             b             |
-+---+---------------------------+
-| 1 | 2016-03-26 15:10:10+00:00 |
-| 2 | 2016-03-26 00:00:00+00:00 |
-+---+---------------------------+
-# Note that the first timestamp is UTC-05:00, which is the equivalent of EST.
+  1 | 2016-03-26 15:10:10+00:00
+  2 | 2016-03-26 00:00:00+00:00
+(2 rows)
 ~~~
 
 ## Supported casting and conversion


### PR DESCRIPTION
Fixes #5964.

- Added `TIMETZ` to v20.1 docs (`time.md` and `data-types.md`).
- Updated example output for `TIME` data type.

@otan for technical review.