### PR TITLE
Simplify destination for CC pages

### DIFF
--- a/_config_cockroachcloud.yml
+++ b/_config_cockroachcloud.yml
@@ -1,7 +1,7 @@
 homepage_title: CockroachCloud Docs
 
 baseurl: "/docs/cockroachcloud"
-destination: _site/cockroachcloud
+destination: _site/docs/cockroachcloud
 
 versions:
   stable: v19.2

--- a/netlify/build
+++ b/netlify/build
@@ -8,7 +8,6 @@ gem install bundler
 bundle install
 build _config_cockroachdb.yml
 build _config_cockroachcloud.yml
-mv _site/cockroachcloud _site/docs/cockroachcloud
 
 cp _site/docs/_redirects _site/_redirects
 cat _site/docs/cockroachcloud/_redirects >> _site/_redirects


### PR DESCRIPTION
Previously, we would build the CC pages to _site/cockroachcloud
and then have Netlify move the pages to _site/docs/cockroachcloud.
Instead, we now use the latter as the destination directly in the
_config_cockroachcloud.yml.