### PR TITLE
Add --trace flag to docs build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,19 +44,19 @@ jekyll-action := build
 
 .PHONY: cockroachdb-build
 cockroachdb-build: bootstrap
-	bundle exec jekyll $(jekyll-action) --incremental --config _config_base.yml,_config_cockroachdb.yml$(extra-config) $(JEKYLLFLAGS)
+	bundle exec jekyll $(jekyll-action) --incremental --trace --config _config_base.yml,_config_cockroachdb.yml$(extra-config) $(JEKYLLFLAGS)
 
 .PHONY: cockroachdb
 cockroachdb: jekyll-action := serve --port 4000
 cockroachdb: bootstrap
-	bundle exec jekyll $(jekyll-action) --incremental --config _config_base.yml,_config_cockroachdb.yml,_config_cockroachdb_local.yml$(extra-config) $(JEKYLLFLAGS)
+	bundle exec jekyll $(jekyll-action) --incremental --trace --config _config_base.yml,_config_cockroachdb.yml,_config_cockroachdb_local.yml$(extra-config) $(JEKYLLFLAGS)
 
 .PHONY: standard
 standard: cockroachdb
 
 .PHONY: cockroachcloud-build
 cockroachcloud-build: bootstrap
-	bundle exec jekyll $(jekyll-action) --incremental --config _config_base.yml,_config_cockroachcloud.yml$(extra-config) $(JEKYLLFLAGS)
+	bundle exec jekyll $(jekyll-action) --incremental --trace --config _config_base.yml,_config_cockroachcloud.yml$(extra-config) $(JEKYLLFLAGS)
 
 .PHONY: cockroachcloud
 cockroachcloud: jekyll-action := serve --port 4001

--- a/netlify/build
+++ b/netlify/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function build {
-	bundle exec jekyll build --config _config_base.yml,$1
+	bundle exec jekyll build --trace --config _config_base.yml,$1
 }
 
 gem install bundler


### PR DESCRIPTION
This gives us greater insight into errors building the site.
For example, where there's a JSON syntax error in a sidenav
file, without this flag, there's no clear indication.