### PR TITLE
Clean up outdated join limit variable usages

### DIFF
--- a/_includes/v19.1/misc/session-vars.html
+++ b/_includes/v19.1/misc/session-vars.html
@@ -109,7 +109,7 @@
 
   <tr>
    <td>
-    <code>experimental_reorder_joins_limit</code>
+    <code>reorder_joins_limit</code>
    </td>
    <td>Maximum number of joins that the optimizer will attempt to reorder when searching for an optimal query execution plan. For more information, see <a href="cost-based-optimizer.html#join-reordering">Join reordering</a>.</td>
    <td>

--- a/_includes/v19.2/misc/session-vars.html
+++ b/_includes/v19.2/misc/session-vars.html
@@ -121,7 +121,7 @@
 
   <tr>
    <td>
-    <code>experimental_reorder_joins_limit</code>
+    <code>reorder_joins_limit</code>
    </td>
    <td>Maximum number of joins that the optimizer will attempt to reorder when searching for an optimal query execution plan. For more information, see <a href="cost-based-optimizer.html#join-reordering">Join reordering</a>.</td>
    <td>

--- a/_includes/v20.1/misc/session-vars.html
+++ b/_includes/v20.1/misc/session-vars.html
@@ -121,7 +121,7 @@
 
   <tr>
    <td>
-    <code>experimental_reorder_joins_limit</code>
+    <code>reorder_joins_limit</code>
    </td>
    <td>Maximum number of joins that the optimizer will attempt to reorder when searching for an optimal query execution plan. For more information, see <a href="cost-based-optimizer.html#join-reordering">Join reordering</a>.</td>
    <td>


### PR DESCRIPTION
In CockroachDB 19.1+ , the variable `experimental_reorder_joins_limit`
is now known as `reorder_joins_limit`.

Fixes #6174.