### PR TITLE
Tweak savepoint language on upgrade finalization

### DIFF
--- a/v20.1/upgrade-cockroach-version.md
+++ b/v20.1/upgrade-cockroach-version.md
@@ -95,7 +95,7 @@ When upgrading from v19.2 to v20.1, certain features and performance improvement
 
 - **`CREATEROLE` and `NOCREATEROLE` privileges:** After finalization, it will be possible to allow or disallow a user or role to create, alter, or drop other roles via the `CREATEROLE` or `NOCREATEROLE` privilege.
 
-- **User-defined savepoints:** After finalization, it will be possible to use user-defined [`SAVEPOINT`s](savepoint.html) for nested transactions or for transaction retries in ORMs that require specific savepoint names. Previously, only the CockroachDB-defined `cockroach-restart` savepoint was supported.
+- **Nested transactions:** After finalization, it will be possible to create [nested transactions](transactions.html#nested-transactions) using [`SAVEPOINT`s](savepoint.html).
 
 - **`TIMETZ` data type:** After finalization, it will be possible to use the [`TIMETZ`](../v20.1/time.html#timetz) data type to store a time of day with a time zone offset from UTC.
 


### PR DESCRIPTION
This change:

- Brings the language on the 'Upgrade CockroachDB' page in line with how
  we are talking about nested transactions elsewhere

- Corrects an erroneous reference to changing retry savepoint names for
  ORM usage, which was first made available in 19.1.