### PR TITLE
Index table column text; bump Algolia max record size; clean up comments (Fixes 7107)

### DIFF
--- a/jekyll-algolia-dev/lib/jekyll-algolia.rb
+++ b/jekyll-algolia-dev/lib/jekyll-algolia.rb
@@ -26,7 +26,7 @@ module Jekyll
     # config - A hash of Jekyll config option (merge of _config.yml options and
     # options passed on the command line)
     #
-    # The gist of the plugin works by instanciating a Jekyll site,
+    # The gist of the plugin works by instantiating a Jekyll site,
     # monkey-patching its `write` method and building it.
     def self.init(config = {})
       # Monkey patch Jekyll and external plugins
@@ -61,7 +61,7 @@ module Jekyll
 
     # Public: Run the main Algolia module
     #
-    # Actually "process" the site, which will acts just like a regular `jekyll
+    # Actually "process" the site, which will act just like a regular `jekyll
     # build` except that our monkey patched `write` method will be called
     # instead.
     #

--- a/jekyll-algolia-dev/lib/jekyll/algolia/configurator.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/configurator.rb
@@ -12,9 +12,9 @@ module Jekyll
       ALGOLIA_DEFAULTS = {
         'extensions_to_index' => nil,
         'files_to_exclude' => nil,
-        'nodes_to_index' => 'p',
+        'nodes_to_index' => 'p,td',
         'indexing_batch_size' => 1000,
-        'max_record_size' => 10_000,
+        'max_record_size' => 20_000,
         'settings' => {
           # Searchable attributes
           'searchableAttributes' => %w[

--- a/jekyll-algolia-dev/lib/jekyll/algolia/hooks.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/hooks.rb
@@ -46,23 +46,24 @@ module Jekyll
       # but a custom hook like this one can allow more fine-grained
       # customisation.
       def self.should_be_excluded?(filepath)
-        #We want to include the rease files
+        # We want to include release files
         return false if filepath.start_with?('release')
 
-        # We exclude from index if its not the stable version or if its dev
-        # version with different content
+        # Exclude from index if files are not part of stable version.
+        # If valid stable version does not exist, index dev version.
         versions = Configurator.config['versions']
         stable_version = versions['stable']
         dev_version = versions['dev']
 
         if filepath.start_with?(stable_version)
-          # If is stable we want to include
+          # Do not exclude from index if files are part of stable version
           false
         elsif filepath.start_with?(dev_version)
-          # Won't be indexed if stable version exists
+          # Do exclude dev version from index if a stable version exists
           has_stable_version?(filepath, dev_version, stable_version)
         else
-          # Exclude from index other versions
+          # For all cases that do not fall into the above two categories,
+          # do exclude
           true
         end
       end


### PR DESCRIPTION
This change does a few things:
- Ask Algolia to start indexing text between \<td\> tags (doing this instead of \<table\> to avoid exceeding Algolia's record size restrictions)
- Bump our Algolia max record size from 10KB to 20KB, since we upgraded to a paid plan
- Clean up some existing code comments for better clarity