### PR TITLE
Recursive CTE docs

### DIFF
--- a/_includes/v20.1/sql/diagrams/delete.html
+++ b/_includes/v20.1/sql/diagrams/delete.html
@@ -1,66 +1,52 @@
-<div><svg width="666" height="340">
+<div><svg width="689" height="471">
 <polygon points="9 61 1 57 1 65"></polygon>
 <polygon points="17 61 9 57 9 65"></polygon>
-<rect x="51" y="47" width="56" height="32" rx="10"></rect>
-<rect x="49" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+<rect x="51" y="47" width="58" height="32" rx="10"></rect>
+<rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="59" y="65">WITH</text>
-<a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
-<rect x="147" y="47" width="144" height="32"></rect>
-<rect x="145" y="45" width="144" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="155" y="65">common_table_expr</text>
-</a>
-<rect x="147" y="3" width="24" height="32" rx="10"></rect>
-<rect x="145" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="155" y="21">,</text>
-<rect x="351" y="47" width="70" height="32" rx="10"></rect>
-<rect x="349" y="45" width="70" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="359" y="65">DELETE</text>
-<rect x="441" y="47" width="58" height="32" rx="10"></rect>
-<rect x="439" y="45" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="449" y="65">FROM</text>
-<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="519" y="47" width="90" height="32"></rect>
-<rect x="517" y="45" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="527" y="65">table_name</text>
-</a>
-<rect x="65" y="177" width="38" height="32" rx="10"></rect>
-<rect x="63" y="175" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="73" y="195">AS</text>
-<a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="143" y="145" width="124" height="32"></rect>
-<rect x="141" y="143" width="124" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="151" y="163">table_alias_name</text>
-</a>
-<rect x="327" y="145" width="68" height="32" rx="10"></rect>
-<rect x="325" y="143" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="335" y="163">WHERE</text>
-<a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-<rect x="415" y="145" width="62" height="32"></rect>
-<rect x="413" y="143" width="62" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="423" y="163">a_expr</text>
-</a>
-<a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
-<rect x="537" y="145" width="88" height="32"></rect>
-<rect x="535" y="143" width="88" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="545" y="163">sort_clause</text>
-</a>
-<a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
-<rect x="229" y="263" width="88" height="32"></rect>
-<rect x="227" y="261" width="88" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="237" y="281">limit_clause</text>
-</a>
-<rect x="377" y="263" width="100" height="32" rx="10"></rect>
-<rect x="375" y="261" width="100" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="281">RETURNING</text>
-<a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
-<rect x="517" y="263" width="80" height="32"></rect>
-<rect x="515" y="261" width="80" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="525" y="281">target_list</text>
-</a>
-<rect x="517" y="307" width="82" height="32" rx="10"></rect>
-<rect x="515" y="305" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="525" y="325">NOTHING</text>
-<path class="line" d="m17 61 h2 m20 0 h10 m56 0 h10 m20 0 h10 m144 0 h10 m-184 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m164 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-164 0 h10 m24 0 h10 m0 0 h120 m-280 44 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v14 m300 0 v-14 m-300 14 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m0 0 h270 m20 -34 h10 m70 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-628 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h232 m-262 0 h20 m242 0 h20 m-282 0 q10 0 10 10 m262 0 q0 -10 10 -10 m-272 10 v12 m262 0 v-12 m-262 12 q0 10 10 10 m242 0 q10 0 10 -10 m-232 10 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m124 0 h10 m40 -32 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m68 0 h10 m0 0 h10 m62 0 h10 m40 -32 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-480 118 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -32 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m100 0 h10 m20 0 h10 m80 0 h10 m0 0 h2 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m43 -76 h-3"></path>
-<polygon points="657 245 665 241 665 249"></polygon>
-<polygon points="657 245 649 241 649 249"></polygon>
-</svg></div>
+<rect x="149" y="79" width="98" height="32" rx="10"></rect>
+<rect x="147" y="77" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="157" y="97">RECURSIVE</text><a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
+<rect x="307" y="47" width="150" height="32"></rect>
+<rect x="305" y="45" width="150" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="315" y="65">common_table_expr</text></a><rect x="307" y="3" width="24" height="32" rx="10"></rect>
+<rect x="305" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="315" y="21">,</text>
+<rect x="517" y="47" width="70" height="32" rx="10"></rect>
+<rect x="515" y="45" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="65">DELETE</text>
+<rect x="607" y="47" width="60" height="32" rx="10"></rect>
+<rect x="605" y="45" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="615" y="65">FROM</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="81" y="161" width="96" height="32"></rect>
+<rect x="79" y="159" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="89" y="179">table_name</text></a><a xlink:href="sql-grammar.html#opt_index_flags" xlink:title="opt_index_flags">
+<rect x="197" y="161" width="122" height="32"></rect>
+<rect x="195" y="159" width="122" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="205" y="179">opt_index_flags</text></a><rect x="379" y="225" width="38" height="32" rx="10"></rect>
+<rect x="377" y="223" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="387" y="243">AS</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="457" y="193" width="134" height="32"></rect>
+<rect x="455" y="191" width="134" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="465" y="211">table_alias_name</text></a><rect x="115" y="307" width="70" height="32" rx="10"></rect>
+<rect x="113" y="305" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="123" y="325">WHERE</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="205" y="307" width="64" height="32"></rect>
+<rect x="203" y="305" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="213" y="325">a_expr</text></a><a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
+<rect x="329" y="307" width="94" height="32"></rect>
+<rect x="327" y="305" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="337" y="325">sort_clause</text></a><a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
+<rect x="483" y="307" width="94" height="32"></rect>
+<rect x="481" y="305" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="491" y="325">limit_clause</text></a><rect x="395" y="393" width="100" height="32" rx="10"></rect>
+<rect x="393" y="391" width="100" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="403" y="411">RETURNING</text><a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
+<rect x="535" y="393" width="86" height="32"></rect>
+<rect x="533" y="391" width="86" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="543" y="411">target_list</text></a><rect x="535" y="437" width="86" height="32" rx="10"></rect>
+<rect x="533" y="435" width="86" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="543" y="455">NOTHING</text>
+<path class="line" d="m17 61 h2 m20 0 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m40 -32 h10 m150 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m-446 44 h20 m446 0 h20 m-486 0 q10 0 10 10 m466 0 q0 -10 10 -10 m-476 10 v46 m466 0 v-46 m-466 46 q0 10 10 10 m446 0 q10 0 10 -10 m-456 10 h10 m0 0 h436 m20 -66 h10 m70 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-630 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m0 0 h10 m122 0 h10 m20 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-242 10 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m70 0 h10 m0 0 h10 m64 0 h10 m40 -32 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -32 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-266 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m100 0 h10 m20 0 h10 m86 0 h10 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m43 -76 h-3"></path>
+<polygon points="679 375 687 371 687 379"></polygon>
+<polygon points="679 375 671 371 671 379"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/insert.html
+++ b/_includes/v20.1/sql/diagrams/insert.html
@@ -1,81 +1,62 @@
-<div><svg width="714" height="442">
+<div><svg width="685" height="573">
 <polygon points="9 61 1 57 1 65"></polygon>
 <polygon points="17 61 9 57 9 65"></polygon>
-<rect x="51" y="47" width="56" height="32" rx="10"></rect>
-<rect x="49" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+<rect x="51" y="47" width="58" height="32" rx="10"></rect>
+<rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="59" y="65">WITH</text>
-<a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
-<rect x="147" y="47" width="144" height="32"></rect>
-<rect x="145" y="45" width="144" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="155" y="65">common_table_expr</text>
-</a>
-<rect x="147" y="3" width="24" height="32" rx="10"></rect>
-<rect x="145" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="155" y="21">,</text>
-<rect x="351" y="47" width="70" height="32" rx="10"></rect>
-<rect x="349" y="45" width="70" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="359" y="65">INSERT</text>
-<rect x="441" y="47" width="54" height="32" rx="10"></rect>
-<rect x="439" y="45" width="54" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="449" y="65">INTO</text>
-<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="515" y="47" width="90" height="32"></rect>
-<rect x="513" y="45" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="523" y="65">table_name</text>
-</a>
-<rect x="45" y="205" width="38" height="32" rx="10"></rect>
-<rect x="43" y="203" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="53" y="223">AS</text>
-<a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="103" y="205" width="124" height="32"></rect>
-<rect x="101" y="203" width="124" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="111" y="223">table_alias_name</text>
-</a>
-<rect x="307" y="173" width="26" height="32" rx="10"></rect>
-<rect x="305" y="171" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="315" y="191">(</text>
-<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="373" y="173" width="104" height="32"></rect>
-<rect x="371" y="171" width="104" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="191">column_name</text>
-</a>
-<rect x="373" y="129" width="24" height="32" rx="10"></rect>
-<rect x="371" y="127" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="381" y="147">,</text>
-<rect x="517" y="173" width="26" height="32" rx="10"></rect>
-<rect x="515" y="171" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="525" y="191">)</text>
-<a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="583" y="173" width="90" height="32"></rect>
-<rect x="581" y="171" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="591" y="191">select_stmt</text>
-</a>
-<rect x="287" y="239" width="80" height="32" rx="10"></rect>
-<rect x="285" y="237" width="80" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="295" y="257">DEFAULT</text>
-<rect x="387" y="239" width="72" height="32" rx="10"></rect>
-<rect x="385" y="237" width="72" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="395" y="257">VALUES</text>
-<a xlink:href="sql-grammar.html#on_conflict" xlink:title="on_conflict">
-<rect x="231" y="381" width="84" height="32"></rect>
-<rect x="229" y="379" width="84" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="239" y="399">on_conflict</text>
-</a>
-<rect x="375" y="349" width="100" height="32" rx="10"></rect>
-<rect x="373" y="347" width="100" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="383" y="367">RETURNING</text>
-<a xlink:href="sql-grammar.html#target_elem" xlink:title="target_elem">
-<rect x="535" y="349" width="92" height="32"></rect>
-<rect x="533" y="347" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="543" y="367">target_elem</text>
-</a>
-<rect x="535" y="305" width="24" height="32" rx="10"></rect>
-<rect x="533" y="303" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="543" y="323">,</text>
-<rect x="515" y="393" width="82" height="32" rx="10"></rect>
-<rect x="513" y="391" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="523" y="411">NOTHING</text>
-<path class="line" d="m17 61 h2 m20 0 h10 m56 0 h10 m20 0 h10 m144 0 h10 m-184 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m164 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-164 0 h10 m24 0 h10 m0 0 h120 m-280 44 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v14 m300 0 v-14 m-300 14 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m0 0 h270 m20 -34 h10 m70 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-624 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m38 0 h10 m0 0 h10 m124 0 h10 m60 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m124 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-124 0 h10 m24 0 h10 m0 0 h80 m20 44 h10 m26 0 h10 m-276 0 h20 m256 0 h20 m-296 0 q10 0 10 10 m276 0 q0 -10 10 -10 m-286 10 v14 m276 0 v-14 m-276 14 q0 10 10 10 m256 0 q10 0 10 -10 m-266 10 h10 m0 0 h246 m20 -34 h10 m90 0 h10 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v46 m426 0 v-46 m-426 46 q0 10 10 10 m406 0 q10 0 10 -10 m-416 10 h10 m80 0 h10 m0 0 h10 m72 0 h10 m0 0 h214 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-526 176 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m40 -32 h10 m100 0 h10 m40 0 h10 m92 0 h10 m-132 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m112 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-112 0 h10 m24 0 h10 m0 0 h68 m-152 44 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m82 0 h10 m0 0 h50 m-312 -44 h20 m312 0 h20 m-352 0 q10 0 10 10 m332 0 q0 -10 10 -10 m-342 10 v58 m332 0 v-58 m-332 58 q0 10 10 10 m312 0 q10 0 10 -10 m-322 10 h10 m0 0 h302 m23 -78 h-3"></path>
-<polygon points="705 363 713 359 713 367"></polygon>
-<polygon points="705 363 697 359 697 367"></polygon>
-</svg></div>
+<rect x="149" y="79" width="98" height="32" rx="10"></rect>
+<rect x="147" y="77" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="157" y="97">RECURSIVE</text><a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
+<rect x="307" y="47" width="150" height="32"></rect>
+<rect x="305" y="45" width="150" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="315" y="65">common_table_expr</text></a><rect x="307" y="3" width="24" height="32" rx="10"></rect>
+<rect x="305" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="315" y="21">,</text>
+<rect x="517" y="47" width="70" height="32" rx="10"></rect>
+<rect x="515" y="45" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="65">INSERT</text>
+<rect x="607" y="47" width="56" height="32" rx="10"></rect>
+<rect x="605" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="615" y="65">INTO</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="170" y="161" width="96" height="32"></rect>
+<rect x="168" y="159" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="178" y="179">table_name</text></a><rect x="306" y="193" width="38" height="32" rx="10"></rect>
+<rect x="304" y="191" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="314" y="211">AS</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="364" y="193" width="134" height="32"></rect>
+<rect x="362" y="191" width="134" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="372" y="211">table_alias_name</text></a><rect x="93" y="303" width="26" height="32" rx="10"></rect>
+<rect x="91" y="301" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="101" y="321">(</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="159" y="303" width="108" height="32"></rect>
+<rect x="157" y="301" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="167" y="321">column_name</text></a><rect x="159" y="259" width="24" height="32" rx="10"></rect>
+<rect x="157" y="257" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="167" y="277">,</text>
+<rect x="307" y="303" width="26" height="32" rx="10"></rect>
+<rect x="305" y="301" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="315" y="321">)</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="373" y="303" width="94" height="32"></rect>
+<rect x="371" y="301" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="381" y="321">select_stmt</text></a><rect x="73" y="369" width="80" height="32" rx="10"></rect>
+<rect x="71" y="367" width="80" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="81" y="387">DEFAULT</text>
+<rect x="173" y="369" width="72" height="32" rx="10"></rect>
+<rect x="171" y="367" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="181" y="387">VALUES</text><a xlink:href="sql-grammar.html#on_conflict" xlink:title="on_conflict">
+<rect x="527" y="335" width="88" height="32"></rect>
+<rect x="525" y="333" width="88" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="535" y="353">on_conflict</text></a><rect x="339" y="479" width="100" height="32" rx="10"></rect>
+<rect x="337" y="477" width="100" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="347" y="497">RETURNING</text><a xlink:href="sql-grammar.html#target_elem" xlink:title="target_elem">
+<rect x="499" y="479" width="98" height="32"></rect>
+<rect x="497" y="477" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="507" y="497">target_elem</text></a><rect x="499" y="435" width="24" height="32" rx="10"></rect>
+<rect x="497" y="433" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="507" y="453">,</text>
+<rect x="479" y="523" width="86" height="32" rx="10"></rect>
+<rect x="477" y="521" width="86" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="487" y="541">NOTHING</text>
+<path class="line" d="m17 61 h2 m20 0 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m40 -32 h10 m150 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m-446 44 h20 m446 0 h20 m-486 0 q10 0 10 10 m466 0 q0 -10 10 -10 m-476 10 v46 m466 0 v-46 m-466 46 q0 10 10 10 m446 0 q10 0 10 -10 m-456 10 h10 m0 0 h436 m20 -66 h10 m70 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-537 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m38 0 h10 m0 0 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-509 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m26 0 h10 m20 0 h10 m108 0 h10 m-148 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m128 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-128 0 h10 m24 0 h10 m0 0 h84 m20 44 h10 m26 0 h10 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v14 m280 0 v-14 m-280 14 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m0 0 h250 m20 -34 h10 m94 0 h10 m-434 0 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v46 m434 0 v-46 m-434 46 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m80 0 h10 m0 0 h10 m72 0 h10 m0 0 h222 m40 -66 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-360 176 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m40 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m-158 44 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m86 0 h10 m0 0 h52 m-318 -44 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v58 m338 0 v-58 m-338 58 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m23 -78 h-3"></path>
+<polygon points="675 493 683 489 683 497"></polygon>
+<polygon points="675 493 667 489 667 497"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/select.html
+++ b/_includes/v20.1/sql/diagrams/select.html
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <div><svg width="1348" height="504">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
@@ -114,3 +115,77 @@
 <polygon points="1339 17 1347 13 1347 21"></polygon>
 <polygon points="1339 17 1331 13 1331 21"></polygon>
 </svg></div>
+=======
+<div><svg width="1349" height="505">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon><a xlink:href="sql-grammar.html#select_clause" xlink:title="select_clause">
+<rect x="51" y="3" width="106" height="32"></rect>
+<rect x="49" y="1" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="59" y="21">select_clause</text></a><a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
+<rect x="197" y="3" width="94" height="32"></rect>
+<rect x="195" y="1" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="205" y="21">sort_clause</text></a><a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
+<rect x="217" y="79" width="94" height="32"></rect>
+<rect x="215" y="77" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="225" y="97">sort_clause</text></a><a xlink:href="sql-grammar.html#for_locking_clause" xlink:title="for_locking_clause">
+<rect x="371" y="47" width="138" height="32"></rect>
+<rect x="369" y="45" width="138" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="379" y="65">for_locking_clause</text></a><a xlink:href="sql-grammar.html#opt_select_limit" xlink:title="opt_select_limit">
+<rect x="529" y="47" width="120" height="32"></rect>
+<rect x="527" y="45" width="120" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="537" y="65">opt_select_limit</text></a><a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
+<rect x="391" y="91" width="94" height="32"></rect>
+<rect x="389" y="89" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="399" y="109">limit_clause</text></a><a xlink:href="sql-grammar.html#offset_clause" xlink:title="offset_clause">
+<rect x="525" y="123" width="104" height="32"></rect>
+<rect x="523" y="121" width="104" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="533" y="141">offset_clause</text></a><a xlink:href="sql-grammar.html#offset_clause" xlink:title="offset_clause">
+<rect x="391" y="167" width="104" height="32"></rect>
+<rect x="389" y="165" width="104" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="399" y="185">offset_clause</text></a><a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
+<rect x="535" y="199" width="94" height="32"></rect>
+<rect x="533" y="197" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="543" y="217">limit_clause</text></a><a xlink:href="sql-grammar.html#opt_for_locking_clause" xlink:title="opt_for_locking_clause">
+<rect x="689" y="91" width="166" height="32"></rect>
+<rect x="687" y="89" width="166" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="697" y="109">opt_for_locking_clause</text></a><rect x="51" y="287" width="58" height="32" rx="10"></rect>
+<rect x="49" y="285" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="59" y="305">WITH</text>
+<rect x="149" y="319" width="98" height="32" rx="10"></rect>
+<rect x="147" y="317" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="157" y="337">RECURSIVE</text><a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
+<rect x="307" y="287" width="150" height="32"></rect>
+<rect x="305" y="285" width="150" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="315" y="305">common_table_expr</text></a><rect x="307" y="243" width="24" height="32" rx="10"></rect>
+<rect x="305" y="241" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="315" y="261">,</text><a xlink:href="sql-grammar.html#select_clause" xlink:title="select_clause">
+<rect x="497" y="287" width="106" height="32"></rect>
+<rect x="495" y="285" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="505" y="305">select_clause</text></a><a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
+<rect x="643" y="319" width="94" height="32"></rect>
+<rect x="641" y="317" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="651" y="337">sort_clause</text></a><a xlink:href="sql-grammar.html#for_locking_clause" xlink:title="for_locking_clause">
+<rect x="797" y="319" width="138" height="32"></rect>
+<rect x="795" y="317" width="138" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="805" y="337">for_locking_clause</text></a><a xlink:href="sql-grammar.html#opt_select_limit" xlink:title="opt_select_limit">
+<rect x="955" y="319" width="120" height="32"></rect>
+<rect x="953" y="317" width="120" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="963" y="337">opt_select_limit</text></a><a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
+<rect x="817" y="363" width="94" height="32"></rect>
+<rect x="815" y="361" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="825" y="381">limit_clause</text></a><a xlink:href="sql-grammar.html#offset_clause" xlink:title="offset_clause">
+<rect x="951" y="395" width="104" height="32"></rect>
+<rect x="949" y="393" width="104" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="959" y="413">offset_clause</text></a><a xlink:href="sql-grammar.html#offset_clause" xlink:title="offset_clause">
+<rect x="817" y="439" width="104" height="32"></rect>
+<rect x="815" y="437" width="104" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="825" y="457">offset_clause</text></a><a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
+<rect x="961" y="471" width="94" height="32"></rect>
+<rect x="959" y="469" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="969" y="489">limit_clause</text></a><a xlink:href="sql-grammar.html#opt_for_locking_clause" xlink:title="opt_for_locking_clause">
+<rect x="1115" y="363" width="166" height="32"></rect>
+<rect x="1113" y="361" width="166" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="1123" y="381">opt_for_locking_clause</text></a><path class="line" d="m17 17 h2 m20 0 h10 m106 0 h10 m20 0 h10 m94 0 h10 m0 0 h584 m-718 0 h20 m698 0 h20 m-738 0 q10 0 10 10 m718 0 q0 -10 10 -10 m-728 10 v24 m718 0 v-24 m-718 24 q0 10 10 10 m698 0 q10 0 10 -10 m-688 10 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -32 h10 m138 0 h10 m0 0 h10 m120 0 h10 m0 0 h206 m-524 0 h20 m504 0 h20 m-544 0 q10 0 10 10 m524 0 q0 -10 10 -10 m-534 10 v24 m524 0 v-24 m-524 24 q0 10 10 10 m504 0 q10 0 10 -10 m-494 10 h10 m94 0 h10 m20 0 h10 m0 0 h114 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v12 m144 0 v-12 m-144 12 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-278 -32 h20 m278 0 h20 m-318 0 q10 0 10 10 m298 0 q0 -10 10 -10 m-308 10 v56 m298 0 v-56 m-298 56 q0 10 10 10 m278 0 q10 0 10 -10 m-288 10 h10 m104 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -108 h10 m166 0 h10 m40 -88 h406 m-1290 0 h20 m1270 0 h20 m-1310 0 q10 0 10 10 m1290 0 q0 -10 10 -10 m-1300 10 v264 m1290 0 v-264 m-1290 264 q0 10 10 10 m1270 0 q10 0 10 -10 m-1280 10 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m40 -32 h10 m150 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m106 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -32 h10 m0 0 h494 m-524 0 h20 m504 0 h20 m-544 0 q10 0 10 10 m524 0 q0 -10 10 -10 m-534 10 v12 m524 0 v-12 m-524 12 q0 10 10 10 m504 0 q10 0 10 -10 m-514 10 h10 m138 0 h10 m0 0 h10 m120 0 h10 m0 0 h206 m-514 -10 v20 m524 0 v-20 m-524 20 v24 m524 0 v-24 m-524 24 q0 10 10 10 m504 0 q10 0 10 -10 m-494 10 h10 m94 0 h10 m20 0 h10 m0 0 h114 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v12 m144 0 v-12 m-144 12 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-278 -32 h20 m278 0 h20 m-318 0 q10 0 10 10 m298 0 q0 -10 10 -10 m-308 10 v56 m298 0 v-56 m-298 56 q0 10 10 10 m278 0 q10 0 10 -10 m-288 10 h10 m104 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -108 h10 m166 0 h10 m43 -360 h-3"></path>
+<polygon points="1339 17 1347 13 1347 21"></polygon>
+<polygon points="1339 17 1331 13 1331 21"></polygon></svg></div>
+>>>>>>> Recursive CTE docs

--- a/_includes/v20.1/sql/diagrams/update.html
+++ b/_includes/v20.1/sql/diagrams/update.html
@@ -1,118 +1,97 @@
-<div><svg width="666" height="724">
+<div><svg width="881" height="837">
 <polygon points="9 61 1 57 1 65"></polygon>
 <polygon points="17 61 9 57 9 65"></polygon>
-<rect x="51" y="47" width="56" height="32" rx="10"></rect>
-<rect x="49" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+<rect x="51" y="47" width="58" height="32" rx="10"></rect>
+<rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="59" y="65">WITH</text>
-<a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
-<rect x="147" y="47" width="144" height="32"></rect>
-<rect x="145" y="45" width="144" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="155" y="65">common_table_expr</text>
-</a>
-<rect x="147" y="3" width="24" height="32" rx="10"></rect>
-<rect x="145" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="155" y="21">,</text>
-<rect x="351" y="47" width="74" height="32" rx="10"></rect>
-<rect x="349" y="45" width="74" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="359" y="65">UPDATE</text>
-<a xlink:href="sql-grammar.html#relation_expr" xlink:title="relation_expr">
-<rect x="445" y="47" width="90" height="32"></rect>
-<rect x="443" y="45" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="453" y="65">table_name</text>
-</a>
-<rect x="212" y="193" width="38" height="32" rx="10"></rect>
-<rect x="210" y="191" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="220" y="211">AS</text>
-<a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="290" y="161" width="124" height="32"></rect>
-<rect x="288" y="159" width="124" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="298" y="179">table_alias_name</text>
-</a>
-<rect x="454" y="129" width="44" height="32" rx="10"></rect>
-<rect x="452" y="127" width="44" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="462" y="147">SET</text>
-<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="65" y="303" width="104" height="32"></rect>
-<rect x="63" y="301" width="104" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="73" y="321">column_name</text>
-</a>
-<rect x="189" y="303" width="30" height="32" rx="10"></rect>
-<rect x="187" y="301" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="197" y="321">=</text>
-<a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-<rect x="239" y="303" width="62" height="32"></rect>
-<rect x="237" y="301" width="62" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="247" y="321">a_expr</text>
-</a>
-<rect x="65" y="391" width="26" height="32" rx="10"></rect>
-<rect x="63" y="389" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="73" y="409">(</text>
-<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="131" y="391" width="104" height="32"></rect>
-<rect x="129" y="389" width="104" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="139" y="409">column_name</text>
-</a>
-<rect x="131" y="347" width="24" height="32" rx="10"></rect>
-<rect x="129" y="345" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="139" y="365">,</text>
-<rect x="275" y="391" width="26" height="32" rx="10"></rect>
-<rect x="273" y="389" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="283" y="409">)</text>
-<rect x="321" y="391" width="30" height="32" rx="10"></rect>
-<rect x="319" y="389" width="30" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="329" y="409">=</text>
-<rect x="371" y="391" width="26" height="32" rx="10"></rect>
-<rect x="369" y="389" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="379" y="409">(</text>
-<a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="437" y="391" width="90" height="32"></rect>
-<rect x="435" y="389" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="445" y="409">select_stmt</text>
-</a>
-<a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-<rect x="457" y="479" width="62" height="32"></rect>
-<rect x="455" y="477" width="62" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="465" y="497">a_expr</text>
-</a>
-<rect x="457" y="435" width="24" height="32" rx="10"></rect>
-<rect x="455" y="433" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="465" y="453">,</text>
-<rect x="579" y="391" width="26" height="32" rx="10"></rect>
-<rect x="577" y="389" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="587" y="409">)</text>
-<rect x="45" y="259" width="24" height="32" rx="10"></rect>
-<rect x="43" y="257" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="53" y="277">,</text>
-<rect x="112" y="561" width="68" height="32" rx="10"></rect>
-<rect x="110" y="559" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="120" y="579">WHERE</text>
-<a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-<rect x="200" y="561" width="62" height="32"></rect>
-<rect x="198" y="559" width="62" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="208" y="579">a_expr</text>
-</a>
-<a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
-<rect x="322" y="561" width="88" height="32"></rect>
-<rect x="320" y="559" width="88" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="330" y="579">sort_clause</text>
-</a>
-<a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
-<rect x="470" y="561" width="88" height="32"></rect>
-<rect x="468" y="559" width="88" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="478" y="579">limit_clause</text>
-</a>
-<rect x="377" y="647" width="100" height="32" rx="10"></rect>
-<rect x="375" y="645" width="100" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="385" y="665">RETURNING</text>
-<a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
-<rect x="517" y="647" width="80" height="32"></rect>
-<rect x="515" y="645" width="80" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="525" y="665">target_list</text>
-</a>
-<rect x="517" y="691" width="82" height="32" rx="10"></rect>
-<rect x="515" y="689" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="525" y="709">NOTHING</text>
-<path class="line" d="m17 61 h2 m20 0 h10 m56 0 h10 m20 0 h10 m144 0 h10 m-184 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m164 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-164 0 h10 m24 0 h10 m0 0 h120 m-280 44 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v14 m300 0 v-14 m-300 14 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m0 0 h270 m20 -34 h10 m74 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-407 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h232 m-262 0 h20 m242 0 h20 m-282 0 q10 0 10 10 m262 0 q0 -10 10 -10 m-272 10 v12 m262 0 v-12 m-262 12 q0 10 10 10 m242 0 q10 0 10 -10 m-232 10 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m124 0 h10 m20 -32 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-517 174 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m104 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m62 0 h10 m0 0 h304 m-580 0 h20 m560 0 h20 m-600 0 q10 0 10 10 m580 0 q0 -10 10 -10 m-590 10 v68 m580 0 v-68 m-580 68 q0 10 10 10 m560 0 q10 0 10 -10 m-570 10 h10 m26 0 h10 m20 0 h10 m104 0 h10 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m124 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-124 0 h10 m24 0 h10 m0 0 h80 m20 44 h10 m26 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m90 0 h10 m0 0 h12 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v68 m142 0 v-68 m-142 68 q0 10 10 10 m122 0 q10 0 10 -10 m-112 10 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m40 -44 h10 m26 0 h10 m-600 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m600 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-600 0 h10 m24 0 h10 m0 0 h556 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-597 226 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m68 0 h10 m0 0 h10 m62 0 h10 m40 -32 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -32 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-265 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m100 0 h10 m20 0 h10 m80 0 h10 m0 0 h2 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m43 -76 h-3"></path>
-<polygon points="657 629 665 625 665 633"></polygon>
-<polygon points="657 629 649 625 649 633"></polygon>
-</svg></div>
+<rect x="149" y="79" width="98" height="32" rx="10"></rect>
+<rect x="147" y="77" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="157" y="97">RECURSIVE</text><a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
+<rect x="307" y="47" width="150" height="32"></rect>
+<rect x="305" y="45" width="150" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="315" y="65">common_table_expr</text></a><rect x="307" y="3" width="24" height="32" rx="10"></rect>
+<rect x="305" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="315" y="21">,</text>
+<rect x="517" y="47" width="74" height="32" rx="10"></rect>
+<rect x="515" y="45" width="74" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="65">UPDATE</text><a xlink:href="sql-grammar.html#relation_expr" xlink:title="relation_expr">
+<rect x="611" y="47" width="96" height="32"></rect>
+<rect x="609" y="45" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="619" y="65">table_name</text></a><a xlink:href="sql-grammar.html#opt_index_flags" xlink:title="opt_index_flags">
+<rect x="203" y="161" width="122" height="32"></rect>
+<rect x="201" y="159" width="122" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="211" y="179">opt_index_flags</text></a><rect x="385" y="225" width="38" height="32" rx="10"></rect>
+<rect x="383" y="223" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="393" y="243">AS</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="463" y="193" width="134" height="32"></rect>
+<rect x="461" y="191" width="134" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="471" y="211">table_alias_name</text></a><rect x="637" y="161" width="44" height="32" rx="10"></rect>
+<rect x="635" y="159" width="44" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="645" y="179">SET</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="65" y="335" width="108" height="32"></rect>
+<rect x="63" y="333" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="73" y="353">column_name</text></a><rect x="193" y="335" width="30" height="32" rx="10"></rect>
+<rect x="191" y="333" width="30" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="201" y="353">=</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="243" y="335" width="64" height="32"></rect>
+<rect x="241" y="333" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="251" y="353">a_expr</text></a><rect x="65" y="423" width="26" height="32" rx="10"></rect>
+<rect x="63" y="421" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="73" y="441">(</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="131" y="423" width="108" height="32"></rect>
+<rect x="129" y="421" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="139" y="441">column_name</text></a><rect x="131" y="379" width="24" height="32" rx="10"></rect>
+<rect x="129" y="377" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="139" y="397">,</text>
+<rect x="279" y="423" width="26" height="32" rx="10"></rect>
+<rect x="277" y="421" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="287" y="441">)</text>
+<rect x="325" y="423" width="30" height="32" rx="10"></rect>
+<rect x="323" y="421" width="30" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="333" y="441">=</text>
+<rect x="375" y="423" width="26" height="32" rx="10"></rect>
+<rect x="373" y="421" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="383" y="441">(</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="441" y="455" width="94" height="32"></rect>
+<rect x="439" y="453" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="449" y="473">select_stmt</text></a><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="441" y="543" width="64" height="32"></rect>
+<rect x="439" y="541" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="449" y="561">a_expr</text></a><rect x="545" y="543" width="24" height="32" rx="10"></rect>
+<rect x="543" y="541" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="553" y="561">,</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="629" y="543" width="64" height="32"></rect>
+<rect x="627" y="541" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="637" y="561">a_expr</text></a><rect x="629" y="499" width="24" height="32" rx="10"></rect>
+<rect x="627" y="497" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="637" y="517">,</text>
+<rect x="793" y="423" width="26" height="32" rx="10"></rect>
+<rect x="791" y="421" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="801" y="441">)</text>
+<rect x="45" y="291" width="24" height="32" rx="10"></rect>
+<rect x="43" y="289" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="309">,</text><a xlink:href="sql-grammar.html#opt_from_list" xlink:title="opt_from_list">
+<rect x="129" y="641" width="104" height="32"></rect>
+<rect x="127" y="639" width="104" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="137" y="659">opt_from_list</text></a><rect x="273" y="673" width="70" height="32" rx="10"></rect>
+<rect x="271" y="671" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="281" y="691">WHERE</text><a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="363" y="673" width="64" height="32"></rect>
+<rect x="361" y="671" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="371" y="691">a_expr</text></a><a xlink:href="sql-grammar.html#sort_clause" xlink:title="sort_clause">
+<rect x="487" y="673" width="94" height="32"></rect>
+<rect x="485" y="671" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="495" y="691">sort_clause</text></a><a xlink:href="sql-grammar.html#limit_clause" xlink:title="limit_clause">
+<rect x="641" y="673" width="94" height="32"></rect>
+<rect x="639" y="671" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="649" y="691">limit_clause</text></a><rect x="587" y="759" width="100" height="32" rx="10"></rect>
+<rect x="585" y="757" width="100" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="595" y="777">RETURNING</text><a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
+<rect x="727" y="759" width="86" height="32"></rect>
+<rect x="725" y="757" width="86" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="735" y="777">target_list</text></a><rect x="727" y="803" width="86" height="32" rx="10"></rect>
+<rect x="725" y="801" width="86" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="735" y="821">NOTHING</text>
+<path class="line" d="m17 61 h2 m20 0 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m40 -32 h10 m150 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m-446 44 h20 m446 0 h20 m-486 0 q10 0 10 10 m466 0 q0 -10 10 -10 m-476 10 v46 m466 0 v-46 m-466 46 q0 10 10 10 m446 0 q10 0 10 -10 m-456 10 h10 m0 0 h436 m20 -66 h10 m74 0 h10 m0 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-548 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m122 0 h10 m20 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-242 10 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m20 -32 h10 m134 0 h10 m20 -32 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-700 174 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m108 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h512 m-794 0 h20 m774 0 h20 m-814 0 q10 0 10 10 m794 0 q0 -10 10 -10 m-804 10 v68 m794 0 v-68 m-794 68 q0 10 10 10 m774 0 q10 0 10 -10 m-784 10 h10 m26 0 h10 m20 0 h10 m108 0 h10 m-148 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m128 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-128 0 h10 m24 0 h10 m0 0 h84 m20 44 h10 m26 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h322 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v12 m352 0 v-12 m-352 12 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m94 0 h10 m0 0 h218 m-342 -10 v20 m352 0 v-20 m-352 20 v68 m352 0 v-68 m-352 68 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m64 0 h10 m20 0 h10 m24 0 h10 m40 0 h10 m64 0 h10 m-104 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m84 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-84 0 h10 m24 0 h10 m0 0 h40 m-124 44 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v14 m144 0 v-14 m-144 14 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m0 0 h114 m-208 -34 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v30 m228 0 v-30 m-228 30 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m0 0 h198 m40 -170 h10 m26 0 h10 m-814 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m814 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-814 0 h10 m24 0 h10 m0 0 h770 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-774 306 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m104 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m70 0 h10 m0 0 h10 m64 0 h10 m40 -32 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -32 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m100 0 h10 m20 0 h10 m86 0 h10 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m43 -76 h-3"></path>
+<polygon points="871 741 879 737 879 745"></polygon>
+<polygon points="871 741 863 737 863 745"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/upsert.html
+++ b/_includes/v20.1/sql/diagrams/upsert.html
@@ -1,71 +1,57 @@
-<div><svg width="714" height="402">
+<div><svg width="689" height="533">
 <polygon points="9 61 1 57 1 65"></polygon>
 <polygon points="17 61 9 57 9 65"></polygon>
-<rect x="51" y="47" width="56" height="32" rx="10"></rect>
-<rect x="49" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+<rect x="51" y="47" width="58" height="32" rx="10"></rect>
+<rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="59" y="65">WITH</text>
-<a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
-<rect x="147" y="47" width="144" height="32"></rect>
-<rect x="145" y="45" width="144" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="155" y="65">common_table_expr</text>
-</a>
-<rect x="147" y="3" width="24" height="32" rx="10"></rect>
-<rect x="145" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="155" y="21">,</text>
-<rect x="351" y="47" width="72" height="32" rx="10"></rect>
-<rect x="349" y="45" width="72" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="359" y="65">UPSERT</text>
-<rect x="443" y="47" width="54" height="32" rx="10"></rect>
-<rect x="441" y="45" width="54" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="451" y="65">INTO</text>
-<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="517" y="47" width="90" height="32"></rect>
-<rect x="515" y="45" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="525" y="65">table_name</text>
-</a>
-<rect x="45" y="205" width="38" height="32" rx="10"></rect>
-<rect x="43" y="203" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="53" y="223">AS</text>
-<a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="103" y="205" width="124" height="32"></rect>
-<rect x="101" y="203" width="124" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="111" y="223">table_alias_name</text>
-</a>
-<rect x="307" y="173" width="26" height="32" rx="10"></rect>
-<rect x="305" y="171" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="315" y="191">(</text>
-<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="373" y="173" width="104" height="32"></rect>
-<rect x="371" y="171" width="104" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="381" y="191">column_name</text>
-</a>
-<rect x="373" y="129" width="24" height="32" rx="10"></rect>
-<rect x="371" y="127" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="381" y="147">,</text>
-<rect x="517" y="173" width="26" height="32" rx="10"></rect>
-<rect x="515" y="171" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="525" y="191">)</text>
-<rect x="583" y="173" width="90" height="32"></rect>
-<rect x="581" y="171" width="90" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="591" y="191">select_stmt</text>
-<rect x="287" y="239" width="80" height="32" rx="10"></rect>
-<rect x="285" y="237" width="80" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="295" y="257">DEFAULT</text>
-<rect x="387" y="239" width="72" height="32" rx="10"></rect>
-<rect x="385" y="237" width="72" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="395" y="257">VALUES</text>
-<rect x="425" y="325" width="100" height="32" rx="10"></rect>
-<rect x="423" y="323" width="100" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="433" y="343">RETURNING</text>
-<a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
-<rect x="565" y="325" width="80" height="32"></rect>
-<rect x="563" y="323" width="80" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="573" y="343">target_list</text>
-</a>
-<rect x="565" y="369" width="82" height="32" rx="10"></rect>
-<rect x="563" y="367" width="82" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="573" y="387">NOTHING</text>
-<path class="line" d="m17 61 h2 m20 0 h10 m56 0 h10 m20 0 h10 m144 0 h10 m-184 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m164 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-164 0 h10 m24 0 h10 m0 0 h120 m-280 44 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v14 m300 0 v-14 m-300 14 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m0 0 h270 m20 -34 h10 m72 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-626 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m38 0 h10 m0 0 h10 m124 0 h10 m60 -32 h10 m26 0 h10 m20 0 h10 m104 0 h10 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m124 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-124 0 h10 m24 0 h10 m0 0 h80 m20 44 h10 m26 0 h10 m-276 0 h20 m256 0 h20 m-296 0 q10 0 10 10 m276 0 q0 -10 10 -10 m-286 10 v14 m276 0 v-14 m-276 14 q0 10 10 10 m256 0 q10 0 10 -10 m-266 10 h10 m0 0 h246 m20 -34 h10 m90 0 h10 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v46 m426 0 v-46 m-426 46 q0 10 10 10 m406 0 q10 0 10 -10 m-416 10 h10 m80 0 h10 m0 0 h10 m72 0 h10 m0 0 h214 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-332 120 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m100 0 h10 m20 0 h10 m80 0 h10 m0 0 h2 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m43 -76 h-3"></path>
-<polygon points="705 307 713 303 713 311"></polygon>
-<polygon points="705 307 697 303 697 311"></polygon>
-</svg></div>
+<rect x="149" y="79" width="98" height="32" rx="10"></rect>
+<rect x="147" y="77" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="157" y="97">RECURSIVE</text><a xlink:href="sql-grammar.html#common_table_expr" xlink:title="common_table_expr">
+<rect x="307" y="47" width="150" height="32"></rect>
+<rect x="305" y="45" width="150" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="315" y="65">common_table_expr</text></a><rect x="307" y="3" width="24" height="32" rx="10"></rect>
+<rect x="305" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="315" y="21">,</text>
+<rect x="517" y="47" width="74" height="32" rx="10"></rect>
+<rect x="515" y="45" width="74" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="525" y="65">UPSERT</text>
+<rect x="611" y="47" width="56" height="32" rx="10"></rect>
+<rect x="609" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="619" y="65">INTO</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="172" y="161" width="96" height="32"></rect>
+<rect x="170" y="159" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="180" y="179">table_name</text></a><rect x="308" y="193" width="38" height="32" rx="10"></rect>
+<rect x="306" y="191" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="316" y="211">AS</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="366" y="193" width="134" height="32"></rect>
+<rect x="364" y="191" width="134" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="374" y="211">table_alias_name</text></a><rect x="169" y="303" width="26" height="32" rx="10"></rect>
+<rect x="167" y="301" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="177" y="321">(</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="235" y="303" width="108" height="32"></rect>
+<rect x="233" y="301" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="243" y="321">column_name</text></a><rect x="235" y="259" width="24" height="32" rx="10"></rect>
+<rect x="233" y="257" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="243" y="277">,</text>
+<rect x="383" y="303" width="26" height="32" rx="10"></rect>
+<rect x="381" y="301" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="391" y="321">)</text>
+<rect x="449" y="303" width="94" height="32"></rect>
+<rect x="447" y="301" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="457" y="321">select_stmt</text><rect x="149" y="369" width="80" height="32" rx="10"></rect>
+<rect x="147" y="367" width="80" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="157" y="387">DEFAULT</text>
+<rect x="249" y="369" width="72" height="32" rx="10"></rect>
+<rect x="247" y="367" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="257" y="387">VALUES</text>
+<rect x="395" y="455" width="100" height="32" rx="10"></rect>
+<rect x="393" y="453" width="100" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="403" y="473">RETURNING</text><a xlink:href="sql-grammar.html#target_list" xlink:title="target_list">
+<rect x="535" y="455" width="86" height="32"></rect>
+<rect x="533" y="453" width="86" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="543" y="473">target_list</text></a><rect x="535" y="499" width="86" height="32" rx="10"></rect>
+<rect x="533" y="497" width="86" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="543" y="517">NOTHING</text>
+<path class="line" d="m17 61 h2 m20 0 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m40 -32 h10 m150 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m-446 44 h20 m446 0 h20 m-486 0 q10 0 10 10 m466 0 q0 -10 10 -10 m-476 10 v46 m466 0 v-46 m-466 46 q0 10 10 10 m446 0 q10 0 10 -10 m-456 10 h10 m0 0 h436 m20 -66 h10 m74 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-539 114 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m38 0 h10 m0 0 h10 m134 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-435 142 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m26 0 h10 m20 0 h10 m108 0 h10 m-148 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m128 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-128 0 h10 m24 0 h10 m0 0 h84 m20 44 h10 m26 0 h10 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v14 m280 0 v-14 m-280 14 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m0 0 h250 m20 -34 h10 m94 0 h10 m-434 0 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v46 m434 0 v-46 m-434 46 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m80 0 h10 m0 0 h10 m72 0 h10 m0 0 h222 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 120 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m100 0 h10 m20 0 h10 m86 0 h10 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m43 -76 h-3"></path>
+<polygon points="679 437 687 433 687 441"></polygon>
+<polygon points="679 437 671 433 671 441"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/with_clause.html
+++ b/_includes/v20.1/sql/diagrams/with_clause.html
@@ -1,50 +1,53 @@
-<div><svg width="765" height="449">
+<div><svg width="765" height="481">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="39" y="21">WITH</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="45" y="157" width="134" height="32"></rect>
-<rect x="43" y="155" width="134" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="53" y="175">table_alias_name</text></a><rect x="219" y="157" width="26" height="32" rx="10"></rect>
-<rect x="217" y="155" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="227" y="175">(</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
-<rect x="285" y="157" width="56" height="32"></rect>
-<rect x="283" y="155" width="56" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="293" y="175">name</text></a><rect x="285" y="113" width="24" height="32" rx="10"></rect>
-<rect x="283" y="111" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="293" y="131">,</text>
-<rect x="381" y="157" width="26" height="32" rx="10"></rect>
-<rect x="379" y="155" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="389" y="175">)</text>
-<rect x="447" y="157" width="38" height="32" rx="10"></rect>
-<rect x="445" y="155" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="455" y="175">AS</text>
-<rect x="505" y="157" width="26" height="32" rx="10"></rect>
-<rect x="503" y="155" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="513" y="175">(</text><a xlink:href="sql-grammar.html#preparable_stmt" xlink:title="preparable_stmt">
-<rect x="551" y="157" width="126" height="32"></rect>
-<rect x="549" y="155" width="126" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="559" y="175">preparable_stmt</text></a><rect x="697" y="157" width="26" height="32" rx="10"></rect>
-<rect x="695" y="155" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="705" y="175">)</text>
-<rect x="45" y="69" width="24" height="32" rx="10"></rect>
-<rect x="43" y="67" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="53" y="87">,</text><a xlink:href="sql-grammar.html#insert_stmt" xlink:title="insert_stmt">
-<rect x="615" y="239" width="92" height="32"></rect>
-<rect x="613" y="237" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="257">insert_stmt</text></a><a xlink:href="sql-grammar.html#update_stmt" xlink:title="update_stmt">
-<rect x="615" y="283" width="102" height="32"></rect>
-<rect x="613" y="281" width="102" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="301">update_stmt</text></a><a xlink:href="sql-grammar.html#delete_stmt" xlink:title="delete_stmt">
-<rect x="615" y="327" width="96" height="32"></rect>
-<rect x="613" y="325" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="345">delete_stmt</text></a><a xlink:href="sql-grammar.html#upsert_stmt" xlink:title="upsert_stmt">
-<rect x="615" y="371" width="98" height="32"></rect>
-<rect x="613" y="369" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="389">upsert_stmt</text></a><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="615" y="415" width="94" height="32"></rect>
-<rect x="613" y="413" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="433">select_stmt</text></a><path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-108 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m20 44 h10 m26 0 h10 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v14 m228 0 v-14 m-228 14 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m0 0 h198 m20 -34 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m-718 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m698 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-698 0 h10 m24 0 h10 m0 0 h654 m22 88 l2 0 m2 0 l2 0 m2 0 l2 0 m-192 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m92 0 h10 m0 0 h10 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m96 0 h10 m0 0 h6 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m98 0 h10 m0 0 h4 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m94 0 h10 m0 0 h8 m23 -176 h-3"></path>
-<polygon points="755 253 763 249 763 257"></polygon>
-<polygon points="755 253 747 249 747 257"></polygon></svg></div>
+<text class="terminal" x="39" y="21">WITH</text>
+<rect x="129" y="35" width="98" height="32" rx="10"></rect>
+<rect x="127" y="33" width="98" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="137" y="53">RECURSIVE</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="45" y="189" width="134" height="32"></rect>
+<rect x="43" y="187" width="134" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="53" y="207">table_alias_name</text></a><rect x="219" y="189" width="26" height="32" rx="10"></rect>
+<rect x="217" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="227" y="207">(</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="285" y="189" width="56" height="32"></rect>
+<rect x="283" y="187" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="293" y="207">name</text></a><rect x="285" y="145" width="24" height="32" rx="10"></rect>
+<rect x="283" y="143" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="293" y="163">,</text>
+<rect x="381" y="189" width="26" height="32" rx="10"></rect>
+<rect x="379" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="389" y="207">)</text>
+<rect x="447" y="189" width="38" height="32" rx="10"></rect>
+<rect x="445" y="187" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="455" y="207">AS</text>
+<rect x="505" y="189" width="26" height="32" rx="10"></rect>
+<rect x="503" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="513" y="207">(</text><a xlink:href="sql-grammar.html#preparable_stmt" xlink:title="preparable_stmt">
+<rect x="551" y="189" width="126" height="32"></rect>
+<rect x="549" y="187" width="126" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="559" y="207">preparable_stmt</text></a><rect x="697" y="189" width="26" height="32" rx="10"></rect>
+<rect x="695" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="705" y="207">)</text>
+<rect x="45" y="101" width="24" height="32" rx="10"></rect>
+<rect x="43" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="119">,</text><a xlink:href="sql-grammar.html#insert_stmt" xlink:title="insert_stmt">
+<rect x="615" y="271" width="92" height="32"></rect>
+<rect x="613" y="269" width="92" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="623" y="289">insert_stmt</text></a><a xlink:href="sql-grammar.html#update_stmt" xlink:title="update_stmt">
+<rect x="615" y="315" width="102" height="32"></rect>
+<rect x="613" y="313" width="102" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="623" y="333">update_stmt</text></a><a xlink:href="sql-grammar.html#delete_stmt" xlink:title="delete_stmt">
+<rect x="615" y="359" width="96" height="32"></rect>
+<rect x="613" y="357" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="623" y="377">delete_stmt</text></a><a xlink:href="sql-grammar.html#upsert_stmt" xlink:title="upsert_stmt">
+<rect x="615" y="403" width="98" height="32"></rect>
+<rect x="613" y="401" width="98" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="623" y="421">upsert_stmt</text></a><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="615" y="447" width="94" height="32"></rect>
+<rect x="613" y="445" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="623" y="465">select_stmt</text></a><path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-266 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m20 44 h10 m26 0 h10 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v14 m228 0 v-14 m-228 14 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m0 0 h198 m20 -34 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m-718 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m698 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-698 0 h10 m24 0 h10 m0 0 h654 m22 88 l2 0 m2 0 l2 0 m2 0 l2 0 m-192 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m92 0 h10 m0 0 h10 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m96 0 h10 m0 0 h6 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m98 0 h10 m0 0 h4 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m94 0 h10 m0 0 h8 m23 -176 h-3"></path>
+<polygon points="755 285 763 281 763 289"></polygon>
+<polygon points="755 285 747 281 747 289"></polygon></svg></div>


### PR DESCRIPTION
Recursive CTE docs...

Fixes #5956.

- Updated 20.1 `delete`, `insert`, `select`, `update`, `upsert`, and `with_clause` diagrams.
- Added new section and examples to 20.1 "Common Table Expressions" doc page.




**Note** 
I did not update the `stmt_block` diagram (the primary SQL grammar chart), due to an issue with the [Railroad Diagram Generator](https://bottlecaps.de/rr/ui) API. This will block this PR from being merged, as other diagrams reference this chart. See #6472 for more details.