### PR TITLE
Updates to vectorized execution documentation

### DIFF
--- a/_includes/v19.2/sql/disk-spilling-ops.md
+++ b/_includes/v19.2/sql/disk-spilling-ops.md
@@ -1,5 +1,6 @@
 - Global [sorts](query-order.html).
 - [Window functions](window-functions.html).
+- [Unordered aggregations](query-order.html#processing-order-during-aggregations).
 - [Hash joins](joins.html#hash-joins).
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 

--- a/v19.1/experimental-features.md
+++ b/v19.1/experimental-features.md
@@ -132,7 +132,7 @@ This example uses the `users` table from our open-source, fictional peer-to-peer
 
 ## Functions and Operators
 
-The table below lists the experimental SQL functions and operators available in CockroachDB 2.1.  For more information, see each function's documentation at [Functions and Operators](functions-and-operators.html).
+The table below lists the experimental SQL functions and operators available in CockroachDB.  For more information, see each function's documentation at [Functions and Operators](functions-and-operators.html).
 
 | Function                                                                         | Description                                     |
 |----------------------------------------------------------------------------------+-------------------------------------------------|

--- a/v19.2/experimental-features.md
+++ b/v19.2/experimental-features.md
@@ -126,7 +126,7 @@ The [`SHOW RANGE ... FOR ROW`](show-range-for-row.html) statement shows informat
 
 ## Functions and Operators
 
-The table below lists the experimental SQL functions and operators available in CockroachDB 2.1.  For more information, see each function's documentation at [Functions and Operators](functions-and-operators.html).
+The table below lists the experimental SQL functions and operators available in CockroachDB.  For more information, see each function's documentation at [Functions and Operators](functions-and-operators.html).
 
 | Function                                                                         | Description                                     |
 |----------------------------------------------------------------------------------+-------------------------------------------------|
@@ -140,10 +140,7 @@ The table below lists the experimental SQL functions and operators available in 
 
 {% include {{page.version.version}}/sql/disk-spilling-ops.md %}
 
-To turn vectorized execution on for all operations, do one of the following:
-
-- Set the `sql.defaults.vectorize` [cluster setting](cluster-settings.html) to `experimental_on`.
-- Set the `vectorize` [session variable](set-vars.html) to `experimental_on`.
+To turn vectorized execution on for all operations, set the `vectorize` [session variable](set-vars.html) to `experimental_on`.
 
 ## See Also
 

--- a/v19.2/vectorized-execution.md
+++ b/v19.2/vectorized-execution.md
@@ -12,18 +12,18 @@ Many SQL databases execute [query plans](https://en.wikipedia.org/wiki/Query_pla
 
 By default, vectorized execution is enabled in CockroachDB for [all operations that are guaranteed to execute in memory](#disk-spilling-operations), on tables with [supported data types](#supported-data-types).
 
-You can turn vectorized execution on or off for all operations with the `sql.defaults.vectorize` [cluster setting](cluster-settings.html) or the `vectorize` [session variable](set-vars.html). The following options are supported for both the cluster setting and session variable:
+You can turn vectorized execution on or off for all operations in the current session with the `vectorize` [session variable](set-vars.html). The following options are supported:
 
 Option | Description
 ----------|------------
 `auto` | Instructs CockroachDB to use the vectorized execution engine on operations that always execute in memory, without the need to spill intermediate results to disk.<br><br>**Default:** `vectorize=auto`
-`experimental_on` | Turns on vectorized execution for all operations. We do not recommend using this setting in production environments, as it can lead to memory issues.<br/>See [Known Limitations](#known-limitations) for more information.
+`experimental_on` | Turns on vectorized execution for all operations. We do not recommend using this option in production environments, as it can lead to memory issues.<br/>See [Known Limitations](#known-limitations) for more information.
 `off` | Turns off vectorized execution for all operations.
 
-For information about configuring cluster settings, see [Cluster Settings](cluster-settings.html).<br>For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
+For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
 
 {{site.data.alerts.callout_success}}
-To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If the `vectorize` property is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
+To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
 {{site.data.alerts.end}}
 
 ### Setting the row threshold for vectorized execution
@@ -32,7 +32,7 @@ The efficiency of vectorized execution increases with the number of rows process
 
 By default, vectorized execution is enabled for queries on tables of 1000 rows or more. If the number of rows in a table falls below 1000, CockroachDB uses the row-oriented execution engine instead.
 
-For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan with the `vectorize_row_count_threshold` [cluster setting](cluster-settings.html). This setting is ignored if `vectorize=experimental_on`.
+For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan in the current session with the `vectorize_row_count_threshold` [session variable](set-vars.html). This variable is ignored if `vectorize=experimental_on`.
 
 
 ## How vectorized execution works
@@ -47,7 +47,7 @@ For information about vectorized execution in the context of the CockroachDB arc
 
 For detailed examples of vectorized query execution for hash and merge joins, see the blog posts [40x faster hash joiner with vectorized execution](https://www.cockroachlabs.com/blog/vectorized-hash-joiner/) and [Vectorizing the merge joiner in CockroachDB](https://www.cockroachlabs.com/blog/vectorizing-the-merge-joiner-in-cockroachdb/).
 
-## Known Limitations
+## Known limitations
 
 Vectorized execution is not as extensively tested as CockroachDB's existing row-oriented execution engine. In addition, some data types are not supported, and support for some operations is experimental.
 
@@ -64,7 +64,9 @@ Vectorized execution is supported for the following [data types](data-types.html
 - [`TIMESTAMP`](timestamp.html)
 - [`UUID`](uuid.html)
 
-In all [`vectorize` modes](#configuring-vectorized-execution), queries on tables that contain unsupported data types are executed with the row-oriented execution engine. Using [`EXPLAIN(VEC)`](explain.html#vec-option) on queries of tables that include unsupported data types will return an unhandled data type error.
+{{site.data.alerts.callout_info}}
+CockroachDB uses the vectorized engine to execute queries on columns with supported data types, even if a column's parent table includes unused columns with unsupported data types.
+{{site.data.alerts.end}}
 
 ### Queries with constant `NULL` arguments
 
@@ -85,8 +87,5 @@ You can configure a node's budget for in-memory query processing at node startup
 ## See also
 
 - [SQL Layer](architecture/sql-layer.html)
-- [Cluster Settings](cluster-settings.html)
-- [`SET CLUSTER SETTING`](set-cluster-setting.html)
-- [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
 - [`SET` &lt;session variable&gt;](set-vars.html)
 - [`SHOW` &lt;session variable&gt;](show-vars.html)

--- a/v20.1/data-types.md
+++ b/v20.1/data-types.md
@@ -20,7 +20,7 @@ Type | Description | Example | [Vectorized Execution](vectorized-execution.html)
 [`FLOAT`](float.html) | A 64-bit, inexact, floating-point number.  | `1.2345` | Supported
 [`INET`](inet.html) | An IPv4 or IPv6 address.  | `192.168.0.1` | Not supported
 [`INT`](int.html) | A signed integer, up to 64 bits. | `12345` | Supported
-[`INTERVAL`](interval.html) | A span of time.  | `INTERVAL '2h30m30s'` | Not supported
+[`INTERVAL`](interval.html) | A span of time.  | `INTERVAL '2h30m30s'` | Supported
 [`JSONB`](jsonb.html) | JSON (JavaScript Object Notation) data.  | `'{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'` | Not supported
 [`SERIAL`](serial.html) | A pseudo-type that combines an [integer type](int.html) with a [`DEFAULT` expression](default-value.html).  | `148591304110702593` | Not supported
 [`STRING`](string.html) | A string of Unicode characters. | `'a1b2c3'` | Supported

--- a/v20.1/experimental-features.md
+++ b/v20.1/experimental-features.md
@@ -128,7 +128,7 @@ The [`SHOW RANGE ... FOR ROW`](show-range-for-row.html) statement shows informat
 
 ## Functions and Operators
 
-The table below lists the experimental SQL functions and operators available in CockroachDB 2.1.  For more information, see each function's documentation at [Functions and Operators](functions-and-operators.html).
+The table below lists the experimental SQL functions and operators available in CockroachDB.  For more information, see each function's documentation at [Functions and Operators](functions-and-operators.html).
 
 | Function                                                                         | Description                                     |
 |----------------------------------------------------------------------------------+-------------------------------------------------|
@@ -142,10 +142,7 @@ The table below lists the experimental SQL functions and operators available in 
 
 {% include {{page.version.version}}/sql/disk-spilling-ops.md %}
 
-To turn vectorized execution on for all operations, do one of the following:
-
-- Set the `sql.defaults.vectorize` [cluster setting](cluster-settings.html) to `experimental_on`.
-- Set the `vectorize` [session variable](set-vars.html) to `experimental_on`.
+To turn vectorized execution on for all operations, set the `vectorize` [session variable](set-vars.html) to `experimental_on`.
 
 ## See Also
 

--- a/v20.1/vectorized-execution.md
+++ b/v20.1/vectorized-execution.md
@@ -12,18 +12,18 @@ Many SQL databases execute [query plans](https://en.wikipedia.org/wiki/Query_pla
 
 By default, vectorized execution is enabled in CockroachDB for [all operations that are guaranteed to execute in memory](#disk-spilling-operations), on tables with [supported data types](#supported-data-types).
 
-You can turn vectorized execution on or off for all operations with the `sql.defaults.vectorize` [cluster setting](cluster-settings.html) or the `vectorize` [session variable](set-vars.html). The following options are supported for both the cluster setting and session variable:
+You can turn vectorized execution on or off for all operations in the current session with the `vectorize` [session variable](set-vars.html). The following options are supported:
 
 Option | Description
 ----------|------------
 `auto` | Instructs CockroachDB to use the vectorized execution engine on operations that always execute in memory, without the need to spill intermediate results to disk.<br><br>**Default:** `vectorize=auto`
-`experimental_on` | Turns on vectorized execution for all operations. We do not recommend using this setting in production environments, as it can lead to memory issues.<br/>See [Known Limitations](#known-limitations) for more information.
+`experimental_on` | Turns on vectorized execution for all operations. We do not recommend using this option in production environments, as it can lead to memory issues.<br/>See [Known Limitations](#known-limitations) for more information.
 `off` | Turns off vectorized execution for all operations.
 
-For information about configuring cluster settings, see [Cluster Settings](cluster-settings.html).<br>For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
+For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
 
 {{site.data.alerts.callout_success}}
-To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If the `vectorize` property is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
+To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
 {{site.data.alerts.end}}
 
 ### Setting the row threshold for vectorized execution
@@ -32,8 +32,7 @@ The efficiency of vectorized execution increases with the number of rows process
 
 By default, vectorized execution is enabled for queries on tables of 1000 rows or more. If the number of rows in a table falls below 1000, CockroachDB uses the row-oriented execution engine instead.
 
-For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan with the `vectorize_row_count_threshold` [cluster setting](cluster-settings.html). This setting is ignored if `vectorize=experimental_on`.
-
+For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan in the current session with the `vectorize_row_count_threshold` [session variable](set-vars.html). This variable is ignored if `vectorize=experimental_on`.
 
 ## How vectorized execution works
 
@@ -47,7 +46,7 @@ For information about vectorized execution in the context of the CockroachDB arc
 
 For detailed examples of vectorized query execution for hash and merge joins, see the blog posts [40x faster hash joiner with vectorized execution](https://www.cockroachlabs.com/blog/vectorized-hash-joiner/) and [Vectorizing the merge joiner in CockroachDB](https://www.cockroachlabs.com/blog/vectorizing-the-merge-joiner-in-cockroachdb/).
 
-## Known Limitations
+## Known limitations
 
 Vectorized execution is not as extensively tested as CockroachDB's existing row-oriented execution engine. In addition, some data types are not supported, and support for some operations is experimental.
 
@@ -61,11 +60,14 @@ Vectorized execution is supported for the following [data types](data-types.html
 - [`DECIMAL`](decimal.html)
 - [`FLOAT`](float.html)
 - [`INT`](int.html)
+- [`INTERVAL`](interval.html)
 - [`STRING`](string.html)
 - [`TIMESTAMP`/`TIMESTAMPTZ`](timestamp.html)
 - [`UUID`](uuid.html)
 
-In all [`vectorize` modes](#configuring-vectorized-execution), queries on tables that contain unsupported data types are executed with the row-oriented execution engine. Using [`EXPLAIN(VEC)`](explain.html#vec-option) on queries of tables that include unsupported data types will return an unhandled data type error.
+{{site.data.alerts.callout_info}}
+CockroachDB uses the vectorized engine to execute queries on columns with supported data types, even if a column's parent table includes unused columns with unsupported data types.
+{{site.data.alerts.end}}
 
 ### Queries with constant `NULL` arguments
 
@@ -86,8 +88,5 @@ You can configure a node's budget for in-memory query processing at node startup
 ## See also
 
 - [SQL Layer](architecture/sql-layer.html)
-- [Cluster Settings](cluster-settings.html)
-- [`SET CLUSTER SETTING`](set-cluster-setting.html)
-- [`SHOW CLUSTER SETTING`](show-cluster-setting.html)
 - [`SET` &lt;session variable&gt;](set-vars.html)
 - [`SHOW` &lt;session variable&gt;](show-vars.html)


### PR DESCRIPTION
Fixes #6464. 
Fixes #6441.  
Fixes #6921.

Also, removes documentation about the private cluster settings for vectorized execution.

- Removed references to `vectorize` cluster setting (this cluster setting is not public), in favor of the `vectorize` session variable.
- Added unordered aggregations to list of experimental disk-spilling operations in 19.2 (this has been resolved for 20.1, which will be documented in a forthcoming PR on 20.1 vectorized updates to disk-spilling operations).
- Fixed some typos.
- Added note about the vectorized engine skipping unused columns of unsupported data (#6464 and #6441).
- Added `INTERVAL` to list of supported data types in 20.1.