### PR TITLE
Revert commit that forces reindexing on all builds

### DIFF
--- a/netlify/build
+++ b/netlify/build
@@ -12,8 +12,8 @@ build _config_cockroachcloud.yml
 cp _site/docs/_redirects _site/_redirects
 cat _site/docs/cockroachcloud/_redirects >> _site/_redirects
 
-# Run Algolia
-# if [[ "$CONTEXT" = "production" ]]; then
+# Run Algolia if building master
+if [[ "$CONTEXT" = "production" ]]; then
 	echo "Building Algolia index..."
 	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml --builds-config _config_cockroachdb.yml,_config_cockroachcloud.yml
-# fi;
+fi;


### PR DESCRIPTION
I happened to notice that we are forcing reindexing on all builds, including for PR branches: 
https://github.com/cockroachdb/docs/commit/28298fa67b8013633dfd1705bb5ae085e17b82a3#diff-fc7ff7079492ad92dcee358fffdfb6db

There was probably a reason for this at some point, but I think it's safe to restore to default settings now.