### PR TITLE
Databases cannot be renamed if in explicit sequence reference

### DIFF
--- a/v20.1/create-sequence.md
+++ b/v20.1/create-sequence.md
@@ -13,6 +13,7 @@ The `CREATE SEQUENCE` [statement](sql-statements.html) creates a new sequence in
 - Using a sequence is slower than [auto-generating unique IDs with the `gen_random_uuid()`, `uuid_v4()` or `unique_rowid()` built-in functions](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb). Incrementing a sequence requires a write to persistent storage, whereas auto-generating a unique ID does not. Therefore, use auto-generated unique IDs unless an incremental sequence is preferred or required.
 - A column that uses a sequence can have a gap in the sequence values if a transaction advances the sequence and is then rolled back. Sequence updates are committed immediately and aren't rolled back along with their containing transaction. This is done to avoid blocking concurrent transactions that use the same sequence.
 - {% include {{page.version.version}}/performance/use-hash-sharded-indexes.md %}
+- If a table references a sequence, and the reference explicitly specifies a database name, that [database cannot be renamed](rename-database.html). In this case, you can drop the column in the table that references the sequence, or you can modify the reference so that it does not specify the database name.
 
 ## Required privileges
 


### PR DESCRIPTION
Fixes #6908.

- Added additional bullet to Considerations on `CREATE SEQUENCE` page.
- Reworked limitations on, added limitation and example to Rename Database page.
- Updated examples on Rename Database page.