### PR TITLE
Document that inverted indexes work on arrays

### DIFF
--- a/_includes/v20.1/sql/operators.md
+++ b/_includes/v20.1/sql/operators.md
@@ -112,7 +112,7 @@
 <tr><td>timetz <code>-</code> <a href="interval.html">interval</a></td><td>timetz</td></tr>
 </tbody></table>
 <table><thead>
-<tr><td><code>-></code></td><td>Return</td></tr>
+<tr><td><a name="operator-get-object-field"></a><code>-></code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td>jsonb <code>-></code> <a href="int.html">int</a></td><td>jsonb</td></tr>
 <tr><td>jsonb <code>-></code> <a href="string.html">string</a></td><td>jsonb</td></tr>
@@ -144,7 +144,7 @@
 <tr><td><a href="int.html">int</a> <code>//</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
 </tbody></table>
 <table><thead>
-<tr><td><code><</code></td><td>Return</td></tr>
+<tr><td><a name="operator-less-than"></a><code><</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code><</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code><</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -201,7 +201,7 @@
 <tr><td>varbit <code><<</code> <a href="int.html">int</a></td><td>varbit</td></tr>
 </tbody></table>
 <table><thead>
-<tr><td><code><=</code></td><td>Return</td></tr>
+<tr><td><a name="operator-less-than-or-equal"></a><code><=</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code><=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code><=</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -251,13 +251,13 @@
 <tr><td>varbit <code><=</code> varbit</td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
-<tr><td><code><@</code></td><td>Return</td></tr>
+<tr><td><a name="operator-is-contained-by"><code><@</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td>anyelement <code><@</code> anyelement</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>jsonb <code><@</code> jsonb</td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
-<tr><td><code>=</code></td><td>Return</td></tr>
+<tr><td><a name="operator-equals"></a><code>=</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code>=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>=</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -329,7 +329,7 @@
 <tr><td>jsonb <code>?|</code> <a href="string.html">string[]</a></td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
-<tr><td><code>@></code></td><td>Return</td></tr>
+<tr><td><a name="operator-contains"></a><code>@></code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td>anyelement <code>@></code> anyelement</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>jsonb <code>@></code> jsonb</td><td><a href="bool.html">bool</a></td></tr>

--- a/v20.1/array.md
+++ b/v20.1/array.md
@@ -8,13 +8,13 @@ The `ARRAY` data type stores one-dimensional, 1-indexed, homogeneous arrays of a
 
 The `ARRAY` data type is useful for ensuring compatibility with ORMs and other tools. However, if such compatibility is not a concern, it's more flexible to design your schema with normalized tables.
 
+<span class="version-tag">New in v20.1:</span> CockroachDB supports indexing array columns with [inverted indexes](inverted-indexes.html). This permits accelerating containment queries ([`@>`](functions-and-operators.html#operator-contains) and [`<@`](functions-and-operators.html#operator-is-contained-by)) on array columns by adding an index to them.
 
 {{site.data.alerts.callout_info}}
-CockroachDB does not support nested arrays, creating database indexes on arrays, and ordering by arrays.
+CockroachDB does not support nested arrays or ordering by arrays.
 {{site.data.alerts.end}}
 
 {% include {{page.version.version}}/sql/vectorized-support.md %}
-
 
 ## Syntax
 
@@ -86,6 +86,7 @@ For a complete list of array functions built into CockroachDB, see the [document
 ~~~
 
 ### Accessing an array element using array index
+
 {{site.data.alerts.callout_info}}
 Arrays in CockroachDB are 1-indexed.
 {{site.data.alerts.end}}
@@ -276,4 +277,5 @@ CockroachDB implicitly casts the string literal as an `INT[]`:
 
 ## See also
 
-[Data Types](data-types.html)
+- [Data Types](data-types.html)
+- [Inverted Indexes](inverted-indexes.html)


### PR DESCRIPTION
Fixes #6919.

Summary of changes:

- Update the 'Inverted indexes' page to mention support for SQL `ARRAY`
  type.  Add links to array docs.

- Update the `ARRAY` data type reference to mention this as well.

- Update the 'Functions and operators' page to use anchors so we can
  link directly to the containment operators `>@` and `@>` being
  mentioned.