### PR TITLE
Document viewing locking strength with EXPLAIN

### DIFF
--- a/_includes/v20.1/misc/session-vars.html
+++ b/_includes/v20.1/misc/session-vars.html
@@ -107,6 +107,7 @@
 
   <tr>
    <td>
+    <a name="enable-implicit-select-for-update"></a>
     <code>enable_implicit_select_for_update</code>
    </td>
    <td><span class="version-tag">New in v20.1</span>: Indicates whether <a href="update.html"><code>UPDATE</code></a> statements acquire locks using the <code>FOR UPDATE</code> locking mode during their initial row scan, which improves performance for contended workloads.  For more information about how <code>FOR UPDATE</code> locking works, see the documentation for <a href="select-for-update.html"><code>SELECT FOR UPDATE</code></a>.</td>


### PR DESCRIPTION
Fixes #6699, #6903, #6920.

Summary of changes:

- Add a new section to EXPLAIN docs called 'Find out if a statement is
  using SELECT FOR UPDATE locking', with an example showing how to
  check.

- List out the SQL statements that have support enabled by default for
  SFU locking.