### PR TITLE
Multiple foreign key constraints can exist on the same column

### DIFF
--- a/_includes/v20.1/performance/overview.md
+++ b/_includes/v20.1/performance/overview.md
@@ -32,7 +32,6 @@ A few notes about the schema:
 - There are just three self-explanatory tables: In essence, `users` represents the people registered for the service, `vehicles` represents the pool of vehicles for the service, and `rides` represents when and where users have participated.   
 - Each table has a composite primary key, with `city` being first in the key. Although not necessary initially in the single-region deployment, once you scale the cluster to multiple regions, these compound primary keys will enable you to [geo-partition data at the row level](partitioning.html#partition-using-primary-key) by `city`. As such, this tutorial demonstrates a schema designed for future scaling.
 - The [`IMPORT`](import.html) feature you'll use to import the data does not support foreign keys, so you'll import the data without [foreign key constraints](foreign-key.html). However, the import will create the secondary indexes required to add the foreign keys later.
-- The `rides` table contains both `city` and the seemingly redundant `vehicle_city`. This redundancy is necessary because, while it is not possible to apply more than one foreign key constraint to a single column, you will need to apply two foreign key constraints to the `rides` table, and each will require city as part of the constraint. The duplicate `vehicle_city`, which is kept in sync with `city` via a [`CHECK` constraint](check.html), lets you overcome [this limitation](https://github.com/cockroachdb/cockroach/issues/23580).
 
 ### Important concepts
 


### PR DESCRIPTION
Fixes #6607.  

- Added notes and example to Foreign Key docs page.
- Removed single-column requirement from Foreign Key docs page.
- Removed note from Performance docs.

https://github.com/cockroachdb/cockroach/pull/43417 affects more than just docs about foreign keys... In specific, we need to update the MovR schema to take advantage of this lifted restriction. That schema needs to be updated for a number of other things as well, so I consider updating the schema out of the scope of this docs issue.