### PR TITLE
Vectorized execution support for disk-spilling operators

### DIFF
--- a/_includes/v19.2/sql/disk-spilling-ops.md
+++ b/_includes/v19.2/sql/disk-spilling-ops.md
@@ -1,7 +1,7 @@
-- Global [sorts](query-order.html).
-- [Window functions](window-functions.html).
-- [Unordered aggregations](query-order.html#processing-order-during-aggregations).
-- [Hash joins](joins.html#hash-joins).
+- Global [sorts](query-order.html)
+- [Window functions](window-functions.html)
+- [Unordered aggregations](query-order.html#processing-order-during-aggregations)
+- [Hash joins](joins.html#hash-joins)
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 
-These operations require [memory buffering](https://en.wikipedia.org/wiki/Data_buffer) during execution, and are therefore prone to spilling intermediate execution results to disk. We do not recommend using vectorized execution in production environments for operations that could spill to disk, as these operations can buffer an unlimited number of rows before they can start producing output, causing memory issues.
+During the execution of these operations, some intermediate results are written to an [in-memory data buffer](https://en.wikipedia.org/wiki/Data_buffer). In CockroachDB v19.2, the vectorized engine does not spill the contents of intermediate data buffers to disk. As a result, memory-intensive queries can buffer an unlimited quantity of data in memory and lead to memory issues.

--- a/_includes/v20.1/misc/session-vars.html
+++ b/_includes/v20.1/misc/session-vars.html
@@ -368,7 +368,7 @@
    <td>
     <code>vectorize</code>
    </td>
-   <td>The vectorized execution engine mode. Options include <code>auto</code>, <code>experimental_on</code>, and <code>off</code>.
+   <td>The vectorized execution engine mode. Options include <code>auto</code>, <code>on</code>, and <code>off</code>.
      For more details, see <a href="vectorized-execution.html#configuring-vectorized-execution">Configuring vectorized execution for CockroachDB</a>.
    </td>
    <td>

--- a/_includes/v20.1/sql/disk-spilling-ops.md
+++ b/_includes/v20.1/sql/disk-spilling-ops.md
@@ -1,6 +1,0 @@
-- Global [sorts](query-order.html).
-- [Window functions](window-functions.html).
-- [Hash joins](joins.html#hash-joins).
-- [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
-
-These operations require [memory buffering](https://en.wikipedia.org/wiki/Data_buffer) during execution, and are therefore prone to spilling intermediate execution results to disk. We do not recommend using vectorized execution in production environments for operations that could spill to disk, as these operations can buffer an unlimited number of rows before they can start producing output, causing memory issues.

--- a/v19.2/experimental-features.md
+++ b/v19.2/experimental-features.md
@@ -134,9 +134,9 @@ The table below lists the experimental SQL functions and operators available in 
 | [`experimental_strptime`](functions-and-operators.html#date-and-time-functions)  | Format time using standard `strptime` notation. |
 | [`experimental_uuid_v4()`](functions-and-operators.html#id-generation-functions) | Return a UUID.                                  |
 
-## Vectorized execution on disk-spilling operations
+## Vectorized execution on memory-intensive operations
 
-[Vectorized query execution](vectorized-execution.html) in CockroachDB is experimental for the following [disk-spilling operations](vectorized-execution.html#disk-spilling-operations):
+[Vectorized query execution](vectorized-execution.html) in CockroachDB is experimental for the following [memory-intensive operations](vectorized-execution.html#memory-intensive-operations):
 
 {% include {{page.version.version}}/sql/disk-spilling-ops.md %}
 

--- a/v19.2/explain.md
+++ b/v19.2/explain.md
@@ -18,7 +18,7 @@ Using `EXPLAIN`'s output, you can optimize your queries by taking the following 
 
 - Avoid scanning an entire table, which is the slowest way to access data. You can avoid this by [creating indexes](indexes.html) that contain at least one of the columns that the query is filtering in its `WHERE` clause.
 
-- <span class="version-tag">New in v19.2:</span> By default, the [vectorized execution](vectorized-execution.html) engine is enabled for all [supported operations](vectorized-execution.html#disk-spilling-operations) and [data types](vectorized-execution.html#supported-data-types). If you are querying a table with a small number of rows, it might be more efficient to use row-oriented execution. The `vectorize_row_count_threshold` [cluster setting](cluster-settings.html) specifies the minimum number of rows required to use the vectorized engine to execute a query plan.
+- <span class="version-tag">New in v19.2:</span> By default, the [vectorized execution](vectorized-execution.html) engine is enabled for all [supported operations](vectorized-execution.html#memory-intensive-operations) and [data types](vectorized-execution.html#supported-data-types). If you are querying a table with a small number of rows, it might be more efficient to use row-oriented execution. The `vectorize_row_count_threshold` [cluster setting](cluster-settings.html) specifies the minimum number of rows required to use the vectorized engine to execute a query plan.
 
 You can find out if your queries are performing entire table scans by using `EXPLAIN` to see which:
 

--- a/v19.2/known-limitations.md
+++ b/v19.2/known-limitations.md
@@ -29,7 +29,7 @@ An `x` value less than `1` would result in the following error:
 pq: check constraint violated
 ~~~
 
-[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/35370)
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/35370)
 
 ## Unresolved limitations
 
@@ -39,7 +39,7 @@ The [`COMMENT ON`](comment-on.html) statement associates comments to databases, 
 
 As a workaround, alongside a `BACKUP`, run the [`cockroach dump`](cockroach-dump.html) command with `--dump-mode=schema` for each table in the backup. This will emit `COMMENT ON` statements alongside `CREATE` statements.
 
-[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/44396)
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/44396)
 
 ### Adding stores to a node
 
@@ -59,7 +59,7 @@ Once restarted, monitor the Replica Quiescence graph on the [**Replication Dashb
 
 Once in a stable state, the risk of this issue recurring can be mitigated by increasing your [`range_max_bytes`](configure-zone.html#variables) to 134217728 (128MiB). We always recommend testing changes to `range_max_bytes` in a development environment before making changes on production.
 
-[Tracking Github Issue](https://github.com/cockroachdb/cockroach/issues/39117)
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/39117)
 
 ### Requests to restarted node in need of snapshots may hang
 

--- a/v19.2/vectorized-execution.md
+++ b/v19.2/vectorized-execution.md
@@ -8,19 +8,27 @@ toc: true
 
 Many SQL databases execute [query plans](https://en.wikipedia.org/wiki/Query_plan) one row of table data at a time. Row-oriented execution models can offer good performance for [online transaction processing (OLTP)](https://en.wikipedia.org/wiki/Online_transaction_processing) queries, but suboptimal performance for [online analytical processing (OLAP)](https://en.wikipedia.org/wiki/Online_analytical_processing) queries. The CockroachDB vectorized execution engine dramatically improves performance over [row-oriented execution](https://en.wikipedia.org/wiki/Column-oriented_DBMS#Row-oriented_systems) by processing each component of a query plan on type-specific batches of column data.
 
+{{site.data.alerts.callout_info}}
+CockroachDB does not support vectorized execution for all data types. For details, see [supported data types](#supported-data-types).
+{{site.data.alerts.end}}
+
 ## Configuring vectorized execution
 
-By default, vectorized execution is enabled in CockroachDB for [all operations that are guaranteed to execute in memory](#disk-spilling-operations), on tables with [supported data types](#supported-data-types).
+By default, vectorized execution is enabled in CockroachDB for [all queries that are guaranteed to execute in memory](#memory-intensive-operations), on tables with [supported data types](#supported-data-types).
 
-You can turn vectorized execution on or off for all operations in the current session with the `vectorize` [session variable](set-vars.html). The following options are supported:
+You can turn vectorized execution on or off for all queries in the current session with the `vectorize` [session variable](set-vars.html). The following options are supported:
 
 Option | Description
 ----------|------------
-`auto` | Instructs CockroachDB to use the vectorized execution engine on operations that always execute in memory, without the need to spill intermediate results to disk.<br><br>**Default:** `vectorize=auto`
-`experimental_on` | Turns on vectorized execution for all operations. We do not recommend using this option in production environments, as it can lead to memory issues.<br/>See [Known Limitations](#known-limitations) for more information.
-`off` | Turns off vectorized execution for all operations.
+`auto` | Instructs CockroachDB to use the vectorized execution engine on most queries that execute in memory, without the need to spill intermediate results to disk. See [Memory-intensive operations](#memory-intensive-operations) for more information.<br><br>**Default:** `vectorize=auto`
+`experimental_on` | Turns on vectorized execution for all supported queries. We do not recommend using this option in production environments, as it can lead to memory issues.<br/>See [Known limitations](#known-limitations) for more information.
+`off` | Turns off vectorized execution for all queries.
 
 For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
+
+{{site.data.alerts.callout_success}}
+CockroachDB supports vectorized execution on columns with [supported data types](#supported-data-types) only. Setting the `vectorize` session variable to `experimental_on` does not turn vectorized execution on for queries on columns with unsupported data types.
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_success}}
 To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
@@ -76,13 +84,13 @@ For example, `SELECT x IS NOT NULL FROM t` is supported, but `SELECT x + NULL FR
 
 For more information, see the [tracking issue](https://github.com/cockroachdb/cockroach/issues/41001).
 
-### Disk-spilling operations
+### Memory-intensive operations
 
 Support for vectorized execution is experimental for the following memory-intensive operations:
 
 {% include {{page.version.version}}/sql/disk-spilling-ops.md %}
 
-You can configure a node's budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If a SQL query exceeds the memory budget, the node spills intermediate execution results to disk. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity.
+We do not recommend using vectorized execution in production environments for memory-intensive queries that cannot spill to disk. Executing these queries with the vectorized execution engine (i.e., with the `vectorize` [session variable](set-vars.html) set to `experimental_on`) can cause CockroachDB nodes to run out of memory and crash.
 
 ## See also
 

--- a/v20.1/experimental-features.md
+++ b/v20.1/experimental-features.md
@@ -135,13 +135,6 @@ The table below lists the experimental SQL functions and operators available in 
 | [`experimental_strptime`](functions-and-operators.html#date-and-time-functions)  | Format time using standard `strptime` notation. |
 | [`experimental_uuid_v4()`](functions-and-operators.html#id-generation-functions) | Return a UUID.                                  |
 
-## Vectorized execution on disk-spilling operations
-
-[Vectorized query execution](vectorized-execution.html) in CockroachDB is experimental for the following [disk-spilling operations](vectorized-execution.html#disk-spilling-operations):
-
-{% include {{page.version.version}}/sql/disk-spilling-ops.md %}
-
-To turn vectorized execution on for all operations, set the `vectorize` [session variable](set-vars.html) to `experimental_on`.
 
 ## Temporary objects
 
@@ -158,4 +151,3 @@ To turn vectorized execution on for all operations, set the `vectorize` [session
 - [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html)
 - [`SHOW TRACE FOR SESSION`](show-trace.html)
 - [`SHOW RANGE ... FOR ROW`](show-range-for-row.html)
-- [Vectorized Query Execution](vectorized-execution.html)

--- a/v20.1/vectorized-execution.md
+++ b/v20.1/vectorized-execution.md
@@ -8,19 +8,27 @@ CockroachDB supports [column-oriented](https://en.wikipedia.org/wiki/Column-orie
 
 Many SQL databases execute [query plans](https://en.wikipedia.org/wiki/Query_plan) one row of table data at a time. Row-oriented execution models can offer good performance for [online transaction processing (OLTP)](https://en.wikipedia.org/wiki/Online_transaction_processing) queries, but suboptimal performance for [online analytical processing (OLAP)](https://en.wikipedia.org/wiki/Online_analytical_processing) queries. The CockroachDB vectorized execution engine dramatically improves performance over [row-oriented execution](https://en.wikipedia.org/wiki/Column-oriented_DBMS#Row-oriented_systems) by processing each component of a query plan on type-specific batches of column data.
 
+{{site.data.alerts.callout_info}}
+CockroachDB does not support vectorized execution for all data types. For details, see [supported data types](#supported-data-types).
+{{site.data.alerts.end}}
+
 ## Configuring vectorized execution
 
-By default, vectorized execution is enabled in CockroachDB for [all operations that are guaranteed to execute in memory](#disk-spilling-operations), on tables with [supported data types](#supported-data-types).
+By default, vectorized execution is enabled in CockroachDB for [all queries that are guaranteed to execute in memory](#disk-spilling-operations), on tables with [supported data types](#supported-data-types).
 
-You can turn vectorized execution on or off for all operations in the current session with the `vectorize` [session variable](set-vars.html). The following options are supported:
+You can turn vectorized execution on or off for all queries in the current session with the `vectorize` [session variable](set-vars.html). The following options are supported:
 
-Option | Description
+Option    | Description
 ----------|------------
-`auto` | Instructs CockroachDB to use the vectorized execution engine on operations that always execute in memory, without the need to spill intermediate results to disk.<br><br>**Default:** `vectorize=auto`
-`experimental_on` | Turns on vectorized execution for all operations. We do not recommend using this option in production environments, as it can lead to memory issues.<br/>See [Known Limitations](#known-limitations) for more information.
-`off` | Turns off vectorized execution for all operations.
+`auto` | Instructs CockroachDB to use the vectorized execution engine on most queries that execute in memory, without the need to [spill intermediate results to disk](#disk-spilling-operations).<br><br>**Default:** `vectorize=auto`
+`on`   | Turns on vectorized execution for all supported queries.
+`off`  | Turns off vectorized execution for all queries.
 
 For information about setting session variables, see [`SET` &lt;session variable&gt;](set-vars.html).
+
+{{site.data.alerts.callout_success}}
+CockroachDB supports vectorized execution on columns with [supported data types](#supported-data-types) only. Setting the `vectorize` session variable to `on` does not turn vectorized execution on for queries on columns with unsupported data types.
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_success}}
 To see if CockroachDB will use the vectorized execution engine for a query, run a simple [`EXPLAIN`](explain.html) statement on the query. If `vectorize` is `true`, the query will be executed with the vectorized engine. If it is `false`, the row-oriented execution engine is used instead.
@@ -32,7 +40,7 @@ The efficiency of vectorized execution increases with the number of rows process
 
 By default, vectorized execution is enabled for queries on tables of 1000 rows or more. If the number of rows in a table falls below 1000, CockroachDB uses the row-oriented execution engine instead.
 
-For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan in the current session with the `vectorize_row_count_threshold` [session variable](set-vars.html). This variable is ignored if `vectorize=experimental_on`.
+For performance tuning, you can change the minimum number of rows required to use the vectorized engine to execute a query plan in the current session with the `vectorize_row_count_threshold` [session variable](set-vars.html). This variable is ignored if `vectorize=on`.
 
 ## How vectorized execution works
 
@@ -46,11 +54,23 @@ For information about vectorized execution in the context of the CockroachDB arc
 
 For detailed examples of vectorized query execution for hash and merge joins, see the blog posts [40x faster hash joiner with vectorized execution](https://www.cockroachlabs.com/blog/vectorized-hash-joiner/) and [Vectorizing the merge joiner in CockroachDB](https://www.cockroachlabs.com/blog/vectorizing-the-merge-joiner-in-cockroachdb/).
 
-## Known limitations
+## Disk-spilling operations
 
-Vectorized execution is not as extensively tested as CockroachDB's existing row-oriented execution engine. In addition, some data types are not supported, and support for some operations is experimental.
+By default, vectorized execution is disabled for the following memory-intensive operations:
 
-### Supported data types
+- Global [sorts](query-order.html)
+- [Window functions](window-functions.html)
+- [Unordered aggregations](query-order.html#processing-order-during-aggregations)
+- [Hash joins](joins.html#hash-joins)
+- [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
+
+To turn vectorized execution on for these operations, set the `vectorize` [session variable](set-vars.html) to `on`.
+
+These operations require [memory buffering](https://en.wikipedia.org/wiki/Data_buffer) during execution. If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk. By default, the memory limit allocated per operator is 64MiB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
+
+You can also configure a node's total budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If the queries running on the node exceed the memory budget, the node spills intermediate execution results to disk. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity. If the maximum on-disk storage capacity is reached, the query will return an error during execution.
+
+## Supported data types
 
 Vectorized execution is supported for the following [data types](data-types.html) and their aliases:
 
@@ -69,6 +89,8 @@ Vectorized execution is supported for the following [data types](data-types.html
 CockroachDB uses the vectorized engine to execute queries on columns with supported data types, even if a column's parent table includes unused columns with unsupported data types.
 {{site.data.alerts.end}}
 
+## Known limitations
+
 ### Queries with constant `NULL` arguments
 
 The vectorized execution engine does not support queries that contain constant `NULL` arguments, with the exception of the `IS` projection operators `IS NULL` and `IS NOT NULL`.
@@ -76,14 +98,6 @@ The vectorized execution engine does not support queries that contain constant `
 For example, `SELECT x IS NOT NULL FROM t` is supported, but `SELECT x + NULL FROM t` returns an `unable to vectorize execution plan` error.
 
 For more information, see the [tracking issue](https://github.com/cockroachdb/cockroach/issues/41001).
-
-### Disk-spilling operations
-
-Support for vectorized execution is experimental for the following memory-intensive operations:
-
-{% include {{page.version.version}}/sql/disk-spilling-ops.md %}
-
-You can configure a node's budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If a SQL query exceeds the memory budget, the node spills intermediate execution results to disk. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity.
 
 ## See also
 


### PR DESCRIPTION
Fixes #5968.
Fixes #6203. 
Fixes #6922. 
Fixes #6924.
Fixes #6905.
Fixes #6618.
Fixes #6621.
Fixes #6979.
Fixes #7141.

- Updated `vectorize` settings on 20.1 Vectorized Execution doc page and Session Variables table.
- Added notes to Window Functions and Selection Queries pages about experimental support in vectorized.
- Updated 20.1 Vectorized Execution page for clarity, accuracy around disk-spilling support.
- Updated 19.2 Vectorized Execution page for clarity.