### PR TITLE
Encrypted BACKUP

### DIFF
--- a/_includes/v20.1/backups/encrypted-backup-description.md
+++ b/_includes/v20.1/backups/encrypted-backup-description.md
@@ -1,0 +1,11 @@
+<span class="version-tag">New in v20.1:</span> You can encrypt full or incremental backups by using the [`encryption_passphrase` option](backup.html#with-encryption-passphrase). Files written by the backup (including `BACKUP` manifests and data files) are encrypted using the specified passphrase to derive a key. To restore the encrypted backup, the same `encryption_passphrase` option (with the same passphrase) must included in the [`RESTORE`](restore.html) statement.
+
+When used with [incremental backups](backup.html#incremental-backups), the `encryption_passphrase` option is applied to all the [backup file URLs](backup.html#backup-file-urls), which means the same passphrase must be used when appending another incremental backup to an existing backup. Similarly, when used with [locality-aware backups](backup.html#create-locality-aware-backups), the passphrase provided is applied to files in all localities.
+
+Encryption is done using [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode), and GCM is used to both encrypt and authenticate the files. A random [salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) is used to derive a once-per-backup [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) key from the specified passphrase, and then a random [initialization vector](https://en.wikipedia.org/wiki/Initialization_vector) is used per-file. CockroachDB uses [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) with 64,000 iterations for the key derivation.
+
+{{site.data.alerts.callout_info}}
+`BACKUP` and `RESTORE` will use more memory when using encryption, as both the plain-text and cipher-text of a given file are held in memory during encryption and decryption.
+{{site.data.alerts.end}}
+
+For an example of an encrypted backup, see [Create encrypted backups](backup.html#create-an-encrypted-backup).

--- a/v20.1/backup.md
+++ b/v20.1/backup.md
@@ -16,7 +16,7 @@ Because CockroachDB is designed with high fault tolerance, these backups are des
 
 ### Backup targets
 
-<span class="version-tag">New in v20.1</span> You can backup a full cluster, which includes:
+<span class="version-tag">New in v20.1:</span> You can backup a full cluster, which includes:
 
 - All user tables
 - Relevant system tables
@@ -55,13 +55,15 @@ Full backups contain an unreplicated copy of your data and can always be used to
 
 #### Incremental backups
 
-Incremental backups are smaller and faster to produce than full backups because they contain only the data that has changed since a base set of backups you specify (which must include one full backup, and can include many incremental backups). You can take incremental backups either as of a given timestamp or with full [revision history](backup.html#backups-with-revision-history).
+Incremental backups are smaller and faster to produce than full backups because they contain only the data that has changed since a base set of backups you specify (which must include one full backup, and can include many incremental backups). You can take incremental backups either as of a given timestamp or with full [revision history](#backups-with-revision-history).
 
 {{site.data.alerts.callout_danger}}
 Incremental backups can only be created within the garbage collection period of the base backup's most recent timestamp. This is because incremental backups are created by finding which data has been created or modified since the most recent timestamp in the base backup––that timestamp data, though, is deleted by the garbage collection process.
 
 You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html).
 {{site.data.alerts.end}}
+
+For an example of an incremental backup, see the [Create incremental backups](#create-incremental-backups) section.
 
 ### Backups with revision history
 
@@ -71,6 +73,10 @@ You can create full or incremental backups [with revision history](#with-revisio
 - Taking incremental backups with revision history allows you to back up every change made since the last backup and within the garbage collection period leading up to and including the given timestamp. You can take incremental backups with revision history even when your previous full or incremental backups were taken without revision history.
 
 You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html). Taking backups with revision history allows for point-in-time restores within the revision history.
+
+### Encrypted backups
+
+{% include {{ page.version.version }}/backups/encrypted-backup-description.md %}
 
 ## Performance
 
@@ -115,14 +121,21 @@ If initiated correctly, the statement returns when the backup is finished or if 
 `table_pattern` | The table(s) or [view(s)](views.html) you want to back up.
 `database_name` | The name of the database(s) you want to back up (i.e., create backups of all tables and views in the database).|
 `destination` | The URL where you want to store the backup.<br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls).
-`AS OF SYSTEM TIME timestamp` | Back up data as it existed as of [`timestamp`](as-of-system-time.html). The `timestamp` must be more recent than your cluster's last garbage collection (which defaults to occur every 25 hours, but is [configurable per table](configure-replication-zones.html#replication-zone-variables)).
-`INCREMENTAL FROM full_backup_location` | Create an incremental backup using the full backup stored at the URL `full_backup_location` as its base. For information about this URL structure, see [Backup File URLs](#backup-file-urls).<br><br>**Note:** It is not possible to create an incremental backup if one or more tables were [created](create-table.html), [dropped](drop-table.html), or [truncated](truncate.html) after the full backup. In this case, you must create a new [full backup](#full-backups).
+`timestamp` | Back up data as it existed as of [`timestamp`](as-of-system-time.html). The `timestamp` must be more recent than your cluster's last garbage collection (which defaults to occur every 25 hours, but is [configurable per table](configure-replication-zones.html#replication-zone-variables)).
+`full_backup_location` | Create an incremental backup using the full backup stored at the URL `full_backup_location` as its base. For information about this URL structure, see [Backup File URLs](#backup-file-urls).<br><br>**Note:** It is not possible to create an incremental backup if one or more tables were [created](create-table.html), [dropped](drop-table.html), or [truncated](truncate.html) after the full backup. In this case, you must create a new [full backup](#full-backups).
 `incremental_backup_location` | Create an incremental backup that includes all backups listed at the provided URLs. <br/><br/>Lists of incremental backups must be sorted from oldest to newest. The newest incremental backup's timestamp must be within the table's garbage collection period. <br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). <br/><br/>For more information about garbage collection, see [Configure Replication Zones](configure-replication-zones.html#replication-zone-variables).
-`WITH revision_history`<a name="with-revision-history"></a> | Create a backup with full [revision history](#backups-with-revision-history), which records every change made to the cluster within the garbage collection period leading up to and including the given timestamp.
+`kv_option_list` | Control the backup behavior with [these options](#options).
 
 {{site.data.alerts.callout_info}}
 The `BACKUP` statement cannot be used within a [transaction](transactions.html).
 {{site.data.alerts.end}}
+
+## Options
+
+ Option                                                          | Value                   | Description
+-----------------------------------------------------------------+-------------------------+------------------------------
+`revision_history`<a name="with-revision-history"></a>           | N/A                     | Create a backup with full [revision history](#backups-with-revision-history), which records every change made to the cluster within the garbage collection period leading up to and including the given timestamp.
+`encryption_passphrase`<a name="with-encryption-passphrase"></a> | [`STRING`](string.html) | <span class="version-tag">New in v20.1:</span> The passphrase used to encrypt the files (`BACKUP` manifest and data files) that the `BACKUP` statement generates. This same passphrase is needed to decrypt the file when it is used to [restore](restore.html).
 
 ## Required privileges
 
@@ -140,7 +153,7 @@ Per our guidance in the [Performance](#performance) section, we recommend starti
 
 ### Backup a cluster
 
-<span class="version-tag">New in v20.1</span> To backup a full cluster:
+<span class="version-tag">New in v20.1:</span> To backup a full cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -187,7 +200,7 @@ AS OF SYSTEM TIME '-10s' WITH revision_history;
 
 ### Create incremental backups
 
-<span class="version-tag">New in v20.1</span> If you backup to a destination already containing a backup, an incremental backup will be produced in a subdirectory with a date-based name (e.g., `destination/day/time_1`, `destination/day/time_2`):
+<span class="version-tag">New in v20.1:</span> If you backup to a destination already containing a backup, an incremental backup will be produced in a subdirectory with a date-based name (e.g., `destination/day/time_1`, `destination/day/time_2`):
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -303,6 +316,38 @@ INCREMENTAL FROM
 {{site.data.alerts.callout_info}}
 Note that only the backup URIs you set as the `default` when you created the previous backup(s) are needed in the `INCREMENTAL FROM` clause of your incremental `BACKUP` statement (as shown in the example). This is because the `default` destination for a locality-aware backup contains a manifest file that contains all the metadata required to create additional incremental backups based on it.
 {{site.data.alerts.end}}
+
+### Create an encrypted backup
+
+<span class="version-tag">New in v20.1:</span> To create an [encrypted backup](#encrypted-backups), use the `encryption_passphrase` option:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543214409874014209 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+To [restore](restore.html), use the same `encryption_passphrase`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
 
 ## See also
 

--- a/v20.1/encryption.md
+++ b/v20.1/encryption.md
@@ -203,13 +203,11 @@ To disable encryption, specify `key=plain`. The data keys will be stored in plai
 To rotate keys, specify `key=/path/to/my/new-aes-128.key` and `old-key=/path/to/my/old-aes-128.key`. The data keys
 will be decrypted using the old key and then encrypted using the new key. A new data key will also be generated.
 
+## Encrypted backups (Enterprise)
+
+{% include {{ page.version.version }}/backups/encrypted-backup-description.md %}
+
 ## Encryption caveats
-
-### Unencrypted backups
-
-Backups taken with the `BACKUP` statement are not encrypted even if Encryption at Rest is enabled. Encryption at Rest only applies to the CockroachDB node's data on the local disk. If you want encrypted backups, you will need to encrypt your backup files using your preferred encryption method.
-
-A workaround for the issue is to use a cloud storage provider that is configured to transparently encrypt your data (e.g., AWS S3 default encryption).
 
 ### Higher CPU utilization
 

--- a/v20.1/restore.md
+++ b/v20.1/restore.md
@@ -18,13 +18,13 @@ Because CockroachDB is designed with high fault tolerance, restores are designed
 
 You can restore:
 
-- <span class="version-tag">New in v20.1</span> [A full cluster](#full-cluster)
+- <span class="version-tag">New in v20.1:</span> [A full cluster](#full-cluster)
 - [Databases](#databases)
 - [Tables](#tables)
 
 #### Full cluster
 
-<span class="version-tag">New in v20.1</span> You can restore a full cluster, which includes:
+<span class="version-tag">New in v20.1:</span> You can restore a full cluster, which includes:
 
 - All user tables
 - Relevant system tables
@@ -90,7 +90,7 @@ Full backup + <br>incremental backups | If the full backup and incremental backu
 
 If the full or incremental backup was taken [with revision history](backup.html#backups-with-revision-history), you can restore the data as it existed at an arbitrary point-in-time within the revision history captured by that backup. Use the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause to specify the point-in-time.
 
-<span class="version-tag">New in v20.1</span> Additionally, if you want to restore a specific incremental backup, you can do so by specifying the `end_time` of the backup by using the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause. To find the incremental backup's `end_time`, use [`SHOW BACKUP`](show-backup.html). 
+<span class="version-tag">New in v20.1:</span> Additionally, if you want to restore a specific incremental backup, you can do so by specifying the `end_time` of the backup by using the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause. To find the incremental backup's `end_time`, use [`SHOW BACKUP`](show-backup.html).
 
 If you do not specify a point-in-time, the data will be restored to the backup timestamp; that is, the restore will work as if the data was backed up without revision history.
 
@@ -161,12 +161,13 @@ You can include the following options as key-value pairs in the `kv_option_list`
 <a name="skip_missing_foreign_keys"></a>`skip_missing_foreign_keys` | N/A                                         | Use to remove the [foreign key](foreign-key.html) constraints before restoring.<br><br>Example: `WITH skip_missing_foreign_keys`
 <a name="skip_missing_sequences"></a>`skip_missing_sequences`       | N/A                                         | Use to ignore [sequence](show-sequences.html) dependencies (i.e., the `DEFAULT` expression that uses the sequence).<br><br>Example: `WITH skip_missing_sequences`
 `skip_missing_views`                                                | N/A                                         | Use to skip restoring [views](views.html) that cannot be restored because their dependencies are not being restored at the same time.<br><br>Example: `WITH skip_missing_views`
+`encryption_passphrase`                                             | Passphrase used to create the [encrypted backup](backup.html#encrypted-backups) | <span class="version-tag">New in v20.1:</span> The passphrase used to decrypt the file(s) that were encrypted by the [`BACKUP`](backup.html#encrypted-backups) statement.
 
 ## Examples
 
 ### Restore a cluster
 
-<span class="version-tag">New in v20.1</span> To restore a full cluster:
+<span class="version-tag">New in v20.1:</span> To restore a full cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -198,7 +199,7 @@ You can include the following options as key-value pairs in the `kv_option_list`
 
 ### Restore from incremental backups
 
-<span class="version-tag">New in v20.1</span> Restoring from incremental backups requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+<span class="version-tag">New in v20.1:</span> Restoring from incremental backups requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -321,6 +322,34 @@ can be restored by running:
 > RESTORE FROM
   	('s3://us-east-bucket/database-bank-2019-10-07-weekly', 's3://us-west-bucket/database-bank-2019-10-07-weekly'),
 	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly', 's3://us-west-bucket/database-bank-2019-10-08-nightly');
+~~~
+
+### Restore from an encrypted backup
+
+<span class="version-tag">New in v20.1:</span> To decrypt an [encrypted backup](backup.html#encrypted-backups), use the `encryption_passphrase` and the same passphrase that was used to create the backup.
+
+For example, an encrypted backup created with:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+
+Can be restored with:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
 ~~~
 
 ## See also


### PR DESCRIPTION
General change:
- Added the `encrypted_backups_description.md` include, which is used in `backups.md` and `encryption.md`

Changes to `backups.md`:
- Added **Encrypted backups** section 
- Added a **Backup options** section 
- Added **Create encrypted backups** example
- Added missing colons to New in v20.1 tags

Changes to `restore.md`:
- Added a **Restore from an encrypted backup** example
- Added missing colons to New in v20.1 tags

Changes to `encryption.md`:
- Removed **Encryption cavaets > Unencrypted backups** subsection
- Added a **Encrypted backups (Enterprise)** section

Closes #6011