### PR TITLE
update Admin UI security 'workaround'

### DIFF
--- a/_includes/v19.1/orchestration/test-cluster-secure.md
+++ b/_includes/v19.1/orchestration/test-cluster-secure.md
@@ -95,10 +95,6 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     ~~~ sql
     > \q
     ~~~
-
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](orchestrate-cockroachdb-with-kubernetes.html#step-5-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
@@ -207,10 +203,6 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     ~~~ sql
     > \q
     ~~~
-
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](orchestrate-cockroachdb-with-kubernetes.html#step-5-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
 </section>
 
 {{site.data.alerts.callout_success}}

--- a/_includes/v19.1/orchestration/test-cluster-secure.md
+++ b/_includes/v19.1/orchestration/test-cluster-secure.md
@@ -86,7 +86,7 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 6. Exit the SQL shell and pod:
@@ -198,7 +198,7 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 6. Exit the SQL shell and pod:

--- a/_includes/v19.2/orchestration/test-cluster-secure.md
+++ b/_includes/v19.2/orchestration/test-cluster-secure.md
@@ -103,10 +103,6 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     ~~~ sql
     > \q
     ~~~
-
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](orchestrate-cockroachdb-with-kubernetes.html#step-5-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
@@ -215,10 +211,6 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     ~~~ sql
     > \q
     ~~~
-
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](orchestrate-cockroachdb-with-kubernetes.html#step-5-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
 </section>
 
 {{site.data.alerts.callout_success}}

--- a/_includes/v19.2/orchestration/test-cluster-secure.md
+++ b/_includes/v19.2/orchestration/test-cluster-secure.md
@@ -94,7 +94,7 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 5. Exit the SQL shell and pod:
@@ -206,7 +206,7 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 6. Exit the SQL shell and pod:

--- a/_includes/v20.1/orchestration/test-cluster-secure.md
+++ b/_includes/v20.1/orchestration/test-cluster-secure.md
@@ -103,10 +103,6 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     ~~~ sql
     > \q
     ~~~
-
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](orchestrate-cockroachdb-with-kubernetes.html#step-5-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
@@ -215,10 +211,6 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
     ~~~ sql
     > \q
     ~~~
-
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](orchestrate-cockroachdb-with-kubernetes.html#step-5-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
 </section>
 
 {{site.data.alerts.callout_success}}

--- a/_includes/v20.1/orchestration/test-cluster-secure.md
+++ b/_includes/v20.1/orchestration/test-cluster-secure.md
@@ -94,7 +94,7 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 5. Exit the SQL shell and pod:
@@ -206,7 +206,7 @@ To use the built-in SQL client, you need to launch a pod that runs indefinitely 
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 6. Exit the SQL shell and pod:

--- a/v19.1/admin-ui-overview.md
+++ b/v19.1/admin-ui-overview.md
@@ -40,8 +40,6 @@ For security reasons, non-admin users access only the data over which they have 
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
 If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">GRANT admin TO \<sql_user\>;</code>
-
-Note that you may need to restart a node for new `admin` roles to take effect.
 {{site.data.alerts.end}}
 
 Secure area | Privileged information

--- a/v19.1/admin-ui-overview.md
+++ b/v19.1/admin-ui-overview.md
@@ -39,7 +39,7 @@ For security reasons, non-admin users access only the data over which they have 
 {{site.data.alerts.callout_info}}
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
-If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '\<sql_user\>', true);</code>
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">GRANT admin TO \<sql_user\>;</code>
 
 Note that you may need to restart a node for new `admin` roles to take effect.
 {{site.data.alerts.end}}

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -351,7 +351,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 5. Exit the SQL shell and pod:

--- a/v19.1/secure-a-cluster.md
+++ b/v19.1/secure-a-cluster.md
@@ -234,10 +234,6 @@ Exit the SQL shell on node 2:
 > \q
 ~~~
 
-    {{site.data.alerts.callout_info}}
-    You may need to restart a node for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
-
 ## Step 5. Access the Admin UI
 
 The CockroachDB [Admin UI](admin-ui-overview.html) gives you insight into the overall health of your cluster as well as the performance of the client workload.

--- a/v19.1/secure-a-cluster.md
+++ b/v19.1/secure-a-cluster.md
@@ -224,7 +224,7 @@ Assign `max` to the `admin` role:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true);
+> GRANT admin TO max;
 ~~~
 
 Exit the SQL shell on node 2:

--- a/v19.2/admin-ui-overview.md
+++ b/v19.2/admin-ui-overview.md
@@ -40,8 +40,6 @@ For security reasons, non-admin users access only the data over which they have 
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
 If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">GRANT admin TO \<sql_user\>;</code>
-
-Note that you may need to restart a node for new `admin` roles to take effect.
 {{site.data.alerts.end}}
 
 Secure area | Privileged information

--- a/v19.2/admin-ui-overview.md
+++ b/v19.2/admin-ui-overview.md
@@ -39,7 +39,7 @@ For security reasons, non-admin users access only the data over which they have 
 {{site.data.alerts.callout_info}}
 The default `root` user is a member of the `admin` role, but on CockroachDB clusters prior to v20.1, the Admin UI cannot be accessed by `root`. To access the secure Admin UI areas, [grant a user membership to the `admin` role](grant-roles.html) using an [enterprise license](enterprise-licensing.html#obtain-a-license) (a trial license can be used).
 
-If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', '\<sql_user\>', true);</code>
+If you don't have an enterprise license, use this command to manually create a secondary `admin` user: <code style="white-space:pre-wrap">GRANT admin TO \<sql_user\>;</code>
 
 Note that you may need to restart a node for new `admin` roles to take effect.
 {{site.data.alerts.end}}

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -353,7 +353,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 5. Exit the SQL shell and pod:

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -266,10 +266,6 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > \q
     ~~~
 
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](#step-6-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
-
 ## Step 4. Run a sample workload
 
 CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -256,7 +256,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true);
+    > GRANT admin TO max;
     ~~~
 
 7. Exit the SQL shell on node 2:

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -353,7 +353,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'roach', true);
+    > GRANT admin TO roach;
     ~~~
 
 5. Exit the SQL shell and pod:

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -266,10 +266,6 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
     > \q
     ~~~
 
-    {{site.data.alerts.callout_info}}
-    You may need to [restart a node](#step-6-simulate-node-failure) for new `admin` roles to take effect.
-    {{site.data.alerts.end}}
-
 ## Step 4. Run a sample workload
 
 CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -256,7 +256,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > INSERT INTO system.role_members (role, member, "isAdmin") VALUES ('admin', 'max', true);
+    > GRANT admin TO max;
     ~~~
 
 7. Exit the SQL shell on node 2:


### PR DESCRIPTION
Updates the documented access workaround to use `GRANT role` rather than `INSERT INTO`.

Fixes #6649 