### PR TITLE
Add formatted tables to search indexing

### DIFF
--- a/jekyll-algolia-dev/lib/jekyll-algolia.rb
+++ b/jekyll-algolia-dev/lib/jekyll-algolia.rb
@@ -26,7 +26,7 @@ module Jekyll
     # config - A hash of Jekyll config option (merge of _config.yml options and
     # options passed on the command line)
     #
-    # The gist of the plugin works by instanciating a Jekyll site,
+    # The gist of the plugin works by instantiating a Jekyll site,
     # monkey-patching its `write` method and building it.
     def self.init(config = {})
       # Monkey patch Jekyll and external plugins
@@ -61,7 +61,7 @@ module Jekyll
 
     # Public: Run the main Algolia module
     #
-    # Actually "process" the site, which will acts just like a regular `jekyll
+    # Actually "process" the site, which will act just like a regular `jekyll
     # build` except that our monkey patched `write` method will be called
     # instead.
     #

--- a/jekyll-algolia-dev/lib/jekyll/algolia/hooks.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/hooks.rb
@@ -46,23 +46,31 @@ module Jekyll
       # but a custom hook like this one can allow more fine-grained
       # customisation.
       def self.should_be_excluded?(filepath)
-        #We want to include the rease files
+        # We want to include release files
         return false if filepath.start_with?('release')
 
-        # We exclude from index if its not the stable version or if its dev
-        # version with different content
         versions = Configurator.config['versions']
         stable_version = versions['stable']
         dev_version = versions['dev']
 
+        # Index formatted tables if they are part of stable version
+        includePath = "_includes/".dup
+        includePath.concat(stable_version)
+        includePath.concat('/sql')
+
+        return false if filepath.start_with?(includePath)
+
+        # Exclude from index if files are not part of stable version.
+        # If valid stable version does not exist, index dev version.
         if filepath.start_with?(stable_version)
-          # If is stable we want to include
+          # Do not exclude from index if files are part of stable version
           false
         elsif filepath.start_with?(dev_version)
-          # Won't be indexed if stable version exists
+          # Do exclude dev version from index if a stable version exists
           has_stable_version?(filepath, dev_version, stable_version)
         else
-          # Exclude from index other versions
+          # For all cases that do not fall into the above two categories,
+          # do exclude
           true
         end
       end


### PR DESCRIPTION
This change allows tables pulled from the `_includes` folder to be indexed for search results.

This change also contains minor typo fixes and comment clarification for Algolia code.