### PR TITLE
Update learn-cockroachdb-sql.md

### DIFF
--- a/v19.2/learn-cockroachdb-sql.md
+++ b/v19.2/learn-cockroachdb-sql.md
@@ -244,17 +244,17 @@ To filter the results, add a `WHERE` clause identifying the columns and values t
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SELECT id, name FROM users WHERE city = 'chicago';
+> SELECT id, name FROM users WHERE city = 'san francisco';
 ~~~
 
 ~~~
-                   id                  |       name
+                   id                  |       name        
 +--------------------------------------+------------------+
-  80000000-0000-4000-8000-000000000019 | Matthew Clay
-  851eb851-eb85-4000-8000-00000000001a | Samantha Coffey
-  8a3d70a3-d70a-4000-8000-00000000001b | Jessica Martinez
-  8f5c28f5-c28f-4000-8000-00000000001c | John Hines
-  947ae147-ae14-4800-8000-00000000001d | Kenneth Barnes
+  75c28f5c-28f5-4400-8000-000000000017 | William Wood      
+  7ae147ae-147a-4000-8000-000000000018 | Alfred Garcia     
+  80000000-0000-4000-8000-000000000019 | Matthew Clay      
+  851eb851-eb85-4000-8000-00000000001a | Samantha Coffey   
+  8a3d70a3-d70a-4000-8000-00000000001b | Jessica Martinez  
 (5 rows)
 ~~~
 

--- a/v19.2/learn-cockroachdb-sql.md
+++ b/v19.2/learn-cockroachdb-sql.md
@@ -248,13 +248,13 @@ To filter the results, add a `WHERE` clause identifying the columns and values t
 ~~~
 
 ~~~
-                   id                  |       name        
+                   id                  |       name
 +--------------------------------------+------------------+
-  75c28f5c-28f5-4400-8000-000000000017 | William Wood      
-  7ae147ae-147a-4000-8000-000000000018 | Alfred Garcia     
-  80000000-0000-4000-8000-000000000019 | Matthew Clay      
-  851eb851-eb85-4000-8000-00000000001a | Samantha Coffey   
-  8a3d70a3-d70a-4000-8000-00000000001b | Jessica Martinez  
+  75c28f5c-28f5-4400-8000-000000000017 | William Wood
+  7ae147ae-147a-4000-8000-000000000018 | Alfred Garcia
+  80000000-0000-4000-8000-000000000019 | Matthew Clay
+  851eb851-eb85-4000-8000-00000000001a | Samantha Coffey
+  8a3d70a3-d70a-4000-8000-00000000001b | Jessica Martinez
 (5 rows)
 ~~~
 


### PR DESCRIPTION
While running the in memory demo the original query returned no results. Looking up a name it appears that `chicago` was swapped for `san francisco`.

Version Info

Build Tag:    v19.2.2
Build Time:   2019/12/11 01:33:43
Distribution: CCL
Platform:     linux amd64 (x86_64-unknown-linux-gnu)
Go Version:   go1.12.12
C Compiler:   gcc 6.3.0
Build SHA-1:  3cbd05602d4aeaebbccea18d66ad0fdf8db482a5
Build Type:   release