### PR TITLE
Various replication report docs improvements

### DIFF
--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -570,12 +570,6 @@
             "urls": [
               "/${VERSION}/rotate-certificates.html"
             ]
-          },
-          {
-            "title": "Query Replication Reports",
-            "urls": [
-              "/${VERSION}/query-replication-reports.html"
-            ]
           }
         ]
       },
@@ -610,6 +604,12 @@
             "title": "Understand Debug Logs",
             "urls": [
               "/${VERSION}/debug-and-error-logs.html"
+            ]
+          },
+          {
+            "title": "Replication Reports",
+            "urls": [
+              "/${VERSION}/query-replication-reports.html"
             ]
           },
           {

--- a/v20.1/cluster-setup-troubleshooting.md
+++ b/v20.1/cluster-setup-troubleshooting.md
@@ -486,6 +486,18 @@ To view command commit latency:
 
 **Expected values for a healthy cluster**: On SSDs, this should be between 1 and 100 milliseconds.  On HDDs, this should be no more than 1 second.  Note that we [strongly recommend running CockroachDB on SSDs](recommended-production-settings.html#storage).
 
+## Check for under-replicated or unavailable data
+
+To see if any data is under-replicated or unavailable in your cluster, use the `system.replication_stats` report as described in [Replication Reports](query-replication-reports.html).
+
+## Check for replication zone constraint violations
+
+To see if any of your cluster's [data placement constraints](configure-replication-zones.html#replication-constraints) are being violated, use the `system.replication_constraint_stats` report as described in [Replication Reports](query-replication-reports.html).
+
+## Check for critical localities
+
+To see which of your [localities](cockroach-start.html#locality) (if any) are critical, use the `system.replication_critical_localities` report as described in [Replication Reports](query-replication-reports.html). A locality is "critical" for a range if all of the nodes in that locality becoming [unreachable](#node-liveness-issues) would cause the range to become unavailable. In other words, the locality contains a majority of the range's replicas.
+
 ## Something else?
 
 If we do not have a solution here, you can try using our other [support resources](support-resources.html), including:

--- a/v20.1/configure-replication-zones.md
+++ b/v20.1/configure-replication-zones.md
@@ -130,6 +130,10 @@ Constraint Scope | Description | Syntax
 
 See [Cluster Topography](recommended-production-settings.html#topology) recommendations for production deployments.
 
+### Troubleshooting zone constraint violations
+
+To see if any of the data placement constraints defined in your replication zone configurations are being violated, use the `system.replication_constraint_stats` report as described in [Replication Reports](query-replication-reports.html).
+
 ## View replication zones
 
 Use the [`SHOW ZONE CONFIGURATIONS`](#view-all-replication-zones) statement to view details about existing replication zones.
@@ -686,3 +690,4 @@ There's no need to make zone configuration changes; by default, the cluster is c
 - [`SHOW PARTITIONS`](show-partitions.html)
 - [SQL Statements](sql-statements.html)
 - [Table Partitioning](partitioning.html)
+- [Replication Reports](query-replication-reports.html)

--- a/v20.1/query-replication-reports.md
+++ b/v20.1/query-replication-reports.md
@@ -1,5 +1,5 @@
 ---
-title: Query Replication Reports
+title: Replication Reports
 summary: Verify that your cluster's data replication, data placement, and zone configurations are working as expected.
 keywords: availability zone, zone config, zone configs, zone configuration, constraint, constraints
 toc: true
@@ -64,6 +64,10 @@ The `system.replication_stats` report contains information about whether data is
 
 For an example using this table, see [Find out which databases and tables have under-replicated ranges](#find-out-which-databases-and-tables-have-under-replicated-ranges).
 
+<span class="version-tag">New in v20.1:</span> Ranges are considered under-replicated when one of the replicas is unresponsive. This includes the case when the node where the replica is stored is not running.
+
+<span class="version-tag">New in v20.1:</span> This report considers a node to be dead (for the purposes of calculating the `unavailable_ranges` and `under_replicated_ranges` columns) if its [liveness record](cluster-setup-troubleshooting.html#check-node-liveness-record-last-update) is expired, which occurs if the node is unresponsive for more than a few seconds. In versions of CockroachDB prior to 20.1, this report used the value of the [cluster setting](cluster-settings.html) `server.time_until_store_dead`, which defaults to 5 minutes.
+
 #### Columns
 
 | Column name             | Data type          | Description                                                                                                                           |
@@ -85,6 +89,8 @@ That said, a locality being critical is not necessarily a bad thing as long as y
 As described in [Configure Replication Zones](configure-replication-zones.html#descriptive-attributes-assigned-to-nodes), localities are key-value pairs defined at [node startup time](cockroach-start.html#locality), and are ordered into _locality tiers_ that range from most inclusive to least inclusive (e.g. region before datacenter as in `region=eu,dc=paris`).
 
 For an example using this table, see [Find out which databases and tables have ranges in critical localities](#find-out-which-databases-and-tables-have-ranges-in-critical-localities).
+
+<span class="version-tag">New in v20.1:</span> This report considers a node to be dead (for the purposes of calculating the `at_risk_ranges` column) if its [liveness record](cluster-setup-troubleshooting.html#check-node-liveness-record-last-update) is expired, which occurs if the node is unresponsive for more than a few seconds. In versions of CockroachDB prior to 20.1, this report used the value of the [cluster setting](cluster-settings.html) `server.time_until_store_dead`, which defaults to 5 minutes.
 
 #### Columns
 


### PR DESCRIPTION
Fixes #6604, fixes #6857, fixes #6323.

Summary of changes:

- Update replication reports docs to note that nodes are considered dead
  or unavailable much more quickly than before.

- Rename from 'Query Replication Reports' to 'Replication Reports' to
  mitigate some reported confusion about the name of the feature.

- Move 'Replication Reports' into the 'Troubleshooting' section of the
  docs, as that's more in line with their use.

- Add more links from 'Configure Replication Zones' to 'Replication
  Reports' page, so users know how to verify their constraints are being
  respected.

- Update 'Troubleshooting Cluster Setup' docs with links to replication
  reports for various cases.