### PR TITLE
Added examples of COMMENT ON TABLE in SHOW CREATE TABLE output

### DIFF
--- a/v20.1/comment-on.md
+++ b/v20.1/comment-on.md
@@ -82,6 +82,34 @@ To view table comments, use [`SHOW TABLES`](show-tables.html):
 (6 rows)
 ~~~
 
+<span class="version-tag">New in v20.1:</span> You can also view comments on a table with [`SHOW CREATE`](show-create.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TABLE vehicles;
+~~~
+
+~~~
+  table_name |                                          create_statement
+-------------+------------------------------------------------------------------------------------------------------
+  vehicles   | CREATE TABLE vehicles (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     type VARCHAR NULL,
+             |     owner_id UUID NULL,
+             |     creation_time TIMESTAMP NULL,
+             |     status VARCHAR NULL,
+             |     current_location VARCHAR NULL,
+             |     ext JSONB NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     CONSTRAINT fk_city_ref_users FOREIGN KEY (city, owner_id) REFERENCES users(city, id),
+             |     INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC),
+             |     FAMILY "primary" (id, city, type, owner_id, creation_time, status, current_location, ext)
+             | );
+             | COMMENT ON TABLE vehicles IS 'This table contains information about vehicles registered with MovR.'
+(1 row)
+~~~
+
 ### Add a comment to a column
 
 To add a comment to a column:

--- a/v20.1/show-create.md
+++ b/v20.1/show-create.md
@@ -132,6 +132,38 @@ To get just a view's `SELECT` statement, you can query the `views` table in the 
 (1 row)
 ~~~
 
+### Show the `CREATE TABLE` statement for a table with a comment
+
+<span class="version-tag">New in v20.1:</span> If you [add a comment](comment-on.html) on a table, `SHOW CREATE TABLE` will display the comment.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> COMMENT ON TABLE users IS 'This table contains information about users.';
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TABLE users;
+~~~
+
+~~~
+  table_name |                             create_statement
+-------------+---------------------------------------------------------------------------
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | );
+             | COMMENT ON TABLE users IS 'This table contains information about users.'
+(1 row)
+~~~
+
+For more information, see [`COMMENT ON`](comment-on.html).
+
 ## See also
 
 - [`CREATE TABLE`](create-table.html)

--- a/v20.1/show-tables.md
+++ b/v20.1/show-tables.md
@@ -184,6 +184,29 @@ To view a table's comments:
 (6 rows)
 ~~~
 
+<span class="version-tag">New in v20.1:</span> You can also view comments on a table with [`SHOW CREATE`](show-create.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TABLE users;
+~~~
+
+~~~
+  table_name |                             create_statement
+-------------+---------------------------------------------------------------------------
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | );
+             | COMMENT ON TABLE users IS 'This table contains information about users.'
+(1 row)
+~~~
+
 For more information, see [`COMMENT ON`](comment-on.html).
 
 ### Show virtual tables with comments


### PR DESCRIPTION
Fixes #6609.

Added examples of `COMMENT ON TABLE` in `SHOW CREATE TABLE` output to:
- `COMMENT ON` page
- `SHOW TABLES` page
- `SHOW CREATE` page