### PR TITLE
Update support information

### DIFF
--- a/v19.1/support-resources.md
+++ b/v19.1/support-resources.md
@@ -7,9 +7,10 @@ toc: false
 If you're having an issue with CockroachDB, you can reach out for support from Cockroach Labs and our community:
 
 - [Troubleshooting documentation](troubleshooting-overview.html)
-- [StackOverflow](http://stackoverflow.com/questions/tagged/cockroachdb)
 - [CockroachDB Community Forum](https://forum.cockroachlabs.com)
-- [Gitter](https://gitter.im/cockroachdb/cockroach)
+- [CockroachDB Community Slack](https://cockroachdb.slack.com)
+- [StackOverflow](http://stackoverflow.com/questions/tagged/cockroachdb)
 - [File a GitHub issue](file-an-issue.html)
+- [CockroachDB Support Portal](https://support.cockroachlabs.com)
 
 We also rely on contributions from users like you. If you know how to help users who might be struggling with a problem, we hope you will!

--- a/v19.2/support-resources.md
+++ b/v19.2/support-resources.md
@@ -7,9 +7,10 @@ toc: false
 If you're having an issue with CockroachDB, you can reach out for support from Cockroach Labs and our community:
 
 - [Troubleshooting documentation](troubleshooting-overview.html)
-- [StackOverflow](http://stackoverflow.com/questions/tagged/cockroachdb)
 - [CockroachDB Community Forum](https://forum.cockroachlabs.com)
-- [Gitter](https://gitter.im/cockroachdb/cockroach)
+- [CockroachDB Community Slack](https://cockroachdb.slack.com)
+- [StackOverflow](http://stackoverflow.com/questions/tagged/cockroachdb)
 - [File a GitHub issue](file-an-issue.html)
+- [CockroachDB Support Portal](https://support.cockroachlabs.com)
 
 We also rely on contributions from users like you. If you know how to help users who might be struggling with a problem, we hope you will!

--- a/v20.1/support-resources.md
+++ b/v20.1/support-resources.md
@@ -7,9 +7,10 @@ toc: false
 If you're having an issue with CockroachDB, you can reach out for support from Cockroach Labs and our community:
 
 - [Troubleshooting documentation](troubleshooting-overview.html)
-- [StackOverflow](http://stackoverflow.com/questions/tagged/cockroachdb)
 - [CockroachDB Community Forum](https://forum.cockroachlabs.com)
-- [Gitter](https://gitter.im/cockroachdb/cockroach)
+- [CockroachDB Community Slack](https://cockroachdb.slack.com)
+- [StackOverflow](http://stackoverflow.com/questions/tagged/cockroachdb)
 - [File a GitHub issue](file-an-issue.html)
+- [CockroachDB Support Portal](https://support.cockroachlabs.com)
 
 We also rely on contributions from users like you. If you know how to help users who might be struggling with a problem, we hope you will!


### PR DESCRIPTION
Fixes #6686.

Summary of changes:

- Update 'Support Resources' page with links to Slack and the Support
  Portal.  Remove old Gitter link.

- Apply changes to versions: 19.1, 19.2, 20.1.