### PR TITLE
Add cockroach nodelocal upload docs

### DIFF
--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -1821,6 +1821,12 @@
             ]
           },
           {
+            "title": "<code>cockroach nodelocal upload</code>",
+            "urls": [
+              "/${VERSION}/cockroach-nodelocal-upload.html"
+            ]
+          },
+          {
             "title": "<code>cockroach dump</code>",
             "urls": [
               "/${VERSION}/cockroach-dump.html"

--- a/_includes/v20.1/misc/external-urls.md
+++ b/_includes/v20.1/misc/external-urls.md
@@ -8,7 +8,7 @@ Amazon                                                      | `s3`        | Buck
 Azure                                                       | `azure`     | N/A (see [Example file URLs](#example-file-urls) | `AZURE_ACCOUNT_KEY`, `AZURE_ACCOUNT_NAME`
 Google Cloud&nbsp;[<sup>2</sup>](#considerations)           | `gs`        | Bucket name                                      | `AUTH` (optional; can be `default`, `implicit`, or `specified`), `CREDENTIALS`
 HTTP&nbsp;[<sup>3</sup>](#considerations)                   | `http`      | Remote host                                      | N/A
-NFS/Local&nbsp;[<sup>4</sup>](#considerations)              | `nodelocal` | Empty or `nodeID` [<sup>5</sup>](#considerations) (see [Example file URLs](#example-file-urls)) | N/A
+NFS/Local&nbsp;[<sup>4</sup>](#considerations)              | `nodelocal` | `nodeID` or `self` [<sup>5</sup>](#considerations) (see [Example file URLs](#example-file-urls)) | N/A
 S3-compatible services&nbsp;[<sup>6</sup>](#considerations) | `s3`        | Bucket name                                      | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`&nbsp;[<sup>7</sup>](#considerations) (optional), `AWS_ENDPOINT`
 
 {{site.data.alerts.callout_info}}
@@ -29,7 +29,7 @@ If your environment requires an HTTP or HTTPS proxy server for outgoing connecti
 
 - <sup>4</sup> The file system backup location on the NFS drive is relative to the path specified by the `--external-io-dir` flag set while [starting the node](cockroach-start.html). If the flag is set to `disabled`, then imports from local directories and NFS drives are disabled.
 
-- <sup>5</sup>  <span class="version-tag">New in v20.1:</span> If a `nodeID` is provided, the data files will be in the `extern` directory of the specified node. Currently, using a `nodeID` is optional but strongly encouraged. If you do not specify a `nodeID` when using `nodelocal` storage, the individual data files will be in the `extern` directories of arbitrary nodes and will likely not work as intended; to work correctly, each node must have the [`--external-io-dir` flag](cockroach-start.html#general) point to the same NFS mount or other network-backed, shared storage.
+- <sup>5</sup>  <span class="version-tag">New in v20.1:</span> Using a `nodeID` is required and the data files will be in the `extern` directory of the specified node. In most cases (including single-node clusters), using `nodelocal://1/<path>` is sufficient. Use `self` if you do not want to specify a `nodeID`, and the individual data files will be in the `extern` directories of arbitrary nodes; however, to work correctly, each node must have the [`--external-io-dir` flag](cockroach-start.html#general) point to the same NFS mount or other network-backed, shared storage.
 
 - <sup>6</sup> A custom root CA can be appended to the system's default CAs by setting the `cloudstorage.http.custom_ca` [cluster setting](cluster-settings.html), which will be used when verifying certificates from an S3-compatible service.
 
@@ -43,4 +43,4 @@ Amazon S3    | `s3://acme-co/employees.sql?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCE
 Azure        | `azure://employees.sql?AZURE_ACCOUNT_KEY=123&AZURE_ACCOUNT_NAME=acme-co`         
 Google Cloud | `gs://acme-co/employees.sql`                                                     
 HTTP         | `http://localhost:8080/employees.sql`                                            
-NFS/Local    | `nodelocal:///path/employees`, `nodelocal://2/path/employees`&nbsp;[<sup>5</sup>](#considerations)
+NFS/Local    | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>5</sup>](#considerations)

--- a/v20.1/cockroach-commands.md
+++ b/v20.1/cockroach-commands.md
@@ -30,6 +30,7 @@ Command | Usage
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge multiple log files from different machines into a single stream.
 [`cockroach workload`](cockroach-workload.html) | Run a built-in load generator against a cluster.
+[`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) | <span class="version-tag">New in v20.1:</span> Upload a file to a node's local file system.
 
 ## Environment variables
 

--- a/v20.1/cockroach-commands.md
+++ b/v20.1/cockroach-commands.md
@@ -30,7 +30,7 @@ Command | Usage
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.
 [`cockroach debug merge-logs`](cockroach-debug-merge-logs.html) | Merge multiple log files from different machines into a single stream.
 [`cockroach workload`](cockroach-workload.html) | Run a built-in load generator against a cluster.
-[`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) | <span class="version-tag">New in v20.1:</span> Upload a file to a node's local file system.
+[`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) | <span class="version-tag">New in v20.1:</span> Upload a file to the `externalIODir` on a node's local file system.
 
 ## Environment variables
 

--- a/v20.1/cockroach-nodelocal-upload.md
+++ b/v20.1/cockroach-nodelocal-upload.md
@@ -1,0 +1,90 @@
+---
+title: cockroach nodelocal upload
+summary: Upload a file to a node's local file system.
+toc: true
+---
+
+<span class="version-tag">New in v20.1:</span> The `cockroach nodelocal upload` [command](cockroach-commands.html) uploads a file to a node's (the gateway node, by default) local file system.
+
+This command takes in a source file to upload and a destination filename. It will
+then use a SQL connection to upload the file to the node's local file system, at `externalIODir/destination/filename`.
+
+{{site.data.alerts.callout_info}}
+The source file is only uploaded to one node, not all of the nodes.
+{{site.data.alerts.end}}
+
+## Synopsis
+
+Upload a file:
+
+~~~ shell
+$ cockroach nodelocal upload <location/of/file> <destination/of/file> [flags]
+~~~
+
+View help:
+
+~~~ shell
+$ cockroach nodelocal upload --help
+~~~
+
+## Flags
+
+ Flag            | Description
+-----------------+-----------------------------------------------------
+`--certs-dir`    | The path to the [certificate directory](cockroach-cert.html) containing the CA and client certificates and client key.<br><br>**Env Variable:** `COCKROACH_CERTS_DIR`<br>**Default:** `${HOME}/.cockroach-certs/`
+`--echo-sql`     | Reveal the SQL statements sent implicitly by the command-line utility.
+`--host`         | The server host and port number to connect to. This can be the address of any node in the cluster. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
+`--insecure`     | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
+`--url`          | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments.<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL
+`--user`<br>`-u` | The [SQL user](create-user.html) that will own the client session.<br><br>**Env Variable:** `COCKROACH_USER`<br>**Default:** `root`
+
+## Examples
+
+### Upload a file
+
+To upload a file to the default node (i.e., the gateway node):
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach nodelocal upload ./grants.csv test/grants.csv --certs-dir=certs
+~~~
+
+~~~
+successfully uploaded to nodelocal://1/test/grants.csv
+~~~
+
+Then, you can use the file to [`IMPORT`](import.html) or [`IMPORT INTO`](import-into.html) data.
+
+### Upload a file to a specific node
+
+To upload a file to a specific node (e.g., node 2), use the `--host` flag:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach nodelocal upload ./grants.csv grants.csv --host=localhost:26259 --insecure
+~~~
+
+~~~
+successfully uploaded to nodelocal://2/grants.csv
+~~~
+
+Or, use the `--url` flag:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach nodelocal upload ./grants.csv grants.csv --url=postgresql://root@localhost:26258?sslmode=disable --insecure
+~~~
+
+~~~
+successfully uploaded to nodelocal://3/grants.csv
+~~~
+
+Then, you can use the file to [`IMPORT`](import.html) or [`IMPORT INTO`](import-into.html) data.
+
+## See also
+
+- [Other Cockroach Commands](cockroach-commands.html)
+- [Troubleshooting Overview](troubleshooting-overview.html)
+- [Import Data](import-data.html)
+- [`IMPORT`](import.html)
+- [`IMPORT INTO`](import-into.html)

--- a/v20.1/cockroach-nodelocal-upload.md
+++ b/v20.1/cockroach-nodelocal-upload.md
@@ -4,7 +4,7 @@ summary: Upload a file to a node's local file system.
 toc: true
 ---
 
-<span class="version-tag">New in v20.1:</span> The `cockroach nodelocal upload` [command](cockroach-commands.html) uploads a file to a node's (the gateway node, by default) local file system.
+<span class="version-tag">New in v20.1:</span> The `cockroach nodelocal upload` [command](cockroach-commands.html) uploads a file to the external IO directory on a node's (the gateway node, by default) local file system.
 
 This command takes in a source file to upload and a destination filename. It will
 then use a SQL connection to upload the file to the node's local file system, at `externalIODir/destination/filename`.
@@ -12,6 +12,14 @@ then use a SQL connection to upload the file to the node's local file system, at
 {{site.data.alerts.callout_info}}
 The source file is only uploaded to one node, not all of the nodes.
 {{site.data.alerts.end}}
+
+## Required privileges
+
+Only members of the `admin` role can run `cockroach nodelocal upload`. By default, the `root` user belongs to the `admin` role.
+
+## Considerations
+
+The node you're uploading to must not have external-io disabled.
 
 ## Synopsis
 

--- a/v20.1/import-into.md
+++ b/v20.1/import-into.md
@@ -100,7 +100,7 @@ To import a local file, you have the following options:
 - Option 2. Make the file accessible from each local node's store:
     1. Create an `extern` directory on each node's store. The pathname will differ depending on the [`--store` flag passed to `cockroach start` (if any)](cockroach-start.html#general), but will look something like `/path/to/cockroach-data/extern/`.
     2. Copy the file to each node's `extern` directory.
-    3. Assuming the file is called `data.sql`, you can access it in your `IMPORT` statement using the following [import file URL](#import-file-urls): `'nodelocal:///data.sql'`.
+    3. Assuming the file is called `data.sql`, you can access it in your `IMPORT` statement using the following [import file URL](#import-file-urls): `'nodelocal://1/data.sql'`.
 
 ## Performance
 

--- a/v20.1/import-into.md
+++ b/v20.1/import-into.md
@@ -89,18 +89,16 @@ On [`cockroach start`](cockroach-start.html), if you set `--max-disk-temp-storag
 
 ### Import file location
 
-We strongly recommend using cloud/remote storage (Amazon S3, Google Cloud Platform, etc.) for the data you want to import.
-
-Local files are supported; however, they must be accessible to all nodes in the cluster using identical [Import file URLs](#import-file-urls).
+We strongly recommend using cloud/remote storage (Amazon S3, Google Cloud Platform, etc.) for the data you want to import, but local files are supported as well.
 
 To import a local file, you have the following options:
 
 - Option 1. Run a [local file server](create-a-file-server.html) to make the file accessible from all nodes.
 
-- Option 2. Make the file accessible from each local node's store:
-    1. Create an `extern` directory on each node's store. The pathname will differ depending on the [`--store` flag passed to `cockroach start` (if any)](cockroach-start.html#general), but will look something like `/path/to/cockroach-data/extern/`.
-    2. Copy the file to each node's `extern` directory.
-    3. Assuming the file is called `data.sql`, you can access it in your `IMPORT` statement using the following [import file URL](#import-file-urls): `'nodelocal://1/data.sql'`.
+- Option 2. Make the file accessible from a local node's store. You can do this by using [`cockroach nodelocal upload`](cockroach-nodelocal-upload.html) or by manually placing the file in the `extern` directory:
+    1. Create an `extern` directory on a node's store. The pathname will differ depending on the [`--store` flag passed to `cockroach start` (if any)](cockroach-start.html#general), but will look something like `/path/to/cockroach-data/extern/`.
+    2. Copy the file to a node's `extern` directory.
+    3. Assuming the file is called `data.sql` and you uploaded it to node 1, you can access it in your `IMPORT` statement using the following [import file URL](#import-file-urls): `'nodelocal://1/data.sql'`.
 
 ## Performance
 

--- a/v20.1/import.md
+++ b/v20.1/import.md
@@ -159,7 +159,7 @@ To import a local file, you have the following options:
 - Option 2. Make the file accessible from each local node's store:
     1. Create an `extern` directory on each node's store. The pathname will differ depending on the [`--store` flag passed to `cockroach start` (if any)](cockroach-start.html#general), but will look something like `/path/to/cockroach-data/extern/`.
     2. Copy the file to each node's `extern` directory.
-    3. Assuming the file is called `data.sql`, you can access it in your `IMPORT` statement using the following [import file URL](#import-file-urls): `'nodelocal:///data.sql'`.
+    3. Assuming the file is called `data.sql`, you can access it in your `IMPORT` statement using the following [import file URL](#import-file-urls): `'nodelocal://1/data.sql'`.
 
 ### Table users and privileges
 

--- a/v20.1/show-backup.md
+++ b/v20.1/show-backup.md
@@ -68,7 +68,7 @@ You can add number of rows and the schema of the backed up table.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUP SCHEMAS 'nodelocal:///extern/employee.sql';
+> SHOW BACKUP SCHEMAS 'nodelocal://1/extern/employee.sql';
 ~~~
 
 ~~~


### PR DESCRIPTION
Changes:

- Added `cockroach-nodelocal-upload.md`, which explains the new command
- Added `cockroach nodelocal upload` to the sidebar nav
- Added `cockroach nodelocal upload` to `cockroach-commands.md`
- Updated existing nodelocal URI examples / notes to include a `nodeID`, which is now required

Closes #6010, #6788.