### PR TITLE
Schema change jobs

### DIFF
--- a/_includes/v20.1/known-limitations/schema-change-ddl-inside-multi-statement-transactions.md
+++ b/_includes/v20.1/known-limitations/schema-change-ddl-inside-multi-statement-transactions.md
@@ -1,6 +1,6 @@
 Schema change [DDL](https://en.wikipedia.org/wiki/Data_definition_language#ALTER_statement) statements that run inside a multi-statement transaction with non-DDL statements can fail at [`COMMIT`](commit-transaction.html) time, even if other statements in the transaction succeed.  This leaves such transactions in a "partially committed, partially aborted" state that may require manual intervention to determine whether the DDL statements succeeded.
 
-<span class="version-tag">New in v19.2:</span> If such a failure occurs, CockroachDB will emit a new CockroachDB-specific error code, `XXA00`, and the following error message:
+If such a failure occurs, CockroachDB will emit a new CockroachDB-specific error code, `XXA00`, and the following error message:
 
 ```
 transaction committed but schema change aborted with error: <description of error>

--- a/_includes/v20.1/known-limitations/schema-changes-within-transactions.md
+++ b/_includes/v20.1/known-limitations/schema-changes-within-transactions.md
@@ -1,10 +1,12 @@
 Within a single [transaction](transactions.html):
 
 - DDL statements cannot be mixed with DML statements. As a workaround, you can split the statements into separate transactions. For more details, [see examples of unsupported statements](online-schema-changes.html#examples-of-statements-that-fail).
-- A [`CREATE TABLE`](create-table.html) statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
+- As of version v2.1, you can run schema changes inside the same transaction as a [`CREATE TABLE`](create-table.html) statement. For more information, [see this example](online-schema-changes.html#run-schema-changes-inside-a-transaction-with-create-table).
+- A `CREATE TABLE` statement containing [`FOREIGN KEY`](foreign-key.html) or [`INTERLEAVE`](interleave-in-parent.html) clauses cannot be followed by statements that reference the new table.
 - A table cannot be dropped and then recreated with the same name. This is not possible within a single transaction because `DROP TABLE` does not immediately drop the name of the table. As a workaround, split the [`DROP TABLE`](drop-table.html) and [`CREATE TABLE`](create-table.html) statements into separate transactions.
-- [Schema change DDL statements inside a multi-statement transaction can fail while other statements succeed](#schema-change-ddl-statements-inside-a-multi-statement-transaction-can-fail-while-other-statements-succeed)
+- [Schema change DDL statements inside a multi-statement transaction can fail while other statements succeed](#schema-change-ddl-statements-inside-a-multi-statement-transaction-can-fail-while-other-statements-succeed).
+- As of v19.1, some schema changes can be used in combination in a single `ALTER TABLE` statement. For a list of commands that can be combined, see [`ALTER TABLE`](alter-table.html). For a demonstration, see [Add and rename columns atomically](rename-column.html#add-and-rename-columns-atomically).
 
-{{site.data.alerts.callout_success}}
-As of version v2.1, you can run schema changes inside the same transaction as a `CREATE TABLE` statement. For more information, [see this example](online-schema-changes.html#run-schema-changes-inside-a-transaction-with-create-table). Also, as of v19.1, some schema changes can be used in combination in a single `ALTER TABLE` statement. For a list of commands that can be combined, see [`ALTER TABLE`](alter-table.html). For a demonstration, see [Add and rename columns atomically](rename-column.html#add-and-rename-columns-atomically).
+{{site.data.alerts.callout_info}}
+If a schema change within a transaction fails, manual intervention may be needed to determine which has failed. After determining which schema change(s) failed, you can then retry the schema changes.
 {{site.data.alerts.end}}

--- a/v20.1/cancel-job.md
+++ b/v20.1/cancel-job.md
@@ -4,8 +4,7 @@ summary: The CANCEL JOB statement stops long-running jobs.
 toc: true
 ---
 
-The `CANCEL JOB` [statement](sql-statements.html) lets you stop long-running jobs, which include [`IMPORT`](import.html) jobs, enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs, schema changes, [user-created table statistics](create-statistics.html) jobs, [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and [changefeeds](change-data-capture.html).
-
+The `CANCEL JOB` [statement](sql-statements.html) lets you stop long-running jobs, which include [`IMPORT`](import.html) jobs, enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs, schema changes, [user-created table statistics](create-statistics.html) jobs, [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, [changefeeds](change-data-capture.html), and [schema change](online-schema-changes.html) jobs.
 
 ## Limitations
 

--- a/v20.1/online-schema-changes.md
+++ b/v20.1/online-schema-changes.md
@@ -31,7 +31,7 @@ At a high level, online schema changes are accomplished by using a bridging stra
 
 1. A user initiates a schema change by executing [`ALTER TABLE`][alter-table], [`CREATE INDEX`][create-index], [`TRUNCATE`][truncate], etc.
 
-2. The schema change engine converts the original schema to the new schema in discrete steps while ensuring that the underlying table data is always in a consistent state. These changes are executed as a [background job][show-jobs].
+2. The schema change engine converts the original schema to the new schema in discrete steps while ensuring that the underlying table data is always in a consistent state. These changes are executed as a [background job][show-jobs], and can be [paused](pause-job.html), [resumed](resume-job.html), and [canceled](cancel-job.html).
 
 This approach allows the schema change engine to roll out a new schema while the previous version is still in use. It then backfills or deletes the underlying table data as needed in the background, while the cluster is still running and servicing reads and writes from your application.
 
@@ -40,6 +40,10 @@ During the backfilling process, the schema change engine updates the underlying 
 Once backfilling is complete, all nodes will switch over to the new schema, and will allow reads and writes of the table using the new schema.
 
 For more technical details, see [How online schema changes are possible in CockroachDB][blog].
+
+{{site.data.alerts.callout_info}}
+If a schema change fails, the schema change job will be cleaned up automatically. However, there are limitations with rolling back schema changes within a transaction; for more information, [see below](#schema-change-ddl-statements-inside-a-multi-statement-transaction-can-fail-while-other-statements-succeed).
+{{site.data.alerts.end}}
 
 ## Examples
 
@@ -112,6 +116,8 @@ You can check on the status of the schema change jobs on your system at any time
 +--------------------+---------------+-----------------------------------------------------------------------------+-----------+-----------+----------------------------+----------------------------+----------------------------+----------------------------+--------------------+-------+----------------+
 (1 row)
 ~~~
+
+All schema change jobs can be [paused](pause-job.html), [resumed](resume-job.html), and [canceled](cancel-job.html).
 
 ## Limitations
 

--- a/v20.1/pause-job.md
+++ b/v20.1/pause-job.md
@@ -4,11 +4,9 @@ summary: The PAUSE JOB statement lets you temporarily halt the process of potent
 toc: true
 ---
 
-The `PAUSE JOB` [statement](sql-statements.html) lets you pause [`IMPORT`](import.html) jobs, enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs, [user-created table statistics](create-statistics.html) jobs, [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, and [`changefeeds`](change-data-capture.html).
+The `PAUSE JOB` [statement](sql-statements.html) lets you pause [`IMPORT`](import.html) jobs, enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs, [user-created table statistics](create-statistics.html) jobs, [automatic table statistics](cost-based-optimizer.html#table-statistics) jobs, [`changefeeds`](change-data-capture.html), and [schema change](online-schema-changes.html) jobs.
 
 After pausing jobs, you can resume them with [`RESUME JOB`](resume-job.html).
-
-{{site.data.alerts.callout_info}}You cannot pause schema changes.{{site.data.alerts.end}}
 
 ## Required privileges
 

--- a/v20.1/resume-job.md
+++ b/v20.1/resume-job.md
@@ -4,10 +4,7 @@ summary: The RESUME JOB statement lets you resume jobs that were previously paus
 toc: true
 ---
 
- The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html) [`IMPORT`](import.html) jobs, enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs, and [`changefeeds`](change-data-capture.html).
-
-{{site.data.alerts.callout_info}}You cannot pause schema changes.{{site.data.alerts.end}}
-
+ The `RESUME JOB` [statement](sql-statements.html) lets you resume [paused](pause-job.html) [`IMPORT`](import.html) jobs, enterprise [`BACKUP`](backup.html) and [`RESTORE`](restore.html) jobs, [`changefeeds`](change-data-capture.html), and [schema change](online-schema-changes.html) jobs.
 
 ## Required privileges
 

--- a/v20.1/show-jobs.md
+++ b/v20.1/show-jobs.md
@@ -6,7 +6,7 @@ toc: true
 
 The `SHOW JOBS` [statement](sql-statements.html) lists all of the types of long-running tasks your cluster has performed in the last 12 hours, including:
 
-- Schema changes through [`ALTER TABLE`](alter-table.html), [`DROP DATABASE`](drop-database.html), [`DROP TABLE`](drop-table.html), and [`TRUNCATE`](truncate.html).
+- Most [schema changes](online-schema-changes.html)
 - Enterprise [`BACKUP`](backup.html), [`RESTORE`](restore.html), and [`IMPORT`](import.html).
 - [User-created table statistics](create-statistics.html) created for use by the [cost-based optimizer](cost-based-optimizer.html).
 - The [automatic table statistics](cost-based-optimizer.html#table-statistics) are not displayed on running the `SHOW JOBS` statement. To view the automatic table statistics, use `SHOW AUTOMATIC JOBS`.
@@ -21,6 +21,7 @@ To block a call to `SHOW JOBS` that returns after all specified job ID(s) have a
 - For jobs older than 12 hours, query the `crdb_internal.jobs` table.
 - Jobs are deleted after 14 days. This interval can be changed via the `jobs.retention_time` [cluster setting](cluster-settings.html).
 - While the `SHOW JOBS WHEN COMPLETE` statement is blocking, it will time out after 24 hours.
+- <span class="version-tag">New in v20.1:</span> Garbage collection jobs are created for [dropped tables](drop-table.html) and [dropped indexes](drop-index.html), and will execute after the [GC TTL](configure-replication-zones.html#replication-zone-variables) has elapsed (default is 25 hours). These jobs cannot be canceled.
 
 ## Required privileges
 
@@ -138,6 +139,8 @@ You can show just schema change jobs by using `SHOW JOBS` as the data source for
 +---------------+-----------------+----------------------------------------------------+...
  27536791415282 |  SCHEMA CHANGE  | ALTER TABLE test.public.foo ADD COLUMN bar VARCHAR |...
 ~~~
+
+<span class="version-tag">New in v20.1:</span> [Scheme change](online-schema-changes.html) jobs can be [paused](pause-job.html), [resumed](resume-job.html), and [canceled](cancel-job.html).
 
 ### Show job when complete
 


### PR DESCRIPTION
- All schema changes are now run as jobs and can be paused, resumed, and 
canceled (Closes #6894, #6017)
- Clarify what happens if a schema change fails (Closes #5044)