### PR TITLE
Changing precision level of TIME and TIMESTAMP columns

### DIFF
--- a/v20.1/time.md
+++ b/v20.1/time.md
@@ -67,9 +67,9 @@ A `TIMETZ` column supports values up to 12 bytes in width, but the total storage
 
 ## Precision
 
-<span class="version-tag">New in v20.1:</span> CockroachDB supports precision levels from 0 (seconds) to 6 (microseconds) for `TIME`/`TIMETZ` values. Precision in time values specifies the number of fractional digits retained in the seconds field.  By default, `TIME`/`TIMETZ` values have a precision of 6 (microseconds).
+<span class="version-tag">New in v20.1:</span> CockroachDB supports precision levels from 0 (seconds) to 6 (microseconds) for `TIME`/`TIMETZ` values. Precision in time values specifies the number of fractional digits retained in the seconds field. For example, specifying a `TIME` value as `TIME(3)` truncates the time precision to milliseconds. By default, `TIME`/`TIMETZ` values have a precision of 6 (microseconds).
 
-For example, specifying a `TIME` value as `TIME(3)` truncates the time precision to milliseconds.
+You can use an [`ALTER COLUMN ... SET DATA TYPE`](alter-column.html) statement to change the precision level of a `TIME`-typed column. If there is already a non-default precision level specified for the column, the precision level can only be changed to an equal or greater precision level. For an example, see [Create a table with a `TIME`-typed column, with precision](#create-a-table-with-a-time-typed-column-with-precision).
 
 {{site.data.alerts.callout_info}}
 If you downgrade to a version of CockroachDB that does not support precision for `TIME`/`TIMETZ` values, all `TIME`/`TIMETZ` values previously specified with precision will be stored with full precision.
@@ -171,6 +171,47 @@ Comparing `TIME` values:
         2 | 0000-01-01 05:41:39.1235+00:00
 (2 rows)
 ~~~
+
+To change the precision level of a column, you can use an [`ALTER COLUMN ... SET DATA TYPE`](alter-column.html) statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE time ALTER COLUMN time_val SET DATA TYPE TIME(5);
+~~~
+
+~~~
+ALTER TABLE
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW COLUMNS FROM time;
+~~~
+
+~~~
+  column_name | data_type | is_nullable | column_default | generation_expression |  indices  | is_hidden
+--------------+-----------+-------------+----------------+-----------------------+-----------+------------
+  time_id     | INT8      |    false    | NULL           |                       | {primary} |   false
+  time_val    | TIME(5)   |    true     | NULL           |                       | {}        |   false
+(2 rows)
+~~~
+
+{{site.data.alerts.callout_info}}
+If a non-default precision level has already been specified, you cannot change the precision to a lower level.
+{{site.data.alerts.end}}
+
+In this case, the `time_val` column, which is of type `TIME(5)`, cannot be changed to a precision level below `5`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE time ALTER COLUMN time_val SET DATA TYPE TIME(3);
+~~~
+
+~~~
+ERROR: unimplemented: type conversion from TIME(5) to TIME(3) requires overwriting existing values which is not yet implemented
+SQLSTATE: 0A000
+~~~
+
 
 ## Supported casting & conversion
 


### PR DESCRIPTION
Fixes #6901.  

- Added paragraph, examples about changing precision levels to `TIME` and `TIMESTAMP` docs.