### PR TITLE
Document inconsistent time zone env var

### DIFF
--- a/v20.1/cockroach-start.md
+++ b/v20.1/cockroach-start.md
@@ -195,6 +195,14 @@ Field | Description
 `clusterID` | The ID of the cluster.<br><br>When trying to join a node to an existing cluster, if this ID is different than the ID of the existing cluster, the node has started a new cluster. This may be due to conflicting information in the node's data directory. For additional guidance, see the [troubleshooting](common-errors.html#node-belongs-to-cluster-cluster-id-but-is-attempting-to-connect-to-a-gossip-network-for-cluster-another-cluster-id) docs.
 `nodeID` | The ID of the node.
 
+## Environment variables
+
+The following environment variables change the behavior of `cockroach start`:
+
+| Variable                            | Description                                                                                                                                                         |
+|-------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `COCKROACH_INCONSISTENT_TIME_ZONES` | If set, CockroachDB will start even if time zones are not properly configured. This will cause incorrect SQL results, and other issues. For test environments only. |
+
 ## Known limitations
 
 {% include {{ page.version.version }}/known-limitations/adding-stores-to-node.md %}


### PR DESCRIPTION
Fixes #6928.

Summary of changes:

- Document a new env var `COCKROACH_INCONSISTENT_TIME_ZONES`, which
  allows you to start CRDB even if timezones are not properly
  configured (and thus things will break).  For testing only.