### PR TITLE
document Admin UI security update

### DIFF
--- a/_includes/v19.1/orchestration/test-cluster-secure.md
+++ b/_includes/v19.1/orchestration/test-cluster-secure.md
@@ -80,7 +80,16 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
       You will need this username and password to access the Admin UI later.
 
-5. Exit the SQL shell and pod:
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+6. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -179,7 +188,16 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     You will need this username and password to access the Admin UI later.
 
-5. Exit the SQL shell and pod:
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+6. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/_includes/v19.1/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v19.1/prod-deployment/secure-test-load-balancing.md
@@ -38,6 +38,6 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
 5. To monitor the load generator's progress, open the [Admin UI](admin-ui-access-and-navigate.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
 
-    For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
+    For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password) and [assign them to an `admin` role if necessary](admin-ui-overview.html#admin-ui-access). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
 
     Since the load generator is pointed at the load balancer, the connections will be evenly distributed across nodes. To verify this, click **Metrics** on the left, select the **SQL** dashboard, and then check the **SQL Connections** graph. You can use the **Graph** menu to filter the graph for specific nodes.

--- a/_includes/v19.2/orchestration/test-cluster-secure.md
+++ b/_includes/v19.2/orchestration/test-cluster-secure.md
@@ -88,7 +88,16 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
       You will need this username and password to access the Admin UI later.
 
-4. Exit the SQL shell and pod:
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+5. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -187,7 +196,16 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     You will need this username and password to access the Admin UI later.
 
-5. Exit the SQL shell and pod:
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+6. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/_includes/v19.2/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v19.2/prod-deployment/secure-test-load-balancing.md
@@ -38,6 +38,6 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
 5. To monitor the load generator's progress, open the [Admin UI](admin-ui-access-and-navigate.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
 
-    For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
+    For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password) and [assign them to an `admin` role if necessary](admin-ui-overview.html#admin-ui-access). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
 
     Since the load generator is pointed at the load balancer, the connections will be evenly distributed across nodes. To verify this, click **Metrics** on the left, select the **SQL** dashboard, and then check the **SQL Connections** graph. You can use the **Graph** menu to filter the graph for specific nodes.

--- a/_includes/v20.1/orchestration/test-cluster-secure.md
+++ b/_includes/v20.1/orchestration/test-cluster-secure.md
@@ -88,7 +88,16 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
       You will need this username and password to access the Admin UI later.
 
-4. Exit the SQL shell and pod:
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+5. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -187,7 +196,16 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     You will need this username and password to access the Admin UI later.
 
-5. Exit the SQL shell and pod:
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+6. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/_includes/v20.1/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v20.1/prod-deployment/secure-test-load-balancing.md
@@ -38,6 +38,6 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes several
 
 5. To monitor the load generator's progress, open the [Admin UI](admin-ui-access-and-navigate.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
 
-    For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
+    For each user who should have access to the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password) and [assign them to an `admin` role if necessary](admin-ui-overview.html#admin-ui-access). On accessing the Admin UI, the users will see a Login screen, where they will need to enter their usernames and passwords.
 
     Since the load generator is pointed at the load balancer, the connections will be evenly distributed across nodes. To verify this, click **Metrics** on the left, select the **SQL** dashboard, and then check the **SQL Connections** graph. You can use the **Graph** menu to filter the graph for specific nodes.

--- a/v19.1/admin-ui-cluster-overview-page.md
+++ b/v19.1/admin-ui-cluster-overview-page.md
@@ -37,7 +37,7 @@ CPUs | The number of CPU cores on the machine.
 Capacity Usage | The storage capacity used by CockroachDB as a percentage of the total usable capacity on the node. The value is represented numerically and as a bar graph.
 Mem Usage | The memory used by CockroachDB as a percentage of the total memory on the node. The value is represented numerically and as a bar graph.
 Version | The build tag of the CockroachDB version installed on the node.
-Logs | Click **Logs** to see detailed logs for the node.
+Logs | Click **Logs** to see detailed logs for the node. [Requires `admin` privileges](admin-ui-overview.html#admin-ui-access) on secure clusters.
 
 ### Dead Nodes
 

--- a/v19.1/admin-ui-databases-page.md
+++ b/v19.1/admin-ui-databases-page.md
@@ -3,6 +3,10 @@ title: Database Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Databases** page of the Admin UI provides details of the databases configured, the tables in each database, and the grants assigned to each user. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Databases** on the left-hand navigation bar.
 
 

--- a/v19.1/admin-ui-debug-pages.md
+++ b/v19.1/admin-ui-debug-pages.md
@@ -20,14 +20,14 @@ On the right-side of the page, the following information is displayed:
 
 The following debug reports and configuration views are useful for monitoring and troubleshooting CockroachDB:
 
-Report | Description
---------|----
-[Custom Time Series Chart](admin-ui-custom-chart-debug-page.html) | Create a custom chart of time series data.
-Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems.
-Network Latency | Check latencies between all nodes in your cluster.
-Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration.
-Cluster Settings | View all cluster settings and their configured values.
-Localities | Check node localities for your cluster.
+Report | Description | Access level
+--------|-----|--------
+[Custom Time Series Chart](admin-ui-custom-chart-debug-page.html) | Create a custom chart of time series data. | All users
+Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
+Network Latency | Check latencies between all nodes in your cluster. | All users
+Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
+Cluster Settings | View all cluster settings and their configured values. | All users
+Localities | Check node localities for your cluster. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 
 ## Even More Advanced Debugging
 

--- a/v19.1/admin-ui-debug-pages.md
+++ b/v19.1/admin-ui-debug-pages.md
@@ -26,7 +26,7 @@ Report | Description | Access level
 Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 Network Latency | Check latencies between all nodes in your cluster. | All users
 Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
-Cluster Settings | View all cluster settings and their configured values. | All users
+Cluster Settings | View cluster settings and their configured values. | All users can view data according to their privileges
 Localities | Check node localities for your cluster. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 
 ## Even More Advanced Debugging

--- a/v19.1/admin-ui-jobs-page.md
+++ b/v19.1/admin-ui-jobs-page.md
@@ -3,6 +3,10 @@ title: Jobs Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Jobs** page of the Admin UI provides details about the backup/restore jobs, schema changes, [user-created table statistics](create-statistics.html) and [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and changefeeds performed across all nodes in the cluster. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Jobs** on the left-hand navigation bar.
 
 

--- a/v19.1/admin-ui-jobs-page.md
+++ b/v19.1/admin-ui-jobs-page.md
@@ -12,7 +12,7 @@ The **Jobs** page of the Admin UI provides details about the backup/restore jobs
 
 ## Job details
 
-The **Jobs** table displays the ID, description, user, creation time, and status of each backup and restore job, schema changes, user-created table statistics and automatic table statistics jobs, and changefeeds performed across all nodes in the cluster. To view the job's the full description, click the drop-down arrow in the first column.
+The **Jobs** table displays the ID, description, user, creation time, and status of each backup and restore job, schema changes, user-created table statistics and automatic table statistics jobs, and changefeeds performed across all nodes in the cluster. To view the job's full description, click the drop-down arrow in the first column.
 
 <img src="{{ 'images/v19.1/admin_ui_jobs_page_new.png' | relative_url }}" alt="CockroachDB Admin UI Jobs Page" style="border:1px solid #eee;max-width:100%" />
 

--- a/v19.1/admin-ui-overview.md
+++ b/v19.1/admin-ui-overview.md
@@ -28,6 +28,28 @@ Area | Description
 
 The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
 
+## Admin UI access
+
+On insecure clusters, all areas of the Admin UI are accessible to all users.
+
+On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html#admin-role). These areas display information from privileged HTTP endpoints that operate with [`root` user](authorization.html#root-user) permissions.
+
+For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
+
+{{site.data.alerts.callout_info}}
+The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
+
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: `INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)`
+{{site.data.alerts.end}}
+
+Secure area | Privileged information
+-----|-----
+[Node Map](enable-node-map.html) | Database and table names
+[Database Details](admin-ui-databases-page.html) | Stored table data	
+[Statements Details](admin-ui-statements-page.html) | SQL statements
+[Jobs Details](admin-ui-jobs-page.html) | SQL statements and operational details
+[Advanced Debugging Pages](admin-ui-debug-pages.html) (some reports) | Stored table data, operational details, internal IP addresses, names, credentials, application data (depending on report)
+
 {{site.data.alerts.callout_info}}
 By default, the Admin UI shares anonymous usage details with Cockroach Labs. For information about the details shared and how to opt-out of reporting, see [Diagnostics Reporting](diagnostics-reporting.html).
 {{site.data.alerts.end}}

--- a/v19.1/admin-ui-overview.md
+++ b/v19.1/admin-ui-overview.md
@@ -32,7 +32,7 @@ The Admin UI also provides details about the way data is **Distributed**, the st
 
 On insecure clusters, all areas of the Admin UI are accessible to all users.
 
-On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html#admin-role). These areas display information from privileged HTTP endpoints that operate with [`root` user](authorization.html#root-user) permissions.
+On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html). These areas display information from privileged HTTP endpoints that operate with `root` user permissions.
 
 For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
 

--- a/v19.1/admin-ui-overview.md
+++ b/v19.1/admin-ui-overview.md
@@ -1,12 +1,13 @@
 ---
 title: Admin UI Overview
 summary: Use the Admin UI to monitor and optimize cluster performance.
-toc: false
 redirect_from: explore-the-admin-ui.html
 key: explore-the-admin-ui.html
 ---
 
-The CockroachDB Admin UI provides details about your cluster and database configuration, and helps you optimize cluster performance by monitoring the following areas:
+The CockroachDB Admin UI provides details about your cluster and database configuration, and helps you optimize cluster performance.
+
+## Admin UI areas
 
 Area | Description
 --------|----
@@ -24,22 +25,20 @@ Area | Description
 [Database Details](admin-ui-databases-page.html) | View details about the system and user databases in the cluster.
 [Statements Details](admin-ui-statements-page.html) | Identify frequently executed or high latency [SQL statements](sql-statements.html)
 [Jobs Details](admin-ui-jobs-page.html) | View details of the jobs running in the cluster.
-[Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports.
-
-The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
+[Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports. These include details about data distribution, the state of specific queues, and slow query metrics. These details are largely intended for use by CockroachDB developers.
 
 ## Admin UI access
 
 On insecure clusters, all areas of the Admin UI are accessible to all users.
 
-On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html). These areas display information from privileged HTTP endpoints that operate with `root` user permissions.
+On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html#terminology). These areas display information from privileged HTTP endpoints that operate with `root` user permissions.
 
 For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
 
 {{site.data.alerts.callout_info}}
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
-If you don't have an enterprise license, use this command to manually create a secondary `admin` user: `INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)`
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)</code>
 {{site.data.alerts.end}}
 
 Secure area | Privileged information

--- a/v19.1/admin-ui-statements-page.md
+++ b/v19.1/admin-ui-statements-page.md
@@ -3,6 +3,10 @@ title: Statements Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Statements** page helps you identify frequently executed or high latency [SQL statements](sql-statements.html). The **Statements** page also allows you to view the details of an individual SQL statement by clicking on the statement to view the **Statement Details** page.
 
 To view the **Statements** page, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Statements** on the left.

--- a/v19.1/enable-node-map.md
+++ b/v19.1/enable-node-map.md
@@ -4,6 +4,10 @@ summary: Learn how to enable the node map in the Admin UI.
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Node Map** visualizes the geographical configuration of a multi-regional cluster by plotting the node localities on a world map. The **Node Map** also provides real-time cluster metrics, with the ability to drill down to individual nodes to monitor and troubleshoot the cluster health and performance.
 
 This page walks you through the process of setting up and enabling the **Node Map**.

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -345,7 +345,16 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
       You will need this username and password to access the Admin UI in Step 4.
 
-4. Exit the SQL shell and pod:
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+5. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/v19.1/secure-a-cluster.md
+++ b/v19.1/secure-a-cluster.md
@@ -218,6 +218,15 @@ Finally, [create a user with a password](create-user.html#create-a-user-with-a-p
 > CREATE USER roach WITH PASSWORD 'Q7gc8rEdS';
 ~~~
 
+On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+Assign `max` to the `admin` role:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+~~~
+
 Exit the SQL shell on node 2:
 
 {% include copy-clipboard.html %}

--- a/v19.2/admin-ui-cluster-overview-page.md
+++ b/v19.2/admin-ui-cluster-overview-page.md
@@ -37,7 +37,7 @@ CPUs | The number of CPU cores on the machine.
 Capacity Usage | The storage capacity used by CockroachDB as a percentage of the total usable capacity on the node. The value is represented numerically and as a bar graph.
 Mem Usage | The memory used by CockroachDB as a percentage of the total memory on the node. The value is represented numerically and as a bar graph.
 Version | The build tag of the CockroachDB version installed on the node.
-Logs | Click **Logs** to see detailed logs for the node.
+Logs | Click **Logs** to see detailed logs for the node. [Requires `admin` privileges](admin-ui-overview.html#admin-ui-access) on secure clusters.
 
 ### Dead Nodes
 

--- a/v19.2/admin-ui-databases-page.md
+++ b/v19.2/admin-ui-databases-page.md
@@ -3,6 +3,10 @@ title: Database Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Databases** page of the Admin UI provides details of the databases configured, the tables in each database, and the grants assigned to each user. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Databases** on the left-hand navigation bar.
 
 

--- a/v19.2/admin-ui-debug-pages.md
+++ b/v19.2/admin-ui-debug-pages.md
@@ -20,14 +20,14 @@ On the right-side of the page, the following information is displayed:
 
 The following debug reports and configuration views are useful for monitoring and troubleshooting CockroachDB:
 
-Report | Description
---------|----
-[Custom Time Series Chart](admin-ui-custom-chart-debug-page.html) | Create a custom chart of time series data.
-Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems.
-Network Latency | Check latencies between all nodes in your cluster.
-Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration.
-Cluster Settings | View all cluster settings and their configured values.
-Localities | Check node localities for your cluster.
+Report | Description | Access level
+--------|-----|--------
+[Custom Time Series Chart](admin-ui-custom-chart-debug-page.html) | Create a custom chart of time series data. | All users
+Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
+Network Latency | Check latencies between all nodes in your cluster. | All users
+Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
+Cluster Settings | View all cluster settings and their configured values. | All users
+Localities | Check node localities for your cluster. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 
 ## Even More Advanced Debugging
 

--- a/v19.2/admin-ui-debug-pages.md
+++ b/v19.2/admin-ui-debug-pages.md
@@ -26,7 +26,7 @@ Report | Description | Access level
 Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 Network Latency | Check latencies between all nodes in your cluster. | All users
 Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
-Cluster Settings | View all cluster settings and their configured values. | All users
+Cluster Settings | View cluster settings and their configured values. | All users can view data according to their privileges
 Localities | Check node localities for your cluster. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 
 ## Even More Advanced Debugging

--- a/v19.2/admin-ui-jobs-page.md
+++ b/v19.2/admin-ui-jobs-page.md
@@ -3,6 +3,10 @@ title: Jobs Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Jobs** page of the Admin UI provides details about the backup/restore jobs, schema changes, [user-created table statistics](create-statistics.html) and [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and changefeeds performed across all nodes in the cluster. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Jobs** on the left-hand navigation bar.
 
 

--- a/v19.2/admin-ui-jobs-page.md
+++ b/v19.2/admin-ui-jobs-page.md
@@ -12,7 +12,7 @@ The **Jobs** page of the Admin UI provides details about the backup/restore jobs
 
 ## Job details
 
-The **Jobs** table displays the ID, description, user, creation time, and status of each backup and restore job, schema changes, user-created table statistics and automatic table statistics jobs, and changefeeds performed across all nodes in the cluster. To view the job's the full description, click the drop-down arrow in the first column.
+The **Jobs** table displays the ID, description, user, creation time, and status of each backup and restore job, schema changes, user-created table statistics and automatic table statistics jobs, and changefeeds performed across all nodes in the cluster. To view the job's full description, click the drop-down arrow in the first column.
 
 <img src="{{ 'images/v19.2/admin_ui_jobs_page_new.png' | relative_url }}" alt="CockroachDB Admin UI Jobs Page" style="border:1px solid #eee;max-width:100%" />
 

--- a/v19.2/admin-ui-overview.md
+++ b/v19.2/admin-ui-overview.md
@@ -28,6 +28,28 @@ Area | Description
 
 The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
 
+## Admin UI access
+
+On insecure clusters, all areas of the Admin UI are accessible to all users.
+
+On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html#admin-role). These areas display information from privileged HTTP endpoints that operate with [`root` user](authorization.html#root-user) permissions.
+
+For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
+
+{{site.data.alerts.callout_info}}
+The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
+
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: `INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)`
+{{site.data.alerts.end}}
+
+Secure area | Privileged information
+-----|-----
+[Node Map](enable-node-map.html) | Database and table names
+[Database Details](admin-ui-databases-page.html) | Stored table data	
+[Statements Details](admin-ui-statements-page.html) | SQL statements
+[Jobs Details](admin-ui-jobs-page.html) | SQL statements and operational details
+[Advanced Debugging Pages](admin-ui-debug-pages.html) (some reports) | Stored table data, operational details, internal IP addresses, names, credentials, application data (depending on report)
+
 {{site.data.alerts.callout_info}}
 By default, the Admin UI shares anonymous usage details with Cockroach Labs. For information about the details shared and how to opt-out of reporting, see [Diagnostics Reporting](diagnostics-reporting.html).
 {{site.data.alerts.end}}

--- a/v19.2/admin-ui-overview.md
+++ b/v19.2/admin-ui-overview.md
@@ -1,12 +1,13 @@
 ---
 title: Admin UI Overview
 summary: Use the Admin UI to monitor and optimize cluster performance.
-toc: false
 redirect_from: explore-the-admin-ui.html
 key: explore-the-admin-ui.html
 ---
 
-The CockroachDB Admin UI provides details about your cluster and database configuration, and helps you optimize cluster performance by monitoring the following areas:
+The CockroachDB Admin UI provides details about your cluster and database configuration, and helps you optimize cluster performance.
+
+## Admin UI areas
 
 Area | Description
 --------|----
@@ -24,9 +25,7 @@ Area | Description
 [Database Details](admin-ui-databases-page.html) | View details about the system and user databases in the cluster.
 [Statements Details](admin-ui-statements-page.html) | Identify frequently executed or high latency [SQL statements](sql-statements.html)
 [Jobs Details](admin-ui-jobs-page.html) | View details of the jobs running in the cluster.
-[Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports.
-
-The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
+[Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports. These include details about data distribution, the state of specific queues, and slow query metrics. These details are largely intended for use by CockroachDB developers.
 
 ## Admin UI access
 
@@ -39,7 +38,7 @@ For security reasons, non-admin users access only the data over which they have 
 {{site.data.alerts.callout_info}}
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
-If you don't have an enterprise license, use this command to manually create a secondary `admin` user: `INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)`
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)</code>
 {{site.data.alerts.end}}
 
 Secure area | Privileged information

--- a/v19.2/admin-ui-statements-page.md
+++ b/v19.2/admin-ui-statements-page.md
@@ -3,6 +3,10 @@ title: Statements Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Statements** page helps you identify frequently executed or high latency [SQL statements](sql-statements.html). The **Statements** page also allows you to view the details of an individual SQL statement by clicking on the statement to view the **Statement Details** page.
 
 To view the **Statements** page, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Statements** on the left.

--- a/v19.2/enable-node-map.md
+++ b/v19.2/enable-node-map.md
@@ -4,6 +4,10 @@ summary: Learn how to enable the node map in the Admin UI.
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Node Map** visualizes the geographical configuration of a multi-regional cluster by plotting the node localities on a world map. The **Node Map** also provides real-time cluster metrics, with the ability to drill down to individual nodes to monitor and troubleshoot the cluster health and performance.
 
 This page walks you through the process of setting up and enabling the **Node Map**.

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -347,7 +347,16 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
       You will need this username and password to access the Admin UI in Step 4.
 
-4. Exit the SQL shell and pod:
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+5. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -308,7 +308,30 @@ The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the ov
 
     <img src="{{ 'images/v19.2/admin_ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-3. Use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Run the [cockroach sql](cockroach-sql.html) command against node 1:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach sql --certs-dir=certs --host=localhost:26257
+    ~~~
+
+6. Assign `max` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+    ~~~
+
+7. Exit the SQL shell on node 1:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > \q
+    ~~~
+
+8. Now you can use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
 
 ## Step 6. Simulate node failure
 

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -175,7 +175,7 @@ You can use either [`cockroach cert`](cockroach-cert.html) commands or [`openssl
 
 Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use CockroachDB's built-in SQL client.
 
-1. Run the [cockroach sql](cockroach-sql.html) command against node 1:
+1. Run the [`cockroach sql`](cockroach-sql.html) command against node 1:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -250,7 +250,16 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > CREATE USER max WITH PASSWORD 'roach';
     ~~~
 
-6. Exit the SQL shell on node 2:
+6. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `max` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+    ~~~
+
+7. Exit the SQL shell on node 2:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -308,30 +317,7 @@ The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the ov
 
     <img src="{{ 'images/v19.2/admin_ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
-
-    Run the [cockroach sql](cockroach-sql.html) command against node 1:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql --certs-dir=certs --host=localhost:26257
-    ~~~
-
-6. Assign `max` to the `admin` role:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
-    ~~~
-
-7. Exit the SQL shell on node 1:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > \q
-    ~~~
-
-8. Now you can use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+5. Use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
 
 ## Step 6. Simulate node failure
 

--- a/v20.1/admin-ui-cluster-overview-page.md
+++ b/v20.1/admin-ui-cluster-overview-page.md
@@ -37,7 +37,7 @@ CPUs | The number of CPU cores on the machine.
 Capacity Usage | The storage capacity used by CockroachDB as a percentage of the total usable capacity on the node. The value is represented numerically and as a bar graph.
 Mem Usage | The memory used by CockroachDB as a percentage of the total memory on the node. The value is represented numerically and as a bar graph.
 Version | The build tag of the CockroachDB version installed on the node.
-Logs | Click **Logs** to see detailed logs for the node.
+Logs | Click **Logs** to see detailed logs for the node. [Requires `admin` privileges](admin-ui-overview.html#admin-ui-access) on secure clusters.
 
 ### Dead Nodes
 

--- a/v20.1/admin-ui-databases-page.md
+++ b/v20.1/admin-ui-databases-page.md
@@ -3,6 +3,10 @@ title: Database Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Databases** page of the Admin UI provides details of the databases configured, the tables in each database, and the grants assigned to each user. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Databases** on the left-hand navigation bar.
 
 

--- a/v20.1/admin-ui-debug-pages.md
+++ b/v20.1/admin-ui-debug-pages.md
@@ -20,14 +20,14 @@ On the right-side of the page, the following information is displayed:
 
 The following debug reports and configuration views are useful for monitoring and troubleshooting CockroachDB:
 
-Report | Description
---------|----
-[Custom Time Series Chart](admin-ui-custom-chart-debug-page.html) | Create a custom chart of time series data.
-Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems.
-Network Latency | Check latencies between all nodes in your cluster.
-Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration.
-Cluster Settings | View all cluster settings and their configured values.
-Localities | Check node localities for your cluster.
+Report | Description | Access level
+--------|-----|--------
+[Custom Time Series Chart](admin-ui-custom-chart-debug-page.html) | Create a custom chart of time series data. | All users
+Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
+Network Latency | Check latencies between all nodes in your cluster. | All users
+Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
+Cluster Settings | View all cluster settings and their configured values. | All users
+Localities | Check node localities for your cluster. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 
 ## Even More Advanced Debugging
 

--- a/v20.1/admin-ui-debug-pages.md
+++ b/v20.1/admin-ui-debug-pages.md
@@ -26,7 +26,7 @@ Report | Description | Access level
 Problem Ranges | View ranges in your cluster that are unavailable, underreplicated, slow, or have other problems. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 Network Latency | Check latencies between all nodes in your cluster. | All users
 Data Distribution and Zone Configs | View the distribution of table data across nodes and verify zone configuration. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
-Cluster Settings | View all cluster settings and their configured values. | All users
+Cluster Settings | View cluster settings and their configured values. | All users can view data according to their privileges
 Localities | Check node localities for your cluster. | [`admin` users only on secure clusters](admin-ui-overview.html#admin-ui-access)
 
 ## Even More Advanced Debugging

--- a/v20.1/admin-ui-jobs-page.md
+++ b/v20.1/admin-ui-jobs-page.md
@@ -3,6 +3,10 @@ title: Jobs Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Jobs** page of the Admin UI provides details about the backup/restore jobs, schema changes, [user-created table statistics](create-statistics.html) and [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and changefeeds performed across all nodes in the cluster. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Jobs** on the left-hand navigation bar.
 
 

--- a/v20.1/admin-ui-jobs-page.md
+++ b/v20.1/admin-ui-jobs-page.md
@@ -3,16 +3,12 @@ title: Jobs Page
 toc: true
 ---
 
-{{site.data.alerts.callout_info}}
-On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
-{{site.data.alerts.end}}
-
-The **Jobs** page of the Admin UI provides details about the backup/restore jobs, schema changes, [user-created table statistics](create-statistics.html) and [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and changefeeds performed across all nodes in the cluster. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Jobs** on the left-hand navigation bar.
+The **Jobs** page of the Admin UI provides details about backup/restore jobs, schema changes, [user-created table statistics](create-statistics.html) and [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and changefeeds. All users can see their own jobs, and `admin` users can view all jobs performed across all nodes in the cluster. To view these details, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Jobs** on the left-hand navigation bar.
 
 
 ## Job details
 
-The **Jobs** table displays the ID, description, user, creation time, and status of each backup and restore job, schema changes, user-created table statistics and automatic table statistics jobs, and changefeeds performed across all nodes in the cluster. To view the job's the full description, click the drop-down arrow in the first column.
+The **Jobs** table displays the ID, description, user, creation time, and status of backup and restore jobs, schema changes, user-created table statistics and automatic table statistics jobs, and changefeeds. To view the job's full description, click the drop-down arrow in the first column.
 
 <img src="{{ 'images/v20.1/admin_ui_jobs_page_new.png' | relative_url }}" alt="CockroachDB Admin UI Jobs Page" style="border:1px solid #eee;max-width:100%" />
 

--- a/v20.1/admin-ui-overview.md
+++ b/v20.1/admin-ui-overview.md
@@ -28,6 +28,28 @@ Area | Description
 
 The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
 
+## Admin UI access
+
+On insecure clusters, all areas of the Admin UI are accessible to all users.
+
+On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html#admin-role). These areas display information from privileged HTTP endpoints that operate with [`root` user](authorization.html#root-user) permissions.
+
+For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
+
+{{site.data.alerts.callout_info}}
+The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
+
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: `INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)`
+{{site.data.alerts.end}}
+
+Secure area | Privileged information
+-----|-----
+[Node Map](enable-node-map.html) | Database and table names
+[Database Details](admin-ui-databases-page.html) | Stored table data	
+[Statements Details](admin-ui-statements-page.html) | SQL statements
+[Jobs Details](admin-ui-jobs-page.html) | SQL statements and operational details
+[Advanced Debugging Pages](admin-ui-debug-pages.html) (some reports) | Stored table data, operational details, internal IP addresses, names, credentials, application data (depending on report)
+
 {{site.data.alerts.callout_info}}
 By default, the Admin UI shares anonymous usage details with Cockroach Labs. For information about the details shared and how to opt-out of reporting, see [Diagnostics Reporting](diagnostics-reporting.html).
 {{site.data.alerts.end}}

--- a/v20.1/admin-ui-overview.md
+++ b/v20.1/admin-ui-overview.md
@@ -23,7 +23,7 @@ Area | Description
 [Events](admin-ui-access-and-navigate.html#events-panel) | View a list of recent cluster events.
 [Database Details](admin-ui-databases-page.html) | View details about the system and user databases in the cluster.
 [Statements Details](admin-ui-statements-page.html) | Identify frequently executed or high latency [SQL statements](sql-statements.html)
-[Jobs Details](admin-ui-jobs-page.html) | View details of the jobs running in the cluster.
+[Jobs Details](admin-ui-jobs-page.html) | View details of jobs running in the cluster.
 [Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports.
 
 The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
@@ -34,7 +34,7 @@ On insecure clusters, all areas of the Admin UI are accessible to all users.
 
 On secure clusters, certain areas of the Admin UI can only be accessed by [`admin` users](authorization.html#admin-role). These areas display information from privileged HTTP endpoints that operate with [`root` user](authorization.html#root-user) permissions.
 
-For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
+For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables, jobs, and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
 
 {{site.data.alerts.callout_info}}
 The default `root` user is a member of the `admin` role.
@@ -45,7 +45,6 @@ Secure area | Privileged information
 [Node Map](enable-node-map.html) | Database and table names
 [Database Details](admin-ui-databases-page.html) | Stored table data	
 [Statements Details](admin-ui-statements-page.html) | SQL statements
-[Jobs Details](admin-ui-jobs-page.html) | SQL statements and operational details
 [Advanced Debugging Pages](admin-ui-debug-pages.html) (some reports) | Stored table data, operational details, internal IP addresses, names, credentials, application data (depending on report)
 
 {{site.data.alerts.callout_info}}

--- a/v20.1/admin-ui-overview.md
+++ b/v20.1/admin-ui-overview.md
@@ -37,9 +37,7 @@ On secure clusters, certain areas of the Admin UI can only be accessed by [`admi
 For security reasons, non-admin users access only the data over which they have privileges (e.g., their tables and list of sessions), and data that does not require privileges (e.g., cluster health, node status, metrics).
 
 {{site.data.alerts.callout_info}}
-The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
-
-If you don't have an enterprise license, use this command to manually create a secondary `admin` user: `INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '<sql_user>', true)`
+The default `root` user is a member of the `admin` role.
 {{site.data.alerts.end}}
 
 Secure area | Privileged information

--- a/v20.1/admin-ui-overview.md
+++ b/v20.1/admin-ui-overview.md
@@ -1,12 +1,13 @@
 ---
 title: Admin UI Overview
 summary: Use the Admin UI to monitor and optimize cluster performance.
-toc: false
 redirect_from: explore-the-admin-ui.html
 key: explore-the-admin-ui.html
 ---
 
-The CockroachDB Admin UI provides details about your cluster and database configuration, and helps you optimize cluster performance by monitoring the following areas:
+The CockroachDB Admin UI provides details about your cluster and database configuration, and helps you optimize cluster performance.
+
+## Admin UI areas
 
 Area | Description
 --------|----
@@ -24,9 +25,7 @@ Area | Description
 [Database Details](admin-ui-databases-page.html) | View details about the system and user databases in the cluster.
 [Statements Details](admin-ui-statements-page.html) | Identify frequently executed or high latency [SQL statements](sql-statements.html)
 [Jobs Details](admin-ui-jobs-page.html) | View details of jobs running in the cluster.
-[Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports.
-
-The Admin UI also provides details about the way data is **Distributed**, the state of specific **Queues**, and metrics for **Slow Queries**, but these details are largely internal and intended for use by CockroachDB developers.
+[Advanced Debugging Pages](admin-ui-debug-pages.html) | View advanced monitoring and troubleshooting reports. These include details about data distribution, the state of specific queues, and slow query metrics. These details are largely intended for use by CockroachDB developers.
 
 ## Admin UI access
 

--- a/v20.1/admin-ui-statements-page.md
+++ b/v20.1/admin-ui-statements-page.md
@@ -3,6 +3,10 @@ title: Statements Page
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Statements** page helps you identify frequently executed or high latency [SQL statements](sql-statements.html). The **Statements** page also allows you to view the details of an individual SQL statement by clicking on the statement to view the **Statement Details** page.
 
 To view the **Statements** page, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and then click **Statements** on the left.

--- a/v20.1/enable-node-map.md
+++ b/v20.1/enable-node-map.md
@@ -4,6 +4,10 @@ summary: Learn how to enable the node map in the Admin UI.
 toc: true
 ---
 
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
 The **Node Map** visualizes the geographical configuration of a multi-regional cluster by plotting the node localities on a world map. The **Node Map** also provides real-time cluster metrics, with the ability to drill down to individual nodes to monitor and troubleshoot the cluster health and performance.
 
 This page walks you through the process of setting up and enabling the **Node Map**.

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -347,7 +347,16 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
       You will need this username and password to access the Admin UI in Step 4.
 
-4. Exit the SQL shell and pod:
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `roach` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    ~~~
+
+5. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -175,7 +175,7 @@ You can use either [`cockroach cert`](cockroach-cert.html) commands or [`openssl
 
 Now that your cluster is live, you can use any node as a SQL gateway. To test this out, let's use CockroachDB's built-in SQL client.
 
-1. Run the [cockroach sql](cockroach-sql.html) command against node 1:
+1. Run the [`cockroach sql`](cockroach-sql.html) command against node 1:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -250,7 +250,16 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > CREATE USER max WITH PASSWORD 'roach';
     ~~~
 
-6. Exit the SQL shell on node 2:
+6. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Assign `max` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+    ~~~
+
+7. Exit the SQL shell on node 2:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -308,30 +317,7 @@ The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the ov
 
     <img src="{{ 'images/v20.1/admin_ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
-
-    Run the [cockroach sql](cockroach-sql.html) command against node 1:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ cockroach sql --certs-dir=certs --host=localhost:26257
-    ~~~
-
-6. Assign `max` to the `admin` role:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
-    ~~~
-
-7. Exit the SQL shell on node 1:
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    > \q
-    ~~~
-
-8. Now you can use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+5. Use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
 
 ## Step 6. Simulate node failure
 

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -308,7 +308,30 @@ The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the ov
 
     <img src="{{ 'images/v20.1/admin_ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
-3. Use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+
+    Run the [cockroach sql](cockroach-sql.html) command against node 1:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach sql --certs-dir=certs --host=localhost:26257
+    ~~~
+
+6. Assign `max` to the `admin` role:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+    ~~~
+
+7. Exit the SQL shell on node 1:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > \q
+    ~~~
+
+8. Now you can use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
 
 ## Step 6. Simulate node failure
 


### PR DESCRIPTION
Fixes #6331 
Fixes #6517
Fixes #6580
Fixes #6617 

This PR does the following on 19.2 and 19.1:

- Adds an "Admin UI access" subheading to Admin UI Overview page explaining why we limit access & listing the restricted Admin UI sections
  - They are called "secure areas" to emphasize that this is a security feature
  - The list of "privileged information" in the table may not be complete
- Describes the two status-quo workarounds for core users provided in the [doc](https://docs.google.com/document/d/1EHxEpsWXM--A-Dq-0YCxwWEJqpDJq2KVdIP_QOeBdNo/edit#) 
- Adds an info callout & link back to "Admin UI access" on the relevant Admin UI pages
- Updates tutorials in which we suggest checking any of the restricted Admin UI pages
  - These tutorials generally emphasize speed (of starting, monitoring, testing a cluster) over conceptual thoroughness. As such, I specifically use the SQL workaround that doesn't require an enterprise license.

Should the above also apply to 2.1?