### PR TITLE
Use correct `foo@foo_idx` syntax in examples

### DIFF
--- a/v19.1/online-schema-changes.md
+++ b/v19.1/online-schema-changes.md
@@ -141,7 +141,7 @@ The following statements fail due to [limited support for schema changes within 
   BEGIN;
   SAVEPOINT cockroach_restart;
   CREATE INDEX foo_idx ON foo (id, name);
-  SELECT * from foo_idx;
+  SELECT * from foo@foo_idx;
   RELEASE SAVEPOINT cockroach_restart;
   COMMIT;
 ~~~

--- a/v19.2/online-schema-changes.md
+++ b/v19.2/online-schema-changes.md
@@ -141,7 +141,7 @@ The following statements fail due to [limited support for schema changes within 
   BEGIN;
   SAVEPOINT cockroach_restart;
   CREATE INDEX foo_idx ON foo (id, name);
-  SELECT * from foo_idx;
+  SELECT * from foo@foo_idx;
   RELEASE SAVEPOINT cockroach_restart;
   COMMIT;
 ~~~

--- a/v2.1/online-schema-changes.md
+++ b/v2.1/online-schema-changes.md
@@ -133,7 +133,7 @@ The following statements fail due to the [no schema changes within transactions]
   BEGIN;
   SAVEPOINT cockroach_restart;
   CREATE INDEX foo_idx ON foo (id, name);
-  SELECT * from foo_idx;
+  SELECT * from foo@foo_idx;
   RELEASE SAVEPOINT cockroach_restart;
   COMMIT;
 ~~~

--- a/v20.1/online-schema-changes.md
+++ b/v20.1/online-schema-changes.md
@@ -145,7 +145,7 @@ The following statements fail due to [limited support for schema changes within 
   BEGIN;
   SAVEPOINT cockroach_restart;
   CREATE INDEX foo_idx ON foo (id, name);
-  SELECT * from foo_idx;
+  SELECT * from foo@foo_idx;
   RELEASE SAVEPOINT cockroach_restart;
   COMMIT;
 ~~~


### PR DESCRIPTION
Fixes #7070.

Summary of changes:

- Update example on 'Online Schema Changes' page that was not using the
  correct syntax for running a selection query against a specific
  index.

- (Funnily enough, the error message produced was the same either way,
  which is probably why this slipped in.  That, and lack of #7067.)