### PR TITLE
Correct name of latest alpha release

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -45,10 +45,10 @@ release_info:
     start_time: 2019-12-16 11:01:26.34274101 +0000 UTC
   v20.1:
     name: v20.1.0
-    version: v20.1.0-alpha.20200130
+    version: v20.1.0-alpha.20200123
     docker_image: cockroachdb/cockroach-unstable
-    build_time: 2020/01/30 11:00:26 (go1.13.4)
-    start_time: 2020-01-30 11:01:26.34274101 +0000 UTC
+    build_time: 2020/01/23 11:00:26 (go1.13.4)
+    start_time: 2020-01-23 11:01:26.34274101 +0000 UTC
 
 include: ["_redirects"]
 exclude:

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -148,7 +148,7 @@
 - title: Testing Releases
   releases:
     - date: Jan 30, 2020
-      version: v20.1.0-alpha.20200130
+      version: v20.1.0-alpha.20200123
     - date: Dec 16, 2019
       version: v20.1.0-alpha.20191216
     - date: Nov 18, 2019

--- a/releases/v20.1.0-alpha.20200123.md
+++ b/releases/v20.1.0-alpha.20200123.md
@@ -1,7 +1,8 @@
 ---
-title: What&#39;s New in v20.1.0-alpha.20200130
+title: What&#39;s New in v20.1.0-alpha.20200123
 toc: true
-summary: Additions and changes in CockroachDB version v20.1.0-alpha.20200130 since version v20.1.0-alpha20191216
+summary: Additions and changes in CockroachDB version v20.1.0-alpha.20200123 since version v20.1.0-alpha20191216
+redirect_from: /releases/v20.1.0-alpha.20200130.html
 ---
 
 ## January 30, 2020
@@ -32,17 +33,17 @@ Get future release notes emailed to you:
 ### Downloads
 
 <div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200130.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200130.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200130.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200130.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200123.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200123.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200123.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.0-alpha.20200123.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 
 ### Docker image
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-unstable:v20.1.0-alpha.20200130
+$ docker pull cockroachdb/cockroach-unstable:v20.1.0-alpha.20200123
 ~~~
 
 ### Security updates


### PR DESCRIPTION
We released on 1/30, so the docs look for binaries, etc.,
using that date. However, the release is tagged with 1/23.
Thus, broken links. This PR corrects that. However, this
results in a somewhat confusing descrepancy between the
release date and the release name.

Fixes #6405.