### PR TITLE
Decommissioned nodes are considered ready

### DIFF
--- a/v19.1/remove-nodes.md
+++ b/v19.1/remove-nodes.md
@@ -12,13 +12,11 @@ For information about temporarily stopping a node (e.g., for planned maintenance
 
 ### How it works
 
-When you decommission a node, CockroachDB lets the node finish in-flight requests, rejects any new requests, and transfers all **range replicas** and **range leases** off the node so that it can be safely shut down.
+When you decommission a node, all range replicas on the node are transferred to other nodes.
 
-Basic terms:
+During and after decommissioning, the node continues to accept new SQL connections. Even without replicas, the node can still function as a gateway to route connections to relevant data. However, note that the [`/health?ready=1` monitoring endpoint](monitoring-and-alerting.html#health-ready-1) considers the node "unready" and returns a `503 Service Unavailable` status response code so load balancers stop directing traffic to the node. This behavior has been fixed in v20.1.
 
-- **Range**: CockroachDB stores all user data and almost all system data in a giant sorted map of key value pairs. This keyspace is divided into "ranges", contiguous chunks of the keyspace, so that every key can always be found in a single range.
-- **Range Replica:** CockroachDB replicates each range (3 times by default) and stores each replica on a different node.
-- **Range Lease:** For each range, one of the replicas holds the "range lease". This replica, referred to as the "leaseholder", is the one that receives and coordinates all read and write requests for the range.
+After decommissioning, it's typical to stop the node via a process manager or orchestration tool, or by sending `SIGTERM` manually, at which point the node is drained of in-flight SQL connections and new SQL connections are rejected.
 
 ### Considerations
 

--- a/v19.2/remove-nodes.md
+++ b/v19.2/remove-nodes.md
@@ -12,13 +12,11 @@ For information about temporarily stopping a node (e.g., for planned maintenance
 
 ### How it works
 
-When you decommission a node, CockroachDB lets the node finish in-flight requests, rejects any new requests, and transfers all **range replicas** and **range leases** off the node so that it can be safely shut down.
+When you decommission a node, all range replicas on the node are transferred to other nodes.
 
-Basic terms:
+During and after decommissioning, the node continues to accept new SQL connections. Even without replicas, the node can still function as a gateway to route connections to relevant data. However, note that the [`/health?ready=1` monitoring endpoint](monitoring-and-alerting.html#health-ready-1) considers the node "unready" and returns a `503 Service Unavailable` status response code so load balancers stop directing traffic to the node. This behavior has been fixed in v20.1.
 
-- **Range**: CockroachDB stores all user data and almost all system data in a giant sorted map of key-value pairs. This keyspace is divided into "ranges", contiguous chunks of the keyspace, so that every key can always be found in a single range.
-- **Range Replica:** CockroachDB replicates each range (3 times by default) and stores each replica on a different node.
-- **Range Lease:** For each range, one of the replicas holds the "range lease". This replica, referred to as the "leaseholder", is the one that receives and coordinates all read and write requests for the range.
+After decommissioning, it's typical to stop the node via a process manager or orchestration tool, or by sending `SIGTERM` manually, at which point the node is drained of in-flight SQL connections and new SQL connections are rejected.
 
 ### Considerations
 
@@ -36,7 +34,7 @@ If you try to decommission a node, the process will hang indefinitely because th
 
 <div style="text-align: center;"><img src="{{ 'images/v19.2/decommission-scenario1.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 
-The decommissioning node will be marked as **Suspect** in the Admin UI. 
+The decommissioning node will be marked as **Suspect** in the Admin UI.
 
 {{site.data.alerts.callout_info}}
 Adding a 4th node to the cluster at this point will neither enable the decommissioning process to complete nor change the **Suspect** node status. You can [recommission](#recommission-nodes) the node to return it to a healthy state.
@@ -66,7 +64,7 @@ If you try to decommission a node, the cluster will successfully rebalance all r
 
 <div style="text-align: center;"><img src="{{ 'images/v19.2/decommission-scenario3.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 
-The decommissioning node will be marked as **Suspect** in the Admin UI. 
+The decommissioning node will be marked as **Suspect** in the Admin UI.
 
 {{site.data.alerts.callout_info}}
 Adding a 6th node to the cluster at this point will neither enable the decommissioning process to complete nor change the **Suspect** node status. You can [recommission](#recommission-nodes) the node to return it to a healthy state.

--- a/v20.1/monitoring-and-alerting.md
+++ b/v20.1/monitoring-and-alerting.md
@@ -8,7 +8,6 @@ Despite CockroachDB's various [built-in safeguards against failure](frequently-a
 
 This page explains available monitoring tools and critical events and metrics to alert on.
 
-
 ## Monitoring tools
 
 ### Admin UI
@@ -94,8 +93,14 @@ Otherwise, it returns an HTTP `200 OK` status response code with details about t
 
 The `http://<node-host>:<http-port>/health?ready=1` endpoint returns an HTTP `503 Service Unavailable` status response code with an error in the following scenarios:
 
-- The node is being [decommissioned](remove-nodes.html) or in the process of [shutting down](cockroach-quit.html) and is therefore not able to accept SQL connections and execute queries. This is especially useful for making sure load balancers do not direct traffic to nodes that are live but not "ready", which is a necessary check during [rolling upgrades](upgrade-cockroach-version.html).
-    {{site.data.alerts.callout_success}}If you find that your load balancer's health check is not always recognizing a node as unready before the node shuts down, you can increase the <code>server.shutdown.drain_wait</code> <a href="cluster-settings.html">cluster setting</a> to cause a node to return <code>503 Service Unavailable</code> even before it has started shutting down.{{site.data.alerts.end}}
+- The node is draining open SQL connections and rejecting new SQL connections because it is in the process of shutting down. This is especially useful for making sure load balancers do not direct traffic to nodes that are live but not "ready", which is a necessary check during [rolling upgrades](upgrade-cockroach-version.html).
+
+    {{site.data.alerts.callout_success}}
+    If you find that your load balancer's health check is not always recognizing a node as unready before the node shuts down, you can increase the `server.shutdown.drain_wait` [cluster setting](cluster-settings.html) to cause a node to return `503 Service Unavailable` even before it has started shutting down.
+    {{site.data.alerts.end}}
+
+    <span class="version-tag">Changed in v20.1:</span> In previous releases, nodes in the process of [decommissioning](remove-nodes.html) or already fully decommissioned would be considered unready and return `503 Service Unavailable`. This is no longer the case. Although such nodes no longer store replicas after decommissioning, they can still function as gateways to route SQL connections to relevant data.  
+
 - The node is unable to communicate with a majority of the other nodes in the cluster, likely because the cluster is unavailable due to too many nodes being down.
 
 {% include copy-clipboard.html %}

--- a/v20.1/remove-nodes.md
+++ b/v20.1/remove-nodes.md
@@ -12,13 +12,11 @@ For information about temporarily stopping a node (e.g., for planned maintenance
 
 ### How it works
 
-When you decommission a node, CockroachDB lets the node finish in-flight requests, rejects any new requests, and transfers all **range replicas** and **range leases** off the node so that it can be safely shut down.
+When you decommission a node, all range replicas on the node are transferred to other nodes.
 
-Basic terms:
+During and after decommissioning, the node continues to accept new SQL connections. Even without replicas, the node can still function as a gateway to route connections to relevant data. For this reason, the [`/health?ready=1` monitoring endpoint](monitoring-and-alerting.html#health-ready-1) continues to consider the node "ready" so load balancers can continue directing traffic to the node.
 
-- **Range**: CockroachDB stores all user data and almost all system data in a giant sorted map of key-value pairs. This keyspace is divided into "ranges", contiguous chunks of the keyspace, so that every key can always be found in a single range.
-- **Range Replica:** CockroachDB replicates each range (3 times by default) and stores each replica on a different node.
-- **Range Lease:** For each range, one of the replicas holds the "range lease". This replica, referred to as the "leaseholder", is the one that receives and coordinates all read and write requests for the range.
+After decommissioning, it's typical to stop the node via a process manager or orchestration tool, or by sending `SIGTERM` manually, at which point the node is drained of in-flight SQL connections, new SQL connections are rejected, and the [`/health?ready=1` monitoring endpoint](monitoring-and-alerting.html#health-ready-1) starts returning a `503 Service Unavailable` status response code so load balancers stop directing traffic to the node.
 
 ### Considerations
 
@@ -36,7 +34,7 @@ If you try to decommission a node, the process will hang indefinitely because th
 
 <div style="text-align: center;"><img src="{{ 'images/v20.1/decommission-scenario1.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 
-The decommissioning node will be marked as **Suspect** in the Admin UI. 
+The decommissioning node will be marked as **Suspect** in the Admin UI.
 
 {{site.data.alerts.callout_info}}
 Adding a 4th node to the cluster at this point will neither enable the decommissioning process to complete nor change the **Suspect** node status. You can [recommission](#recommission-nodes) the node to return it to a healthy state.
@@ -66,7 +64,7 @@ If you try to decommission a node, the cluster will successfully rebalance all r
 
 <div style="text-align: center;"><img src="{{ 'images/v20.1/decommission-scenario3.2.png' | relative_url }}" alt="Decommission Scenario 1" style="max-width:50%" /></div>
 
-The decommissioning node will be marked as **Suspect** in the Admin UI. 
+The decommissioning node will be marked as **Suspect** in the Admin UI.
 
 {{site.data.alerts.callout_info}}
 Adding a 6th node to the cluster at this point will neither enable the decommissioning process to complete nor change the **Suspect** node status. You can [recommission](#recommission-nodes) the node to return it to a healthy state.


### PR DESCRIPTION
Update health endpoint doc to clarify that a node is considered
unready when it can no longer accept new SQL connectsions, for
example, when shutting down. This excludes decomissioning since
a decommissioned node, although absent of data, can still serve
as a SQL gateway.

Fixes #6589.