### PR TITLE
Mark savepoints as 'New in v20.1' in more places

### DIFF
--- a/v20.1/release-savepoint.md
+++ b/v20.1/release-savepoint.md
@@ -4,7 +4,7 @@ summary: Commit a nested transaction.
 toc: true
 ---
 
-The `RELEASE SAVEPOINT` statement commits the [nested transaction](transactions.html#nested-transactions) starting at the corresponding `SAVEPOINT` statement using the same savepoint name, including all its nested sub-transactions.
+<span class="version-tag">New in v20.1:</span> The `RELEASE SAVEPOINT` statement commits the [nested transaction](transactions.html#nested-transactions) starting at the corresponding `SAVEPOINT` statement using the same savepoint name, including all its nested sub-transactions.  This is in addition to continued support for working with [retry savepoints](savepoint.html#savepoints-for-client-side-transaction-retries).
 
 ## Synopsis
 

--- a/v20.1/rollback-transaction.md
+++ b/v20.1/rollback-transaction.md
@@ -10,7 +10,7 @@ There are two ways to use `ROLLBACK`:
 
 - The `ROLLBACK` statement [rolls back the entire transaction](#rollback-a-transaction).
 
-- The `ROLLBACK TO SAVEPOINT` statement [rolls back and restarts the nested transaction](#rollback-a-nested-transaction) started at the corresponding `SAVEPOINT` statement.  It can be used for working with [standard savepoints](savepoint.html#savepoints-for-nested-transactions) and for implementing [client-side transaction retries](transactions.html#client-side-intervention).  For examples of each usage, see:
+- <span class="version-tag">New in v20.1:</span> The `ROLLBACK TO SAVEPOINT` statement [rolls back and restarts the nested transaction](#rollback-a-nested-transaction) started at the corresponding `SAVEPOINT` statement, for working with [standard savepoints](savepoint.html#savepoints-for-nested-transactions).  This is in addition to the existing support for working with [client-side transaction retries](transactions.html#client-side-intervention).  For examples of each usage, see:
 
   - [Rollback a nested transaction](#rollback-a-nested-transaction)
   - [Retry a transaction](#retry-a-transaction)

--- a/v20.1/savepoint.md
+++ b/v20.1/savepoint.md
@@ -6,6 +6,8 @@ toc: true
 
 A savepoint is a marker that defines the beginning of a [nested transaction](transactions.html#nested-transactions). This marker can be later used to commit or roll back just the effects of the nested transaction without affecting the progress of the enclosing transaction.
 
+<span class="version-tag">New in v20.1:</span> CockroachDB supports [general purpose savepoints for nested transactions](#savepoints-for-nested-transactions), in addition to continued support for [special-purpose retry savepoints](#savepoints-for-client-side-transaction-retries).
+
 {% include {{page.version.version}}/sql/savepoint-ddl-rollbacks.md %}
 
 ## Synopsis

--- a/v20.1/sql-statements.md
+++ b/v20.1/sql-statements.md
@@ -91,7 +91,7 @@ Statement | Usage
 ----------|------------
 [`BEGIN`](begin-transaction.html)| Initiate a [transaction](transactions.html).
 [`COMMIT`](commit-transaction.html) | Commit the current [transaction](transactions.html).
-[`SAVEPOINT`](savepoint.html) | Start a [nested transaction](transactions.html#nested-transactions).
+[`SAVEPOINT`](savepoint.html) | <span class="version-tag">New in v20.1:</span> Start a [nested transaction](transactions.html#nested-transactions).
 [`RELEASE SAVEPOINT`](release-savepoint.html) | Commit a [nested transaction](transactions.html#nested-transactions).
 [`ROLLBACK TO SAVEPOINT`](rollback-transaction.html#rollback-a-nested-transaction) | Roll back and restart the [nested transaction](transactions.html#nested-transactions) started at the corresponding `SAVEPOINT` statement.
 [`ROLLBACK`](rollback-transaction.html) | Roll back the current [transaction](transactions.html) and all of its [nested transaction](transactions.html#nested-transactions), discarding all transactional updates made by statements inside the transaction.


### PR DESCRIPTION
Addresses  #5953.

Summary of changes:

- Add 'new in v20.1' tags and appropriate verbiage to the following
  parts of the docs that were missed in some previous work in this area:

  - RELEASE SAVEPOINT
  - ROLLBACK
  - SAVEPOINT
  - 'SQL Statements'