### PR TITLE
Don't link to testing releases for minor versions

### DIFF
--- a/v19.2/cockroachcloud-upgrade-policy.md
+++ b/v19.2/cockroachcloud-upgrade-policy.md
@@ -10,7 +10,7 @@ This page describes the upgrade policy for CockroachCloud.
 CockroachCloud supports the [latest major version](https://www.cockroachlabs.com/docs/stable/) of CockroachDB and the version immediately preceding it. Support for these versions includes minor version updates and security patches.
 
 ## Minor Version Upgrades
-[Minor versions](https://www.cockroachlabs.com/docs/releases/#testing-releases) (or "point" releases) are stable, backward-compatible improvements to the major versions of CockroachDB. CockroachCloud automatically upgrades all clusters to the latest supported minor version (for example, v19.2.1 → v19.2.2).
+[Minor versions](https://www.cockroachlabs.com/docs/releases/) (or "point" releases) are stable, backward-compatible improvements to the major versions of CockroachDB. CockroachCloud automatically upgrades all clusters to the latest supported minor version (for example, v19.2.1 → v19.2.2).
 
 {{site.data.alerts.callout_danger}}
 Single-node clusters will experience some downtime during cluster maintenance.

--- a/v20.1/cockroachcloud-upgrade-policy.md
+++ b/v20.1/cockroachcloud-upgrade-policy.md
@@ -10,7 +10,7 @@ This page describes the upgrade policy for CockroachCloud.
 CockroachCloud supports the [latest major version](https://www.cockroachlabs.com/docs/stable/) of CockroachDB and the version immediately preceding it. Support for these versions includes minor version updates and security patches.
 
 ## Minor Version Upgrades
-[Minor versions](https://www.cockroachlabs.com/docs/releases/#testing-releases) (or "point" releases) are stable, backward-compatible improvements to the major versions of CockroachDB. CockroachCloud automatically upgrades all clusters to the latest supported minor version (for example, v19.2.1 → v19.2.2).
+[Minor versions](https://www.cockroachlabs.com/docs/releases/) (or "point" releases) are stable, backward-compatible improvements to the major versions of CockroachDB. CockroachCloud automatically upgrades all clusters to the latest supported minor version (for example, v19.2.1 → v19.2.2).
 
 {{site.data.alerts.callout_danger}}
 Single-node clusters will experience some downtime during cluster maintenance.


### PR DESCRIPTION
When mentioning minor versions in the CC upgrade policy,
we were linking to testing releases (alpha/beta), which is
something different. We don't have distinct links for major
and minor versions of stable releases, so for now,
we're just linking to the list of "production" releases
in both cases.