### PR TITLE
Document how to access secure Admin UI from Chrome

### DIFF
--- a/_includes/v19.1/misc/chrome-localhost.md
+++ b/_includes/v19.1/misc/chrome-localhost.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+If you are using Google Chrome as your browser, and you are getting an error about not being able to reach `localhost` because its certificate has been revoked, go to <a href="chrome://flags/#allow-insecure-localhost" data-proofer-ignore>chrome://flags/#allow-insecure-localhost</a>, enable "Allow invalid certificates for resources loaded from localhost", and then restart the browser. Enabling this Chrome feature degrades security for all sites running on `localhost`, not just CockroachDB's Admin UI, so be sure to enable the feature only temporarily.
+{{site.data.alerts.end}}

--- a/_includes/v19.1/orchestration/monitor-cluster.md
+++ b/_includes/v19.1/orchestration/monitor-cluster.md
@@ -26,6 +26,8 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
 2. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password you created earlier.
 
+    {% include {{ page.version.version }}/misc/chrome-localhost.md %}
+
 {% else %}
 
 2. Go to <a href="http://localhost:8080/" data-proofer-ignore>http://localhost:8080</a>.

--- a/_includes/v19.1/orchestration/test-cluster-secure.md
+++ b/_includes/v19.1/orchestration/test-cluster-secure.md
@@ -80,13 +80,14 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
       You will need this username and password to access the Admin UI later.
 
-5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 6. Exit the SQL shell and pod:
@@ -188,13 +189,14 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     You will need this username and password to access the Admin UI later.
 
-5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 6. Exit the SQL shell and pod:

--- a/_includes/v19.2/misc/chrome-localhost.md
+++ b/_includes/v19.2/misc/chrome-localhost.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+If you are using Google Chrome as your browser, and you are getting an error about not being able to reach `localhost` because its certificate has been revoked, go to <a href="chrome://flags/#allow-insecure-localhost" data-proofer-ignore>chrome://flags/#allow-insecure-localhost</a>, enable "Allow invalid certificates for resources loaded from localhost", and then restart the browser. Enabling this Chrome feature degrades security for all sites running on `localhost`, not just CockroachDB's Admin UI, so be sure to enable the feature only temporarily.
+{{site.data.alerts.end}}

--- a/_includes/v19.2/orchestration/monitor-cluster.md
+++ b/_includes/v19.2/orchestration/monitor-cluster.md
@@ -26,6 +26,8 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
 2. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password you created earlier.
 
+    {% include {{ page.version.version }}/misc/chrome-localhost.md %}
+
 {% else %}
 
 2. Go to <a href="http://localhost:8080/" data-proofer-ignore>http://localhost:8080</a>.

--- a/_includes/v19.2/orchestration/test-cluster-secure.md
+++ b/_includes/v19.2/orchestration/test-cluster-secure.md
@@ -88,13 +88,14 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
       You will need this username and password to access the Admin UI later.
 
-4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 5. Exit the SQL shell and pod:
@@ -196,13 +197,14 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     You will need this username and password to access the Admin UI later.
 
-5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 6. Exit the SQL shell and pod:

--- a/_includes/v20.1/misc/chrome-localhost.md
+++ b/_includes/v20.1/misc/chrome-localhost.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+If you are using Google Chrome as your browser, and you are getting an error about not being able to reach `localhost` because its certificate has been revoked, go to <a href="chrome://flags/#allow-insecure-localhost" data-proofer-ignore>chrome://flags/#allow-insecure-localhost</a>, enable "Allow invalid certificates for resources loaded from localhost", and then restart the browser. Enabling this Chrome feature degrades security for all sites running on `localhost`, not just CockroachDB's Admin UI, so be sure to enable the feature only temporarily.
+{{site.data.alerts.end}}

--- a/_includes/v20.1/orchestration/monitor-cluster.md
+++ b/_includes/v20.1/orchestration/monitor-cluster.md
@@ -26,6 +26,8 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
 2. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password you created earlier.
 
+    {% include {{ page.version.version }}/misc/chrome-localhost.md %}
+
 {% else %}
 
 2. Go to <a href="http://localhost:8080/" data-proofer-ignore>http://localhost:8080</a>.

--- a/_includes/v20.1/orchestration/test-cluster-secure.md
+++ b/_includes/v20.1/orchestration/test-cluster-secure.md
@@ -88,13 +88,14 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
       You will need this username and password to access the Admin UI later.
 
-4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 5. Exit the SQL shell and pod:
@@ -196,13 +197,14 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     You will need this username and password to access the Admin UI later.
 
-5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+5. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 6. Exit the SQL shell and pod:

--- a/v19.1/admin-ui-overview.md
+++ b/v19.1/admin-ui-overview.md
@@ -39,7 +39,7 @@ For security reasons, non-admin users access only the data over which they have 
 {{site.data.alerts.callout_info}}
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
-If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '\<sql_user\>', true)</code>
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '\<sql_user\>', true);</code>
 {{site.data.alerts.end}}
 
 Secure area | Privileged information

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -345,13 +345,14 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
       You will need this username and password to access the Admin UI in Step 4.
 
-4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 5. Exit the SQL shell and pod:

--- a/v19.1/secure-a-cluster.md
+++ b/v19.1/secure-a-cluster.md
@@ -218,13 +218,14 @@ Finally, [create a user with a password](create-user.html#create-a-user-with-a-p
 > CREATE USER roach WITH PASSWORD 'Q7gc8rEdS';
 ~~~
 
-On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
 Assign `max` to the `admin` role:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+> INSERT INTO system.role_members (role, member, "isAdmin")
+    VALUES ('admin', 'max', true);
 ~~~
 
 Exit the SQL shell on node 2:
@@ -234,11 +235,39 @@ Exit the SQL shell on node 2:
 > \q
 ~~~
 
+## Step 5. Access the Admin UI
+
+The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
+
+1. Go to <a href="https://localhost:8080" data-proofer-ignore>https://localhost:8080</a>. Note that your browser will consider the CockroachDB-created certificate invalid; you'll need to click through a warning message to get to the UI.
+
+    {% include {{ page.version.version }}/misc/chrome-localhost.md %}
+
+2. Log in with the username and password you created earlier (`max`/`roach`).
+
+3. On the [**Cluster Overview**](admin-ui-cluster-overview-page.html), notice that three nodes are live, with an identical replica count on each node:
+
+    <img src="{{ 'images/v20.1/admin_ui_cluster_overview_3_nodes.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
+
+    This demonstrates CockroachDB's [automated replication](demo-data-replication.html) of data via the Raft consensus protocol.    
+
+    {{site.data.alerts.callout_info}}
+    Capacity metrics can be incorrect when running multiple nodes on a single machine. For more details, see this [limitation](known-limitations.html#available-capacity-metric-in-the-admin-ui).
+    {{site.data.alerts.end}}
+
+4. Click [**Metrics**](admin-ui-overview-dashboard.html) to access a variety of time series dashboards, including graphs of SQL queries and service latency over time:
+
+    <img src="{{ 'images/v20.1/admin_ui_overview_dashboard_3_nodes.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
+
+5. Use the [**Databases**](admin-ui-databases-page.html), [**Statements**](admin-ui-statements-page.html), and [**Jobs**](admin-ui-jobs-page.html) pages to view details about your databases and tables, to assess the performance of specific queries, and to monitor the status of long-running operations like schema changes, respectively.
+
 ## Step 5. Monitor the cluster
 
-Access the [Admin UI](admin-ui-overview.html) for your cluster by pointing a browser to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>, or to the address in the `admin` field in the standard output of any node on startup. Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.
+Access the [Admin UI](admin-ui-overview.html) for your cluster by pointing a browser to <a href="https://localhost:8080" data-proofer-ignore>https://localhost:8080</a>, or to the address in the `admin` field in the standard output of any node on startup. Note that your browser will consider the CockroachDB-created certificate invalid; you’ll need to click through a warning message to get to the UI.
 
-Log in with the username and password created in the [Test the cluster](#step-4-test-the-cluster) step. Then click **Metrics** on the left-hand navigation bar.
+{% include {{ page.version.version }}/misc/chrome-localhost.md %}
+
+Log in with the username and password created earlier (`max`/`roach`). Then click **Metrics** on the left-hand navigation bar.
 
 <img src="{{ 'images/v19.1/admin_ui_overview_dashboard.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -347,13 +347,14 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
       You will need this username and password to access the Admin UI in Step 4.
 
-4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 5. Exit the SQL shell and pod:

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -250,13 +250,14 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > CREATE USER max WITH PASSWORD 'roach';
     ~~~
 
-6. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+6. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `max` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'max', true);
     ~~~
 
 7. Exit the SQL shell on node 2:
@@ -299,7 +300,9 @@ CockroachDB also comes with a number of [built-in workloads](cockroach-workload.
 
 The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
 
-1. Go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>. Note that your browser will consider the CockroachDB-created certificate invalid; you'll need to click through a warning message to get to the UI.
+1. Go to <a href="https://localhost:8080" data-proofer-ignore>https://localhost:8080</a>. Note that your browser will consider the CockroachDB-created certificate invalid; you'll need to click through a warning message to get to the UI.
+
+    {% include {{ page.version.version }}/misc/chrome-localhost.md %}
 
 2. Log in with the username and password you created earlier (`max`/`roach`).
 

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -347,13 +347,14 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
       You will need this username and password to access the Admin UI in Step 4.
 
-4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+4. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `roach` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'roach', true);
     ~~~
 
 5. Exit the SQL shell and pod:

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -250,13 +250,14 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > CREATE USER max WITH PASSWORD 'roach';
     ~~~
 
-6. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users. 
+6. On secure clusters, [certain pages of the Admin UI](admin-ui-overview.html#admin-ui-access) can only be accessed by `admin` users.
 
     Assign `max` to the `admin` role:
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true)
+    > INSERT INTO system.role_members (role, member, "isAdmin")
+        VALUES ('admin', 'max', true);
     ~~~
 
 7. Exit the SQL shell on node 2:
@@ -299,7 +300,9 @@ CockroachDB also comes with a number of [built-in workloads](cockroach-workload.
 
 The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.
 
-1. Go to <a href="http://localhost:8080" data-proofer-ignore>http://localhost:8080</a>. Note that your browser will consider the CockroachDB-created certificate invalid; you'll need to click through a warning message to get to the UI.
+1. Go to <a href="https://localhost:8080" data-proofer-ignore>https://localhost:8080</a>. Note that your browser will consider the CockroachDB-created certificate invalid; you'll need to click through a warning message to get to the UI.
+
+    {% include {{ page.version.version }}/misc/chrome-localhost.md %}
 
 2. Log in with the username and password you created earlier (`max`/`roach`).
 


### PR DESCRIPTION
- Add a callout about enabling a required Chrome setting.
  Made this an per-version include and included across
  all relevant pages.
- Add missing semicolon to SQL statement.

Fixes #6946.
Incorporates https://github.com/cockroachdb/docs/pull/6868.