### PR TITLE
TIMESTAMPTZ vectorized support.

### DIFF
--- a/v20.1/vectorized-execution.md
+++ b/v20.1/vectorized-execution.md
@@ -62,7 +62,7 @@ Vectorized execution is supported for the following [data types](data-types.html
 - [`FLOAT`](float.html)
 - [`INT`](int.html)
 - [`STRING`](string.html)
-- [`TIMESTAMP`](timestamp.html)
+- [`TIMESTAMP`/`TIMESTAMPTZ`](timestamp.html)
 - [`UUID`](uuid.html)
 
 In all [`vectorize` modes](#configuring-vectorized-execution), queries on tables that contain unsupported data types are executed with the row-oriented execution engine. Using [`EXPLAIN(VEC)`](explain.html#vec-option) on queries of tables that include unsupported data types will return an unhandled data type error.


### PR DESCRIPTION
Fixes #6452.

Added `TIMESTAMPTZ` to list of supported data types for vectorized execution.

Follow-up to https://github.com/cockroachdb/docs/pull/6327.

