### PR TITLE
Re-organize BACKUP / RESTORE docs

### DIFF
--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -560,6 +560,12 @@
             ]
           },
           {
+            "title": "Back up and Restore Data - Advanced Options",
+            "urls": [
+              "/${VERSION}/backup-and-restore-advanced-options.html"
+            ]
+          },
+          {
             "title": "Create a File Server for <code>IMPORT</code>/<code>BACKUP</code>",
             "urls": [
               "/${VERSION}/create-a-file-server.html"

--- a/_includes/v20.1/backups/advanced-examples-list.md
+++ b/_includes/v20.1/backups/advanced-examples-list.md
@@ -1,0 +1,9 @@
+For examples of advanced `BACKUP` and `RESTORE` use cases, see [Back up and Restore Data - Advanced Options](backup-and-restore-advanced-options.html). Advanced examples include:
+
+- [Incremental backups with a specified destination](backup-and-restore-advanced-options.html#incremental-backups-with-explicitly-specified-destinations)
+- [Backup with revision history and point-in-time restore](backup-and-restore-advanced-options.html#backup-with-revision-history-and-point-in-time-restore)
+- [Locality-aware backup and restore](backup-and-restore-advanced-options.html#locality-aware-backup-and-restore)
+- <span class="version-tag">New in v20.1:</span> [Encrypted backup and restore](backup-and-restore-advanced-options.html#encrypted-backup-and-restore)
+- [Restore into a different database](backup-and-restore-advanced-options.html#restore-into-a-different-database)
+- [Remove the foreign key before restore](backup-and-restore-advanced-options.html#remove-the-foreign-key-before-restore)
+- [Restoring users from `system.users` backup](backup-and-restore-advanced-options.html#restoring-users-from-system-users-backup)

--- a/_includes/v20.1/backups/encrypted-backup-description.md
+++ b/_includes/v20.1/backups/encrypted-backup-description.md
@@ -1,6 +1,6 @@
 <span class="version-tag">New in v20.1:</span> You can encrypt full or incremental backups by using the [`encryption_passphrase` option](backup.html#with-encryption-passphrase). Files written by the backup (including `BACKUP` manifests and data files) are encrypted using the specified passphrase to derive a key. To restore the encrypted backup, the same `encryption_passphrase` option (with the same passphrase) must included in the [`RESTORE`](restore.html) statement.
 
-When used with [incremental backups](backup.html#incremental-backups), the `encryption_passphrase` option is applied to all the [backup file URLs](backup.html#backup-file-urls), which means the same passphrase must be used when appending another incremental backup to an existing backup. Similarly, when used with [locality-aware backups](backup.html#create-locality-aware-backups), the passphrase provided is applied to files in all localities.
+When used with [incremental backups](backup.html#incremental-backups), the `encryption_passphrase` option is applied to all the [backup file URLs](backup.html#backup-file-urls), which means the same passphrase must be used when appending another incremental backup to an existing backup. Similarly, when used with [locality-aware backups](backup-and-restore-advanced-options.html#locality-aware-backup-and-restore), the passphrase provided is applied to files in all localities.
 
 Encryption is done using [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode), and GCM is used to both encrypt and authenticate the files. A random [salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) is used to derive a once-per-backup [AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard) key from the specified passphrase, and then a random [initialization vector](https://en.wikipedia.org/wiki/Initialization_vector) is used per-file. CockroachDB uses [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) with 64,000 iterations for the key derivation.
 
@@ -8,4 +8,4 @@ Encryption is done using [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Coun
 `BACKUP` and `RESTORE` will use more memory when using encryption, as both the plain-text and cipher-text of a given file are held in memory during encryption and decryption.
 {{site.data.alerts.end}}
 
-For an example of an encrypted backup, see [Create encrypted backups](backup.html#create-an-encrypted-backup).
+For an example of an encrypted backup, see [Create an encrypted backup](backup-and-restore-advanced-options.html#create-an-encrypted-backup).

--- a/releases/v20.1.0-rc.1.md
+++ b/releases/v20.1.0-rc.1.md
@@ -162,7 +162,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.1.0-rc.1
 ### Doc updates
 
 - Improved the documentation on [viewing and controlling backup jobs](../v20.1/backup.html#viewing-and-controlling-backups-jobs) and added documentation on [showing a backup with privileges](../v20.1/show-backup.html#show-a-backup-with-privileges). [#7101](https://github.com/cockroachdb/docs/pull/7101)
-- Documented [key/passphrase-based backup encryption](../v20.1/backup.html#encrypted-backups). [#7085](https://github.com/cockroachdb/docs/pull/7085)
+- Documented [key/passphrase-based backup encryption](../v20.1/backup-and-restore-advanced-options.html#encrypted-backup-and-restore). [#7085](https://github.com/cockroachdb/docs/pull/7085)
 - Documented how to use [`EXPLAIN(DISTSQL, TYPES)`](../v20.1/explain.html#distsql-option) to include the data types of the input columns in the generated physical plan. [#7045](https://github.com/cockroachdb/docs/pull/7045)
 - Updated [Azure hardware recommendations](../v20.1/recommended-production-settings.html#azure). [#7005](https://github.com/cockroachdb/docs/pull/7005)
 - Documented [`INTERVAL`](../v20.1/interval.html) duration fields and updated the syntax and precision details. [#7000](https://github.com/cockroachdb/docs/pull/7000)

--- a/v20.1/backup-and-restore-advanced-options.md
+++ b/v20.1/backup-and-restore-advanced-options.md
@@ -1,0 +1,375 @@
+---
+title: Back up and Restore Data - Advanced Options
+summary: Learn about the advanced options you can use when you backup and restore a CockroachDB cluster.
+toc: true
+---
+
+<span class="version-tag">New in v20.1:</span> The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](backup-and-restore.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly, which now falls under advanced usage.
+
+This doc provides information about the advanced options you can use when you [backup](backup.html) and [restore](restore.html) data in a CockroachDB cluster:
+
+- [Incremental backups with a specified destination](#incremental-backups-with-explicitly-specified-destinations)
+- [Backup with revision history and point-in-time restore](#backup-with-revision-history-and-point-in-time-restore)
+- [Locality-aware backup and restore](#locality-aware-backup-and-restore)
+- <span class="version-tag">New in v20.1:</span> [Encrypted backup and restore](#encrypted-backup-and-restore)
+- [Restore into a different database](#restore-into-a-different-database)
+- [Remove the foreign key before restore](#remove-the-foreign-key-before-restore)
+- [Restoring users from `system.users` backup](#restoring-users-from-system-users-backup)
+
+{{site.data.alerts.callout_info}}
+The advanced options covered in this doc are included in [`BACKUP`](backup.html), which is an [enterprise-only](https://www.cockroachlabs.com/product/cockroachdb/) feature. For non-enterprise backups, see [`cockroach dump`](cockroach-dump.html).
+{{site.data.alerts.end}}
+
+## Incremental backups with explicitly specified destinations
+
+To explicitly control where your incremental backups go, use the [`INCREMENTAL FROM`](backup.html) syntax:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank \
+TO 'gs://acme-co-backup/db/bank/2017-03-29-nightly' \
+AS OF SYSTEM TIME '-10s' \
+INCREMENTAL FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly' WITH revision_history;
+~~~
+
+For an example of the simplified incremental backup syntax, see [Create incremental backups](backup.html#create-incremental-backups).
+
+## Backup with revision history and point-in-time restore
+
+You can create full or incremental backups [with revision history](backup.html#with-revision-history):
+
+- Taking full backups with revision history allows you to back up every change made within the garbage collection period leading up to and including the given timestamp.
+- Taking incremental backups with revision history allows you to back up every change made since the last backup and within the garbage collection period leading up to and including the given timestamp. You can take incremental backups with revision history even when your previous full or incremental backups were taken without revision history.
+
+You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html). Taking backups with revision history allows for point-in-time restores within the revision history.
+
+### Create a backup with revision history
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster-2017-03-27-weekly' \
+AS OF SYSTEM TIME '-10s' WITH revision_history;
+~~~
+
+### Point-in-time restore
+
+If the full or incremental backup was taken [with revision history](#backup-with-revision-history-and-point-in-time-restore), you can restore the data as it existed at an arbitrary point-in-time within the revision history captured by that backup. Use the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause to specify the point-in-time.
+
+<span class="version-tag">New in v20.1:</span> Additionally, if you want to restore a specific incremental backup, you can do so by specifying the `end_time` of the backup by using the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause. To find the incremental backup's `end_time`, use [`SHOW BACKUP`](show-backup.html).
+
+If you do not specify a point-in-time, the data will be restored to the backup timestamp; that is, the restore will work as if the data was backed up without revision history.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+AS OF SYSTEM TIME '2017-02-26 10:00:00';
+~~~
+
+### Point-in-time restore from incremental backups
+
+Restoring from incremental backups requires previous full and incremental backups. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' \
+AS OF SYSTEM TIME '2017-02-28 10:00:00';
+~~~
+
+## Locality-aware backup and restore
+
+You can create locality-aware backups such that each node writes files only to the backup destination that matches the [node locality](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes) configured at [node startup](cockroach-start.html).
+
+This is useful for:
+
+- Reducing cloud storage data transfer costs by keeping data within cloud regions.
+- Helping you comply with data domiciling requirements.
+
+A locality-aware backup is specified by a list of URIs, each of which has a `COCKROACH_LOCALITY` URL parameter whose single value is either `default` or a single locality key-value pair such as `region=us-east`. At least one `COCKROACH_LOCALITY` must be the `default`. Given a list of URIs that together contain the locations of all of the files for a single locality-aware backup, [`RESTORE`][restore] can read in that backup.
+
+{{site.data.alerts.callout_info}}
+The locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
+{{site.data.alerts.end}}
+
+During locality-aware backups, backup file placement is determined by leaseholder placement, as each node is responsible for backing up the ranges for which it is the leaseholder.  Nodes write files to the backup storage location whose locality matches their own node localities, with a preference for more specific values in the locality hierarchy.  If there is no match, the `default` locality is used.
+
+{{site.data.alerts.callout_info}}
+The list of URIs passed to [`RESTORE`][restore] may be different from the URIs originally passed to [`BACKUP`][backup]. This is because the files of a locality-aware backup can be moved to different locations, or even consolidated into the same location. The only restriction is that all the files originally written to the same location must remain together. In order for [`RESTORE`][restore] to succeed, all of the files originally written during [`BACKUP`][backup] must be accounted for in the list of location URIs provided.
+{{site.data.alerts.end}}
+
+### Create a locality-aware backup
+
+For example, to create a locality-aware backup where nodes with the locality `region=us-west` write backup files to `s3://us-west-bucket`, and all other nodes write to `s3://us-east-bucket` by default, run:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO
+	  ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
+~~~
+
+can be restored by running:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
+~~~
+
+Note that the first URI in the list has to be the URI specified as the `default` URI when the backup was created. If you have moved your backups to a different location since the backup was originally taken, the first URI must be the new location of the files originally written to the `default` location.
+
+### Restore from a locality-aware backup
+
+You can create locality-aware backups such that each node writes files only to the backup destination that matches the [node locality](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes) configured at [node startup](cockroach-start.html).
+
+A locality-aware backup is specified by a list of URIs, each of which has a `COCKROACH_LOCALITY` URL parameter whose single value is either `default` or a single locality key-value pair such as `region=us-east`. At least one `COCKROACH_LOCALITY` must be the `default`. Given a list of URIs that together contain the locations of all of the files for a single locality-aware backup, [`RESTORE`][restore] can read in that backup.
+
+Note that the list of URIs passed to [`RESTORE`][restore] may be different from the URIs originally passed to [`BACKUP`][backup]. This is because it's possible to move the contents of one of the parts of a locality-aware backup (i.e., the files written to that destination) to a different location, or even to consolidate all the files for a locality-aware backup into a single location.
+
+{{site.data.alerts.callout_info}}
+[`RESTORE`][restore] is not truly locality-aware; while restoring from backups, a node may read from a store that does not match its locality. This can happen in the cases that either the [`BACKUP`][backup] or [`RESTORE`][restore] was not full cluster. Note that during a locality-aware restore, some data may be temporarily located on another node before it is eventually relocated to the appropriate node. To avoid this, you can [manually restore zone configurations from a locality-aware backup](#manually-restore-zone-configurations-from-a-locality-aware-backup).
+{{site.data.alerts.end}}
+
+### Create an incremental locality-aware backup
+
+To make an incremental locality-aware backup from a full locality-aware backup, the syntax is just like for [regular incremental backups](backup.html#create-incremental-backups):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+AS OF SYSTEM TIME '-10s' WITH revision_history;
+~~~
+
+And if you want to explicitly control where your incremental backups go, use the `INCREMENTAL FROM` syntax:
+
+{% include copy-clipboard.html %}
+~~~ sql
+BACKUP TO (${uri_1}, ${uri_2}, ...) INCREMENTAL FROM ${full_backup_uri} ...;
+~~~
+
+For example, to create an incremental locality-aware backup from a previous full locality-aware backup where nodes with the locality `region=us-west` write backup files to `s3://us-west-bucket`, and all other nodes write to `s3://us-east-bucket` by default, run:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+('s3://us-east-bucket/test-cluster-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/test-cluster-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
+INCREMENTAL FROM 's3://us-east-bucket/test-cluster-2019-10-07-weekly';
+~~~
+
+{{site.data.alerts.callout_info}}
+Note that only the backup URIs you set as the `default` when you created the previous backup(s) are needed in the `INCREMENTAL FROM` clause of your incremental `BACKUP` statement (as shown in the example). This is because the `default` destination for a locality-aware backup contains a manifest file that contains all the metadata required to create additional incremental backups based on it.
+{{site.data.alerts.end}}
+
+### Restore from an incremental locality-aware backup
+
+A locality-aware backup URI can also be used in place of any incremental backup URI in [`RESTORE`][restore].
+
+For example, an incremental locality-aware backup created with
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO
+	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
+  INCREMENTAL FROM
+	  's3://us-east-bucket/database-bank-2019-10-07-weekly';
+~~~
+
+can be restored by running:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM
+  	('s3://us-east-bucket/database-bank-2019-10-07-weekly', 's3://us-west-bucket/database-bank-2019-10-07-weekly'),
+	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly', 's3://us-west-bucket/database-bank-2019-10-08-nightly');
+~~~
+
+### Create an incremental locality-aware backup from a previous locality-aware backup
+
+To make an incremental locality-aware backup from another locality-aware backup, the syntax is as follows:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO ({uri_1}, {uri_2}, ...) INCREMENTAL FROM {full_backup}, {incr_backup_1}, {incr_backup_2}, ...;
+~~~
+
+For example, let's say you normally run a full backup every Monday, followed by incremental backups on the remaining days of the week.
+
+By default, all nodes send their backups to your `s3://us-east-bucket`, except for nodes in `region=us-west`, which will send their backups to `s3://us-west-bucket`.
+
+If today is Thursday, October 10th, 2019, your `BACKUP` statement will list the following backup URIs:
+
+- The full locality-aware backup URI from Monday, e.g.,
+  - `s3://us-east-bucket/test-cluster-2019-10-07-weekly`
+- The incremental backup URIs from Tuesday and Wednesday, e.g.,
+  - `s3://us-east-bucket/test-cluster-2019-10-08-nightly`
+  - `s3://us-east-bucket/test-cluster-2019-10-09-nightly`
+
+Given the above, to take the incremental locality-aware backup scheduled for today (Thursday), you will run:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO
+	  ('s3://us-east-bucket/test-cluster-2019-10-10-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/test-cluster-2019-10-10-nightly?COCKROACH_LOCALITY=region%3Dus-west')
+  INCREMENTAL FROM
+	  's3://us-east-bucket/test-cluster-2019-10-07-weekly',
+	  's3://us-east-bucket/test-cluster-2019-10-08-nightly',
+  	's3://us-east-bucket/test-cluster-2019-10-09-nightly';
+~~~
+
+{{site.data.alerts.callout_info}}
+Note that only the backup URIs you set as the `default` when you created the previous backup(s) are needed in the `INCREMENTAL FROM` clause of your incremental `BACKUP` statement (as shown in the example). This is because the `default` destination for a locality-aware backup contains a manifest file that contains all the metadata required to create additional incremental backups based on it.
+{{site.data.alerts.end}}
+
+### Manually restore zone configurations from a locality-aware backup
+
+During a [locality-aware restore](#restore-from-a-locality-aware-backup), some data may be temporarily located on another node before it is eventually relocated to the appropriate node. To avoid this, you need to manually restore [zone configurations](configure-replication-zones.html) first:
+
+Once the locality-aware restore has started, [pause the restore](pause-job.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> PAUSE JOB 27536791415282;
+~~~
+
+The `system.zones` table stores your cluster's [zone configurations](configure-replication-zones.html), which will prevent the data from rebalancing. To restore them, you must restore the `system.zones` table into a new database because you cannot drop the existing `system.zones` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE system.zones \
+FROM 'azure://acme-co-backup?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co' \
+WITH into_db = 'newdb';
+~~~
+
+After it's restored into a new database, you can write the restored `zones` table data to the cluster's existing `system.zones` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO system.zones SELECT * FROM newdb.zones;
+~~~
+
+Then drop the temporary table you created:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DROP TABLE newdb.zones;
+~~~
+
+Then, [resume the restore](resume-job.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESUME JOB 27536791415282;
+~~~
+
+## Encrypted backup and restore
+
+{% include {{ page.version.version }}/backups/encrypted-backup-description.md %}
+
+### Create an encrypted backup
+
+<span class="version-tag">New in v20.1:</span> To create an [encrypted backup](#encrypted-backup-and-restore), use the `encryption_passphrase` option:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543214409874014209 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+To [restore](restore.html), use the same `encryption_passphrase`:
+
+### Restore from an encrypted backup
+
+<span class="version-tag">New in v20.1:</span> To decrypt an [encrypted backup](#encrypted-backup-and-restore), use the `encryption_passphrase` option and the same passphrase that was used to create the backup.
+
+For example, the encrypted backup created in the [previous example](#create-an-encrypted-backup):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+
+Can be restored with:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'gs://acme-co-backup/test-cluster' \
+WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+## Other restore usages
+
+### Restore into a different database
+
+By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db`](restore.html#into_db) option, you can control the target database.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+WITH into_db = 'newdb';
+~~~
+
+### Remove the foreign key before restore
+
+By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.accounts \
+FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+WITH skip_missing_foreign_keys;
+~~~
+
+### Restoring users from `system.users` backup
+
+The `system.users` table stores your cluster's usernames and their hashed passwords. To restore them, you must restore the `system.users` table into a new database because you cannot drop the existing `system.users` table.
+
+After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE system.users \
+FROM 'azure://acme-co-backup/table-users-2017-03-27-full?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co' \
+WITH into_db = 'newdb';
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO system.users SELECT * FROM newdb.users;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DROP TABLE newdb.users;
+~~~
+
+## See also
+
+- [Backup and Restore Data](backup-and-restore.html)
+- [`BACKUP`][backup]
+- [`RESTORE`][restore]
+- [`SQL DUMP`](cockroach-dump.html)
+- [`IMPORT`](import-data.html)
+- [Use the Built-in SQL Client](cockroach-sql.html)
+- [Other Cockroach Commands](cockroach-commands.html)
+
+<!-- Reference links -->
+
+[backup]:  backup.html
+[restore]: restore.html

--- a/v20.1/backup-and-restore.md
+++ b/v20.1/backup-and-restore.md
@@ -1,67 +1,96 @@
 ---
 title: Back up and Restore Data
-summary: Learn how to back up and restore a CockroachDB database.
+summary: Learn how to back up and restore a CockroachDB cluster.
 toc: true
 redirect_from:
 - back-up-data.html
 - restore-data.html
 ---
 
-Because CockroachDB is designed with high fault tolerance, backups are primarily needed for disaster recovery (i.e., if your cluster loses a majority of its nodes). Isolated issues (such as small-scale node outages) do not require any intervention. However, as an operational best practice, we recommend taking regular backups of your data.
+Because CockroachDB is designed with high fault tolerance, backups are primarily needed for disaster recovery (i.e., if your cluster loses a majority of its nodes). Isolated issues (such as small-scale node outages) do not require any intervention. However, as an operational best practice, **we recommend taking regular backups of your data**.
 
-Based on your [license type](https://www.cockroachlabs.com/pricing/), CockroachDB offers two methods to back up and restore your cluster's data: Enterprise and Core.
+Based on your [license type](https://www.cockroachlabs.com/pricing/), CockroachDB offers two methods to backup and restore your cluster's data: [Enterprise](#perform-enterprise-backup-and-restore) and [Core](#perform-core-backup-and-restore).
 
 ## Perform Enterprise backup and restore
 
 If you have an [Enterprise license](enterprise-licensing.html), you can use the [`BACKUP`][backup] statement to efficiently back up your cluster's schemas and data to popular cloud services such as AWS S3, Google Cloud Storage, or NFS, and the [`RESTORE`][restore] statement to efficiently restore schema and data as necessary.
 
-### Manual full backups
+{{site.data.alerts.callout_success}}
+We recommend [automating daily backups of your cluster](#automated-full-and-incremental-backups). To automate backups, you must have a client send the `BACKUP` statement to the cluster. Once the backup is complete, your client will receive a `BACKUP` response.
+{{site.data.alerts.end}}
 
-In most cases, it's recommended to use the [`BACKUP`][backup] command to take full nightly backups of your cluster:
+### Full backups
+
+In most cases, **it's recommended to take full nightly backups of your cluster**. A full cluster backup allows you to do the following:
+
+- Restore table(s) from the cluster
+- Restore database(s) from the cluster
+- Restore a full cluster
+
+To do a full cluster backup, use the [`BACKUP`](backup.html) statement:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO '<full_backup_location>';
+> BACKUP TO '<backup_location>';
 ~~~
 
-If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster:
+If it's ever necessary, you can use the [`RESTORE`] statement to restore a table:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM '<full_backup_location>';
+> RESTORE TABLE bank.customers FROM '<backup_location>';
 ~~~
 
-### Manual full and incremental backups
+Or to restore a  database:
 
-If your cluster increases to a size where it is no longer feasible to take nightly full backups, you might want to consider taking periodic full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE DATABASE bank FROM '<backup_location>';
+~~~
+
+Or to restore your full cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM '<backup_location>';
+~~~
+
+{{site.data.alerts.callout_info}}
+A full cluster restore can only be run on a target cluster that has _never_ had user-created databases or tables.
+{{site.data.alerts.end}}
+
+### Full and incremental backups
+
+If your cluster grows too large for nightly full backups, you can take less frequent full backups (e.g., weekly) with nightly incremental backups. Incremental backups are storage efficient and faster than full backups for larger clusters.
 
 Periodically run the [`BACKUP`][backup] command to take a full backup of your database:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO '<full_backup_location>';
+> BACKUP TO '<backup_location>';
 ~~~
 
-Then create nightly incremental backups based off of the full backups you've already created.
+Then, create nightly incremental backups based off of the full backups you've already created. If you backup to a destination already containing a full backup, an incremental backup will be appended to the full backup in a subdirectory:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO '<incremental_backup_location>'
-    INCREMENTAL FROM '<full_backup_location>', '<list_of_previous_incremental_backup_location>';
+> BACKUP TO '<backup_location>';
 ~~~
 
-If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM '<full_backup_location>', '<list_of_previous_incremental_backup_locations>';
-~~~
-
-{{site.data.alerts.callout_success}}
-[Restoring from incremental backups](restore.html#restore-from-incremental-backups) requires previous full and incremental backups.
+{{site.data.alerts.callout_info}}
+For an example on how to specify the destination of an incremental backup, see [Backup and Restore - Advanced Options](backup-and-restore-advanced-options.html#incremental-backups-with-explicitly-specified-destinations)
 {{site.data.alerts.end}}
 
-### Automated full and incremental backups
+If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster, database(s), and/or table(s). [Restoring from incremental backups](restore.html#restore-from-incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the automatically appended incremental backups (that are stored as subdirectories, like in the example above):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM '<backup_location>';
+~~~
+
+### Examples
+
+#### Automated full and incremental backups
 
 You can automate your backups using scripts and your preferred method of automation, such as cron jobs.
 
@@ -148,64 +177,28 @@ In the sample script, configure the day of the week for which you want to create
 If you miss an incremental backup, delete the `recent_backups.txt` file and run the script. It'll take a full backup for that day and incremental backups for subsequent days.
 {{site.data.alerts.end}}
 
-### Locality-aware backup and restore
+#### Advanced examples
 
-You can create locality-aware backups such that each node writes files only to the backup destination that matches the [node locality](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes) configured at [node startup](cockroach-start.html).
-
-This is useful for:
-
-- Reducing cloud storage data transfer costs by keeping data within cloud regions.
-- Helping you comply with data domiciling requirements.
-
-#### How it works
-
-A locality-aware backup is specified by a list of URIs, each of which has a `COCKROACH_LOCALITY` URL parameter whose single value is either `default` or a single locality key-value pair such as `region=us-east`. At least one `COCKROACH_LOCALITY` must be the `default`. Given a list of URIs that together contain the locations of all of the files for a single locality-aware backup, [`RESTORE`][restore] can read in that backup.
-
-During locality-aware backups, backup file placement is determined by leaseholder placement, as each node is responsible for backing up the ranges for which it is the leaseholder.  Nodes write files to the backup storage location whose locality matches their own node localities, with a preference for more specific values in the locality hierarchy.  If there is no match, the `default` locality is used.
-
-{{site.data.alerts.callout_info}}
-The list of URIs passed to [`RESTORE`][restore] may be different from the URIs originally passed to [`BACKUP`][backup]. This is because the files of a locality-aware backup can be moved to different locations, or even consolidated into the same location. The only restriction is that all the files originally written to the same location must remain together. In order for [`RESTORE`][restore] to succeed, all of the files originally written during [`BACKUP`][backup] must be accounted for in the list of location URIs provided.
-{{site.data.alerts.end}}
-
-#### Usage
-
-For example, to create a locality-aware backup where nodes with the locality `region=us-west` write backup files to `s3://us-west-bucket`, and all other nodes write to `s3://us-east-bucket` by default, run:
-
-{% include copy-clipboard.html %}
-~~~ sql
-BACKUP TO ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
-~~~
-
-To restore the backup created above, run the statement below. Note that the first URI in the list has to be the URI specified as the `default` URI when the backup was created. If you have moved your backups to a different location since the backup was originally taken, the first URI must be the new location of the files originally written to the `default` location.
-
-{% include copy-clipboard.html %}
-~~~ sql
-RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
-~~~
-
-A list of multiple URIs (surrounded by parentheses) specifying a locality-aware backup can also be used in place of any incremental backup URI in [`RESTORE`][restore]. If the original backup was an incremental backup, it can be restored using:
-
-{% include copy-clipboard.html %}
-~~~ sql
-RESTORE FROM 's3://other-full-backup-uri', ('s3://us-east-bucket', 's3://us-west-bucket');
-~~~
-
-For more detailed examples, see [Create locality-aware backups](backup.html#create-locality-aware-backups) and [Restore from a locality-aware backup based on node locality](restore.html#restore-from-a-locality-aware-backup).
-
-{{site.data.alerts.callout_info}}
-The locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
-{{site.data.alerts.end}}
+{% include {{ page.version.version }}/backups/advanced-examples-list.md %}
 
 ## Perform Core backup and restore
 
-If you do not have an Enterprise license, you can perform a core backup. Run the [`cockroach dump`](cockroach-dump.html) command to dump all the tables in the database to a new file (`backup.sql` in the following example):
+If you do not have an Enterprise license, you can perform a core backup. Run the [`cockroach dump`](cockroach-dump.html) command to dump all the tables in the database to a new file (e.g., `backup.sql`):
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach dump <database_name> <flags> > backup.sql
 ~~~
 
-To restore a database from a core backup, [use the `cockroach sql` command to execute the statements in the backup file](cockroach-dump.html#restore-a-table-from-a-backup-file):
+To restore a database from a core backup, use the [`IMPORT PGDUMP`](import.html#import-a-cockroachdb-dump-file) statement:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql --execute="IMPORT PGDUMP 's3://your-external-storage/backup.sql?AWS_ACCESS_KEY_ID=[placeholder]&AWS_SECRET_ACCESS_KEY=[placeholder]'" \
+ <flags>
+~~~
+
+You can also [use the `cockroach sql` command](cockroach-dump.html#restore-a-table-from-a-backup-file) to execute the [`CREATE  TABLE`](create-table.html) and [`INSERT`](insert.html) statements in the backup file:
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -213,11 +206,12 @@ $ cockroach sql --database=[database name] < backup.sql
 ~~~
 
 {{site.data.alerts.callout_success}}
-If you created a backup from another database and want to import it into CockroachDB, see [Import data](import-data.html).
+If you created a backup from another database and want to import it into CockroachDB, see the [Migration Overview](migration-overview.html).
 {{site.data.alerts.end}}
 
 ## See also
 
+- [Back up and Restore Data - Advanced Options](backup-and-restore-advanced-options.html)
 - [`BACKUP`][backup]
 - [`RESTORE`][restore]
 - [`SQL DUMP`](cockroach-dump.html)

--- a/v20.1/backup.md
+++ b/v20.1/backup.md
@@ -8,19 +8,9 @@ toc: true
 `BACKUP` is an [enterprise-only](https://www.cockroachlabs.com/product/cockroachdb/) feature. For non-enterprise backups, see [`cockroach dump`](cockroach-dump.html).
 {{site.data.alerts.end}}
 
-CockroachDB's `BACKUP` [statement](sql-statements.html) allows you to create full or incremental backups of your cluster's schema and data that are consistent as of a given timestamp. Backups can be with or without [revision history](#backups-with-revision-history).
+CockroachDB's `BACKUP` [statement](sql-statements.html) allows you to create [full or incremental backups](backup-and-restore.html#perform-enterprise-backup-and-restore) of your cluster's schema and data that are consistent as of a given timestamp.
 
-Because CockroachDB is designed with high fault tolerance, these backups are designed primarily for disaster recovery (i.e., if your cluster loses a majority of its nodes) through [`RESTORE`](restore.html). Isolated issues (such as small-scale node outages) do not require any intervention.
-
-{{site.data.alerts.callout_info}}
-To view the contents of an enterprise backup created with the `BACKUP` statement, use [`SHOW BACKUP`](show-backup.html).
-{{site.data.alerts.end}}
-
-## Functional details
-
-### Backup targets
-
-<span class="version-tag">New in v20.1:</span> You can backup a full cluster, which includes:
+<span class="version-tag">New in v20.1:</span> You can [backup a full cluster](#backup-a-cluster), which includes:
 
 - All user tables
 - Relevant system tables
@@ -28,94 +18,24 @@ To view the contents of an enterprise backup created with the `BACKUP` statement
 - All [tables](create-table.html) (which automatically includes their [indexes](indexes.html))
 - All [views](views.html)
 
-You can also back up individual tables (which automatically includes their indexes) or [views](views.html). Backing up an individual database will back up all of its tables and views.
+You can also back up:
+
+- [An individual database](#backup-a-database), which includes all of its tables and views
+- [An individual table](#backup-a-table-or-view), which includes its indexes and views
+
+Because CockroachDB is designed with high fault tolerance, these backups are designed primarily for disaster recovery (i.e., if your cluster loses a majority of its nodes) through [`RESTORE`](restore.html). Isolated issues (such as small-scale node outages) do not require any intervention.
 
 {{site.data.alerts.callout_info}}
 `BACKUP` only offers table-level granularity; it _does not_ support backing up subsets of a table.
 {{site.data.alerts.end}}
 
-### Object dependencies
-
-Dependent objects must be backed up at the same time as the objects they depend on.
-
-Object | Depends On
--------|-----------
-Table with [foreign key](foreign-key.html) constraints | The table it `REFERENCES`; however, this dependency can be [removed during the restore](restore.html#skip_missing_foreign_keys).
-Table with a [sequence](create-sequence.html) | The sequence it uses; however, this dependency can be [removed during the restore](restore.html#skip_missing_sequences).
-[Views](views.html) | The tables used in the view's `SELECT` statement.
-[Interleaved tables](interleave-in-parent.html) | The parent table in the [interleaved hierarchy](interleave-in-parent.html#interleaved-hierarchy).
-
-### Users and privileges
-
-The `system.users` table stores your users and their passwords. To restore your users and privilege [grants](grant.html), do a full cluster backup and restore the cluster to a fresh cluster with no user data. You can also backup the `system.users` table, and then use [this procedure](restore.html#restoring-users-from-system-users-backup).
-
-### Backup types
-
-CockroachDB offers two types of backups: [full](#full-backups) and [incremental](#incremental-backups).
-
-#### Full backups
-
-Full backups contain an unreplicated copy of your data and can always be used to restore your cluster. These files are roughly the size of your data and require greater resources to produce than incremental backups. You can take full backups as of a given timestamp and (optionally) include the available [revision history](backup.html#backups-with-revision-history).
-
-#### Incremental backups
-
-Incremental backups are smaller and faster to produce than full backups because they contain only the data that has changed since a base set of backups you specify (which must include one full backup, and can include many incremental backups). You can take incremental backups either as of a given timestamp or with full [revision history](#backups-with-revision-history).
-
-{{site.data.alerts.callout_danger}}
-Incremental backups can only be created within the garbage collection period of the base backup's most recent timestamp. This is because incremental backups are created by finding which data has been created or modified since the most recent timestamp in the base backup––that timestamp data, though, is deleted by the garbage collection process.
-
-You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html).
+{{site.data.alerts.callout_success}}
+To view the contents of an enterprise backup created with the `BACKUP` statement, use [`SHOW BACKUP`](show-backup.html).
 {{site.data.alerts.end}}
 
-For an example of an incremental backup, see the [Create incremental backups](#create-incremental-backups) section.
+## Required privileges
 
-### Backups with revision history
-
-You can create full or incremental backups [with revision history](#with-revision-history):
-
-- Taking full backups with revision history allows you to back up every change made within the garbage collection period leading up to and including the given timestamp.
-- Taking incremental backups with revision history allows you to back up every change made since the last backup and within the garbage collection period leading up to and including the given timestamp. You can take incremental backups with revision history even when your previous full or incremental backups were taken without revision history.
-
-You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html). Taking backups with revision history allows for point-in-time restores within the revision history.
-
-### Encrypted backups
-
-{% include {{ page.version.version }}/backups/encrypted-backup-description.md %}
-
-## Performance
-
-The `BACKUP` process minimizes its impact to the cluster's performance by distributing work to all nodes. Each node backs up only a specific subset of the data it stores (those for which it serves writes; more details about this architectural concept forthcoming), with no two nodes backing up the same data.
-
-For best performance, we also recommend always starting backups with a specific [timestamp](timestamp.html) at least 10 seconds in the past. For example:
-
-~~~ sql
-> BACKUP...AS OF SYSTEM TIME '-10s';
-~~~
-
-This improves performance by decreasing the likelihood that the `BACKUP` will be [retried because it contends with other statements/transactions](transactions.html#transaction-retries). However, because `AS OF SYSTEM TIME` returns historical data, your reads might be stale.
-
-## Automating backups
-
-We recommend automating daily backups of your cluster.
-
-To automate backups, you must have a client send the `BACKUP` statement to the cluster.
-
-Once the backup is complete, your client will receive a `BACKUP` response.
-
-## Viewing and controlling backups jobs
-
-After CockroachDB successfully initiates a backup, it registers the backup as a job, and you can do the following:
-
-- View the backup status with [`SHOW JOBS`](show-jobs.html)
-- Pause the backup with [`PAUSE JOB`](pause-job.html)
-- Resume the backup with [`RESUME JOB`](resume-job.html)
-- Cancel the backup [`CANCEL JOB`](cancel-job.html)
-
-The `BACKUP` statement will return when the backup is finished or if it encounters an error.
-
-{{site.data.alerts.callout_info}}
-The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually means the backup is not complete. This file is created when a backup is initiated, and is replaced with a `BACKUP` file once the backup is finished.
-{{site.data.alerts.end}}
+Only members of the `admin` role can run `BACKUP`. By default, the `root` user belongs to the `admin` role.
 
 ## Synopsis
 
@@ -139,26 +59,90 @@ The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually mea
 The `BACKUP` statement cannot be used within a [transaction](transactions.html).
 {{site.data.alerts.end}}
 
-## Options
+### Options
 
  Option                                                          | Value                   | Description
 -----------------------------------------------------------------+-------------------------+------------------------------
-`revision_history`<a name="with-revision-history"></a>           | N/A                     | Create a backup with full [revision history](#backups-with-revision-history), which records every change made to the cluster within the garbage collection period leading up to and including the given timestamp.
-`encryption_passphrase`<a name="with-encryption-passphrase"></a> | [`STRING`](string.html) | <span class="version-tag">New in v20.1:</span> The passphrase used to encrypt the files (`BACKUP` manifest and data files) that the `BACKUP` statement generates. This same passphrase is needed to decrypt the file when it is used to [restore](restore.html).
+`revision_history`<a name="with-revision-history"></a>           | N/A                     | Create a backup with full [revision history](backup-and-restore-advanced-options.html#backup-with-revision-history-and-point-in-time-restore), which records every change made to the cluster within the garbage collection period leading up to and including the given timestamp.
+`encryption_passphrase`<a name="with-encryption-passphrase"></a> | [`STRING`](string.html) | <span class="version-tag">New in v20.1:</span> The passphrase used to [encrypt the files](backup-and-restore-advanced-options.html#encrypted-backup-and-restore) (`BACKUP` manifest and data files) that the `BACKUP` statement generates. This same passphrase is needed to decrypt the file when it is used to [restore](backup-and-restore-advanced-options.html#restore-from-an-encrypted-backup).
 
-## Required privileges
-
-Only members of the `admin` role can run `BACKUP`. By default, the `root` user belongs to the `admin` role.
+For more information about these options, see [Back up and Restore Data - Advanced Options](backup-and-restore-advanced-options.html).
 
 ### Backup file URLs
 
-We will use the URL provided to construct a secure API call to the service you specify. The path to each backup must be unique, and the URL for your backup's destination/locations must use the following format:
+CockroachDB uses the URL provided to construct a secure API call to the service you specify. The path to each backup must be unique, and the URL for your backup's destination/locations must use the following format:
 
 {% include {{ page.version.version }}/misc/external-urls.md %}
 
+## Functional details
+
+### Object dependencies
+
+Dependent objects must be backed up at the same time as the objects they depend on.
+
+Object | Depends On
+-------|-----------
+Table with [foreign key](foreign-key.html) constraints | The table it `REFERENCES`; however, this dependency can be [removed during the restore](restore.html#skip_missing_foreign_keys).
+Table with a [sequence](create-sequence.html) | The sequence it uses; however, this dependency can be [removed during the restore](restore.html#skip_missing_sequences).
+[Views](views.html) | The tables used in the view's `SELECT` statement.
+[Interleaved tables](interleave-in-parent.html) | The parent table in the [interleaved hierarchy](interleave-in-parent.html#interleaved-hierarchy).
+
+### Users and privileges
+
+The `system.users` table stores your users and their passwords. To restore your users and privilege [grants](grant.html), do a full cluster backup and restore the cluster to a fresh cluster with no user data. You can also backup the `system.users` table, and then use [this procedure](backup-and-restore-advanced-options.html#restoring-users-from-system-users-backup).
+
+### Backup types
+
+CockroachDB offers two types of backups: [full](#full-backups) and [incremental](#incremental-backups).
+
+#### Full backups
+
+Full backups contain an unreplicated copy of your data and can always be used to restore your cluster. These files are roughly the size of your data and require greater resources to produce than incremental backups. You can take full backups as of a given timestamp and (optionally) include the available [revision history](backup-and-restore-advanced-options.html#backup-with-revision-history-and-point-in-time-restore).
+
+#### Incremental backups
+
+Incremental backups are smaller and faster to produce than full backups because they contain only the data that has changed since a base set of backups you specify (which must include one full backup, and can include many incremental backups). You can take incremental backups either as of a given timestamp or with full [revision history](backup-and-restore-advanced-options.html#backup-with-revision-history-and-point-in-time-restore).
+
+{{site.data.alerts.callout_danger}}
+Incremental backups can only be created within the garbage collection period of the base backup's most recent timestamp. This is because incremental backups are created by finding which data has been created or modified since the most recent timestamp in the base backup––that timestamp data, though, is deleted by the garbage collection process.
+
+You can configure garbage collection periods using the `ttlseconds` [replication zone setting](configure-replication-zones.html).
+{{site.data.alerts.end}}
+
+For an example of an incremental backup, see the [Create incremental backups](#create-incremental-backups) example below.
+
+## Performance
+
+The `BACKUP` process minimizes its impact to the cluster's performance by distributing work to all nodes. Each node backs up only a specific subset of the data it stores (those for which it serves writes; more details about this architectural concept forthcoming), with no two nodes backing up the same data.
+
+For best performance, we also recommend always starting backups with a specific [timestamp](timestamp.html) at least 10 seconds in the past. For example:
+
+~~~ sql
+> BACKUP...AS OF SYSTEM TIME '-10s';
+~~~
+
+This improves performance by decreasing the likelihood that the `BACKUP` will be [retried because it contends with other statements/transactions](transactions.html#transaction-retries). However, because `AS OF SYSTEM TIME` returns historical data, your reads might be stale.
+
+## Viewing and controlling backups jobs
+
+After CockroachDB successfully initiates a backup, it registers the backup as a job, and you can do the following:
+
+ Action                | SQL Statement
+-----------------------+-----------------
+View the backup status | [`SHOW JOBS`](show-jobs.html)
+Pause the backup       | [`PAUSE JOB`](pause-job.html)
+Resume the backup      | [`RESUME JOB`](resume-job.html)
+Cancel the backup      | [`CANCEL JOB`](cancel-job.html)
+
+You can also visit the [**Jobs** page](admin-ui-jobs-page.html) of the Admin UI to view job details. The `BACKUP` statement will return when the backup is finished or if it encounters an error.
+
+{{site.data.alerts.callout_info}}
+The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually means the backup is not complete. This file is created when a backup is initiated, and is replaced with a `BACKUP` file once the backup is finished.
+{{site.data.alerts.end}}
+
 ## Examples
 
-Per our guidance in the [Performance](#performance) section, we recommend starting backups from a time at least 10 seconds in the past using [`AS OF SYSTEM TIME`](as-of-system-time.html).
+Per our guidance in the [Performance](#performance) section, we recommend starting backups from a time at least 10 seconds in the past using [`AS OF SYSTEM TIME`](as-of-system-time.html). Each example below follows this guidance.
 
 ### Backup a cluster
 
@@ -171,7 +155,29 @@ Per our guidance in the [Performance](#performance) section, we recommend starti
 AS OF SYSTEM TIME '-10s';
 ~~~
 
-### Backup a single table or view
+### Backup a database
+
+To backup a single database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank \
+TO 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+To backup multiple databases:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank, employees \
+TO 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Backup a table or view
+
+To backup a single table or view:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -180,7 +186,7 @@ TO 'gs://acme-co-backup/bank-customers-2017-03-27-weekly' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
-### Backup multiple tables
+To backup multiple tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -189,27 +195,9 @@ TO 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
-### Backup an entire database
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP DATABASE bank \
-TO 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
-AS OF SYSTEM TIME '-10s';
-~~~
-
-### Backup with revision history
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO \
-'gs://acme-co-backup/test-cluster-2017-03-27-weekly' \
-AS OF SYSTEM TIME '-10s' WITH revision_history;
-~~~
-
 ### Create incremental backups
 
-<span class="version-tag">New in v20.1:</span> If you backup to a destination already containing a backup, an incremental backup will be produced in a subdirectory with a date-based name (e.g., `destination/day/time_1`, `destination/day/time_2`):
+<span class="version-tag">New in v20.1:</span> If you backup to a destination already containing a full backup, an incremental backup will be produced in a subdirectory with a date-based name (e.g., `destination/day/time_1`, `destination/day/time_2`):
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -218,149 +206,23 @@ AS OF SYSTEM TIME '-10s' WITH revision_history;
 AS OF SYSTEM TIME '-10s' WITH revision_history;
 ~~~
 
-To explicitly control where your incremental backups go, use the `INCREMENTAL FROM` syntax:
+This example shows incremental backups [with revision history](#with-revision-history).
 
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP DATABASE bank \
-TO 'gs://acme-co-backup/db/bank/2017-03-29-nightly' \
-AS OF SYSTEM TIME '-10s' \
-INCREMENTAL FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly' WITH revision_history;
-~~~
+For an example on how to control where your incremental backup goes, see [Incremental backups with explicitly specified destinations](backup-and-restore-advanced-options.html#incremental-backups-with-explicitly-specified-destinations).
 
-The examples above show incremental backups [with revision history](#with-revision-history).
+### Advanced examples
 
-### Create locality-aware backups
-
-You can create locality-aware backups such that each node writes files only to the backup destination that matches the [node locality](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes) configured at [node startup](cockroach-start.html).
-
-A locality-aware backup is specified by a list of URIs, each of which has a `COCKROACH_LOCALITY` URL parameter whose single value is either `default` or a single locality key-value pair such as `region=us-east`. At least one `COCKROACH_LOCALITY` must be the `default`.
-
-Backup file placement is determined by leaseholder placement, as each node is responsible for backing up the ranges for which it is the leaseholder.  Nodes write files to the backup storage location whose locality matches their own node localities, with a preference for more specific values in the locality hierarchy.  If there is no match, the `default` locality is used.
-
-{{site.data.alerts.callout_info}}
-Note that the locality query string parameters must be [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding) as [shown below](#example-create-a-locality-aware-backup).
-{{site.data.alerts.end}}
-
-#### Example - Create a locality-aware backup
-
-For example, to create a locality-aware backup where nodes with the locality `region=us-west` write backup files to `s3://us-west-bucket`, and all other nodes write to `s3://us-east-bucket` by default, run:
-
-{% include copy-clipboard.html %}
-~~~ sql
-BACKUP DATABASE bank TO ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
-~~~
-
-The backup created above can be restored by running:
-
-{% include copy-clipboard.html %}
-~~~ sql
-RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
-~~~
-
-#### Example - Create an incremental locality-aware backup
-
-To make an incremental locality-aware backup from a full locality-aware backup, the syntax is just like for [regular incremental backups](#create-incremental-backups):
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO \
-'gs://acme-co-backup/test-cluster' \
-AS OF SYSTEM TIME '-10s' WITH revision_history;
-~~~
-
-And if you want to explicitly control where your incremental backups go, use the `INCREMENTAL FROM` syntax:
-
-{% include copy-clipboard.html %}
-~~~ sql
-BACKUP TO (${uri_1}, ${uri_2}, ...) INCREMENTAL FROM ${full_backup_uri} ...;
-~~~
-
-For example, to create an incremental locality-aware backup from a previous full locality-aware backup where nodes with the locality `region=us-west` write backup files to `s3://us-west-bucket`, and all other nodes write to `s3://us-east-bucket` by default, run:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO \
-('s3://us-east-bucket/test-cluster-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/test-cluster-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
-INCREMENTAL FROM 's3://us-east-bucket/test-cluster-2019-10-07-weekly';
-~~~
-
-{{site.data.alerts.callout_info}}
-Note that only the backup URIs you set as the `default` when you created the previous backup(s) are needed in the `INCREMENTAL FROM` clause of your incremental `BACKUP` statement (as shown in the example). This is because the `default` destination for a locality-aware backup contains a manifest file that contains all the metadata required to create additional incremental backups based on it.
-{{site.data.alerts.end}}
-
-#### Example - Create an incremental locality-aware backup from a previous locality-aware backup
-
-To make an incremental locality-aware backup from another locality-aware backup, the syntax is as follows:
-
-{% include copy-clipboard.html %}
-~~~ sql
-BACKUP TO ({uri_1}, {uri_2}, ...) INCREMENTAL FROM {full_backup}, {incr_backup_1}, {incr_backup_2}, ...;
-~~~
-
-For example, let's say you normally run a full backup every Monday, followed by incremental backups on the remaining days of the week.
-
-By default, all nodes send their backups to your `s3://us-east-bucket`, except for nodes in `region=us-west`, which will send their backups to `s3://us-west-bucket`.
-
-If today is Thursday, October 10th, 2019, your `BACKUP` statement will list the following backup URIs:
-
-- The full locality-aware backup URI from Monday, e.g.,
-  - `s3://us-east-bucket/test-cluster-2019-10-07-weekly`
-- The incremental backup URIs from Tuesday and Wednesday, e.g.,
-  - `s3://us-east-bucket/test-cluster-2019-10-08-nightly`
-  - `s3://us-east-bucket/test-cluster-2019-10-09-nightly`
-
-Given the above, to take the incremental locality-aware backup scheduled for today (Thursday), you will run:
-
-{% include copy-clipboard.html %}
-~~~ sql
-BACKUP TO
-	('s3://us-east-bucket/test-cluster-2019-10-10-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/test-cluster-2019-10-10-nightly?COCKROACH_LOCALITY=region%3Dus-west')
-INCREMENTAL FROM
-	's3://us-east-bucket/test-cluster-2019-10-07-weekly',
-	's3://us-east-bucket/test-cluster-2019-10-08-nightly',
-	's3://us-east-bucket/test-cluster-2019-10-09-nightly';
-~~~
-
-{{site.data.alerts.callout_info}}
-Note that only the backup URIs you set as the `default` when you created the previous backup(s) are needed in the `INCREMENTAL FROM` clause of your incremental `BACKUP` statement (as shown in the example). This is because the `default` destination for a locality-aware backup contains a manifest file that contains all the metadata required to create additional incremental backups based on it.
-{{site.data.alerts.end}}
-
-### Create an encrypted backup
-
-<span class="version-tag">New in v20.1:</span> To create an [encrypted backup](#encrypted-backups), use the `encryption_passphrase` option:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO \
-'gs://acme-co-backup/test-cluster' \
-WITH encryption_passphrase = 'password123';
-~~~
-~~~
-        job_id       |  status   | fraction_completed | rows | index_entries | bytes
----------------------+-----------+--------------------+------+---------------+---------
-  543214409874014209 | succeeded |                  1 | 2597 |          1028 | 467701
-(1 row)
-~~~
-
-To [restore](restore.html), use the same `encryption_passphrase`:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM \
-'gs://acme-co-backup/test-cluster' \
-WITH encryption_passphrase = 'password123';
-~~~
-~~~
-        job_id       |  status   | fraction_completed | rows | index_entries | bytes
----------------------+-----------+--------------------+------+---------------+---------
-  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
-(1 row)
-~~~
+{% include {{ page.version.version }}/backups/advanced-examples-list.md %}
 
 ## See also
 
+- [Backup and Restore Data](backup-and-restore.html)
+- [Back up and Restore Data - Advanced Options](backup-and-restore-advanced-options.html)
 - [`SHOW BACKUP`](show-backup.html)
 - [`RESTORE`](restore.html)
-- [Backup and Restore Data](backup-and-restore.html)
 - [Configure Replication Zones](configure-replication-zones.html)
+
+<!-- Reference links -->
+
+[backup]:  backup.html
+[restore]: restore.html

--- a/v20.1/restore.md
+++ b/v20.1/restore.md
@@ -5,12 +5,61 @@ toc: true
 ---
 
 {{site.data.alerts.callout_info}}
-`RESTORE` is an [enterprise-only](https://www.cockroachlabs.com/product/cockroachdb/) feature. For non-enterprise restores, see [Restore Data](restore-data.html).
+`RESTORE` is an [enterprise-only](https://www.cockroachlabs.com/product/cockroachdb/) feature. For non-enterprise restores, see [Perform core backup and restore](backup-and-restore.html#perform-core-backup-and-restore).
 {{site.data.alerts.end}}
 
 The `RESTORE` [statement](sql-statements.html) restores your cluster's schemas and data from [an enterprise `BACKUP`][backup] stored on a services such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.
 
 Because CockroachDB is designed with high fault tolerance, restores are designed primarily for disaster recovery, i.e., restarting your cluster if it loses a majority of its nodes. Isolated issues (such as small-scale node outages) do not require any intervention.
+
+You can restore:
+
+- <span class="version-tag">New in v20.1:</span> [A full cluster](#full-cluster)
+- [Databases](#databases)
+- [Tables](#tables)
+
+## Synopsis
+
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/restore.html %}
+</div>
+
+## Parameters
+
+ Parameter | Description
+-----------|-------------
+ `table_pattern` | The table or [view](views.html) you want to restore.
+ `database_name` | The name of the database you want to restore (i.e., restore all tables and views in the database). You can restore an entire database only if you had backed up the entire database.
+ `full_backup_location` | The URL where the full backup is stored. <br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls).
+ `incremental_backup_location` | The URL where an incremental backup is stored.  <br/><br/>Lists of incremental backups must be sorted from oldest to newest. The newest incremental backup's timestamp must be within the table's garbage collection period.<br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). <br/><br/>For more information about garbage collection, see [Configure Replication Zones](configure-replication-zones.html#replication-zone-variables).
+ `AS OF SYSTEM TIME timestamp` | Restore data as it existed as of [`timestamp`](as-of-system-time.html). You can restore point-in-time data only if you had taken full or incremental backup [with revision history](backup-and-restore-advanced-options.html#backup-with-revision-history-and-point-in-time-restore).
+ `kv_option_list` | Control your backup's behavior with [these options](#options).
+
+{{site.data.alerts.callout_info}}
+The `RESTORE` statement cannot be used within a [transaction](transactions.html).
+{{site.data.alerts.end}}
+
+## Required privileges
+
+Only members of the `admin` role can run `RESTORE`. By default, the `root` user belongs to the `admin` role.
+
+### Backup file URLs
+
+The URL for your backup's locations must use the following format:
+
+{% include {{ page.version.version }}/misc/external-urls.md %}
+
+### Options
+
+You can include the following options as key-value pairs in the `kv_option_list` to control the restore process's behavior:
+
+ Option                                                             | <div style="width:75px">Value</div>         | Description
+ -------------------------------------------------------------------+---------------+-------------------------------------------------------
+<a name="into_db"></a>`into_db`                                     | Database name                               | Use to [change the target database](backup-and-restore-advanced-options.html#restore-into-a-different-database). This is useful if you want to restore a table that currently exists, but do not want to drop it.<br><br>Example: `WITH into_db = 'newdb'`
+<a name="skip_missing_foreign_keys"></a>`skip_missing_foreign_keys` | N/A                                         | Use to remove the [foreign key](foreign-key.html) constraints before restoring.<br><br>Example: `WITH skip_missing_foreign_keys`
+<a name="skip_missing_sequences"></a>`skip_missing_sequences`       | N/A                                         | Use to ignore [sequence](show-sequences.html) dependencies (i.e., the `DEFAULT` expression that uses the sequence).<br><br>Example: `WITH skip_missing_sequences`
+`skip_missing_views`                                                | N/A                                         | Use to skip restoring [views](views.html) that cannot be restored because their dependencies are not being restored at the same time.<br><br>Example: `WITH skip_missing_views`
+`encryption_passphrase`                                             | Passphrase used to create the [encrypted backup](backup-and-restore-advanced-options.html#encrypted-backup-and-restore) | <span class="version-tag">New in v20.1:</span> The passphrase used to decrypt the file(s) that were encrypted by the [`BACKUP`](backup-and-restore-advanced-options.html#encrypted-backup-and-restore) statement.
 
 ## Functional details
 
@@ -24,15 +73,13 @@ You can restore:
 
 #### Full cluster
 
-<span class="version-tag">New in v20.1:</span> You can restore a full cluster, which includes:
+<span class="version-tag">New in v20.1:</span> A full cluster restore can only be run on a target cluster with no user-created databases or tables. Restoring a full cluster includes:
 
 - All user tables
 - Relevant system tables
 - All [databases](create-database.html)
 - All [tables](create-table.html) (which automatically includes their [indexes](indexes.html))
 - All [views](views.html)
-
-Because this process is designed for disaster recovery, a full cluster restore can only be run on a target cluster with no databases or tables.
 
 {{site.data.alerts.callout_info}}
 When you do a full cluster restore, it will restore the [enterprise license](enterprise-licensing.html) of the cluster you are restoring from. If you want to use a different license in the new cluster, make sure to [update the license](enterprise-licensing.html#set-a-license) _after_ the restore is complete.
@@ -75,7 +122,7 @@ Table with a [sequence](create-sequence.html) | The sequence.
 
 To restore your users and privilege [grants](grant.html), you can do a full cluster backup and restore the cluster to a fresh cluster with no user data.
 
-If you are not doing a full cluster restore, the table-level privileges need to be granted to the users after the restore is complete. To do this, backup the `system.users` table, [restore users and their passwords](#restoring-users-from-system-users-backup), and then [grant](grant.html) the table-level privileges.
+If you are not doing a full cluster restore, the table-level privileges need to be granted to the users after the restore is complete. To do this, backup the `system.users` table, [restore users and their passwords](backup-and-restore-advanced-options.html#restoring-users-from-system-users-backup), and then [grant](grant.html) the table-level privileges.
 
 ### Restore types
 
@@ -86,21 +133,6 @@ Restore Type | Parameters
 Full backup | Include only the path to the full backup.
 Full backup + <br>incremental backups | If the full backup and incremental backups were sent to the same destination, include only the path to the full backup (e.g., `RESTORE FROM 'full_backup_location';`).<br><br>If the incremental backups were sent to a different destination from the full backup, include the path to the full backup as the first argument and the subsequent incremental backups from oldest to newest as the following arguments (e.g., `RESTORE FROM 'full_backup_location', 'incremental_location_1', 'incremental_location_2';`).
 
-### Point-in-time restore
-
-If the full or incremental backup was taken [with revision history](backup.html#backups-with-revision-history), you can restore the data as it existed at an arbitrary point-in-time within the revision history captured by that backup. Use the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause to specify the point-in-time.
-
-<span class="version-tag">New in v20.1:</span> Additionally, if you want to restore a specific incremental backup, you can do so by specifying the `end_time` of the backup by using the [`AS OF SYSTEM TIME`](as-of-system-time.html) clause. To find the incremental backup's `end_time`, use [`SHOW BACKUP`](show-backup.html).
-
-If you do not specify a point-in-time, the data will be restored to the backup timestamp; that is, the restore will work as if the data was backed up without revision history.
-
-#### Example - Point-in-time restore
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
-AS OF SYSTEM TIME '2017-02-26 10:00:00';
-~~~
 
 ## Performance
 
@@ -120,49 +152,6 @@ After the restore has been initiated, you can control it with [`PAUSE JOB`](paus
 If initiated correctly, the statement returns when the restore is finished or if it encounters an error. In some cases, the restore can continue after an error has been returned (the error message will tell you that the restore has resumed in background).
 {{site.data.alerts.end}}
 
-## Synopsis
-
-<div>
-  {% include {{ page.version.version }}/sql/diagrams/restore.html %}
-</div>
-
-## Parameters
-
- Parameter | Description
------------|-------------
- `table_pattern` | The table or [view](views.html) you want to restore.
- `database_name` | The name of the database you want to restore (i.e., restore all tables and views in the database). You can restore an entire database only if you had backed up the entire database.
- `full_backup_location` | The URL where the full backup is stored. <br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls).
- `incremental_backup_location` | The URL where an incremental backup is stored.  <br/><br/>Lists of incremental backups must be sorted from oldest to newest. The newest incremental backup's timestamp must be within the table's garbage collection period.<br/><br/>For information about this URL structure, see [Backup File URLs](#backup-file-urls). <br/><br/>For more information about garbage collection, see [Configure Replication Zones](configure-replication-zones.html#replication-zone-variables).
- `AS OF SYSTEM TIME timestamp` | Restore data as it existed as of [`timestamp`](as-of-system-time.html). You can restore point-in-time data only if you had taken full or incremental backup [with revision history](backup.html#backups-with-revision-history).
- `kv_option_list` | Control your backup's behavior with [these options](#options).
-
-{{site.data.alerts.callout_info}}
-The `RESTORE` statement cannot be used within a [transaction](transactions.html).
-{{site.data.alerts.end}}
-
-## Required privileges
-
-Only members of the `admin` role can run `RESTORE`. By default, the `root` user belongs to the `admin` role.
-
-### Backup file URLs
-
-The URL for your backup's locations must use the following format:
-
-{% include {{ page.version.version }}/misc/external-urls.md %}
-
-### Options
-
-You can include the following options as key-value pairs in the `kv_option_list` to control the restore process's behavior:
-
- Option                                                             | <div style="width:75px">Value</div>         | Description
- -------------------------------------------------------------------+---------------+-------------------------------------------------------
-<a name="into_db"></a>`into_db`                                     | Database name                               | Use to [change the target database](#restore-into-a-different-database). This is useful if you want to restore a table that currently exists, but do not want to drop it.<br><br>Example: `WITH into_db = 'newdb'`
-<a name="skip_missing_foreign_keys"></a>`skip_missing_foreign_keys` | N/A                                         | Use to remove the [foreign key](foreign-key.html) constraints before restoring.<br><br>Example: `WITH skip_missing_foreign_keys`
-<a name="skip_missing_sequences"></a>`skip_missing_sequences`       | N/A                                         | Use to ignore [sequence](show-sequences.html) dependencies (i.e., the `DEFAULT` expression that uses the sequence).<br><br>Example: `WITH skip_missing_sequences`
-`skip_missing_views`                                                | N/A                                         | Use to skip restoring [views](views.html) that cannot be restored because their dependencies are not being restored at the same time.<br><br>Example: `WITH skip_missing_views`
-`encryption_passphrase`                                             | Passphrase used to create the [encrypted backup](backup.html#encrypted-backups) | <span class="version-tag">New in v20.1:</span> The passphrase used to decrypt the file(s) that were encrypted by the [`BACKUP`](backup.html#encrypted-backups) statement.
-
 ## Examples
 
 ### Restore a cluster
@@ -174,20 +163,6 @@ You can include the following options as key-value pairs in the `kv_option_list`
 > RESTORE FROM 'gs://acme-co-backup/test-cluster';
 ~~~
 
-### Restore a single table
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly';
-~~~
-
-### Restore multiple tables
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers, bank.accounts FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly';
-~~~
-
 ### Restore a database
 
 {% include copy-clipboard.html %}
@@ -195,7 +170,25 @@ You can include the following options as key-value pairs in the `kv_option_list`
 > RESTORE DATABASE bank FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly';
 ~~~
 
-{{site.data.alerts.callout_info}}<code>RESTORE DATABASE</code> can only be used if the entire database was backed up.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+`RESTORE DATABASE` can only be used if the entire database was backed up.
+{{site.data.alerts.end}}
+
+### Restore a table
+
+To restore a single table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly';
+~~~
+
+To restore multiple tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers, bank.accounts FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly';
+~~~
 
 ### Restore from incremental backups
 
@@ -214,148 +207,15 @@ To explicitly point to where your incremental backups are, use the `INCREMENTAL 
 FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly';
 ~~~
 
-### Point-in-time restore from incremental backups
+### Advanced examples
 
-Restoring from incremental backups requires previous full and incremental backups. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM \
-'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly' \
-AS OF SYSTEM TIME '2017-02-28 10:00:00';
-~~~
-
-### Restore into a different database
-
-By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db`](#into_db) option, you can control the target database.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers \
-FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
-WITH into_db = 'newdb';
-~~~
-
-### Remove the foreign key before restore
-
-By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.accounts \
-FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly' \
-WITH skip_missing_foreign_keys;
-~~~
-
-### Restoring users from `system.users` backup
-
-The `system.users` table stores your cluster's usernames and their hashed passwords. To restore them, you must restore the `system.users` table into a new database because you cannot drop the existing `system.users` table.
-
-After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE system.users \
-FROM 'azure://acme-co-backup/table-users-2017-03-27-full?AZURE_ACCOUNT_KEY=hash&AZURE_ACCOUNT_NAME=acme-co' \
-WITH into_db = 'newdb';
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> INSERT INTO system.users SELECT * FROM newdb.users;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DROP TABLE newdb.users;
-~~~
-
-### Restore from a locality-aware backup
-
-You can create locality-aware backups such that each node writes files only to the backup destination that matches the [node locality](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes) configured at [node startup](cockroach-start.html).
-
-A locality-aware backup is specified by a list of URIs, each of which has a `COCKROACH_LOCALITY` URL parameter whose single value is either `default` or a single locality key-value pair such as `region=us-east`. At least one `COCKROACH_LOCALITY` must be the `default`. Given a list of URIs that together contain the locations of all of the files for a single locality-aware backup, [`RESTORE`][restore] can read in that backup.
-
-Note that the list of URIs passed to [`RESTORE`][restore] may be different from the URIs originally passed to [`BACKUP`][backup]. This is because it's possible to move the contents of one of the parts of a locality-aware backup (i.e., the files written to that destination) to a different location, or even to consolidate all the files for a locality-aware backup into a single location.
-
-{{site.data.alerts.callout_info}}
-[`RESTORE`][restore] is not truly locality-aware; while restoring from backups, a node may read from a store that does not match its locality. This can happen because [`BACKUP`][backup] does not back up [zone configurations](configure-replication-zones.html), so [`RESTORE`][restore] has no way of knowing how to take node localities into account when restoring data from a backup.
-{{site.data.alerts.end}}
-
-#### Example - Restore from a locality-aware backup
-
-For example, a backup created with
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO
-	  ('s3://us-east-bucket?COCKROACH_LOCALITY=default', 's3://us-west-bucket?COCKROACH_LOCALITY=region%3Dus-west');
-~~~
-
-can be restored by running:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM ('s3://us-east-bucket', 's3://us-west-bucket');
-~~~
-
-Note that the first URI in the list has to be the URI specified as the `default` URI when the backup was created. If you have moved your backups to a different location since the backup was originally taken, the first URI must be the new location of the files originally written to the `default` location.
-
-#### Example - Restore from an incremental locality-aware backup
-
-A locality-aware backup URI can also be used in place of any incremental backup URI in [`RESTORE`][restore].
-
-For example, an incremental locality-aware backup created with
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO
-	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=default', 's3://us-west-bucket/database-bank-2019-10-08-nightly?COCKROACH_LOCALITY=region%3Dus-west')
-  INCREMENTAL FROM
-	  's3://us-east-bucket/database-bank-2019-10-07-weekly';
-~~~
-
-can be restored by running:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM
-  	('s3://us-east-bucket/database-bank-2019-10-07-weekly', 's3://us-west-bucket/database-bank-2019-10-07-weekly'),
-	  ('s3://us-east-bucket/database-bank-2019-10-08-nightly', 's3://us-west-bucket/database-bank-2019-10-08-nightly');
-~~~
-
-### Restore from an encrypted backup
-
-<span class="version-tag">New in v20.1:</span> To decrypt an [encrypted backup](backup.html#encrypted-backups), use the `encryption_passphrase` and the same passphrase that was used to create the backup.
-
-For example, an encrypted backup created with:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> BACKUP TO \
-'gs://acme-co-backup/test-cluster' \
-WITH encryption_passphrase = 'password123';
-~~~
-
-Can be restored with:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM \
-'gs://acme-co-backup/test-cluster' \
-WITH encryption_passphrase = 'password123';
-~~~
-~~~
-        job_id       |  status   | fraction_completed | rows | index_entries | bytes
----------------------+-----------+--------------------+------+---------------+---------
-  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
-(1 row)
-~~~
+{% include {{ page.version.version }}/backups/advanced-examples-list.md %}
 
 ## See also
 
 - [`BACKUP`][backup]
 - [Backup and Restore Data](backup-and-restore.html)
+- [Back up and Restore Data - Advanced Options](backup-and-restore-advanced-options.html)
 - [Configure Replication Zones](configure-replication-zones.html)
 
 <!-- Reference links -->


### PR DESCRIPTION
Summary of Changes:

`backup-and-restore.md`

This doc describes the basic / common usage that most users will need. If a user only reads one doc to understand BACKUP / RESTORE, it should be this one. 

- Simplified the main Enterprise backup / restore example to be of a full cluster and with the new "append" incremental backup syntax
- Added a list of "advanced option examples" that links to the new `Back up and Restore Data - Advanced Options` doc

`BACKUP.md`

- Reorganized the information that was already on the page (removed excess headings but reorganized the information)
- Moved the "advanced usage" examples to the new `Back up and Restore - Advanced Options` doc and added a list of the examples on this doc (to help with CTRL+F)

`RESTORE.md`

- Reorganized the information that was already on the page (removed excess headings but reorganized the information)
- Moved the "advanced usage" examples to the new `Back up and Restore - Advanced Options` doc and added a list of the examples on this doc (to help with CTRL+F)

`backup-and-restore-advanced-options.md`

- Added to v20.1 sidebar
- Includes all of the "advanced usage" examples pulled from the BACKUP / RESTORE docs

Closes #6998