### PR TITLE
Full cluster BACKUP / RESTORE + incremental backups

### DIFF
--- a/_includes/v20.1/prod-deployment/backup.sh
+++ b/_includes/v20.1/prod-deployment/backup.sh
@@ -6,8 +6,7 @@ set -euo pipefail
 # day of the week and incremental backups when run on other days, and tracks
 # recently created backups in a file to pass as the base for incremental backups.
 
-full_day="<day_of_the_week>"                        # Must match (including case) the output of `LC_ALL=C date +%A`.
-what="DATABASE <database_name>"                   # The name of the database you want to backup.
+what=""                                           # Leave empty for full cluster backup, or add "DATABASE database_name" to backup a database.
 base="<storage_URL>/backups"                      # The URL where you want to store the backup.
 extra="<storage_parameters>"                      # Any additional parameters that need to be appended to the BACKUP URI e.g. AWS key params.
 recent=recent_backups.txt                         # File in which recent backups are tracked.
@@ -16,21 +15,7 @@ backup_parameters=<additional backup parameters>  # e.g. "WITH revision_history"
 # Customize the `cockroach sql` command with `--host`, `--certs-dir` or `--insecure`, `--port`, and additional flags as needed to connect to the SQL client.
 runsql() { cockroach sql --insecure -e "$1"; }
 
-destination="${base}/$(date +"%Y%m%d-%H%M")${extra}"
+destination="${base}/$(date +"%Y-%V")${extra}" # %V is the week number of the year, with Monday as the first day of the week.
 
-prev=
-while read -r line; do
-    [[ "$prev" ]] && prev+=", "
-    prev+="'$line'"
-done < "$recent"
-
-if [[ "$(LC_ALL=C date +%A)" = "$full_day" || ! "$prev" ]]; then
-    runsql "BACKUP $what TO '$destination' AS OF SYSTEM TIME '-1m' $backup_parameters"
-    echo "$destination" > "$recent"
-else
-    destination="${base}/$(date +"%Y%m%d-%H%M")-inc${extra}"
-    runsql "BACKUP $what TO '$destination' AS OF SYSTEM TIME '-1m' INCREMENTAL FROM $prev $backup_parameters"
-    echo "$destination" >> "$recent"
-fi
-
+runsql "BACKUP $what TO '$destination' AS OF SYSTEM TIME '-1m' $backup_parameters"
 echo "backed up to ${destination}"

--- a/_includes/v20.1/sql/diagrams/backup.html
+++ b/_includes/v20.1/sql/diagrams/backup.html
@@ -1,73 +1,50 @@
-<div><svg width="758" height="482">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <rect x="31" y="47" width="74" height="32" rx="10"></rect>
-         <rect x="29" y="45" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="65">BACKUP</text>
-         <rect x="165" y="79" width="62" height="32" rx="10"></rect>
-         <rect x="163" y="77" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="173" y="97">TABLE</text>
-         <a xlink:href="sql-grammar.html#table_pattern" xlink:title="table_pattern">
-            <rect x="287" y="47" width="106" height="32"></rect>
-            <rect x="285" y="45" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="295" y="65">table_pattern</text>
-         </a>
-         <rect x="287" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="285" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="295" y="21">,</text>
-         <rect x="145" y="167" width="90" height="32" rx="10"></rect>
-         <rect x="143" y="165" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="153" y="185">DATABASE</text>
-         <a xlink:href="sql-grammar.html#name" xlink:title="name">
-            <rect x="275" y="167" width="54" height="32"></rect>
-            <rect x="273" y="165" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="283" y="185">name</text>
-         </a>
-         <rect x="275" y="123" width="24" height="32" rx="10"></rect>
-         <rect x="273" y="121" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="283" y="141">,</text>
-         <rect x="453" y="47" width="38" height="32" rx="10"></rect>
-         <rect x="451" y="45" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="461" y="65">TO</text>
-         <a xlink:href="sql-grammar.html#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="511" y="47" width="158" height="32"></rect>
-            <rect x="509" y="45" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="519" y="65">string_or_placeholder</text>
-         </a>
-         <rect x="250" y="249" width="156" height="32" rx="10"></rect>
-         <rect x="248" y="247" width="156" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="258" y="267">AS OF SYSTEM TIME</text>
-         
-            <rect x="426" y="249" width="86" height="32"></rect>
-            <rect x="424" y="247" width="86" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="434" y="267">timestamp</text>
-         
-         <rect x="45" y="331" width="158" height="32" rx="10"></rect>
-         <rect x="43" y="329" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="349">INCREMENTAL FROM</text>
-         
-            <rect x="223" y="331" width="148" height="32"></rect>
-            <rect x="221" y="329" width="148" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="231" y="349">full_backup_location</text>
-         
-         <rect x="431" y="331" width="24" height="32" rx="10"></rect>
-         <rect x="429" y="329" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="439" y="349">,</text>
-         
-            <rect x="475" y="331" width="202" height="32"></rect>
-            <rect x="473" y="329" width="202" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="483" y="349">incremental_backup_location</text>
-         
-         <rect x="525" y="449" width="58" height="32" rx="10"></rect>
-         <rect x="523" y="447" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="533" y="467">WITH</text>
-         <a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-            <rect x="603" y="449" width="108" height="32"></rect>
-            <rect x="601" y="447" width="108" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="611" y="467">kv_option_list</text>
-         </a>
-         <path class="line" d="m17 61 h2 m0 0 h10 m74 0 h10 m40 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m40 -32 h10 m106 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m-288 44 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v100 m308 0 v-100 m-308 100 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m90 0 h10 m20 0 h10 m54 0 h10 m-94 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m74 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-74 0 h10 m24 0 h10 m0 0 h30 m20 44 h64 m20 -120 h10 m38 0 h10 m0 0 h10 m158 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-483 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h272 m-302 0 h20 m282 0 h20 m-322 0 q10 0 10 10 m302 0 q0 -10 10 -10 m-312 10 v12 m302 0 v-12 m-302 12 q0 10 10 10 m282 0 q10 0 10 -10 m-292 10 h10 m156 0 h10 m0 0 h10 m86 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-551 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m158 0 h10 m0 0 h10 m148 0 h10 m40 0 h10 m24 0 h10 m0 0 h10 m202 0 h10 m-286 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m266 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-266 0 h10 m0 0 h256 m-306 32 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v14 m326 0 v-14 m-326 14 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m0 0 h296 m-692 -34 h20 m692 0 h20 m-732 0 q10 0 10 10 m712 0 q0 -10 10 -10 m-722 10 v30 m712 0 v-30 m-712 30 q0 10 10 10 m692 0 q10 0 10 -10 m-702 10 h10 m0 0 h682 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-276 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
-         <polygon points="749 431 757 427 757 435"></polygon>
-         <polygon points="749 431 741 427 741 435"></polygon>
-      </svg></div>
+<div><svg width="769" height="499">
+<polygon points="9 61 1 57 1 65"></polygon>
+<polygon points="17 61 9 57 9 65"></polygon>
+<rect x="31" y="47" width="74" height="32" rx="10"></rect>
+<rect x="29" y="45" width="74" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="65">BACKUP</text>
+<rect x="165" y="79" width="62" height="32" rx="10"></rect>
+<rect x="163" y="77" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="173" y="97">TABLE</text><a xlink:href="sql-grammar.html#table_pattern" xlink:title="table_pattern">
+<rect x="287" y="47" width="106" height="32"></rect>
+<rect x="285" y="45" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="295" y="65">table_pattern</text></a><rect x="287" y="3" width="24" height="32" rx="10"></rect>
+<rect x="285" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="295" y="21">,</text>
+<rect x="145" y="167" width="92" height="32" rx="10"></rect>
+<rect x="143" y="165" width="92" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="153" y="185">DATABASE</text><a xlink:href="sql-grammar.html#database_name" xlink:title="database_name">
+<rect x="277" y="167" width="124" height="32"></rect>
+<rect x="275" y="165" width="124" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="285" y="185">database_name</text></a><rect x="277" y="123" width="24" height="32" rx="10"></rect>
+<rect x="275" y="121" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="285" y="141">,</text>
+<rect x="461" y="47" width="38" height="32" rx="10"></rect>
+<rect x="459" y="45" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="469" y="65">TO</text>
+<rect x="519" y="47" width="92" height="32"></rect>
+<rect x="517" y="45" width="92" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="527" y="65">destination</text><rect x="253" y="265" width="158" height="32" rx="10"></rect>
+<rect x="251" y="263" width="158" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="261" y="283">AS OF SYSTEM TIME</text>
+<rect x="431" y="265" width="88" height="32"></rect>
+<rect x="429" y="263" width="88" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="439" y="283">timestamp</text><rect x="45" y="347" width="162" height="32" rx="10"></rect>
+<rect x="43" y="345" width="162" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="365">INCREMENTAL FROM</text>
+<rect x="227" y="347" width="150" height="32"></rect>
+<rect x="225" y="345" width="150" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="235" y="365">full_backup_location</text><rect x="437" y="347" width="24" height="32" rx="10"></rect>
+<rect x="435" y="345" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="445" y="365">,</text>
+<rect x="481" y="347" width="206" height="32"></rect>
+<rect x="479" y="345" width="206" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="489" y="365">incremental_backup_location</text><rect x="535" y="465" width="58" height="32" rx="10"></rect>
+<rect x="533" y="463" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="543" y="483">WITH</text><a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+<rect x="613" y="465" width="108" height="32"></rect>
+<rect x="611" y="463" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="621" y="483">kv_option_list</text></a><path class="line" d="m17 61 h2 m0 0 h10 m74 0 h10 m40 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m40 -32 h10 m106 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m20 44 h8 m-316 0 h20 m296 0 h20 m-336 0 q10 0 10 10 m316 0 q0 -10 10 -10 m-326 10 v100 m316 0 v-100 m-316 100 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m92 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m-286 34 v20 m316 0 v-20 m-316 20 v14 m316 0 v-14 m-316 14 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m0 0 h286 m20 -154 h10 m38 0 h10 m0 0 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-422 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m158 0 h10 m0 0 h10 m88 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-558 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m162 0 h10 m0 0 h10 m150 0 h10 m40 0 h10 m24 0 h10 m0 0 h10 m206 0 h10 m-290 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m270 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-270 0 h10 m0 0 h260 m-310 32 h20 m310 0 h20 m-350 0 q10 0 10 10 m330 0 q0 -10 10 -10 m-340 10 v14 m330 0 v-14 m-330 14 q0 10 10 10 m310 0 q10 0 10 -10 m-320 10 h10 m0 0 h300 m-702 -34 h20 m702 0 h20 m-742 0 q10 0 10 10 m722 0 q0 -10 10 -10 m-732 10 v30 m722 0 v-30 m-722 30 q0 10 10 10 m702 0 q10 0 10 -10 m-712 10 h10 m0 0 h692 m22 -50 l2 0 m2 0 l2 0 m2 0 l2 0 m-276 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
+<polygon points="759 447 767 443 767 451"></polygon>
+<polygon points="759 447 751 443 751 451"></polygon></svg></div>

--- a/_includes/v20.1/sql/diagrams/restore.html
+++ b/_includes/v20.1/sql/diagrams/restore.html
@@ -1,4 +1,4 @@
-<div><svg width="748" height="428">
+<div><svg width="741" height="315">
 <polygon points="9 61 1 57 1 65"></polygon>
 <polygon points="17 61 9 57 9 65"></polygon>
 <rect x="31" y="47" width="82" height="32" rx="10"></rect>
@@ -6,62 +6,33 @@
 <text class="terminal" x="39" y="65">RESTORE</text>
 <rect x="173" y="79" width="62" height="32" rx="10"></rect>
 <rect x="171" y="77" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="181" y="97">TABLE</text>
-<a xlink:href="sql-grammar.html#table_pattern" xlink:title="table_pattern">
-<rect x="295" y="47" width="100" height="32"></rect>
-<rect x="293" y="45" width="100" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="303" y="65">table_pattern</text>
-</a>
-<rect x="295" y="3" width="24" height="32" rx="10"></rect>
+<text class="terminal" x="181" y="97">TABLE</text><a xlink:href="sql-grammar.html#table_pattern" xlink:title="table_pattern">
+<rect x="295" y="47" width="106" height="32"></rect>
+<rect x="293" y="45" width="106" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="303" y="65">table_pattern</text></a><rect x="295" y="3" width="24" height="32" rx="10"></rect>
 <rect x="293" y="1" width="24" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="303" y="21">,</text>
 <rect x="153" y="167" width="92" height="32" rx="10"></rect>
 <rect x="151" y="165" width="92" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="161" y="185">DATABASE</text>
-<a xlink:href="sql-grammar.html#database_name" xlink:title="database_name">
-<rect x="285" y="167" width="116" height="32"></rect>
-<rect x="283" y="165" width="116" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="293" y="185">database_name</text>
-</a>
-<rect x="285" y="123" width="24" height="32" rx="10"></rect>
+<text class="terminal" x="161" y="185">DATABASE</text><a xlink:href="sql-grammar.html#database_name" xlink:title="database_name">
+<rect x="285" y="167" width="124" height="32"></rect>
+<rect x="283" y="165" width="124" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="293" y="185">database_name</text></a><rect x="285" y="123" width="24" height="32" rx="10"></rect>
 <rect x="283" y="121" width="24" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="293" y="141">,</text>
-<rect x="461" y="47" width="58" height="32" rx="10"></rect>
-<rect x="459" y="45" width="58" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="469" y="65">FROM</text>
-<rect x="539" y="47" width="140" height="32"></rect>
-<rect x="537" y="45" width="140" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="547" y="65">full_backup_location</text>
-<rect x="65" y="277" width="194" height="32"></rect>
-<rect x="63" y="275" width="194" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="73" y="295">incremental_backup_location</text>
-<rect x="65" y="233" width="24" height="32" rx="10"></rect>
-<rect x="63" y="231" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="73" y="251">,</text>
-<rect x="339" y="309" width="38" height="32" rx="10"></rect>
-<rect x="337" y="307" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="347" y="327">AS</text>
-<rect x="397" y="309" width="38" height="32" rx="10"></rect>
-<rect x="395" y="307" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="405" y="327">OF</text>
-<rect x="455" y="309" width="74" height="32" rx="10"></rect>
-<rect x="453" y="307" width="74" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="463" y="327">SYSTEM</text>
-<rect x="549" y="309" width="54" height="32" rx="10"></rect>
-<rect x="547" y="307" width="54" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="557" y="327">TIME</text>
-<rect x="623" y="309" width="84" height="32"></rect>
-<rect x="621" y="307" width="84" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="631" y="327">timestamp</text>
-<rect x="521" y="395" width="56" height="32" rx="10"></rect>
-<rect x="519" y="393" width="56" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="529" y="413">WITH</text>
-<a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
-<rect x="597" y="395" width="104" height="32"></rect>
-<rect x="595" y="393" width="104" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="605" y="413">kv_option_list</text>
-</a>
-<path class="line" d="m17 61 h2 m0 0 h10 m82 0 h10 m40 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m40 -32 h10 m100 0 h10 m-140 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m120 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-120 0 h10 m24 0 h10 m0 0 h76 m20 44 h6 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v100 m308 0 v-100 m-308 100 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m92 0 h10 m20 0 h10 m116 0 h10 m-156 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m136 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-136 0 h10 m24 0 h10 m0 0 h92 m40 -76 h10 m58 0 h10 m0 0 h10 m140 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-698 230 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m194 0 h10 m-234 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m214 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-214 0 h10 m24 0 h10 m0 0 h170 m-254 44 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v14 m274 0 v-14 m-274 14 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m0 0 h244 m40 -34 h10 m0 0 h378 m-408 0 h20 m388 0 h20 m-428 0 q10 0 10 10 m408 0 q0 -10 10 -10 m-418 10 v12 m408 0 v-12 m-408 12 q0 10 10 10 m388 0 q10 0 10 -10 m-398 10 h10 m38 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m84 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h190 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v12 m220 0 v-12 m-220 12 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m56 0 h10 m0 0 h10 m104 0 h10 m23 -32 h-3"></path>
-<polygon points="739 377 747 373 747 381"></polygon>
-<polygon points="739 377 731 373 731 381"></polygon>
-</svg></div>
+<rect x="469" y="47" width="60" height="32" rx="10"></rect>
+<rect x="467" y="45" width="60" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="477" y="65">FROM</text><a xlink:href="sql-grammar.html#partitioned_backup_list" xlink:title="partitioned_backup_list">
+<rect x="549" y="47" width="170" height="32"></rect>
+<rect x="547" y="45" width="170" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="557" y="65">partitioned_backup_list</text></a><a xlink:href="sql-grammar.html#opt_as_of_clause" xlink:title="opt_as_of_clause">
+<rect x="335" y="249" width="132" height="32"></rect>
+<rect x="333" y="247" width="132" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="343" y="267">opt_as_of_clause</text></a><rect x="507" y="281" width="58" height="32" rx="10"></rect>
+<rect x="505" y="279" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="515" y="299">WITH</text><a xlink:href="sql-grammar.html#kv_option_list" xlink:title="kv_option_list">
+<rect x="585" y="281" width="108" height="32"></rect>
+<rect x="583" y="279" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="593" y="299">kv_option_list</text></a><path class="line" d="m17 61 h2 m0 0 h10 m82 0 h10 m40 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m40 -32 h10 m106 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m20 44 h8 m-316 0 h20 m296 0 h20 m-336 0 q10 0 10 10 m316 0 q0 -10 10 -10 m-326 10 v100 m316 0 v-100 m-316 100 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m92 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m-286 34 v20 m316 0 v-20 m-316 20 v14 m316 0 v-14 m-316 14 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m0 0 h286 m20 -154 h10 m60 0 h10 m0 0 h10 m170 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-428 202 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m132 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m58 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"></path>
+<polygon points="731 263 739 259 739 267"></polygon>
+<polygon points="731 263 723 259 723 267"></polygon></svg></div>

--- a/v20.1/backup-and-restore.md
+++ b/v20.1/backup-and-restore.md
@@ -17,44 +17,44 @@ If you have an [Enterprise license](enterprise-licensing.html), you can use the 
 
 ### Manual full backups
 
-In most cases, it's recommended to use the [`BACKUP`][backup] command to take full nightly backups of each database in your cluster:
+In most cases, it's recommended to use the [`BACKUP`][backup] command to take full nightly backups of your cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP DATABASE <database_name> TO '<full_backup_location>';
+> BACKUP TO '<full_backup_location>';
 ~~~
 
-If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore a database:
+If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE <database_name> FROM '<full_backup_location>';
+> RESTORE FROM '<full_backup_location>';
 ~~~
 
 ### Manual full and incremental backups
 
-If a database increases to a size where it is no longer feasible to take nightly full backups, you might want to consider taking periodic full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger databases.
+If your cluster increases to a size where it is no longer feasible to take nightly full backups, you might want to consider taking periodic full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
 Periodically run the [`BACKUP`][backup] command to take a full backup of your database:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP DATABASE <database_name> TO '<full_backup_location>';
+> BACKUP TO '<full_backup_location>';
 ~~~
 
 Then create nightly incremental backups based off of the full backups you've already created.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP DATABASE <database_name> TO 'incremental_backup_location'
-INCREMENTAL FROM '<full_backup_location>', '<list_of_previous_incremental_backup_location>';
+> BACKUP TO '<incremental_backup_location>'
+    INCREMENTAL FROM '<full_backup_location>', '<list_of_previous_incremental_backup_location>';
 ~~~
 
-If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore a database:
+If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE <database_name> FROM '<full_backup_location>', '<list_of_previous_incremental_backup_locations>';
+> RESTORE FROM '<full_backup_location>', '<list_of_previous_incremental_backup_locations>';
 ~~~
 
 {{site.data.alerts.callout_success}}
@@ -89,7 +89,7 @@ In the sample script, configure the day of the week for which you want to create
     # recently created backups in a file to pass as the base for incremental backups.
 
     full_day="<day_of_the_week>"                      # Must match (including case) the output of `LC_ALL=C date +%A`.
-    what="DATABASE <database_name>"                   # The name of the database you want to back up.
+    what=""                                           # Leave empty for full cluster backup, or add "DATABASE database_name" to backup a database.
     base="<storage_URL>/backups"                      # The URL where you want to store the backup.
     extra="<storage_parameters>"                      # Any additional parameters that need to be appended to the BACKUP URI (e.g., AWS key params).
     recent=recent_backups.txt                         # File in which recent backups are tracked.
@@ -123,7 +123,7 @@ In the sample script, configure the day of the week for which you want to create
     Variable | Description
     -----|------------
     `full_day` | The day of the week on which you want to take a full backup.
-    `what` | The name of the database you want to back up (i.e., create backups of all tables and views in the database).
+    `what` | Leave empty for a full cluster backup. Otherwise, add `DATABASE <db_name>` to back up a database (i.e., create backups of all tables and views in the database).
     `base` | The URL where you want to store the backup.<br/><br/>URL format: `[scheme]://[host]/[path]` <br/><br/>For information about the components of the URL, see [Backup File URLs](backup.html#backup-file-urls).
     `extra`| The parameters required for the storage.<br/><br/>Parameters format: `?[parameters]` <br/><br/>For information about the storage parameters, see [Backup File URLs](backup.html#backup-file-urls).
     `backup_parameters` | Additional [backup parameters](backup.html#parameters) you might want to specify.
@@ -173,41 +173,39 @@ For example, to create a locality-aware backup where nodes with the locality `re
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE foo TO ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
+BACKUP TO ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
 ~~~
 
 To restore the backup created above, run the statement below. Note that the first URI in the list has to be the URI specified as the `default` URI when the backup was created. If you have moved your backups to a different location since the backup was originally taken, the first URI must be the new location of the files originally written to the `default` location.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-RESTORE DATABASE foo FROM ('s3://us-east-bucket', 's3://us-west-bucket');
+RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
 ~~~
 
 A list of multiple URIs (surrounded by parentheses) specifying a locality-aware backup can also be used in place of any incremental backup URI in [`RESTORE`][restore]. If the original backup was an incremental backup, it can be restored using:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-RESTORE DATABASE foo FROM 's3://other-full-backup-uri', ('s3://us-east-bucket', 's3://us-west-bucket');
+RESTORE FROM 's3://other-full-backup-uri', ('s3://us-east-bucket', 's3://us-west-bucket');
 ~~~
 
 For more detailed examples, see [Create locality-aware backups](backup.html#create-locality-aware-backups) and [Restore from a locality-aware backup based on node locality](restore.html#restore-from-a-locality-aware-backup).
 
 {{site.data.alerts.callout_info}}
-The locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding) as shown below.
-
-[`RESTORE`][restore] is not truly locality-aware; while restoring from backups, a node may read from a store that does not match its locality. This can happen because [`BACKUP`][backup] does not back up [zone configurations](configure-replication-zones.html), so [`RESTORE`][restore] has no way of knowing how to take node localities into account when restoring data from a backup.
+The locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
 {{site.data.alerts.end}}
 
 ## Perform Core backup and restore
 
-In case you do not have an Enterprise license, you can perform a Core backup. Run the [`cockroach dump`](cockroach-dump.html) command to dump all the tables in the database to a new file (`backup.sql` in the following example):
+If you do not have an Enterprise license, you can perform a core backup. Run the [`cockroach dump`](cockroach-dump.html) command to dump all the tables in the database to a new file (`backup.sql` in the following example):
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach dump <database_name> <flags> > backup.sql
 ~~~
 
-To restore a database from a Core backup, [use the `cockroach sql` command to execute the statements in the backup file](cockroach-dump.html#restore-a-table-from-a-backup-file):
+To restore a database from a core backup, [use the `cockroach sql` command to execute the statements in the backup file](cockroach-dump.html#restore-a-table-from-a-backup-file):
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v20.1/backup.md
+++ b/v20.1/backup.md
@@ -4,20 +4,27 @@ summary: Back up your CockroachDB cluster to a cloud storage services such as AW
 toc: true
 ---
 
-{{site.data.alerts.callout_danger}}
-The `BACKUP` feature is only available to [enterprise](https://www.cockroachlabs.com/product/cockroachdb/) users. For non-enterprise backups, see [`cockroach dump`](cockroach-dump.html).
+{{site.data.alerts.callout_info}}
+`BACKUP` is an [enterprise-only](https://www.cockroachlabs.com/product/cockroachdb/) feature. For non-enterprise backups, see [`cockroach dump`](cockroach-dump.html).
 {{site.data.alerts.end}}
 
-CockroachDB's `BACKUP` [statement](sql-statements.html) allows you to create full or incremental backups of your cluster's schema and data that are consistent as of a given timestamp. Backups can be with or without [revision history](backup.html#backups-with-revision-history).
+CockroachDB's `BACKUP` [statement](sql-statements.html) allows you to create full or incremental backups of your cluster's schema and data that are consistent as of a given timestamp. Backups can be with or without [revision history](#backups-with-revision-history).
 
 Because CockroachDB is designed with high fault tolerance, these backups are designed primarily for disaster recovery (i.e., if your cluster loses a majority of its nodes) through [`RESTORE`](restore.html). Isolated issues (such as small-scale node outages) do not require any intervention.
-
 
 ## Functional details
 
 ### Backup targets
 
-You can backup entire tables (which automatically includes their indexes) or [views](views.html). Backing up a database simply backs up all of its tables and views.
+<span class="version-tag">New in v20.1</span> You can backup a full cluster, which includes:
+
+- All user tables
+- Relevant system tables
+- All [databases](create-database.html)
+- All [tables](create-table.html) (which automatically includes their [indexes](indexes.html))
+- All [views](views.html)
+
+You can also back up individual tables (which automatically includes their indexes) or [views](views.html). Backing up an individual database will back up all of its tables and views.
 
 {{site.data.alerts.callout_info}}
 `BACKUP` only offers table-level granularity; it _does not_ support backing up subsets of a table.
@@ -36,15 +43,11 @@ Table with a [sequence](create-sequence.html) | The sequence it uses; however, t
 
 ### Users and privileges
 
-The `system.users` table stores your users and their passwords. To restore your users, you must first backup the `system.users` table, and then use [this procedure](restore.html#restoring-users-from-system-users-backup).
-
-Restored tables inherit privilege grants from the target database; they do not preserve privilege grants from the backed up table because the restoring cluster may have different users.
-
-Table-level privileges must be [granted to users](grant.html) after the restore is complete.
+The `system.users` table stores your users and their passwords. To restore your users and privilege [grants](grant.html), do a full cluster backup and restore the cluster to a fresh cluster with no user data. You can also backup the `system.users` table, and then use [this procedure](restore.html#restoring-users-from-system-users-backup).
 
 ### Backup types
 
-CockroachDB offers two types of backups: full and incremental.
+CockroachDB offers two types of backups: [full](#full-backups) and [incremental](#incremental-backups).
 
 #### Full backups
 
@@ -54,15 +57,15 @@ Full backups contain an unreplicated copy of your data and can always be used to
 
 Incremental backups are smaller and faster to produce than full backups because they contain only the data that has changed since a base set of backups you specify (which must include one full backup, and can include many incremental backups). You can take incremental backups either as of a given timestamp or with full [revision history](backup.html#backups-with-revision-history).
 
-**Note the following restrictions:** Incremental backups can only be created within the garbage collection period of the base backup's most recent timestamp. This is because incremental backups are created by finding which data has been created or modified since the most recent timestamp in the base backup––that timestamp data, though, is deleted by the garbage collection process.
+{{site.data.alerts.callout_danger}}
+Incremental backups can only be created within the garbage collection period of the base backup's most recent timestamp. This is because incremental backups are created by finding which data has been created or modified since the most recent timestamp in the base backup––that timestamp data, though, is deleted by the garbage collection process.
 
 You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html).
+{{site.data.alerts.end}}
 
 ### Backups with revision history
 
-{% include {{ page.version.version }}/misc/beta-warning.md %}
-
-You can create full or incremental backups with revision history:
+You can create full or incremental backups [with revision history](#with-revision-history):
 
 - Taking full backups with revision history allows you to back up every change made within the garbage collection period leading up to and including the given timestamp.
 - Taking incremental backups with revision history allows you to back up every change made since the last backup and within the garbage collection period leading up to and including the given timestamp. You can take incremental backups with revision history even when your previous full or incremental backups were taken without revision history.
@@ -105,6 +108,18 @@ If initiated correctly, the statement returns when the backup is finished or if 
 {% include {{ page.version.version }}/sql/diagrams/backup.html %}
 </div>
 
+## Parameters
+
+ Parameter | Description
+------------|-------------
+`table_pattern` | The table(s) or [view(s)](views.html) you want to back up.
+`database_name` | The name of the database(s) you want to back up (i.e., create backups of all tables and views in the database).|
+`destination` | The URL where you want to store the backup.<br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls).
+`AS OF SYSTEM TIME timestamp` | Back up data as it existed as of [`timestamp`](as-of-system-time.html). The `timestamp` must be more recent than your cluster's last garbage collection (which defaults to occur every 25 hours, but is [configurable per table](configure-replication-zones.html#replication-zone-variables)).
+`INCREMENTAL FROM full_backup_location` | Create an incremental backup using the full backup stored at the URL `full_backup_location` as its base. For information about this URL structure, see [Backup File URLs](#backup-file-urls).<br><br>**Note:** It is not possible to create an incremental backup if one or more tables were [created](create-table.html), [dropped](drop-table.html), or [truncated](truncate.html) after the full backup. In this case, you must create a new [full backup](#full-backups).
+`incremental_backup_location` | Create an incremental backup that includes all backups listed at the provided URLs. <br/><br/>Lists of incremental backups must be sorted from oldest to newest. The newest incremental backup's timestamp must be within the table's garbage collection period. <br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). <br/><br/>For more information about garbage collection, see [Configure Replication Zones](configure-replication-zones.html#replication-zone-variables).
+`WITH revision_history`<a name="with-revision-history"></a> | Create a backup with full [revision history](#backups-with-revision-history), which records every change made to the cluster within the garbage collection period leading up to and including the given timestamp.
+
 {{site.data.alerts.callout_info}}
 The `BACKUP` statement cannot be used within a [transaction](transactions.html).
 {{site.data.alerts.end}}
@@ -112,18 +127,6 @@ The `BACKUP` statement cannot be used within a [transaction](transactions.html).
 ## Required privileges
 
 Only members of the `admin` role can run `BACKUP`. By default, the `root` user belongs to the `admin` role.
-
-## Parameters
-
-| Parameter | Description |
-|-----------|-------------|
-| `table_pattern` | The table or [view](views.html) you want to back up. |
-| `name` | The name of the database you want to back up (i.e., create backups of all tables and views in the database).|
-| `destination` | The URL where you want to store the backup.<br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). |
-| `AS OF SYSTEM TIME timestamp` | Back up data as it existed as of [`timestamp`](as-of-system-time.html). The `timestamp` must be more recent than your cluster's last garbage collection (which defaults to occur every 25 hours, but is [configurable per table](configure-replication-zones.html#replication-zone-variables)). |
-| `WITH revision_history` | Create a backup with full [revision history](backup.html#backups-with-revision-history) that records every change made to the cluster within the garbage collection period leading up to and including the given timestamp. |
-| `INCREMENTAL FROM full_backup_location` | Create an incremental backup using the full backup stored at the URL `full_backup_location` as its base. For information about this URL structure, see [Backup File URLs](#backup-file-urls).<br><br>**Note:** It is not possible to create an incremental backup if one or more tables were [created](create-table.html), [dropped](drop-table.html), or [truncated](truncate.html) after the full backup. In this case, you must create a new [full backup](#full-backups). |
-| `incremental_backup_location` | Create an incremental backup that includes all backups listed at the provided URLs. <br/><br/>Lists of incremental backups must be sorted from oldest to newest. The newest incremental backup's timestamp must be within the table's garbage collection period. <br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). <br/><br/>For more information about garbage collection, see [Configure Replication Zones](configure-replication-zones.html#replication-zone-variables). |
 
 ### Backup file URLs
 
@@ -135,12 +138,23 @@ We will use the URL provided to construct a secure API call to the service you s
 
 Per our guidance in the [Performance](#performance) section, we recommend starting backups from a time at least 10 seconds in the past using [`AS OF SYSTEM TIME`](as-of-system-time.html).
 
+### Backup a cluster
+
+<span class="version-tag">New in v20.1</span> To backup a full cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
 ### Backup a single table or view
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
-TO 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+TO 'gs://acme-co-backup/bank-customers-2017-03-27-weekly' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -166,32 +180,33 @@ AS OF SYSTEM TIME '-10s';
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP DATABASE bank \
-TO 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster-2017-03-27-weekly' \
 AS OF SYSTEM TIME '-10s' WITH revision_history;
 ~~~
 
 ### Create incremental backups
 
-Incremental backups must be based off of full backups you've already created.
+<span class="version-tag">New in v20.1</span> If you backup to a destination already containing a backup, an incremental backup will be produced in a subdirectory with a date-based name (e.g., `destination/day/time_1`, `destination/day/time_2`):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+AS OF SYSTEM TIME '-10s' WITH revision_history;
+~~~
+
+To explicitly control where your incremental backups go, use the `INCREMENTAL FROM` syntax:
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 TO 'gs://acme-co-backup/db/bank/2017-03-29-nightly' \
 AS OF SYSTEM TIME '-10s' \
-INCREMENTAL FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly';
-~~~
-
-### Create incremental backups with revision history
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP DATABASE bank \
-TO 'gs://acme-co-backup/database-bank-2017-03-29-nightly' \
-AS OF SYSTEM TIME '-10s' \
 INCREMENTAL FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly' WITH revision_history;
 ~~~
+
+The examples above show incremental backups [with revision history](#with-revision-history).
 
 ### Create locality-aware backups
 
@@ -202,7 +217,7 @@ A locality-aware backup is specified by a list of URIs, each of which has a `COC
 Backup file placement is determined by leaseholder placement, as each node is responsible for backing up the ranges for which it is the leaseholder.  Nodes write files to the backup storage location whose locality matches their own node localities, with a preference for more specific values in the locality hierarchy.  If there is no match, the `default` locality is used.
 
 {{site.data.alerts.callout_info}}
-Note that the locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding) as shown below.
+Note that the locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding) as [shown below](#example-create-a-locality-aware-backup).
 {{site.data.alerts.end}}
 
 #### Example - Create a locality-aware backup
@@ -218,7 +233,7 @@ The backup created above can be restored by running:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-RESTORE DATABASE bank FROM ('s3://us-east-bucket', 's3://us-west-bucket');
+RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
 ~~~
 
 #### Example - Create an incremental locality-aware backup
@@ -227,16 +242,25 @@ To make an incremental locality-aware backup from a full locality-aware backup, 
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE foo TO (${uri_1}, ${uri_2}, ...) INCREMENTAL FROM ${full_backup_uri} ...;
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+AS OF SYSTEM TIME '-10s' WITH revision_history;
+~~~
+
+And if you want to explicitly control where your incremental backups go, use the `INCREMENTAL FROM` syntax:
+
+{% include copy-clipboard.html %}
+~~~ sql
+BACKUP TO (${uri_1}, ${uri_2}, ...) INCREMENTAL FROM ${full_backup_uri} ...;
 ~~~
 
 For example, to create an incremental locality-aware backup from a previous full locality-aware backup where nodes with the locality `region=us-west` write backup files to `s3://us-west-bucket`, and all other nodes write to `s3://us-east-bucket` by default, run:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE bank TO
-('s3://us-east-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
-INCREMENTAL FROM 's3://us-east-bucket/database-bank-2019-10-07-weekly';
+> BACKUP TO \
+('s3://us-east-bucket/test-cluster-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/test-cluster-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
+INCREMENTAL FROM 's3://us-east-bucket/test-cluster-2019-10-07-weekly';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -249,7 +273,7 @@ To make an incremental locality-aware backup from another locality-aware backup,
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE foo TO ({uri_1}, {uri_2}, ...) INCREMENTAL FROM {full_backup}, {incr_backup_1}, {incr_backup_2}, ...;
+BACKUP TO ({uri_1}, {uri_2}, ...) INCREMENTAL FROM {full_backup}, {incr_backup_1}, {incr_backup_2}, ...;
 ~~~
 
 For example, let's say you normally run a full backup every Monday, followed by incremental backups on the remaining days of the week.
@@ -259,21 +283,21 @@ By default, all nodes send their backups to your `s3://us-east-bucket`, except f
 If today is Thursday, October 10th, 2019, your `BACKUP` statement will list the following backup URIs:
 
 - The full locality-aware backup URI from Monday, e.g.,
-  - `s3://us-east-bucket/database-bank-2019-10-07-weekly`
+  - `s3://us-east-bucket/test-cluster-2019-10-07-weekly`
 - The incremental backup URIs from Tuesday and Wednesday, e.g.,
-  - `s3://us-east-bucket/database-bank-2019-10-08-nightly`
-  - `s3://us-east-bucket/database-bank-2019-10-09-nightly`
+  - `s3://us-east-bucket/test-cluster-2019-10-08-nightly`
+  - `s3://us-east-bucket/test-cluster-2019-10-09-nightly`
 
 Given the above, to take the incremental locality-aware backup scheduled for today (Thursday), you will run:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE bank TO
-	('s3://us-east-bucket/database-bank-2019-10-10-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/database-bank-2019-10-10-nightly?COCKROACH_LOCALITY=region%3Dus-west')
+BACKUP TO
+	('s3://us-east-bucket/test-cluster-2019-10-10-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/test-cluster-2019-10-10-nightly?COCKROACH_LOCALITY=region%3Dus-west')
 INCREMENTAL FROM
-	's3://us-east-bucket/database-bank-2019-10-07-weekly',
-	's3://us-east-bucket/database-bank-2019-10-08-nightly',
-	's3://us-east-bucket/database-bank-2019-10-09-nightly';
+	's3://us-east-bucket/test-cluster-2019-10-07-weekly',
+	's3://us-east-bucket/test-cluster-2019-10-08-nightly',
+	's3://us-east-bucket/test-cluster-2019-10-09-nightly';
 ~~~
 
 {{site.data.alerts.callout_info}}

--- a/v20.1/restore.md
+++ b/v20.1/restore.md
@@ -4,7 +4,9 @@ summary: Restore your CockroachDB cluster to a cloud storage services such as AW
 toc: true
 ---
 
-{{site.data.alerts.callout_danger}}The <code>RESTORE</code> feature is only available to <a href="https://www.cockroachlabs.com/product/cockroachdb/">enterprise</a> users. For non-enterprise restores, see <a href="restore-data.html">Restore Data</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+`RESTORE` is an [enterprise-only](https://www.cockroachlabs.com/product/cockroachdb/) feature. For non-enterprise restores, see [Restore Data](restore-data.html).
+{{site.data.alerts.end}}
 
 The `RESTORE` [statement](sql-statements.html) restores your cluster's schemas and data from [an enterprise `BACKUP`][backup] stored on a services such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.
 
@@ -14,16 +16,45 @@ Because CockroachDB is designed with high fault tolerance, restores are designed
 
 ### Restore targets
 
-You can restore entire tables (which automatically includes their indexes) or [views](views.html) from a backup. This process uses the data stored in the backup to create entirely new tables or views in the [target database](#target-database).
+You can restore:
 
-The notion of "restoring a database" simply restores all of the tables and views that belong to the database, but does not create the database. For more information, see [Target Database](#target-database).
+- <span class="version-tag">New in v20.1</span> [A full cluster](#full-cluster)
+- [Databases](#databases)
+- [Tables](#tables)
 
-{{site.data.alerts.callout_info}}<code>RESTORE</code> only offers table-level granularity; it <em>does not</em> support restoring subsets of a table.{{site.data.alerts.end}}
+#### Full cluster
 
-Because this process is designed for disaster recovery, CockroachDB expects that the tables do not currently exist in the [target database](#target-database). This means the target database must have not have tables or views with the same name as the restored table or view. If any of the restore target's names are being used, you can:
+<span class="version-tag">New in v20.1</span> You can restore a full cluster, which includes:
+
+- All user tables
+- Relevant system tables
+- All [databases](create-database.html)
+- All [tables](create-table.html) (which automatically includes their [indexes](indexes.html))
+- All [views](views.html)
+
+Because this process is designed for disaster recovery, a full cluster restore can only be run on a target cluster with no databases or tables.
+
+#### Databases
+
+To restore a database, the database cannot already exist in the target cluster. Restoring a database will create the database and restore all of its tables and views. By default, tables and views are restored into a database with the name of the database from which they were backed up. However, also consider:
+
+- You can choose to [change the target database](#into_db).
+- If it no longer exists, you must [create the target database](create-database.html).
+
+The target database must have not have tables or views with the same name as the tables or views you're restoring.
+
+#### Tables
+
+You can also restore individual tables (which automatically includes their indexes) or [views](views.html) from a backup. This process uses the data stored in the backup to create entirely new tables or views in the [target database](#databases).
+
+To restore individual tables, the tables can not already exist in the [target database](#databases). This means the target database must not have tables or views with the same name as the restored table or view. If any of the restore target's names are being used, you can:
 
 - [`DROP TABLE`](drop-table.html), [`DROP VIEW`](drop-view.html), or [`DROP SEQUENCE`](drop-sequence.html) and then restore them. Note that a sequence cannot be dropped while it is being used in a column's `DEFAULT` expression, so those expressions must be dropped before the sequence is dropped, and recreated after the sequence is recreated. The `setval` [function](functions-and-operators.html#sequence-functions) can be used to set the value of the sequence to what it was previously.
 - [Restore the table or view into a different database](#into_db).
+
+{{site.data.alerts.callout_info}}
+`RESTORE` only offers table-level granularity; it _does not_ support restoring subsets of a table.
+{{site.data.alerts.end}}
 
 ### Object dependencies
 
@@ -36,45 +67,42 @@ Table with a [sequence](create-sequence.html) | The sequence.
 [Views](views.html) | The tables used in the view's `SELECT` statement.
 [Interleaved tables](interleave-in-parent.html) | The parent table in the [interleaved hierarchy](interleave-in-parent.html#interleaved-hierarchy).
 
-### Target database
-
-By default, tables and views are restored into a database with the name of the database from which they were backed up. However, also consider:
-
-- You can choose to [change the target database](#into_db).
-- If it no longer exists, you must [create the target database](create-database.html).
-
-The target database must have not have tables or views with the same name as the tables or views you're restoring.
-
 ### Users and privileges
 
-Table and view users/privileges are not restored. Restored tables and views instead inherit the privileges of the database into which they're restored.
+To restore your users and privilege [grants](grant.html), you can do a full cluster backup and restore the cluster to a fresh cluster with no user data.
 
-However, every backup includes `system.users`, so you can [restore users and their passwords](#restoring-users-from-system-users-backup).
-
-Table-level privileges must be [granted to users](grant.html) after the restore is complete.
+If you are not doing a full cluster restore, the table-level privileges need to be granted to the users after the restore is complete. To do this, backup the `system.users` table, [restore users and their passwords](#restoring-users-from-system-users-backup), and then [grant](grant.html) the table-level privileges.
 
 ### Restore types
 
-You can either restore from a full backup or from a full backup with incremental backups, based on the backup files you include.
+You can either restore from a full backup or from a full backup with incremental backups, based on the backup files you include:
 
 Restore Type | Parameters
-----|----------
-**Full backup** | Include only the path to the full backup.
-**Full backup + <br/>incremental backups** | Include the path to the full backup as the first argument and the subsequent incremental backups from oldest to newest as the following arguments.
+-------------|----------
+Full backup | Include only the path to the full backup.
+Full backup + <br>incremental backups | If the full backup and incremental backups were sent to the same destination, include only the path to the full backup (e.g., `RESTORE FROM 'full_backup_location';`).<br><br>If the incremental backups were sent to a different destination from the full backup, include the path to the full backup as the first argument and the subsequent incremental backups from oldest to newest as the following arguments (e.g., `RESTORE FROM 'full_backup_location', 'incremental_location_1', 'incremental_location_2';`).
 
 ### Point-in-time restore
-
-{% include {{ page.version.version }}/misc/beta-warning.md %}
 
 If the full or incremental backup was taken [with revision history](backup.html#backups-with-revision-history), you can restore the data as it existed at the specified point-in-time within the revision history captured by that backup.
 
 If you do not specify a point-in-time, the data will be restored to the backup timestamp; that is, the restore will work as if the data was backed up without revision history.
 
+#### Example - Point-in-time restore
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+AS OF SYSTEM TIME '2017-02-26 10:00:00';
+~~~
+
 ## Performance
 
 The `RESTORE` process minimizes its impact to the cluster's performance by distributing work to all nodes. Subsets of the restored data (known as ranges) are evenly distributed among randomly selected nodes, with each range initially restored to only one node. Once the range is restored, the node begins replicating it others.
 
-{{site.data.alerts.callout_info}}When a <code>RESTORE</code> fails or is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+When a `RESTORE` fails or is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.
+{{site.data.alerts.end}}
 
 ## Viewing and controlling restore jobs
 
@@ -92,22 +120,24 @@ If initiated correctly, the statement returns when the restore is finished or if
   {% include {{ page.version.version }}/sql/diagrams/restore.html %}
 </div>
 
-{{site.data.alerts.callout_info}}The <code>RESTORE</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
-
-## Required privileges
-
-Only members of the `admin` role can run `RESTORE`. By default, the `root` user belongs to the `admin` role.
-
 ## Parameters
 
- Parameter | Description |
------------|-------------|
+ Parameter | Description
+-----------|-------------
  `table_pattern` | The table or [view](views.html) you want to restore.
  `database_name` | The name of the database you want to restore (i.e., restore all tables and views in the database). You can restore an entire database only if you had backed up the entire database.
  `full_backup_location` | The URL where the full backup is stored. <br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls).
  `incremental_backup_location` | The URL where an incremental backup is stored.  <br/><br/>Lists of incremental backups must be sorted from oldest to newest. The newest incremental backup's timestamp must be within the table's garbage collection period.<br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). <br/><br/>For more information about garbage collection, see [Configure Replication Zones](configure-replication-zones.html#replication-zone-variables).
  `AS OF SYSTEM TIME timestamp` | Restore data as it existed as of [`timestamp`](as-of-system-time.html). You can restore point-in-time data only if you had taken full or incremental backup [with revision history](backup.html#backups-with-revision-history).
- `kv_option_list` | Control your backup's behavior with [these options](#restore-option-list).
+ `kv_option_list` | Control your backup's behavior with [these options](#options).
+ 
+{{site.data.alerts.callout_info}}
+The `RESTORE` statement cannot be used within a [transaction](transactions.html).
+{{site.data.alerts.end}}
+
+## Required privileges
+
+Only members of the `admin` role can run `RESTORE`. By default, the `root` user belongs to the `admin` role.
 
 ### Backup file URLs
 
@@ -115,39 +145,27 @@ The URL for your backup's locations must use the following format:
 
 {% include {{ page.version.version }}/misc/external-urls.md %}
 
-### Restore option list
+### Options
 
-You can include the following options as key-value pairs in the `kv_option_list` to control the restore process's behavior.
+You can include the following options as key-value pairs in the `kv_option_list` to control the restore process's behavior:
 
-#### `into_db`
-
-- **Description**: If you want to restore a table or view into a database other than the one it originally existed in, you can [change the target database](#restore-into-a-different-database). This is useful if you want to restore a table that currently exists, but do not want to drop it.
-- **Key**: `into_db`
-- **Value**: The name of the database you want to use
-- **Example**: `WITH into_db = 'newdb'`
-
-#### `skip_missing_foreign_keys`
-
-- **Description**: If you want to restore a table with a foreign key but do not want to restore the table it references, you can drop the Foreign Key constraint from the table and then have it restored.
-- **Key**: `skip_missing_foreign_keys`
-- **Value**: *No value*
-- **Example**: `WITH skip_missing_foreign_keys`
-
-#### `skip_missing_sequences`
-
-- **Description**: If you want to restore a table that depends on a sequence but do not want to restore the sequence it references, you can drop the sequence dependency from a table (i.e., the `DEFAULT` expression that uses the sequence) and then have it restored.
-- **Key**: `skip_missing_sequences`
-- **Value**: *No value*
-- **Example**: `WITH skip_missing_sequences`
-
-#### `skip_missing_views`
-
-- **Description**: If you want to restore a table with a [view](views.html) but do not want to restore the view's dependencies, you can drop the view and then have the table restored.
-- **Key**: `skip_missing_views`
-- **Value**: *No value*
-- **Example**: `WITH skip_missing_views`
+ Option                                                             | <div style="width:75px">Value</div>         | Description
+ -------------------------------------------------------------------+---------------+-------------------------------------------------------
+<a name="into_db"></a>`into_db`                                     | Database name                               | Use to [change the target database](#restore-into-a-different-database). This is useful if you want to restore a table that currently exists, but do not want to drop it.<br><br>Example: `WITH into_db = 'newdb'`
+<a name="skip_missing_foreign_keys"></a>`skip_missing_foreign_keys` | N/A                                         | Use to remove the [foreign key](foreign-key.html) constraints before restoring.<br><br>Example: `WITH skip_missing_foreign_keys`
+<a name="skip_missing_sequences"></a>`skip_missing_sequences`       | N/A                                         | Use to ignore [sequence](show-sequences.html) dependencies (i.e., the `DEFAULT` expression that uses the sequence).<br><br>Example: `WITH skip_missing_sequences`
+`skip_missing_views`                                                | N/A                                         | Use to skip restoring [views](views.html) that cannot be restored because their dependencies are not being restored at the same time.<br><br>Example: `WITH skip_missing_views`
 
 ## Examples
+
+### Restore a cluster
+
+<span class="version-tag">New in v20.1</span> To restore a full cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://acme-co-backup/test-cluster';
+~~~
 
 ### Restore a single table
 
@@ -163,7 +181,7 @@ You can include the following options as key-value pairs in the `kv_option_list`
 > RESTORE bank.customers, bank.accounts FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly';
 ~~~
 
-### Restore an entire database
+### Restore a database
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -172,15 +190,16 @@ You can include the following options as key-value pairs in the `kv_option_list`
 
 {{site.data.alerts.callout_info}}<code>RESTORE DATABASE</code> can only be used if the entire database was backed up.{{site.data.alerts.end}}
 
-### Point-in-time restore
+### Restore from incremental backups
+
+<span class="version-tag">New in v20.1</span> Restoring from incremental backups requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
-AS OF SYSTEM TIME '2017-02-26 10:00:00';
+> RESTORE FROM 'gs://acme-co-backup/test-cluster';
 ~~~
 
-### Restore from incremental backups
+To explicitly point to where your incremental backups are, use the `INCREMENTAL FROM` syntax. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -188,22 +207,16 @@ AS OF SYSTEM TIME '2017-02-26 10:00:00';
 FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly';
 ~~~
 
-{{site.data.alerts.callout_success}}
-Restoring from incremental backups requires previous full and incremental backups. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
-{{site.data.alerts.end}}
-
 ### Point-in-time restore from incremental backups
+
+Restoring from incremental backups requires previous full and incremental backups. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE bank.customers \
-FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' \
+> RESTORE FROM \
+'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' \
 AS OF SYSTEM TIME '2017-02-28 10:00:00';
 ~~~
-
-{{site.data.alerts.callout_success}}
-Restoring from incremental backups requires previous full and incremental backups. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
-{{site.data.alerts.end}}
 
 ### Restore into a different database
 
@@ -268,15 +281,15 @@ For example, a backup created with
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE bank TO
-	('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
+> BACKUP TO
+	  ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
 ~~~
 
 can be restored by running:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-RESTORE DATABASE bank FROM ('s3://us-east-bucket', 's3://us-west-bucket');
+> RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
 ~~~
 
 Note that the first URI in the list has to be the URI specified as the `default` URI when the backup was created. If you have moved your backups to a different location since the backup was originally taken, the first URI must be the new location of the files originally written to the `default` location.
@@ -289,19 +302,19 @@ For example, an incremental locality-aware backup created with
 
 {% include copy-clipboard.html %}
 ~~~ sql
-BACKUP DATABASE bank TO
-	('s3://us-east-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
-INCREMENTAL FROM
-	's3://us-east-bucket/database-bank-2019-10-07-weekly';
+> BACKUP TO
+	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
+  INCREMENTAL FROM
+	  's3://us-east-bucket/database-bank-2019-10-07-weekly';
 ~~~
 
 can be restored by running:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-RESTORE DATABASE bank FROM
-	('s3://us-east-bucket/database-bank-2019-10-07-weekly', 's3://us-west-bucket/database-bank-2019-10-07-weekly'),
-	('s3://us-east-bucket/database-bank-2019-10-08-nightly', 's3://us-west-bucket/database-bank-2019-10-08-nightly');
+> RESTORE FROM
+  	('s3://us-east-bucket/database-bank-2019-10-07-weekly', 's3://us-west-bucket/database-bank-2019-10-07-weekly'),
+	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly', 's3://us-west-bucket/database-bank-2019-10-08-nightly');
 ~~~
 
 ## See also


### PR DESCRIPTION
backup-and-restore.md
- Changed examples to focus on full cluster backup / restore
- Edited script to be for a full cluster example
- Finish editing script to account for new incremental backup syntax 

backup.md
- Updated SQL diagram 
- Added information about full cluster backup
- Added new/easier incremental backup syntax (where you just backup to the same destination as the full backup)
- Changed backup examples to be focused primarily on how to do a full cluster backup
- Minor format / language cleanup

restore.md
- Updated SQL diagram
- Added information about full cluster restore
- Added new/easier restore from incremental backup syntax (where you just restore from the one destination)
- Changed restore examples to be focused primarily on how to do a full cluster restore (if applicable)
- Format / language cleanup

Closes #6005, #6440, #6532.