### PR TITLE
SET TIME ZONE supports UTC+- and GMT+- for PG compatibility

### DIFF
--- a/v20.1/set-vars.md
+++ b/v20.1/set-vars.md
@@ -164,17 +164,19 @@ The following demonstrates how to assign a list of values:
 
 ## `SET TIME ZONE`
 
-{{site.data.alerts.callout_danger}}As a best practice, we recommend not using this setting and avoid setting a session time for your database. We instead recommend converting UTC values to the appropriate time zone on the client side.{{site.data.alerts.end}}
-
-You can control your client's default time zone for the current session with <code>SET TIME ZONE</code>. This will apply a session offset to all [`TIMESTAMPTZ`/`TIMESTAMP WITH TIME ZONE`](timestamp.html) and [`TIMETZ`/`TIME WITH TIME ZONE`](time.html) values.
-
-{{site.data.alerts.callout_info}}
-With setting <code>SET TIME ZONE</code>, CockroachDB uses UTC as the default time zone.
+{{site.data.alerts.callout_danger}}
+As a best practice, we recommend not using this setting and avoid setting a session time for your database. We instead recommend converting UTC values to the appropriate time zone on the client side.
 {{site.data.alerts.end}}
+
+You can control the default time zone for a session with `SET TIME ZONE`. This will apply an offset to all [`TIMESTAMPTZ`/`TIMESTAMP WITH TIME ZONE`](timestamp.html) and [`TIMETZ`/`TIME WITH TIME ZONE`](time.html) values in the session. By default, CockroachDB uses UTC as the time zone for `SET TIME ZONE` offsets.
 
 ### Parameters
 
-The time zone value indicates the time zone for the current session. This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`, or `UTC-7`, `UTC+7`) or GMT (e.g., `GMT-7`, `GMT+7`). 
+The input passed to `SET TIME ZONE` indicates the time zone for the current session. This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`, or `UTC-7`, `UTC+7`) or GMT (e.g., `GMT-7`, `GMT+7`). The numeric offset input can also be colon-delimited (e.g., `-7:00`, `GMT+7:00`).
+
+{{site.data.alerts.callout_info}}
+Only offsets specified by integers use the [ISO 8601 time offset](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC) (i.e., the offset input is parsed as hours *east* of the specified time zone). If you explicitly specify `UTC` or `GMT` for the time zone offset (e.g., `UTC-7`,`GMT+7`), or if the numeric input is colon-delimited (e.g.,  `-7:00`, `GMT+7:00`), CockroachDB uses the [POSIX time offset](https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-TIMEZONES) (i.e., hours *west* of the specified time zone). 
+{{site.data.alerts.end}}
 
 All timezone abbreviations are case-sensitive and must be uppercase, with the exception of `UTC`, for which `utc` is an alias.
 

--- a/v20.1/set-vars.md
+++ b/v20.1/set-vars.md
@@ -168,15 +168,14 @@ The following demonstrates how to assign a list of values:
 
 You can control your client's default time zone for the current session with <code>SET TIME ZONE</code>. This will apply a session offset to all [`TIMESTAMPTZ`/`TIMESTAMP WITH TIME ZONE`](timestamp.html) and [`TIMETZ`/`TIME WITH TIME ZONE`](time.html) values.
 
-{{site.data.alerts.callout_info}}With setting <code>SET TIME ZONE</code>, CockroachDB uses UTC as the default time zone.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+With setting <code>SET TIME ZONE</code>, CockroachDB uses UTC as the default time zone.
+{{site.data.alerts.end}}
 
 ### Parameters
 
-The time zone value indicates the time zone for the current session.
+The time zone value indicates the time zone for the current session. This value can be a string representation of a local system-defined time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or negative numeric offset from UTC (e.g., `-7`, `+7`, or `UTC-7`, `UTC+7`) or GMT (e.g., `GMT-7`, `GMT+7`). 
 
-This value can be a string representation of a local system-defined
-time zone (e.g., `'EST'`, `'America/New_York'`) or a positive or
-negative numeric offset from UTC (e.g., `-7`, `+7`).
 All timezone abbreviations are case-sensitive and must be uppercase, with the exception of `UTC`, for which `utc` is an alias.
 
 `DEFAULT`, `LOCAL`, or `0` sets the session time zone to `UTC`.


### PR DESCRIPTION
Fixes #6207.

- Edited `SET TIME ZONE` section for readability.
- Added `UTC+/-` and `GMT+/-` to `SET TIME ZONE` section.