### PR TITLE
PK changes doc update #2

### DIFF
--- a/v20.1/add-constraint.md
+++ b/v20.1/add-constraint.md
@@ -8,11 +8,11 @@ The `ADD CONSTRAINT` [statement](sql-statements.html) is part of `ALTER TABLE` a
 
 - [`UNIQUE`](#add-the-unique-constraint)
 - [`CHECK`](#add-the-check-constraint)
-- [Foreign key](#add-the-foreign-key-constraint-with-cascade)
+- [`FOREIGN KEY`](#add-the-foreign-key-constraint-with-cascade)
 
-{{site.data.alerts.callout_info}}
-The [`PRIMARY KEY`](primary-key.html) can only be applied through [`CREATE TABLE`](create-table.html). The [`DEFAULT`](default-value.html) and [`NOT NULL`](not-null.html) constraints are managed through [`ALTER COLUMN`](alter-column.html).
-{{site.data.alerts.end}}
+To add a primary key constraint to a table, you should explicitly define the primary key at [table creation](create-table.html). To replace an existing primary key, you can use `ADD CONSTRAINT ... PRIMARY KEY`. For details, see [Changing primary keys with `ADD CONSTRAINT ... PRIMARY KEY`](#changing-primary-keys-with-add-constraint-primary-key).
+
+The [`DEFAULT`](default-value.html) and [`NOT NULL`](not-null.html) constraints are managed through [`ALTER COLUMN`](alter-column.html).
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
 
@@ -38,7 +38,22 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
 {% include {{ page.version.version }}/misc/schema-change-view-job.md %}
 
+## Changing primary keys with `ADD CONSTRAINT ... PRIMARY KEY`
+
+<span class="version-tag">New in v20.1:</span> When you change a primary key with [`ALTER TABLE ... ALTER PRIMARY KEY`](alter-primary-key.html), the old primary key index becomes a secondary index. The secondary index created by `ALTER PRIMARY KEY` takes up node memory and can slow down write performance to a cluster. If you do not have queries that filter on the primary key that you are replacing, you can use `ADD CONSTRAINT` to replace the old primary index without creating a secondary index.
+
+`ADD CONSTRAINT ... PRIMARY KEY` can be used to add a primary key to an existing table if one of the following is true:
+
+  - No primary key was explicitly defined at [table creation](create-table.html). In this case, the table is created with a default [primary key on `rowid`](indexes.html#creation). Using `ADD CONSTRAINT ... PRIMARY KEY` drops the default primary key and replaces it with a new primary key.
+  - A [`DROP CONSTRAINT`](drop-constraint.html) statement precedes the `ADD CONSTRAINT ... PRIMARY KEY` statement, in the same transaction. For an example, see [Drop and add the primary key constraint](#drop-and-add-a-primary-key-constraint) below.
+
+{{site.data.alerts.callout_info}}
+`ALTER TABLE ... ADD PRIMARY KEY` is an alias for `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY`.
+{{site.data.alerts.end}}
+
 ## Examples
+
+{% include {{page.version.version}}/sql/movr-statements.md %}
 
 ### Add the `UNIQUE` constraint
 
@@ -46,7 +61,7 @@ Adding the [`UNIQUE` constraint](unique.html) requires that all of a column's va
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> ALTER TABLE orders ADD CONSTRAINT id_customer_unique UNIQUE (id, customer);
+> ALTER TABLE users ADD CONSTRAINT id_name_unique UNIQUE (id, name);
 ~~~
 
 ### Add the `CHECK` constraint
@@ -55,7 +70,7 @@ Adding the [`CHECK` constraint](check.html) requires that all of a column's valu
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> ALTER TABLE orders ADD CONSTRAINT check_id_non_zero CHECK (id > 0);
+> ALTER TABLE rides ADD CONSTRAINT check_revenue_positive CHECK (revenue >= 0);
 ~~~
 
 Check constraints can be added to columns that were created earlier in the transaction. For example:
@@ -63,8 +78,8 @@ Check constraints can be added to columns that were created earlier in the trans
 {% include copy-clipboard.html %}
 ~~~ sql
 > BEGIN;
-> ALTER TABLE customers ADD COLUMN gdpr_status STRING;
-> ALTER TABLE customers ADD CONSTRAINT check_gdpr_status CHECK (gdpr_status IN ('yes', 'no', 'unknown'));
+> ALTER TABLE users ADD COLUMN is_owner STRING;
+> ALTER TABLE users ADD CONSTRAINT check_is_owner CHECK (is_owner IN ('yes', 'no', 'unknown'));
 > COMMIT;
 ~~~
 
@@ -86,42 +101,48 @@ The entire transaction will be rolled back, including any new columns that were 
 
 To add a foreign key constraint, use the steps shown below.
 
-Given two tables, `customers` and `orders`:
+Given two tables, `users` and `vehicles`, without foreign key constraints:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW CREATE customers;
+> SHOW CREATE users;
 ~~~
 
 ~~~
- table_name |                  create_statement
-------------+----------------------------------------------------
- customers  | CREATE TABLE customers (                          +
-            |         id INT8 NOT NULL,                         +
-            |         name STRING NOT NULL,                     +
-            |         address STRING NULL,                      +
-            |         CONSTRAINT "primary" PRIMARY KEY (id ASC),+
-            |         FAMILY "primary" (id, name, address)      +
-            | )
+  table_name |                      create_statement
+-------------+--------------------------------------------------------------
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | )
 (1 row)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW CREATE orders;
+> SHOW CREATE vehicles;
 ~~~
 
 ~~~
- table_name |                                                create_statement
-------------+----------------------------------------------------------------------------------------------------------------
- orders     | CREATE TABLE orders (                                                                                         +
-            |         id INT8 NOT NULL,                                                                                     +
-            |         customer_id INT8 NULL,                                                                                +
-            |         status STRING NOT NULL,                                                                               +
-            |         CONSTRAINT "primary" PRIMARY KEY (id ASC),                                                            +
-            |         FAMILY "primary" (id, customer_id, status),                                                           +
-            |         CONSTRAINT check_status CHECK (status IN ('open':::STRING, 'complete':::STRING, 'cancelled':::STRING))+
-            | )
+  table_name |                                       create_statement
+-------------+------------------------------------------------------------------------------------------------
+  vehicles   | CREATE TABLE vehicles (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     type VARCHAR NULL,
+             |     owner_id UUID NULL,
+             |     creation_time TIMESTAMP NULL,
+             |     status VARCHAR NULL,
+             |     current_location VARCHAR NULL,
+             |     ext JSONB NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, type, owner_id, creation_time, status, current_location, ext)
+             | )
 (1 row)
 ~~~
 
@@ -135,28 +156,97 @@ Using `ON DELETE CASCADE` will ensure that when the referenced row is deleted, a
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> ALTER TABLE orders ADD CONSTRAINT customer_fk FOREIGN KEY (customer_id) REFERENCES customers (id) ON DELETE CASCADE;
+> ALTER TABLE vehicles ADD CONSTRAINT users_fk FOREIGN KEY (city, owner_id) REFERENCES users (city, id) ON DELETE CASCADE;
 ~~~
 
 An index on the referencing columns is automatically created for you when you add a foreign key constraint to an empty table, if an appropriate index does not already exist. You can see it using [`SHOW INDEXES`](show-index.html):
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW INDEXES FROM orders;
+> SHOW INDEXES FROM vehicles;
 ~~~
 
 ~~~
- table_name |          index_name           | non_unique | seq_in_index | column_name | direction | storing | implicit
-------------+-------------------------------+------------+--------------+-------------+-----------+---------+----------
- orders     | primary                       | f          |            1 | id          | ASC       | f       | f
- orders     | orders_auto_index_customer_fk | t          |            1 | customer_id | ASC       | f       | f
- orders     | orders_auto_index_customer_fk | t          |            2 | id          | ASC       | f       | t
-(3 rows)
+  table_name |          index_name          | non_unique | seq_in_index | column_name | direction | storing | implicit
+-------------+------------------------------+------------+--------------+-------------+-----------+---------+-----------
+  vehicles   | primary                      |   false    |            1 | city        | ASC       |  false  |  false
+  vehicles   | primary                      |   false    |            2 | id          | ASC       |  false  |  false
+  vehicles   | vehicles_auto_index_users_fk |    true    |            1 | city        | ASC       |  false  |  false
+  vehicles   | vehicles_auto_index_users_fk |    true    |            2 | owner_id    | ASC       |  false  |  false
+  vehicles   | vehicles_auto_index_users_fk |    true    |            3 | id          | ASC       |  false  |   true
+(5 rows)
 ~~~
 
 {{site.data.alerts.callout_info}}
 Adding a foreign key for a non-empty table without an appropriate index will fail, since foreign key columns must be indexed. For more information about the requirements for creating foreign keys, see [Rules for creating foreign keys](foreign-key.html#rules-for-creating-foreign-keys).
 {{site.data.alerts.end}}
+
+### Drop and add a primary key constraint
+
+Suppose that you want to add `name` to the composite primary key of the `users` table, [without creating a secondary index of the existing primary key](#changing-primary-keys-with-add-constraint-primary-key).
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TABLE users;
+~~~
+
+~~~
+  table_name |                      create_statement
+-------------+--------------------------------------------------------------
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | )
+(1 row)
+~~~
+
+First, add a [`NOT NULL`](not-null.html) constraint to the `name` column with [`ALTER COLUMN`](alter-column.html).
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE users ALTER COLUMN name SET NOT NULL;
+~~~
+
+Then, in the same transaction, [`DROP`](drop-constraint.html) the old `"primary"` constraint and `ADD` the new one:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BEGIN;
+> ALTER TABLE users DROP CONSTRAINT "primary";
+> ALTER TABLE users ADD CONSTRAINT "primary" PRIMARY KEY (city, name, id);
+> COMMIT;
+~~~
+
+~~~
+NOTICE: primary key changes are finalized asynchronously; further schema changes on this table may be restricted until the job completes
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TABLE users;
+~~~
+
+~~~
+  table_name |                          create_statement
+-------------+---------------------------------------------------------------------
+  users      | CREATE TABLE users (
+             |     id UUID NOT NULL,
+             |     city VARCHAR NOT NULL,
+             |     name VARCHAR NOT NULL,
+             |     address VARCHAR NULL,
+             |     credit_card VARCHAR NULL,
+             |     CONSTRAINT "primary" PRIMARY KEY (city ASC, name ASC, id ASC),
+             |     FAMILY "primary" (id, city, name, address, credit_card)
+             | )
+(1 row)
+~~~
+
+Using [`ALTER PRIMARY KEY`](alter-primary-key.html) would have created a `UNIQUE` secondary index called `users_city_id_key`. Instead, there is just one index for the primary key constraint.
 
 ## See also
 
@@ -170,3 +260,4 @@ Adding a foreign key for a non-empty table without an appropriate index will fai
 - [`CREATE TABLE`](create-table.html)
 - [`ALTER TABLE`](alter-table.html)
 - [`SHOW JOBS`](show-jobs.html)
+- ['ALTER PRIMARY KEY'](alter-primary-key.html)

--- a/v20.1/alter-primary-key.md
+++ b/v20.1/alter-primary-key.md
@@ -6,15 +6,17 @@ toc: true
 
  <span class="version-tag">New in v20.1:</span> The `ALTER PRIMARY KEY` [statement](sql-statements.html) is a subcommand of [`ALTER TABLE`](alter-table.html) that can be used to change the [primary key](primary-key.html) of a table.
 
- When you change a primary key with `ALTER PRIMARY KEY`, the old primary key index becomes a secondary index. This helps optimize the performance of queries that still filter on the old primary key column.
-
 ## Details
 
-- You cannot change the primary key of a table that is currently undergoing a primary key change.
-
-- Primary key changes on a table must be in a separate transaction from that table's [`CREATE TABLE`](create-table.html) statement.
+- You cannot change the primary key of a table that is currently undergoing a primary key change, or any other [schema change](online-schema-changes.html).
 
 - `ALTER PRIMARY KEY` might need to rewrite multiple indexes, which can make it an expensive operation.
+
+-  When you change a primary key with `ALTER PRIMARY KEY`, the old primary key index becomes a secondary index. This helps optimize the performance of queries that still filter on the old primary key column.
+
+  {{site.data.alerts.callout_info}}
+  The secondary index created by `ALTER PRIMARY KEY` takes up node memory and can slow down write performance to a cluster. If you do not have queries that filter on the primary key that you are replacing, you can use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key) to change an existing primary key without creating a secondary index. For examples, see the [`ADD CONSTRAINT`](add-constraint.html#examples) and [`DROP CONSTRAINT`](drop-constraint.html#examples) pages.
+  {{site.data.alerts.end}}
 
 ## Synopsis
 
@@ -86,7 +88,7 @@ You can add a column and change the primary key with a couple of `ALTER TABLE` s
 (1 row)
 ~~~
 
-Note that the old primary key index becomes a secondary index, in this case, `users_name_key`.
+Note that the old primary key index becomes a secondary index, in this case, `users_name_key`. If you do not want the old primary key to become a secondary index when changing a primary key, you can use [`DROP CONSTRAINT`](drop-constraint.html)/[`ADD CONSTRAINT`](add-constraint.html) instead.
 
 ### Make a single-column primary key composite for geo-partitioning
 
@@ -102,7 +104,7 @@ Suppose that you are storing the data for users of your application in a table c
 );
 ~~~
 
-Now suppose that you want to expand your business from a single region into multiple regions. After you [deploy your application in multiple regions](topology-patterns.html), you consider [geo-partitioning your data](topology-geo-partitioned-replicas.html) to minimize latency and optimize performance. In order to geo-partition the `user` database, you need to add a column specifies the location of the data (e.g., `region`):
+Now suppose that you want to expand your business from a single region into multiple regions. After you [deploy your application in multiple regions](topology-patterns.html), you consider [geo-partitioning your data](topology-geo-partitioned-replicas.html) to minimize latency and optimize performance. In order to geo-partition the `user` database, you need to add a column specifying the location of the data (e.g., `region`):
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.1/create-table.md
+++ b/v20.1/create-table.md
@@ -106,6 +106,10 @@ CockroachDB allows [enterprise users](enterprise-licensing.html) to [define tabl
 
 In this example, we create the `users` table with a single [primary key](primary-key.html) column defined. In CockroachDB, every table requires a [primary key](primary-key.html). If one is not explicitly defined, a column called `rowid` of the type `INT` is added automatically as the primary key, with the `unique_rowid()` function used to ensure that new rows always default to unique `rowid` values. The primary key is automatically indexed.
 
+{{site.data.alerts.callout_info}}
+ <span class="version-tag">New in v20.1:</span> If no primary key is explicitly defined in a `CREATE TABLE` statement, you can add a primary key to the table with [`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html) or [`ALTER PRIMARY KEY`](alter-primary-key.html). If the `ADD` or `ALTER` statement follows the `CREATE TABLE` statement, and is part of the same transaction, no default primary key will be created. If the table has already been created and the transaction committed, the `ADD` or `ALTER` statements replace the default primary key.
+ {{site.data.alerts.end}}
+
 {{site.data.alerts.callout_info}}Strictly speaking, a primary key's unique index is not created; it is derived from the key(s) under which the data is stored, so it takes no additional space. However, it appears as a normal unique index when using commands like <code>SHOW INDEX</code>.{{site.data.alerts.end}}
 
 {% include copy-clipboard.html %}

--- a/v20.1/indexes.md
+++ b/v20.1/indexes.md
@@ -82,6 +82,7 @@ When designing indexes, it's important to consider which columns you index and t
 - Columns filtered in the `WHERE` clause with the equality operators (`=` or `IN`) should come first in the index, before those referenced with inequality operators (`<`, `>`).
 - Indexes of the same columns in different orders can produce different results for each query. For more information, see [our blog post on index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/)&mdash;specifically the section "Restricting the search space."
 - Avoid indexing on sequential values. Writes to indexes with sequential keys can result in range hotspots that negatively affect performance. Instead, use [randomly generated unique IDs](performance-best-practices-overview.html#unique-id-best-practices), or [multi-column keys](performance-best-practices-overview.html#use-multi-column-primary-keys).
+- Avoid creating secondary indexes that you do not need, as they can slow down write performance and take up node memory. For example, if you want to [change a primary key](constraints.html#change-constraints), and you do not plan to filter queries on the old primary key column(s), do not use [`ALTER PRIMARY KEY`](alter-primary-key.html), which creates a secondary index from the old primary key. Instead, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key), which does not create a secondary index.
 
 ### Storing columns
 

--- a/v20.1/online-schema-changes.md
+++ b/v20.1/online-schema-changes.md
@@ -21,6 +21,10 @@ Schema changes consume additional resources, and if they are run when the cluste
 Support for schema changes within [transactions][txns] is [limited](#limitations). We recommend doing schema changes outside transactions where possible. When a schema management tool uses transactions on your behalf, we recommend only doing one schema change operation per transaction.
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_info}}
+You cannot start an online schema change on a table if a [primary key change](alter-primary-key.html) is currently in progress on the same table.
+{{site.data.alerts.end}}
+
 ## How online schema changes work
 
 At a high level, online schema changes are accomplished by using a bridging strategy involving concurrent uses of multiple versions of the schema. The process is as follows:

--- a/v20.1/primary-key.md
+++ b/v20.1/primary-key.md
@@ -6,9 +6,11 @@ toc: true
 
 The `PRIMARY KEY` [constraint](constraints.html) specifies that the constrained columns' values must uniquely identify each row.
 
-Unlike other constraints which have very specific uses, the `PRIMARY KEY` constraint *should be used for every table* because it provides an intrinsic structure to the table's data. This both makes it easier to understand, as well as improving query performance.
+Unlike other constraints which have very specific uses, the `PRIMARY KEY` constraint *must be used for every table* because it provides an intrinsic structure to the table's data. This both makes it easier to understand, as well as improving query performance.
 
-A table's primary key can be specified in the [`CREATE TABLE`](create-table.html) statement, or using [`ALTER TABLE ... ALTER PRIMARY KEY`](alter-primary-key.html), after the table is created.
+A table's primary key should be explicitly defined in the [`CREATE TABLE`](create-table.html) statement.
+
+<span class="version-tag">New in v20.1:</span> You can change the primary key of an existing table with an [`ALTER TABLE ... ALTER PRIMARY KEY`](alter-primary-key.html) statement, or by using [`DROP CONSTRAINT`](drop-constraint.html) and then [`ADD CONSTRAINT`](add-constraint.html) in the same transaction. For more information, see [Details](#details).
 
 ## Details
 
@@ -26,7 +28,14 @@ A table's primary key can be specified in the [`CREATE TABLE`](create-table.html
 
     If you create a table without defining a primary key, CockroachDB uses a unique identifier for each row, which it then uses for the `primary` index. Because you cannot meaningfully use this unique row identifier column to filter table data, it does not offer any performance optimization. This means you will always have improved performance by defining a primary key for a table. For more information, see our blog post [Index Selection in CockroachDB](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/).
 
-- You can change the primary key of a table using the [`ALTER PRIMARY KEY`](alter-primary-key.html) subcommand in an [`ALTER TABLE`](alter-table.html) statement.
+- <span class="version-tag">New in v20.1:</span> You can change the primary key of an existing table by doing one of the following:
+
+  - Issuing an [`ALTER TABLE ... ALTER PRIMARY KEY`](alter-primary-key.html) statement. When you change a primary key with `ALTER PRIMARY KEY`, the old primary key index becomes a secondary index. This helps optimize the performance of queries that still filter on the old primary key column.
+  - Issuing an [`ALTER TABLE ... DROP CONSTRAINT ... PRIMARY KEY`](drop-constraint.html) statement to drop the primary key, followed by an [`ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html) statement, in the same transaction, to add a new primary key. This replaces the existing primary key without creating a secondary index from the old primary key. For examples, see the [`ADD CONSTRAINT`](add-constraint.html#examples) and [`DROP CONSTRAINT`](drop-constraint.html#examples) pages.
+
+  {{site.data.alerts.callout_info}}
+  You can use an [`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html) statement without a [`DROP CONSTRAINT ... PRIMARY KEY`](drop-constraint.html) if the primary key was not explicitly defined at [table creation](create-table.html), and the current [primary key is on `rowid`](indexes.html#creation).
+  {{site.data.alerts.end}}
 
 ## Syntax
 


### PR DESCRIPTION
Fixes #6914 
Fixes #6912 
Fixes #6911 
Fixes #6904 
Fixes #6975.

This PR covers a few things:
- Updated examples in `ADD CONSTRAINT` docs.
- Updated examples in `DROP CONSTRAINT` docs.
- Added note to `ADD CONSTRAINT` docs about adding primary key in case of `DROP CONSTRAINT` or default primary key on `rowid`. Note that we want to discourage users from not explicitly defining a PK, so the second stipulation isn't explored in detail or with examples.
- Added note about no concurrent PK/schema changes to both `ALTER PRIMARY KEY` and online schema changes docs.
- Added `ADD PRIMARY KEY` to `ALTER TABLE` subcommands table as an alias for `ADD CONSTRAINT ... PRIMARY KEY`.
- Added note to `ADD CONSTRAINT` page about `ADD PRIMARY KEY` being alias.