### PR TITLE
NULLS FIRST|LAST doc

### DIFF
--- a/_includes/v20.1/sql/diagrams/create_index.html
+++ b/_includes/v20.1/sql/diagrams/create_index.html
@@ -1,74 +1,118 @@
-<div><svg width="743" height="409">
-<polygon points="11 17 3 13 3 21"></polygon>
-<polygon points="19 17 11 13 11 21"></polygon>
-<rect x="33" y="3" width="72" height="32" rx="10"></rect>
-<rect x="31" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="41" y="21">CREATE</text>
-<rect x="145" y="35" width="74" height="32" rx="10"></rect>
-<rect x="143" y="33" width="74" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="153" y="53">UNIQUE</text>
-<rect x="259" y="3" width="64" height="32" rx="10"></rect>
-<rect x="257" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="267" y="21">INDEX</text><a xlink:href="sql-grammar.html#opt_index_name" xlink:title="opt_index_name">
-<rect x="363" y="3" width="126" height="32"></rect>
-<rect x="361" y="1" width="126" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="371" y="21">opt_index_name</text></a><rect x="363" y="47" width="34" height="32" rx="10"></rect>
-<rect x="361" y="45" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="371" y="65">IF</text>
-<rect x="417" y="47" width="48" height="32" rx="10"></rect>
-<rect x="415" y="45" width="48" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="425" y="65">NOT</text>
-<rect x="485" y="47" width="70" height="32" rx="10"></rect>
-<rect x="483" y="45" width="70" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="493" y="65">EXISTS</text><a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
-<rect x="575" y="47" width="98" height="32"></rect>
-<rect x="573" y="45" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="583" y="65">index_name</text></a><rect x="31" y="157" width="40" height="32" rx="10"></rect>
-<rect x="29" y="155" width="40" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="39" y="175">ON</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="91" y="157" width="96" height="32"></rect>
-<rect x="89" y="155" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="99" y="175">table_name</text></a><rect x="227" y="189" width="64" height="32" rx="10"></rect>
-<rect x="225" y="187" width="64" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="235" y="207">USING</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
-<rect x="311" y="189" width="56" height="32"></rect>
-<rect x="309" y="187" width="56" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="319" y="207">name</text></a><rect x="407" y="157" width="26" height="32" rx="10"></rect>
-<rect x="405" y="155" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="415" y="175">(</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="473" y="157" width="108" height="32"></rect>
-<rect x="471" y="155" width="108" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="481" y="175">column_name</text></a><rect x="621" y="189" width="46" height="32" rx="10"></rect>
-<rect x="619" y="187" width="46" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="629" y="207">ASC</text>
-<rect x="621" y="233" width="56" height="32" rx="10"></rect>
-<rect x="619" y="231" width="56" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="629" y="251">DESC</text>
-<rect x="473" y="113" width="24" height="32" rx="10"></rect>
-<rect x="471" y="111" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="481" y="131">,</text>
-<rect x="25" y="299" width="26" height="32" rx="10"></rect>
-<rect x="23" y="297" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="33" y="317">)</text>
-<rect x="111" y="331" width="92" height="32" rx="10"></rect>
-<rect x="109" y="329" width="92" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="119" y="349">COVERING</text>
-<rect x="111" y="375" width="84" height="32" rx="10"></rect>
-<rect x="109" y="373" width="84" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="119" y="393">STORING</text>
-<rect x="243" y="331" width="26" height="32" rx="10"></rect>
-<rect x="241" y="329" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="251" y="349">(</text><a xlink:href="sql-grammar.html#name_list" xlink:title="name_list">
-<rect x="289" y="331" width="82" height="32"></rect>
-<rect x="287" y="329" width="82" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="297" y="349">name_list</text></a><rect x="391" y="331" width="26" height="32" rx="10"></rect>
-<rect x="389" y="329" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="399" y="349">)</text><a xlink:href="sql-grammar.html#opt_interleave" xlink:title="opt_interleave">
-<rect x="457" y="299" width="112" height="32"></rect>
-<rect x="455" y="297" width="112" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="465" y="317">opt_interleave</text></a><a xlink:href="sql-grammar.html#opt_partition_by" xlink:title="opt_partition_by">
-<rect x="589" y="299" width="126" height="32"></rect>
-<rect x="587" y="297" width="126" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="597" y="317">opt_partition_by</text></a><path class="line" d="m19 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m64 0 h10 m20 0 h10 m126 0 h10 m0 0 h184 m-350 0 h20 m330 0 h20 m-370 0 q10 0 10 10 m350 0 q0 -10 10 -10 m-360 10 v24 m350 0 v-24 m-350 24 q0 10 10 10 m330 0 q10 0 10 -10 m-340 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m98 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-706 154 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m40 0 h10 m0 0 h10 m96 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h10 m56 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m108 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-244 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m244 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-244 0 h10 m24 0 h10 m0 0 h200 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-736 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m20 0 h10 m0 0 h336 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v12 m366 0 v-12 m-366 12 q0 10 10 10 m346 0 q10 0 10 -10 m-336 10 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m84 0 h10 m0 0 h8 m20 -44 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m112 0 h10 m0 0 h10 m126 0 h10 m3 0 h-3"></path>
-<polygon points="733 313 741 309 741 317"></polygon>
-<polygon points="733 313 725 309 725 317"></polygon></svg></div>
+<div><svg width="726" height="506">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="70" height="32" rx="10"></rect>
+<rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">CREATE</text>
+<rect x="141" y="35" width="74" height="32" rx="10"></rect>
+<rect x="139" y="33" width="74" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="149" y="53">UNIQUE</text>
+<rect x="255" y="3" width="62" height="32" rx="10"></rect>
+<rect x="253" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="263" y="21">INDEX</text>
+<a xlink:href="sql-grammar.html#opt_index_name" xlink:title="opt_index_name">
+<rect x="357" y="3" width="126" height="32"></rect>
+<rect x="355" y="1" width="126" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="365" y="21">opt_index_name</text>
+</a>
+<rect x="357" y="47" width="34" height="32" rx="10"></rect>
+<rect x="355" y="45" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="365" y="65">IF</text>
+<rect x="411" y="47" width="48" height="32" rx="10"></rect>
+<rect x="409" y="45" width="48" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="419" y="65">NOT</text>
+<rect x="479" y="47" width="68" height="32" rx="10"></rect>
+<rect x="477" y="45" width="68" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="487" y="65">EXISTS</text>
+<a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="567" y="47" width="96" height="32"></rect>
+<rect x="565" y="45" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="575" y="65">index_name</text>
+</a>
+<rect x="25" y="157" width="40" height="32" rx="10"></rect>
+<rect x="23" y="155" width="40" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="33" y="175">ON</text>
+<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="85" y="157" width="94" height="32"></rect>
+<rect x="83" y="155" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="93" y="175">table_name</text>
+</a>
+<rect x="219" y="189" width="64" height="32" rx="10"></rect>
+<rect x="217" y="187" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="227" y="207">USING</text>
+<a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="303" y="189" width="54" height="32"></rect>
+<rect x="301" y="187" width="54" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="311" y="207">name</text>
+</a>
+<rect x="397" y="157" width="26" height="32" rx="10"></rect>
+<rect x="395" y="155" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="405" y="175">(</text>
+<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="463" y="157" width="106" height="32"></rect>
+<rect x="461" y="155" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="471" y="175">column_name</text>
+</a>
+<rect x="609" y="189" width="46" height="32" rx="10"></rect>
+<rect x="607" y="187" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="617" y="207">ASC</text>
+<rect x="609" y="233" width="56" height="32" rx="10"></rect>
+<rect x="607" y="231" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="617" y="251">DESC</text>
+<rect x="463" y="113" width="24" height="32" rx="10"></rect>
+<rect x="461" y="111" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="471" y="131">,</text>
+<rect x="49" y="299" width="26" height="32" rx="10"></rect>
+<rect x="47" y="297" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="57" y="317">)</text>
+<rect x="115" y="331" width="64" height="32" rx="10"></rect>
+<rect x="113" y="329" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="123" y="349">USING</text>
+<rect x="199" y="331" width="58" height="32" rx="10"></rect>
+<rect x="197" y="329" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="207" y="349">HASH</text>
+<rect x="277" y="331" width="58" height="32" rx="10"></rect>
+<rect x="275" y="329" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="285" y="349">WITH</text>
+<rect x="355" y="331" width="130" height="32" rx="10"></rect>
+<rect x="353" y="329" width="130" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="363" y="349">BUCKET_COUNT</text>
+<rect x="505" y="331" width="30" height="32" rx="10"></rect>
+<rect x="503" y="329" width="30" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="513" y="349">=</text>
+<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="555" y="331" width="106" height="32"></rect>
+<rect x="553" y="329" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="563" y="349">column_name</text>
+</a>
+<rect x="99" y="429" width="92" height="32" rx="10"></rect>
+<rect x="97" y="427" width="92" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="107" y="447">COVERING</text>
+<rect x="99" y="473" width="82" height="32" rx="10"></rect>
+<rect x="97" y="471" width="82" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="107" y="491">STORING</text>
+<rect x="231" y="429" width="26" height="32" rx="10"></rect>
+<rect x="229" y="427" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="239" y="447">(</text>
+<a xlink:href="sql-grammar.html#name_list" xlink:title="name_list">
+<rect x="277" y="429" width="80" height="32"></rect>
+<rect x="275" y="427" width="80" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="285" y="447">name_list</text>
+</a>
+<rect x="377" y="429" width="26" height="32" rx="10"></rect>
+<rect x="375" y="427" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="385" y="447">)</text>
+<a xlink:href="sql-grammar.html#opt_interleave" xlink:title="opt_interleave">
+<rect x="443" y="397" width="112" height="32"></rect>
+<rect x="441" y="395" width="112" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="451" y="415">opt_interleave</text>
+</a>
+<a xlink:href="sql-grammar.html#opt_partition_by" xlink:title="opt_partition_by">
+<rect x="575" y="397" width="124" height="32"></rect>
+<rect x="573" y="395" width="124" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="583" y="415">opt_partition_by</text>
+</a>
+<path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m62 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-702 154 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m40 0 h10 m0 0 h10 m94 0 h10 m20 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m64 0 h10 m0 0 h10 m54 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m106 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-242 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m242 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-242 0 h10 m24 0 h10 m0 0 h198 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-700 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m20 0 h10 m0 0 h556 m-586 0 h20 m566 0 h20 m-606 0 q10 0 10 10 m586 0 q0 -10 10 -10 m-596 10 v12 m586 0 v-12 m-586 12 q0 10 10 10 m566 0 q10 0 10 -10 m-576 10 h10 m64 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m106 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-666 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h334 m-364 0 h20 m344 0 h20 m-384 0 q10 0 10 10 m364 0 q0 -10 10 -10 m-374 10 v12 m364 0 v-12 m-364 12 q0 10 10 10 m344 0 q10 0 10 -10 m-334 10 h10 m92 0 h10 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m82 0 h10 m0 0 h10 m20 -44 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m112 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
+<polygon points="717 411 725 407 725 415"></polygon>
+<polygon points="717 411 709 407 709 415"></polygon>
+</svg></div>

--- a/_includes/v20.1/sql/diagrams/sort_clause.html
+++ b/_includes/v20.1/sql/diagrams/sort_clause.html
@@ -1,55 +1,69 @@
-<div><svg width="730" height="168">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <rect x="31" y="47" width="66" height="32" rx="10"></rect>
-         <rect x="29" y="45" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="65">ORDER</text>
-         <rect x="117" y="47" width="38" height="32" rx="10"></rect>
-         <rect x="115" y="45" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="125" y="65">BY</text>
-         <a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
-            <rect x="215" y="47" width="62" height="32"></rect>
-            <rect x="213" y="45" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="223" y="65">a_expr</text>
-         </a>
-         <rect x="215" y="91" width="84" height="32" rx="10"></rect>
-         <rect x="213" y="89" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="109">PRIMARY</text>
-         <rect x="319" y="91" width="46" height="32" rx="10"></rect>
-         <rect x="317" y="89" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="327" y="109">KEY</text>
-         <a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-            <rect x="385" y="91" width="90" height="32"></rect>
-            <rect x="383" y="89" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="393" y="109">table_name</text>
-         </a>
-         <rect x="215" y="135" width="62" height="32" rx="10"></rect>
-         <rect x="213" y="133" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="153">INDEX</text>
-         <a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-            <rect x="297" y="135" width="90" height="32"></rect>
-            <rect x="295" y="133" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="305" y="153">table_name</text>
-         </a>
-         <rect x="407" y="135" width="30" height="32" rx="10"></rect>
-         <rect x="405" y="133" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="415" y="153">@</text>
-         <a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
-            <rect x="457" y="135" width="92" height="32"></rect>
-            <rect x="455" y="133" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="465" y="153">index_name</text>
-         </a>
-         <rect x="609" y="79" width="46" height="32" rx="10"></rect>
-         <rect x="607" y="77" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="617" y="97">ASC</text>
-         <rect x="609" y="123" width="54" height="32" rx="10"></rect>
-         <rect x="607" y="121" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="617" y="141">DESC</text>
-         <rect x="195" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="193" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="203" y="21">,</text>
-         <path class="line" d="m17 61 h2 m0 0 h10 m66 0 h10 m0 0 h10 m38 0 h10 m40 0 h10 m62 0 h10 m0 0 h272 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v24 m374 0 v-24 m-374 24 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m84 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m90 0 h10 m0 0 h74 m-364 -10 v20 m374 0 v-20 m-374 20 v24 m374 0 v-24 m-374 24 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m92 0 h10 m40 -88 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m46 0 h10 m0 0 h8 m-84 -10 v20 m94 0 v-20 m-94 20 v24 m94 0 v-24 m-94 24 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m-508 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m508 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-508 0 h10 m24 0 h10 m0 0 h464 m23 44 h-3"></path>
-         <polygon points="721 61 729 57 729 65"></polygon>
-         <polygon points="721 61 713 57 713 65"></polygon>
-      </svg></div>
+<div><svg width="632" height="342">
+<polygon points="11 17 3 13 3 21"></polygon>
+<polygon points="19 17 11 13 11 21"></polygon>
+<rect x="33" y="3" width="66" height="32" rx="10"></rect>
+<rect x="31" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="41" y="21">ORDER</text>
+<rect x="119" y="3" width="38" height="32" rx="10"></rect>
+<rect x="117" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="127" y="21">BY</text>
+<a xlink:href="sql-grammar.html#a_expr" xlink:title="a_expr">
+<rect x="65" y="113" width="64" height="32"></rect>
+<rect x="63" y="111" width="64" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="73" y="131">a_expr</text>
+</a>
+<rect x="169" y="145" width="46" height="32" rx="10"></rect>
+<rect x="167" y="143" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="177" y="163">ASC</text>
+<rect x="169" y="189" width="56" height="32" rx="10"></rect>
+<rect x="167" y="187" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="177" y="207">DESC</text>
+<rect x="285" y="145" width="64" height="32" rx="10"></rect>
+<rect x="283" y="143" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="293" y="163">NULLS</text>
+<rect x="389" y="145" width="60" height="32" rx="10"></rect>
+<rect x="387" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="397" y="163">FIRST</text>
+<rect x="389" y="189" width="54" height="32" rx="10"></rect>
+<rect x="387" y="187" width="54" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="397" y="207">LAST</text>
+<rect x="85" y="233" width="82" height="32" rx="10"></rect>
+<rect x="83" y="231" width="82" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="93" y="251">PRIMARY</text>
+<rect x="187" y="233" width="46" height="32" rx="10"></rect>
+<rect x="185" y="231" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="195" y="251">KEY</text>
+<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="253" y="233" width="94" height="32"></rect>
+<rect x="251" y="231" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="261" y="251">table_name</text>
+</a>
+<rect x="85" y="277" width="62" height="32" rx="10"></rect>
+<rect x="83" y="275" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="93" y="295">INDEX</text>
+<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="167" y="277" width="94" height="32"></rect>
+<rect x="165" y="275" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="175" y="295">table_name</text>
+</a>
+<rect x="281" y="277" width="32" height="32" rx="10"></rect>
+<rect x="279" y="275" width="32" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="289" y="295">@</text>
+<a xlink:href="sql-grammar.html#index_name" xlink:title="index_name">
+<rect x="333" y="277" width="96" height="32"></rect>
+<rect x="331" y="275" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="341" y="295">index_name</text>
+</a>
+<rect x="489" y="265" width="46" height="32" rx="10"></rect>
+<rect x="487" y="263" width="46" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="497" y="283">ASC</text>
+<rect x="489" y="309" width="56" height="32" rx="10"></rect>
+<rect x="487" y="307" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="497" y="327">DESC</text>
+<rect x="45" y="69" width="24" height="32" rx="10"></rect>
+<rect x="43" y="67" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="87">,</text>
+<path class="line" d="m19 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-176 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m64 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m40 -76 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m64 0 h10 m20 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m54 0 h10 m0 0 h6 m40 -76 h76 m-540 0 h20 m520 0 h20 m-560 0 q10 0 10 10 m540 0 q0 -10 10 -10 m-550 10 v100 m540 0 v-100 m-540 100 q0 10 10 10 m520 0 q10 0 10 -10 m-510 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m94 0 h10 m0 0 h82 m-384 0 h20 m364 0 h20 m-404 0 q10 0 10 10 m384 0 q0 -10 10 -10 m-394 10 v24 m384 0 v-24 m-384 24 q0 10 10 10 m364 0 q10 0 10 -10 m-374 10 h10 m62 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m32 0 h10 m0 0 h10 m96 0 h10 m40 -44 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-540 -196 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m560 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-560 0 h10 m24 0 h10 m0 0 h516 m23 44 h-3"></path>
+<polygon points="623 127 631 123 631 131"></polygon>
+<polygon points="623 127 615 123 615 131"></polygon>
+</svg></div>

--- a/v20.1/query-order.md
+++ b/v20.1/query-order.md
@@ -39,6 +39,12 @@ the sorting key as-is, and thus is meaningless.
 The optional keyword `DESC` inverts the direction of the column(s)
 selected by the selection that immediately precedes.
 
+<span class="version-tag">New in v20.1:</span> CockroachDB supports `NULLS FIRST`/`NULLS LAST` in `ORDER BY` clauses for compatibility with [PostgreSQL row-sorting syntax](https://www.postgresql.org/docs/current/queries-order.html).
+
+{{site.data.alerts.callout_info}}
+Support for `NULLS LAST` is currently syntax-only. If you specify `NULLS LAST` in an `ORDER BY` clause, CockroachDB uses `NULLS FIRST` and does not return an error.
+{{site.data.alerts.end}}
+
 ## Order preservation
 
 In general, the order of the intermediate results of a query is not guaranteed,


### PR DESCRIPTION
Fixes #5911. 

- Updated `create_index` and `sort_clause` diagrams. `create_index` and `sort_clause` BNF files were updated in https://github.com/cockroachdb/cockroach/pull/41544/files. Due to the exclusion of `opt_nulls_order` in `diagrams.go`, the generated diagram for `create_index` did not really change. Adding latest diagrams generated for each of the BNF files, for completeness.
- Added note about CRDB support for `NULLS FIRST|LAST` being for compatibility with PostgreSQL.

Adding you, @yuzefovich, since you were first reviewer on https://github.com/cockroachdb/cockroach/pull/41544.