### PR TITLE
document new diagnostics.reporting cluster setting

### DIFF
--- a/_includes/v20.1/sql/settings/settings.md
+++ b/_includes/v20.1/sql/settings/settings.md
@@ -10,6 +10,7 @@
 <tr><td><code>diagnostics.reporting.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable reporting diagnostic metrics to cockroach labs</td></tr>
 <tr><td><code>diagnostics.reporting.interval</code></td><td>duration</td><td><code>1h0m0s</code></td><td>interval at which diagnostics data should be reported</td></tr>
 <tr><td><code>diagnostics.sql_stat_reset.interval</code></td><td>duration</td><td><code>1h0m0s</code></td><td>interval controlling how often SQL statement statistics should be reset (should be less than diagnostics.forced_sql_stat_reset.interval). It has a max value of 24H.</td></tr>
+<tr><td><code>diagnostics.reporting.send_crash_reports</code></td><td>boolean</td><td><code>true</code></td><td>send crash and panic reports</td></tr>
 <tr><td><code>enterprise.license</code></td><td>string</td><td><code></code></td><td>the encoded cluster license</td></tr>
 <tr><td><code>external.graphite.endpoint</code></td><td>string</td><td><code></code></td><td>if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port</td></tr>
 <tr><td><code>external.graphite.interval</code></td><td>duration</td><td><code>10s</code></td><td>the interval at which metrics are pushed to Graphite (if enabled)</td></tr>

--- a/v19.2/diagnostics-reporting.md
+++ b/v19.2/diagnostics-reporting.md
@@ -33,18 +33,23 @@ To make sure that absolutely no diagnostic details are shared, you can set the e
 
 ### After cluster initialization
 
-To stop sending diagnostic details to Cockroach Labs once a cluster is running, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SET CLUSTER SETTING`](set-cluster-setting.html) statement, which switches the `diagnostics.reporting.enabled` [cluster setting](cluster-settings.html) to `false`:
+To stop sending diagnostic details to Cockroach Labs once a cluster is running, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SET CLUSTER SETTING`](set-cluster-setting.html) statements, which switch the `diagnostics.reporting.enabled` and `diagnostics.reporting.send_crash_reports` [cluster settings](cluster-settings.html) to `false`:
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > SET CLUSTER SETTING diagnostics.reporting.enabled = false;
 ~~~
 
-This change will not be instantaneous, as it must be propagated to other nodes in the cluster.
+{% include copy-clipboard.html %}
+~~~ sql
+>  SET CLUSTER SETTING diagnostics.reporting.send_crash_reports = false;
+~~~
+
+These changes will not be instantaneous, as they must be propagated to other nodes in the cluster.
 
 ## Check the state of diagnostics reporting
 
-To check the state of diagnostics reporting, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SHOW CLUSTER SETTING`](show-cluster-setting.html) statement:
+To check the state of diagnostics reporting, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SHOW CLUSTER SETTING`](show-cluster-setting.html) statements:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -53,12 +58,24 @@ To check the state of diagnostics reporting, [use the built-in SQL client](cockr
 
 ~~~
   diagnostics.reporting.enabled
-+-------------------------------+
+---------------------------------
               false
 (1 row)
 ~~~
 
-If the setting is `false`, diagnostics reporting is off; if the setting is `true`, diagnostics reporting is on.
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CLUSTER SETTING diagnostics.reporting.send_crash_reports;
+~~~
+
+~~~
+  diagnostics.reporting.send_crash_reports
+--------------------------------------------
+                   false
+(1 row)
+~~~
+
+If the settings are `false`, diagnostics reporting is off; if the settings are `true`, diagnostics reporting is on.
 
 ## See also
 

--- a/v19.2/set-cluster-setting.md
+++ b/v19.2/set-cluster-setting.md
@@ -58,15 +58,32 @@ To opt out of [automatic diagnostic reporting](diagnostics-reporting.html) of us
 
 {% include copy-clipboard.html %}
 ~~~ sql
+>  SET CLUSTER SETTING diagnostics.reporting.send_crash_reports = false;
+~~~
+
+Check that the changes were made: 
+
+{% include copy-clipboard.html %}
+~~~ sql
 > SHOW CLUSTER SETTING diagnostics.reporting.enabled;
 ~~~
 
 ~~~
-+-------------------------------+
-| diagnostics.reporting.enabled |
-+-------------------------------+
-| false                         |
-+-------------------------------+
+  diagnostics.reporting.enabled
+---------------------------------
+              false
+(1 row)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CLUSTER SETTING diagnostics.reporting.send_crash_reports;
+~~~
+
+~~~
+  diagnostics.reporting.send_crash_reports
+--------------------------------------------
+                   false
 (1 row)
 ~~~
 

--- a/v20.1/diagnostics-reporting.md
+++ b/v20.1/diagnostics-reporting.md
@@ -33,18 +33,23 @@ To make sure that absolutely no diagnostic details are shared, you can set the e
 
 ### After cluster initialization
 
-To stop sending diagnostic details to Cockroach Labs once a cluster is running, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SET CLUSTER SETTING`](set-cluster-setting.html) statement, which switches the `diagnostics.reporting.enabled` [cluster setting](cluster-settings.html) to `false`:
+To stop sending diagnostic details to Cockroach Labs once a cluster is running, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SET CLUSTER SETTING`](set-cluster-setting.html) statements, which switch the `diagnostics.reporting.enabled` and `diagnostics.reporting.send_crash_reports` [cluster settings](cluster-settings.html) to `false`:
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > SET CLUSTER SETTING diagnostics.reporting.enabled = false;
 ~~~
 
-This change will not be instantaneous, as it must be propagated to other nodes in the cluster.
+{% include copy-clipboard.html %}
+~~~ sql
+>  SET CLUSTER SETTING diagnostics.reporting.send_crash_reports = false;
+~~~
+
+These changes will not be instantaneous, as they must be propagated to other nodes in the cluster.
 
 ## Check the state of diagnostics reporting
 
-To check the state of diagnostics reporting, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SHOW CLUSTER SETTING`](show-cluster-setting.html) statement:
+To check the state of diagnostics reporting, [use the built-in SQL client](cockroach-sql.html) to execute the following [`SHOW CLUSTER SETTING`](show-cluster-setting.html) statements:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -53,12 +58,24 @@ To check the state of diagnostics reporting, [use the built-in SQL client](cockr
 
 ~~~
   diagnostics.reporting.enabled
-+-------------------------------+
+---------------------------------
               false
 (1 row)
 ~~~
 
-If the setting is `false`, diagnostics reporting is off; if the setting is `true`, diagnostics reporting is on.
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CLUSTER SETTING diagnostics.reporting.send_crash_reports;
+~~~
+
+~~~
+  diagnostics.reporting.send_crash_reports
+--------------------------------------------
+                   false
+(1 row)
+~~~
+
+If the settings are `false`, diagnostics reporting is off; if the settings are `true`, diagnostics reporting is on.
 
 ## See also
 

--- a/v20.1/set-cluster-setting.md
+++ b/v20.1/set-cluster-setting.md
@@ -58,15 +58,32 @@ To opt out of [automatic diagnostic reporting](diagnostics-reporting.html) of us
 
 {% include copy-clipboard.html %}
 ~~~ sql
+>  SET CLUSTER SETTING diagnostics.reporting.send_crash_reports = false;
+~~~
+
+Check that the changes were made: 
+
+{% include copy-clipboard.html %}
+~~~ sql
 > SHOW CLUSTER SETTING diagnostics.reporting.enabled;
 ~~~
 
 ~~~
-+-------------------------------+
-| diagnostics.reporting.enabled |
-+-------------------------------+
-| false                         |
-+-------------------------------+
+  diagnostics.reporting.enabled
+---------------------------------
+              false
+(1 row)
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CLUSTER SETTING diagnostics.reporting.send_crash_reports;
+~~~
+
+~~~
+  diagnostics.reporting.send_crash_reports
+--------------------------------------------
+                   false
 (1 row)
 ~~~
 


### PR DESCRIPTION
Fixes #6378.

Also added to Cluster Settings table for 20.1. It was only in 19.2

@roncrdb is there any reason `diagnostics.reporting.send_crash_reports` shouldn't have been included in 20.1?