### PR TITLE
Implicit casting to INT and DECIMAL ARRAY

### DIFF
--- a/v20.1/array.md
+++ b/v20.1/array.md
@@ -241,6 +241,39 @@ You can cast an array to a `STRING` value, for compatibility with PostgreSQL:
 (1 row)
 ~~~
 
+### Implicit casting to `INT` and `DECIMAL` `ARRAY`s
+
+<span class="version-tag">New in v20.1:</span> CockroachDB supports implicit casting from string literals to [`INT`](int.html) and [`DECIMAL`](decimal.html) `ARRAY`s, where appropriate.
+
+For example, if you create a table with a column of type `INT[]`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE TABLE x (a UUID DEFAULT gen_random_uuid() PRIMARY KEY, b INT[]);
+~~~
+
+And then insert a string containing a comma-delimited set of integers contained in brackets:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO x(b) VALUES ('{1,2,3}'), (ARRAY[4,5,6]);
+~~~
+
+CockroachDB implicitly casts the string literal as an `INT[]`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM x;
+~~~
+
+~~~
+                   a                   |    b
+---------------------------------------+----------
+  2ec0ed91-8a82-4f2e-888e-ae86ece4fc60 | {4,5,6}
+  a521d6e9-3a2a-490d-968c-1365cace038a | {1,2,3}
+(2 rows)
+~~~
+
 ## See also
 
 [Data Types](data-types.html)

--- a/v20.1/data-types.md
+++ b/v20.1/data-types.md
@@ -46,6 +46,7 @@ CockroachDB supports explicit type conversions using the following methods:
 
 - Other [built-in conversion functions](functions-and-operators.html) when the type is not a SQL type, for example `from_ip()`, `to_ip()` to convert IP addresses between `STRING` and `BYTES` values.
 
+<span class="version-tag">New in v20.1:</span> CockroachDB also supports implicit casting from string literals to `INT` and `DECIMAL` [`ARRAY`](array.html)s, where appropriate. For an example, see [Implicit casting to `INT` and `DECIMAL` `ARRAY`s](array.html#implicit-casting-to-int-and-decimal-arrays).
 
 You can find each data type's supported conversion and casting on its
 respective page in its section **Supported casting & conversion**.

--- a/v20.1/decimal.md
+++ b/v20.1/decimal.md
@@ -67,13 +67,11 @@ The size of a `DECIMAL` value is variable, starting at 9 bytes. It's recommended
 ~~~
 
 ~~~
-+-------------+---------------+-------------+----------------+-----------------------+-------------+
-| column_name |   data_type   | is_nullable | column_default | generation_expression |   indices   |
-+-------------+---------------+-------------+----------------+-----------------------+-------------+
-| a           | DECIMAL       |    false    | NULL           |                       | {"primary"} |
-| b           | DECIMAL(10,5) |    true     | NULL           |                       | {}          |
-| c           | DECIMAL       |    true     | NULL           |                       | {}          |
-+-------------+---------------+-------------+----------------+-----------------------+-------------+
+  column_name |   data_type   | is_nullable | column_default | generation_expression |  indices  | is_hidden
+--------------+---------------+-------------+----------------+-----------------------+-----------+------------
+  a           | DECIMAL       |    false    | NULL           |                       | {primary} |   false
+  b           | DECIMAL(10,5) |    true     | NULL           |                       | {}        |   false
+  c           | DECIMAL       |    true     | NULL           |                       | {}        |   false
 (3 rows)
 ~~~
 
@@ -88,15 +86,13 @@ The size of a `DECIMAL` value is variable, starting at 9 bytes. It's recommended
 ~~~
 
 ~~~
-+------------------------+---------+-----------------------+
-|           a            |    b    |         c             |
-+------------------------+---------+-----------------------+
-| 1.01234567890123456789 | 1.01235 | 1.0123456789012346789 |
-+------------------------+---------+-----------------------+
-# The value in "a" matches what was inserted exactly.
-# The value in "b" has been rounded to the column's scale.
-# The value in "c" is handled like "a" because NUMERIC is an alias.
+            a            |    b    |           c
+-------------------------+---------+-------------------------
+  1.01234567890123456789 | 1.01235 | 1.01234567890123456789
+(1 row)
 ~~~
+
+The value in column `a` matches what was inserted exactly. The value in column `b` has been rounded to the column's scale. The value in column `c` is handled like the value in column `a` because `NUMERIC` is an alias for `DECIMAL`.
 
 ## Supported casting and conversion
 

--- a/v20.1/int.md
+++ b/v20.1/int.md
@@ -63,22 +63,16 @@ If your application requires arbitrary precision numbers, use the [`DECIMAL`](de
 ~~~
 
 ~~~
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-| column_name | data_type | is_nullable | column_default | generation_expression |   indices   |
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-| a           | INT       |    false    | NULL           |                       | {"primary"} |
-| b           | SMALLINT  |    true     | NULL           |                       | {}          |
-+-------------+-----------+-------------+----------------+-----------------------+-------------+
-(3 rows)
+  column_name | data_type | is_nullable | column_default | generation_expression |  indices  | is_hidden
+--------------+-----------+-------------+----------------+-----------------------+-----------+------------
+  a           | INT8      |    false    | NULL           |                       | {primary} |   false
+  b           | INT2      |    true     | NULL           |                       | {}        |   false
+(2 rows)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ sql
 > INSERT INTO ints VALUES (1, 32);
-~~~
-
-~~~
-INSERT 1
 ~~~
 
 {% include copy-clipboard.html %}
@@ -87,11 +81,9 @@ INSERT 1
 ~~~
 
 ~~~
-+---+----+
-| a | b  |
-+---+----+
-| 1 | 32 |
-+---+----+
+  a | b
+----+-----
+  1 | 32
 (1 row)
 ~~~
 

--- a/v20.1/string.md
+++ b/v20.1/string.md
@@ -115,6 +115,7 @@ The size of a `STRING` value is variable, but it's recommended to keep values un
 
 Type | Details
 -----|--------
+`ARRAY` | Requires supported [`ARRAY`](array.html) string format, e.g., `'{1,2,3}'`.<br>Limited to `ARRAY`s of type [`INT`](int.html) and [`DECIMAL`](decimal.html). 
 `BIT` | Requires supported [`BIT`](bit.html) string format, e.g., `'101001'`.
 `BOOL` | Requires supported [`BOOL`](bool.html) string format, e.g., `'true'`.
 `BYTES` | For more details, [see here](bytes.html#supported-conversions).


### PR DESCRIPTION
Fixes #6206. 

- Added note to "Data Types" page about implicit casting to `INT` and `DECIMAL` `ARRAY`s.
- Added "Implicit casting" subsection, with example, to `ARRAY` page.