### PR TITLE
Uplevel Driver/ORM support in Developer Guide

### DIFF
--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -60,6 +60,12 @@
             ]
           },
           {
+            "title": "Supported Drivers and ORMs",
+            "urls": [
+              "/${VERSION}/install-client-drivers.html"
+            ]
+          },
+          {
             "title": "Connect to the Database",
             "urls": [
               "/${VERSION}/connect-to-the-database.html"
@@ -780,12 +786,6 @@
             "title": "PostgreSQL Compatibility",
             "urls": [
               "/${VERSION}/postgresql-compatibility.html"
-            ]
-          },
-          {
-            "title": "Client Drivers",
-            "urls": [
-              "/${VERSION}/install-client-drivers.html"
             ]
           },
           {

--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -60,6 +60,12 @@
             ]
           },
           {
+            "title": "Supported Drivers and ORMs",
+            "urls": [
+              "/${VERSION}/install-client-drivers.html"
+            ]
+          },
+          {
             "title": "Connect to the Database",
             "urls": [
               "/${VERSION}/connect-to-the-database.html"
@@ -739,12 +745,6 @@
             "title": "PostgreSQL Compatibility",
             "urls": [
               "/${VERSION}/postgresql-compatibility.html"
-            ]
-          },
-          {
-            "title": "Client Drivers",
-            "urls": [
-              "/${VERSION}/install-client-drivers.html"
             ]
           },
           {

--- a/v19.2/install-client-drivers.md
+++ b/v19.2/install-client-drivers.md
@@ -1,20 +1,17 @@
 ---
-title: Install Client Drivers
+title: Supported Client Drivers and ORMs
 summary: CockroachDB supports the PostgreSQL wire protocol, so you can use any available PostgreSQL client drivers.
 toc: false
 ---
 
 CockroachDB supports the PostgreSQL wire protocol, so most available PostgreSQL client drivers should work with CockroachDB.
 
-{{site.data.alerts.callout_success}}
-For code samples using these drivers, see [Build an App with CockroachDB](build-an-app-with-cockroachdb.html).
-{{site.data.alerts.end}}
+Click the links in the table below to see simple example applications for each supported language and library combination.
 
 {% include {{page.version.version}}/misc/drivers.md %}
 
 ## See also
 
-- [Build an App with CockroachDB](build-an-app-with-cockroachdb.html)
 - [Third party database tools](third-party-database-tools.html)
 - [Connection parameters](connection-parameters.html)
 - [Transactions](transactions.html)

--- a/v20.1/install-client-drivers.md
+++ b/v20.1/install-client-drivers.md
@@ -1,20 +1,17 @@
 ---
-title: Install Client Drivers
+title: Supported Client Drivers and ORMs
 summary: CockroachDB supports the PostgreSQL wire protocol, so you can use any available PostgreSQL client drivers.
 toc: false
 ---
 
 CockroachDB supports the PostgreSQL wire protocol, so most available PostgreSQL client drivers should work with CockroachDB.
 
-{{site.data.alerts.callout_success}}
-For code samples using these drivers, see [Build an App with CockroachDB](build-an-app-with-cockroachdb.html).
-{{site.data.alerts.end}}
+Click the links in the table below to see simple example applications for each supported language and library combination.
 
 {% include {{page.version.version}}/misc/drivers.md %}
 
 ## See also
 
-- [Build an App with CockroachDB](build-an-app-with-cockroachdb.html)
 - [Third party database tools](third-party-database-tools.html)
 - [Connection parameters](connection-parameters.html)
 - [Transactions](transactions.html)


### PR DESCRIPTION
Upleveled Driver/ORM support overview in "Develop" section.

I also removed this from the SQL Reference section, as this isn't reference material.