### PR TITLE
document authentication logs

### DIFF
--- a/_includes/v20.1/faq/sql-query-logging.md
+++ b/_includes/v20.1/faq/sql-query-logging.md
@@ -1,7 +1,8 @@
 There are several ways to log SQL queries. The type of logging you use will depend on your requirements.
 
 - For per-table audit logs, turn on [SQL audit logs](#sql-audit-logs).
-- For system troubleshooting and performance optimization, turn on [cluster-wide execution logs](#cluster-wide-execution-logs).
+- For system troubleshooting and performance optimization, turn on [cluster-wide execution logs](#cluster-wide-execution-logs) and [slow query logs](#slow-query-logs).
+- For connection troubleshooting, turn on [authentication logs](#authentication-logs).
 - For local testing, turn on [per-node execution logs](#per-node-execution-logs).
 
 ### SQL audit logs
@@ -18,23 +19,91 @@ SQL audit logging is useful if you want to log all queries that are run against 
 
 For production clusters, the best way to log all queries is to turn on the [cluster-wide setting](cluster-settings.html) `sql.trace.log_statement_execute`:
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > SET CLUSTER SETTING sql.trace.log_statement_execute = true;
 ~~~
 
 With this setting on, each node of the cluster writes all SQL queries it executes to a secondary `cockroach-sql-exec` log file. Use the symlink `cockroach-sql-exec.log` to open the most recent log. When you no longer need to log queries, you can turn the setting back off:
 
+{% include copy-clipboard.html %}
 ~~~ sql
 > SET CLUSTER SETTING sql.trace.log_statement_execute = false;
 ~~~
 
-Another useful cluster setting is `sql.log.slow_query.latency_threshold`, which is used to log only queries whose service latency exceeds a specified threshold value (e.g., 100 milliseconds):
+Log files are written to CockroachDB's standard [log directory](debug-and-error-logs.html#write-to-file).
 
+### Slow query logs
+
+Another useful [cluster setting](cluster-settings.html) is `sql.log.slow_query.latency_threshold`, which is used to log only queries whose service latency exceeds a specified threshold value (e.g., 100 milliseconds):
+
+{% include copy-clipboard.html %}
 ~~~ sql
 > SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '100ms';
 ~~~
 
-Each node that serves as a gateway will then record slow SQL queries to a `cockroach-sql-slow` log file. Use the symlink `cockroach-sql-slow.log` to open the most recent log. For more details on logging slow queries, see [Slow query log](query-behavior-troubleshooting.html#slow-query-log).
+Each node that serves as a gateway will then record slow SQL queries to a `cockroach-sql-slow` log file. Use the symlink `cockroach-sql-slow.log` to open the most recent log. For more details on logging slow queries, see [Using the slow query log](query-behavior-troubleshooting.html#using-the-slow-query-log).
+
+Log files are written to CockroachDB's standard [log directory](debug-and-error-logs.html#write-to-file).
+
+### Authentication logs
+
+{% include {{ page.version.version }}/misc/experimental-warning.md %}
+
+SQL client connections can be logged by turning on the `server.auth_log.sql_connections.enabled` [cluster setting](cluster-settings.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SET CLUSTER SETTING server.auth_log.sql_connections.enabled = true;
+~~~
+
+This will log *connection established* and *connection terminated* events to a `cockroach-auth` log file. Use the symlink `cockroach-auth.log` to open the most recent log. 
+
+{{site.data.alerts.callout_info}}
+In addition to SQL sessions, connection events can include SQL-based liveness probe attempts, as well as attempts to use the [PostgreSQL cancel protocol](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9).
+{{site.data.alerts.end}}
+
+Example log:
+
+~~~
+I200219 05:02:18.147679 1036 sql/pgwire/server.go:445  [n1,client] 16 received connection
+I200219 05:02:18.155284 1036 sql/pgwire/server.go:453  [n1,client,local] 21 disconnected; duration: 7.612943ms
+
+I200219 05:08:43.083907 5235 sql/pgwire/server.go:445  [n1,client=[::1]:34588] 22 received connection
+I200219 05:08:44.171384 5235 sql/pgwire/server.go:453  [n1,client=[::1]:34588,hostssl] 26 disconnected; duration: 1.087489893s
+~~~
+
+Along with the above, SQL client authenticated sessions can be logged by turning on the `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = true;
+~~~
+
+This logs *authentication method selection*, *authentication method application*, *authentication method result*, and *session termination* events to the `cockroach-auth` log file. Use the symlink `cockroach-auth.log` to open the most recent log. 
+
+Example authentication success log (TLS certificate over TCP):
+
+~~~
+I200219 05:08:43.089501 5149 sql/pgwire/auth.go:327  [n1,client=[::1]:34588,hostssl,user=root] 23 connection matches HBA rule:
+# TYPE DATABASE USER ADDRESS METHOD        OPTIONS
+host   all      root all     cert-password
+I200219 05:08:43.091045 5149 sql/pgwire/auth.go:327  [n1,client=[::1]:34588,hostssl,user=root] 24 authentication succeeded
+I200219 05:08:44.169684 5235 sql/pgwire/conn.go:216  [n1,client=[::1]:34588,hostssl,user=root] 25 session terminated; duration: 1.080240961s
+~~~
+
+Example authentication failure log (password over Unix socket):
+
+~~~
+I200219 05:02:18.148961 1037 sql/pgwire/auth.go:327  [n1,client,local,user=root] 17 connection matches HBA rule:
+# TYPE DATABASE USER ADDRESS METHOD   OPTIONS
+local  all      all          password
+I200219 05:02:18.151644 1037 sql/pgwire/auth.go:327  [n1,client,local,user=root] 18 user has no password defined
+I200219 05:02:18.152863 1037 sql/pgwire/auth.go:327  [n1,client,local,user=root] 19 authentication failed: password authentication failed for user root
+I200219 05:02:18.154168 1036 sql/pgwire/conn.go:216  [n1,client,local,user=root] 20 session terminated; duration: 5.261538ms
+~~~
+
+We recommend enabling both `server.auth_log.sql_connections.enabled` and `server.auth_log.sql_sessions.enabled` for complete logging of client connections. For more details on authentication and certificates, see [Authentication](authentication.html).
 
 Log files are written to CockroachDB's standard [log directory](debug-and-error-logs.html#write-to-file).
 

--- a/_includes/v20.1/faq/sql-query-logging.md
+++ b/_includes/v20.1/faq/sql-query-logging.md
@@ -12,8 +12,8 @@ There are several ways to log SQL queries. The type of logging you use will depe
 SQL audit logging is useful if you want to log all queries that are run against specific tables.
 
 - For a tutorial, see [SQL Audit Logging](sql-audit-logging.html).
-
 - For SQL reference documentation, see [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html).
+- Note that SQL audit logs perform one disk I/O per event and will impact performance.
 
 ### Cluster-wide execution logs
 
@@ -57,18 +57,15 @@ SQL client connections can be logged by turning on the `server.auth_log.sql_conn
 > SET CLUSTER SETTING server.auth_log.sql_connections.enabled = true;
 ~~~
 
-This will log *connection established* and *connection terminated* events to a `cockroach-auth` log file. Use the symlink `cockroach-auth.log` to open the most recent log. 
+This will log connection established and connection terminated events to a `cockroach-auth` log file. Use the symlink `cockroach-auth.log` to open the most recent log. 
 
 {{site.data.alerts.callout_info}}
 In addition to SQL sessions, connection events can include SQL-based liveness probe attempts, as well as attempts to use the [PostgreSQL cancel protocol](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9).
 {{site.data.alerts.end}}
 
-Example log:
+This example log shows both types of connection events over a `hostssl` (TLS certificate over TCP) connection:
 
 ~~~
-I200219 05:02:18.147679 1036 sql/pgwire/server.go:445  [n1,client] 16 received connection
-I200219 05:02:18.155284 1036 sql/pgwire/server.go:453  [n1,client,local] 21 disconnected; duration: 7.612943ms
-
 I200219 05:08:43.083907 5235 sql/pgwire/server.go:445  [n1,client=[::1]:34588] 22 received connection
 I200219 05:08:44.171384 5235 sql/pgwire/server.go:453  [n1,client=[::1]:34588,hostssl] 26 disconnected; duration: 1.087489893s
 ~~~
@@ -80,9 +77,9 @@ Along with the above, SQL client authenticated sessions can be logged by turning
 > SET CLUSTER SETTING server.auth_log.sql_sessions.enabled = true;
 ~~~
 
-This logs *authentication method selection*, *authentication method application*, *authentication method result*, and *session termination* events to the `cockroach-auth` log file. Use the symlink `cockroach-auth.log` to open the most recent log. 
+This logs authentication method selection, authentication method application, authentication method result, and session termination events to the `cockroach-auth` log file. Use the symlink `cockroach-auth.log` to open the most recent log. 
 
-Example authentication success log (TLS certificate over TCP):
+This example log shows authentication success over a `hostssl` (TLS certificate over TCP) connection:
 
 ~~~
 I200219 05:08:43.089501 5149 sql/pgwire/auth.go:327  [n1,client=[::1]:34588,hostssl,user=root] 23 connection matches HBA rule:
@@ -92,7 +89,7 @@ I200219 05:08:43.091045 5149 sql/pgwire/auth.go:327  [n1,client=[::1]:34588,host
 I200219 05:08:44.169684 5235 sql/pgwire/conn.go:216  [n1,client=[::1]:34588,hostssl,user=root] 25 session terminated; duration: 1.080240961s
 ~~~
 
-Example authentication failure log (password over Unix socket):
+This example log shows authentication failure log over a `local` (password over Unix socket) connection:
 
 ~~~
 I200219 05:02:18.148961 1037 sql/pgwire/auth.go:327  [n1,client,local,user=root] 17 connection matches HBA rule:
@@ -103,7 +100,9 @@ I200219 05:02:18.152863 1037 sql/pgwire/auth.go:327  [n1,client,local,user=root]
 I200219 05:02:18.154168 1036 sql/pgwire/conn.go:216  [n1,client,local,user=root] 20 session terminated; duration: 5.261538ms
 ~~~
 
-We recommend enabling both `server.auth_log.sql_connections.enabled` and `server.auth_log.sql_sessions.enabled` for complete logging of client connections. For more details on authentication and certificates, see [Authentication](authentication.html).
+For complete logging of client connections, we recommend enabling both `server.auth_log.sql_connections.enabled` and `server.auth_log.sql_sessions.enabled`. Note that both logs perform one disk I/O per event and will impact performance.
+
+For more details on authentication and certificates, see [Authentication](authentication.html).
 
 Log files are written to CockroachDB's standard [log directory](debug-and-error-logs.html#write-to-file).
 

--- a/v20.1/admin-ui-debug-pages.md
+++ b/v20.1/admin-ui-debug-pages.md
@@ -38,7 +38,7 @@ The **Even More Advanced Debugging** section of the page lists additional report
 Depending on your [access level](admin-ui-overview.html#admin-ui-access), the endpoints listed here provide access to:
 
 - [Log files](debug-and-error-logs.html#write-to-file)
-- Secondary log files (e.g., RocksDB logs, [execution logs](query-behavior-troubleshooting.html#cluster-wide-execution-logs), [slow query logs](query-behavior-troubleshooting.html#slow-query-log))
+- Secondary log files (e.g., RocksDB logs, [execution logs](query-behavior-troubleshooting.html#cluster-wide-execution-logs), [slow query logs](query-behavior-troubleshooting.html#slow-query-logs), [authentication logs](query-behavior-troubleshooting.html#authentication-logs))
 - Node status
 - Hot ranges
 - Node-specific metrics

--- a/v20.1/query-behavior-troubleshooting.md
+++ b/v20.1/query-behavior-troubleshooting.md
@@ -12,9 +12,9 @@ For a developer-centric walkthrough of optimizing SQL query performance, see [Ma
 
 ## Identify slow queries
 
-Use the [slow query log](#slow-query-log) or [Admin UI](#admin-ui) to detect slow queries in your cluster.
+Use the [slow query log](#using-the-slow-query-log) or [Admin UI](#using-the-admin-ui) to detect slow queries in your cluster.
 
-### Slow query log
+### Using the slow query log
 
 The slow query log is a record of SQL queries whose service latency exceeds a specified threshold value. When the `sql.log.slow_query.latency_threshold` [cluster setting](cluster-settings.html) is set to a non-zero value, each gateway node will log slow SQL queries to a secondary log file `cockroach-sql-slow.log` in the [log directory](debug-and-error-logs.html#write-to-file).
 
@@ -51,7 +51,7 @@ Service latency is the time taken to execute a query once it is received by the 
 
 {% include {{ page.version.version }}/admin-ui/admin-ui-log-files.md %}
 
-### Admin UI
+### Using the Admin UI
 
 High latency SQL statements are displayed on the [**Statements page**](admin-ui-statements-page.html) of the Admin UI. To view the Statements page, [access the Admin UI](admin-ui-access-and-navigate.html#access-the-admin-ui) and click **Statements** on the left.
 

--- a/v20.1/sql-audit-logging.md
+++ b/v20.1/sql-audit-logging.md
@@ -192,4 +192,4 @@ For reference documentation of the audit log file format, see [`ALTER TABLE ... 
 - [SQL FAQ - generating unique row IDs](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
 - [`CREATE SEQUENCE`](create-sequence.html)
 - [SQL Feature Support](sql-feature-support.html)
-- [Slow query log](query-behavior-troubleshooting.html#slow-query-log)
+- [Slow query log](query-behavior-troubleshooting.html#slow-query-logs)

--- a/v20.1/sql-audit-logging.md
+++ b/v20.1/sql-audit-logging.md
@@ -192,4 +192,5 @@ For reference documentation of the audit log file format, see [`ALTER TABLE ... 
 - [SQL FAQ - generating unique row IDs](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
 - [`CREATE SEQUENCE`](create-sequence.html)
 - [SQL Feature Support](sql-feature-support.html)
-- [Slow query log](query-behavior-troubleshooting.html#slow-query-logs)
+- [Authentication logs](query-behavior-troubleshooting.html#authentication-logs)
+- [Slow query logs](query-behavior-troubleshooting.html#slow-query-logs)


### PR DESCRIPTION
Fixes #6881.
Fixes #5976.

- Added authentication logs to "Troubleshoot Query Behavior" doc.
  - Used examples provided in the [PR](https://github.com/cockroachdb/cockroach/pull/45193).
  - I am assuming `cockroach-auth.log` is a symlink consistent with how short file naming is used with the other logs, but let me know if that is incorrect.
- Made some tweaks to slow query log to add consistency with the new documented logs.