### PR TITLE
Fix typos

### DIFF
--- a/_includes/v19.2/start-in-docker/mac-linux-steps.md
+++ b/_includes/v19.2/start-in-docker/mac-linux-steps.md
@@ -176,7 +176,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 4. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/_includes/v20.1/start-in-docker/mac-linux-steps.md
+++ b/_includes/v20.1/start-in-docker/mac-linux-steps.md
@@ -176,7 +176,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 4. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/v19.2/secure-a-cluster.md
+++ b/v19.2/secure-a-cluster.md
@@ -268,7 +268,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 4. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/v19.2/start-a-local-cluster-in-docker-windows.md
+++ b/v19.2/start-a-local-cluster-in-docker-windows.md
@@ -175,7 +175,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 4. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/v19.2/start-a-local-cluster.md
+++ b/v19.2/start-a-local-cluster.md
@@ -215,7 +215,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 3. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -268,7 +268,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 4. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/v20.1/start-a-local-cluster-in-docker-windows.md
+++ b/v20.1/start-a-local-cluster-in-docker-windows.md
@@ -175,7 +175,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 4. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 

--- a/v20.1/start-a-local-cluster.md
+++ b/v20.1/start-a-local-cluster.md
@@ -215,7 +215,7 @@ Now that your cluster is live, you can use any node as a SQL gateway. To test th
 
 ## Step 3. Run a sample workload
 
-CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
+CockroachDB also comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. Let's run the workload based on CockroachDB's sample vehicle-sharing application, [MovR](movr.html).
 
 1. Load the initial dataset:
 


### PR DESCRIPTION
Change `Let's the workload` to `Let's run the workload`