### PR TITLE
Fix sqlalchemy install in docs to include psycopg2 by default

### DIFF
--- a/v1.0/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v1.0/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -25,8 +25,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v1.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v1.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -27,8 +27,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -32,8 +32,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v19.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v19.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -33,8 +33,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v19.2/install-client-drivers.md
+++ b/v19.2/install-client-drivers.md
@@ -53,8 +53,12 @@ To install SQLAlchemy and a [CockroachDB Python package](https://github.com/cock
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v2.0/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v2.0/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -28,8 +28,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v2.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v2.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -32,8 +32,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -33,8 +33,12 @@ To install SQLAlchemy, as well as a [CockroachDB Python package](https://github.
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 

--- a/v20.1/install-client-drivers.md
+++ b/v20.1/install-client-drivers.md
@@ -53,8 +53,12 @@ To install SQLAlchemy and a [CockroachDB Python package](https://github.com/cock
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ pip install sqlalchemy cockroachdb
+$ pip install sqlalchemy cockroachdb psycopg2
 ~~~
+
+{{site.data.alerts.callout_success}}
+You can substitute psycopg2 for other alternatives that include the psycopg python package.
+{{site.data.alerts.end}}
 
 For other ways to install SQLAlchemy, see the [official documentation](http://docs.sqlalchemy.org/en/latest/intro.html#installation-guide).
 


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroachdb-python/pull/88 and
https://github.com/cockroachdb/cockroachdb-python/issues/87.

CRDB's SQLAlchemy dialect requires the use of psycopg2. Currently,
it is not included in our default install instructions. This PR adds
text to do so, as well as an information prompt in case the user does
not require psycopg2.