### PR TITLE
LATERAL subquery docs

### DIFF
--- a/v20.1/joins.md
+++ b/v20.1/joins.md
@@ -142,6 +142,10 @@ You can override the use of lookup joins using [join hints](cost-based-optimizer
 
 The output of [`EXPLAIN`](explain.html#verbose-option) has been updated to show whether `equality cols are key` for lookup joins, which means that the lookup columns form a key in the target table such that each lookup has at most one result.
 
+## `LATERAL` joins
+
+CockroachDB supports `LATERAL` subquery joins for `INNER` and `LEFT` cross joins. For more information about `LATERAL` subqueries, see [Lateral subqueries](subqueries.html#lateral-subqueries).
+
 ## Performance best practices
 
 {{site.data.alerts.callout_info}}CockroachDBs is currently undergoing major changes to evolve and improve the performance of queries using joins. The restrictions and workarounds listed in this section will be lifted or made unnecessary over time.{{site.data.alerts.end}}

--- a/v20.1/subqueries.md
+++ b/v20.1/subqueries.md
@@ -39,7 +39,7 @@ query only observes 1 row using [`LIMIT`](limit-offset.html).
 
 ## Correlated subqueries
 
-CockroachDB's [cost-based optimizer](cost-based-optimizer.html) supports most correlated subqueries.
+CockroachDB's [cost-based optimizer](cost-based-optimizer.html) supports most [correlated subqueries](https://en.wikipedia.org/wiki/Correlated_subquery).
 
 A subquery is said to be "correlated" when it uses table or column names defined in the surrounding query.
 
@@ -58,6 +58,81 @@ For example, to find every customer with at least one order, run:
 ~~~
 
 The subquery is correlated because it uses `c` defined in the surrounding query.
+
+### `LATERAL` subqueries
+
+<span class="version-tag">New in v20.1:</span> CockroachDB supports `LATERAL` subqueries. A `LATERAL` subquery is a correlated subquery that references another query or subquery in its `SELECT` statement, usually in the context of a [`LEFT` join](joins.html#left-outer-joins) or an [`INNER` join](joins.html#inner-joins). Unlike other correlated subqueries, `LATERAL` subqueries iterate through each row in the referenced query for each row in the inner subquery, like a [for loop](https://en.wikipedia.org/wiki/For_loop).
+
+To create a `LATERAL` subquery, use the `LATERAL` keyword directly before the inner subquery's `SELECT` statement.
+
+For example, the following statement performs an `INNER` join of the `users` table and a subquery of the `rides` table that filters on values in the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT name, address FROM users, LATERAL (SELECT * FROM rides WHERE rides.start_address = users.address AND city = 'new york');
+~~~
+
+~~~
+        name       |           address
++------------------+-----------------------------+
+  Robert Murphy    | 99176 Anderson Mills
+  James Hamilton   | 73488 Sydney Ports Suite 57
+  Judy White       | 18580 Rosario Ville Apt. 61
+  Devin Jordan     | 81127 Angela Ferry Apt. 8
+  Catherine Nelson | 1149 Lee Alley
+  Nicole Mcmahon   | 11540 Patton Extensions
+(6 rows)
+~~~
+
+`LATERAL` subquery joins are especially useful when the join table includes a [computed column](computed-columns.html).
+
+For example, the following query joins a subquery of the `rides` table with a computed column (`adjusted_revenue`), and a subquery of the `users` table that references columns in the `rides` subquery:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT
+   ride_id,
+   vehicle_id,
+   type,
+   adjusted_revenue
+FROM
+   (
+      SELECT
+         id AS ride_id,
+         vehicle_id,
+         revenue - 0.25*revenue AS adjusted_revenue
+      FROM
+         rides
+   )
+   r
+   JOIN
+      LATERAL (
+      SELECT
+         type
+      FROM
+         vehicles
+      WHERE
+         city = 'new york'
+         AND vehicles.id = r.vehicle_id
+         AND r.adjusted_revenue > 65 ) v
+         ON true;
+~~~
+
+~~~
+                ride_id                |              vehicle_id              |    type    | adjusted_revenue
++--------------------------------------+--------------------------------------+------------+------------------+
+  049ba5e3-53f7-4ec0-8000-000000000009 | 11111111-1111-4100-8000-000000000001 | scooter    |          71.2500
+  0624dd2f-1a9f-4e80-8000-00000000000c | 00000000-0000-4000-8000-000000000000 | skateboard |          70.5000
+  08b43958-1062-4e00-8000-000000000011 | 11111111-1111-4100-8000-000000000001 | scooter    |          70.5000
+  0bc6a7ef-9db2-4d00-8000-000000000017 | 00000000-0000-4000-8000-000000000000 | skateboard |          68.2500
+  0d4fdf3b-645a-4c80-8000-00000000001a | 00000000-0000-4000-8000-000000000000 | skateboard |          67.5000
+  1ba5e353-f7ce-4900-8000-000000000036 | 11111111-1111-4100-8000-000000000001 | scooter    |          70.5000
+(6 rows)
+~~~
+
+{{site.data.alerts.callout_info}}
+In a `LATERAL` subquery join, the rows returned by the inner subquery are added to the result of the join with the outer query. Without the `LATERAL` keyword, each subquery is evaluated independently and cannot refer to objects defined in separate queries.
+{{site.data.alerts.end}}
 
 ### Limitations
 


### PR DESCRIPTION
Fixes #5990.

@chrisseto Adding you for technical review

- Added a section on `LATERAL` subqueries to the "Subqueries" documentation page.
- Added a section on `LATERAL` subqueries to the "Join Expressions" documentation page. This section really only links to the main section, on the "Subqueries" page.