### PR TITLE
fix 20.1 roles link

### DIFF
--- a/releases/v20.1.0-beta.3.md
+++ b/releases/v20.1.0-beta.3.md
@@ -63,7 +63,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-beta.3
 - [Usernames](../v20.1/create-user.html) can now contain periods, for compatibility with certificate managers that require domain names to be used as usernames. [#45575][#45575] {% comment %}doc{% endcomment %}
 - User and role principals can now be prevented from logging in using the `NOLOGIN` attribute, which can be set using the [`CREATE USER/ROLE`](../v20.1/create-user.html) or [`ALTER USER/ROLE`](../v20.1/alter-user.html). When using the [`CREATE ROLE`](../v20.1/create-user.html) syntax, `NOLOGIN` is enabled by default whereas when using [`CREATE USER`](../v20.1/create-role.html), it is not. [#45541][#45541] {% comment %}doc{% endcomment %}
 - The `CREATEROLE` option can now be granted to users/roles using [`CREATE USER/ROLE`](../v20.1/create-user.html) or [`ALTER USER/ROLE`](../v20.1/alter-user.html). This delegates the permission to create additional roles. [#44232][#44232] {% comment %}doc{% endcomment %}
-- Any [role](../v20.1/roles.html) created prior to v20.1 will be able to log into clusters started with `--insecure`, unless/until they are given the `NOLOGIN` attribute. For secure clusters, roles cannot log in by virtue of not having a password nor a client certificate. [#45541][#45541] {% comment %}doc{% endcomment %}
+- Any [role](../v20.1/authorization.html#roles) created prior to v20.1 will be able to log into clusters started with `--insecure`, unless/until they are given the `NOLOGIN` attribute. For secure clusters, roles cannot log in by virtue of not having a password nor a client certificate. [#45541][#45541] {% comment %}doc{% endcomment %}
 
 #### Authentication changes
 


### PR DESCRIPTION
Changed a link to a page that was removed for the 20.1 RBAC change.