### PR TITLE
Update google api client for docs_csat script

### DIFF
--- a/scripts/docs_csat.py
+++ b/scripts/docs_csat.py
@@ -17,7 +17,7 @@ Requirements:
 """
 
 
-from apiclient.discovery import build
+from googleapiclient.discovery import build
 import argparse
 from oauth2client.service_account import ServiceAccountCredentials
 import os


### PR DESCRIPTION
apiclient was the original name of the library.
At some point, it was switched over to be googleapiclient.