### PR TITLE
Fix Rust driver examples and documentation, add to drivers list

### DIFF
--- a/_includes/v19.1/app/basic-sample.rs
+++ b/_includes/v19.1/app/basic-sample.rs
@@ -1,36 +1,43 @@
-extern crate postgres;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use postgres::Client;
+use postgres_openssl::MakeTlsConnector;
 
-use postgres::{Connection, TlsMode};
-use postgres::tls::openssl::OpenSsl;
-use postgres::tls::openssl::openssl::ssl::{SslConnectorBuilder, SslMethod};
-use postgres::tls::openssl::openssl::x509::X509_FILETYPE_PEM;
-
-fn ssl_config() -> OpenSsl {
-    // Warning! This API will be changing in the next version of these crates.
-    let mut connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-    connector_builder.set_ca_file("certs/ca.crt").unwrap();
-    connector_builder.set_certificate_chain_file("certs/client.maxroach.crt").unwrap();
-    connector_builder.set_private_key_file("certs/client.maxroach.key", X509_FILETYPE_PEM).unwrap();
-
-    let mut ssl = OpenSsl::new().unwrap();
-    *ssl.connector_mut() = connector_builder.build();
-    ssl
+fn ssl_config() -> Result<MakeTlsConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file("certs/ca.crt")?;
+    builder.set_certificate_chain_file("certs/client.maxroach.crt")?;
+    builder.set_private_key_file("certs/client.maxroach.key", SslFiletype::PEM)?;
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn main() {
-    let tls_mode = TlsMode::Require(&ssl_config());
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", tls_mode)
+    let connector = ssl_config().unwrap();
+    let mut client =
+        Client::connect("postgresql://maxroach@localhost:26257/bank", connector).unwrap();
+
+    // Create the "accounts" table.
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
+            &[],
+        )
         .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute(
-        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+            &[],
+        )
+        .unwrap();
 
     // Print out the balances.
     println!("Initial balances:");
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v19.1/app/insecure/basic-sample.rs
+++ b/_includes/v19.1/app/insecure/basic-sample.rs
@@ -1,20 +1,30 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode};
+use postgres::{Client, NoTls};
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
+
+    // Create the "accounts" table.
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
+            &[],
+        )
         .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute(
-        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+            &[],
+        )
+        .unwrap();
 
     // Print out the balances.
     println!("Initial balances:");
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v19.1/app/insecure/txn-sample.rs
+++ b/_includes/v19.1/app/insecure/txn-sample.rs
@@ -1,32 +1,31 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use postgres::{error::SqlState, Client, Error, NoTls, Transaction};
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -44,14 +43,16 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
 }
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
-        .unwrap();
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v19.1/app/txn-sample.rs
+++ b/_includes/v19.1/app/txn-sample.rs
@@ -1,35 +1,34 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::tls::openssl::OpenSsl;
-use postgres::tls::openssl::openssl::ssl::{SslConnectorBuilder, SslMethod};
-use postgres::tls::openssl::openssl::x509::X509_FILETYPE_PEM;
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use postgres::{error::SqlState, Client, Error, Transaction};
+use postgres_openssl::MakeTlsConnector;
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -46,28 +45,27 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
     Ok(())
 }
 
-fn ssl_config() -> OpenSsl {
-    // Warning! This API will be changing in the next version of these crates.
-    let mut connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-    connector_builder.set_ca_file("certs/ca.crt").unwrap();
-    connector_builder.set_certificate_chain_file("certs/client.maxroach.crt").unwrap();
-    connector_builder.set_private_key_file("certs/client.maxroach.key", X509_FILETYPE_PEM).unwrap();
-
-    let mut ssl = OpenSsl::new().unwrap();
-    *ssl.connector_mut() = connector_builder.build();
-    ssl
+fn ssl_config() -> Result<MakeTlsConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file("certs/ca.crt")?;
+    builder.set_certificate_chain_file("certs/client.maxroach.crt")?;
+    builder.set_private_key_file("certs/client.maxroach.key", SslFiletype::PEM)?;
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn main() {
-    let tls_mode = TlsMode::Require(&ssl_config());
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", tls_mode)
-        .unwrap();
+    let connector = ssl_config().unwrap();
+    let mut client =
+        Client::connect("postgresql://maxroach@localhost:26257/bank", connector).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v19.2/app/insecure/basic-sample.rs
+++ b/_includes/v19.2/app/insecure/basic-sample.rs
@@ -1,26 +1,30 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode};
+use postgres::{Client, NoTls};
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
-        .unwrap();
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
 
     // Create the "accounts" table.
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
+            &[],
+        )
+        .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute(
-        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+            &[],
+        )
+        .unwrap();
 
     // Print out the balances.
     println!("Initial balances:");
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v19.2/app/insecure/txn-sample.rs
+++ b/_includes/v19.2/app/insecure/txn-sample.rs
@@ -1,32 +1,31 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use postgres::{error::SqlState, Client, Error, NoTls, Transaction};
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -44,14 +43,16 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
 }
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
-        .unwrap();
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v19.2/app/txn-sample.rs
+++ b/_includes/v19.2/app/txn-sample.rs
@@ -1,35 +1,34 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::tls::openssl::OpenSsl;
-use postgres::tls::openssl::openssl::ssl::{SslConnectorBuilder, SslMethod};
-use postgres::tls::openssl::openssl::x509::X509_FILETYPE_PEM;
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use postgres::{error::SqlState, Client, Error, Transaction};
+use postgres_openssl::MakeTlsConnector;
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -46,28 +45,27 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
     Ok(())
 }
 
-fn ssl_config() -> OpenSsl {
-    // Warning! This API will be changing in the next version of these crates.
-    let mut connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-    connector_builder.set_ca_file("certs/ca.crt").unwrap();
-    connector_builder.set_certificate_chain_file("certs/client.maxroach.crt").unwrap();
-    connector_builder.set_private_key_file("certs/client.maxroach.key", X509_FILETYPE_PEM).unwrap();
-
-    let mut ssl = OpenSsl::new().unwrap();
-    *ssl.connector_mut() = connector_builder.build();
-    ssl
+fn ssl_config() -> Result<MakeTlsConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file("certs/ca.crt")?;
+    builder.set_certificate_chain_file("certs/client.maxroach.crt")?;
+    builder.set_private_key_file("certs/client.maxroach.key", SslFiletype::PEM)?;
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn main() {
-    let tls_mode = TlsMode::Require(&ssl_config());
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", tls_mode)
-        .unwrap();
+    let connector = ssl_config().unwrap();
+    let mut client =
+        Client::connect("postgresql://maxroach@localhost:26257/bank", connector).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v2.1/app/basic-sample.rs
+++ b/_includes/v2.1/app/basic-sample.rs
@@ -1,36 +1,43 @@
-extern crate postgres;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use postgres::Client;
+use postgres_openssl::MakeTlsConnector;
 
-use postgres::{Connection, TlsMode};
-use postgres::tls::openssl::OpenSsl;
-use postgres::tls::openssl::openssl::ssl::{SslConnectorBuilder, SslMethod};
-use postgres::tls::openssl::openssl::x509::X509_FILETYPE_PEM;
-
-fn ssl_config() -> OpenSsl {
-    // Warning! This API will be changing in the next version of these crates.
-    let mut connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-    connector_builder.set_ca_file("certs/ca.crt").unwrap();
-    connector_builder.set_certificate_chain_file("certs/client.maxroach.crt").unwrap();
-    connector_builder.set_private_key_file("certs/client.maxroach.key", X509_FILETYPE_PEM).unwrap();
-
-    let mut ssl = OpenSsl::new().unwrap();
-    *ssl.connector_mut() = connector_builder.build();
-    ssl
+fn ssl_config() -> Result<MakeTlsConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file("certs/ca.crt")?;
+    builder.set_certificate_chain_file("certs/client.maxroach.crt")?;
+    builder.set_private_key_file("certs/client.maxroach.key", SslFiletype::PEM)?;
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn main() {
-    let tls_mode = TlsMode::Require(&ssl_config());
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", tls_mode)
+    let connector = ssl_config().unwrap();
+    let mut client =
+        Client::connect("postgresql://maxroach@localhost:26257/bank", connector).unwrap();
+
+    // Create the "accounts" table.
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
+            &[],
+        )
         .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute(
-        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+            &[],
+        )
+        .unwrap();
 
     // Print out the balances.
     println!("Initial balances:");
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v2.1/app/insecure/basic-sample.rs
+++ b/_includes/v2.1/app/insecure/basic-sample.rs
@@ -1,20 +1,30 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode};
+use postgres::{Client, NoTls};
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
+
+    // Create the "accounts" table.
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
+            &[],
+        )
         .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute(
-        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+            &[],
+        )
+        .unwrap();
 
     // Print out the balances.
     println!("Initial balances:");
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v2.1/app/insecure/txn-sample.rs
+++ b/_includes/v2.1/app/insecure/txn-sample.rs
@@ -1,32 +1,31 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use postgres::{error::SqlState, Client, Error, NoTls, Transaction};
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -44,14 +43,16 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
 }
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
-        .unwrap();
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v2.1/app/txn-sample.rs
+++ b/_includes/v2.1/app/txn-sample.rs
@@ -1,35 +1,34 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::tls::openssl::OpenSsl;
-use postgres::tls::openssl::openssl::ssl::{SslConnectorBuilder, SslMethod};
-use postgres::tls::openssl::openssl::x509::X509_FILETYPE_PEM;
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use postgres::{error::SqlState, Client, Error, Transaction};
+use postgres_openssl::MakeTlsConnector;
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -46,28 +45,27 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
     Ok(())
 }
 
-fn ssl_config() -> OpenSsl {
-    // Warning! This API will be changing in the next version of these crates.
-    let mut connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-    connector_builder.set_ca_file("certs/ca.crt").unwrap();
-    connector_builder.set_certificate_chain_file("certs/client.maxroach.crt").unwrap();
-    connector_builder.set_private_key_file("certs/client.maxroach.key", X509_FILETYPE_PEM).unwrap();
-
-    let mut ssl = OpenSsl::new().unwrap();
-    *ssl.connector_mut() = connector_builder.build();
-    ssl
+fn ssl_config() -> Result<MakeTlsConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file("certs/ca.crt")?;
+    builder.set_certificate_chain_file("certs/client.maxroach.crt")?;
+    builder.set_private_key_file("certs/client.maxroach.key", SslFiletype::PEM)?;
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn main() {
-    let tls_mode = TlsMode::Require(&ssl_config());
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", tls_mode)
-        .unwrap();
+    let connector = ssl_config().unwrap();
+    let mut client =
+        Client::connect("postgresql://maxroach@localhost:26257/bank", connector).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v20.1/app/insecure/basic-sample.rs
+++ b/_includes/v20.1/app/insecure/basic-sample.rs
@@ -1,26 +1,30 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode};
+use postgres::{Client, NoTls};
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
-        .unwrap();
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
 
     // Create the "accounts" table.
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "CREATE TABLE IF NOT EXISTS accounts (id INT PRIMARY KEY, balance INT)",
+            &[],
+        )
+        .unwrap();
 
     // Insert two rows into the "accounts" table.
-    conn.execute(
-        "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
-        &[],
-    ).unwrap();
+    client
+        .execute(
+            "INSERT INTO accounts (id, balance) VALUES (1, 1000), (2, 250)",
+            &[],
+        )
+        .unwrap();
 
     // Print out the balances.
     println!("Initial balances:");
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v20.1/app/insecure/txn-sample.rs
+++ b/_includes/v20.1/app/insecure/txn-sample.rs
@@ -1,32 +1,31 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use postgres::{error::SqlState, Client, Error, NoTls, Transaction};
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -44,14 +43,16 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
 }
 
 fn main() {
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", TlsMode::None)
-        .unwrap();
+    let mut client = Client::connect("postgresql://maxroach@localhost:26257/bank", NoTls).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/_includes/v20.1/app/txn-sample.rs
+++ b/_includes/v20.1/app/txn-sample.rs
@@ -1,35 +1,34 @@
-extern crate postgres;
-
-use postgres::{Connection, TlsMode, Result};
-use postgres::tls::openssl::OpenSsl;
-use postgres::tls::openssl::openssl::ssl::{SslConnectorBuilder, SslMethod};
-use postgres::tls::openssl::openssl::x509::X509_FILETYPE_PEM;
-use postgres::transaction::Transaction;
-use postgres::error::T_R_SERIALIZATION_FAILURE;
+use openssl::error::ErrorStack;
+use openssl::ssl::{SslConnector, SslFiletype, SslMethod};
+use postgres::{error::SqlState, Client, Error, Transaction};
+use postgres_openssl::MakeTlsConnector;
 
 /// Runs op inside a transaction and retries it as needed.
 /// On non-retryable failures, the transaction is aborted and
 /// rolled back; on success, the transaction is committed.
-fn execute_txn<T, F>(conn: &Connection, mut op: F) -> Result<T>
+fn execute_txn<T, F>(client: &mut Client, op: F) -> Result<T, Error>
 where
-    F: Fn(&Transaction) -> Result<T>,
+    F: Fn(&mut Transaction) -> Result<T, Error>,
 {
-    let txn = conn.transaction()?;
+    let mut txn = client.transaction()?;
     loop {
-        let sp = txn.savepoint("cockroach_restart")?;
-        match op(&sp).and_then(|t| sp.commit().map(|_| t)) {
-            Err(ref err) if err.as_db()
-                               .map(|e| e.code == T_R_SERIALIZATION_FAILURE)
-                               .unwrap_or(false) => {},
+        let mut sp = txn.savepoint("cockroach_restart")?;
+        match op(&mut sp).and_then(|t| sp.commit().map(|_| t)) {
+            Err(ref err)
+                if err
+                    .code()
+                    .map(|e| *e == SqlState::T_R_SERIALIZATION_FAILURE)
+                    .unwrap_or(false) => {}
             r => break r,
         }
-    }.and_then(|t| txn.commit().map(|_| t))
+    }
+    .and_then(|t| txn.commit().map(|_| t))
 }
 
-fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<()> {
+fn transfer_funds(txn: &mut Transaction, from: i64, to: i64, amount: i64) -> Result<(), Error> {
     // Read the balance.
-    let from_balance: i64 = txn.query("SELECT balance FROM accounts WHERE id = $1", &[&from])?
-        .get(0)
+    let from_balance: i64 = txn
+        .query_one("SELECT balance FROM accounts WHERE id = $1", &[&from])?
         .get(0);
 
     assert!(from_balance >= amount);
@@ -46,28 +45,27 @@ fn transfer_funds(txn: &Transaction, from: i64, to: i64, amount: i64) -> Result<
     Ok(())
 }
 
-fn ssl_config() -> OpenSsl {
-    // Warning! This API will be changing in the next version of these crates.
-    let mut connector_builder = SslConnectorBuilder::new(SslMethod::tls()).unwrap();
-    connector_builder.set_ca_file("certs/ca.crt").unwrap();
-    connector_builder.set_certificate_chain_file("certs/client.maxroach.crt").unwrap();
-    connector_builder.set_private_key_file("certs/client.maxroach.key", X509_FILETYPE_PEM).unwrap();
-
-    let mut ssl = OpenSsl::new().unwrap();
-    *ssl.connector_mut() = connector_builder.build();
-    ssl
+fn ssl_config() -> Result<MakeTlsConnector, ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_ca_file("certs/ca.crt")?;
+    builder.set_certificate_chain_file("certs/client.maxroach.crt")?;
+    builder.set_private_key_file("certs/client.maxroach.key", SslFiletype::PEM)?;
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn main() {
-    let tls_mode = TlsMode::Require(&ssl_config());
-    let conn = Connection::connect("postgresql://maxroach@localhost:26257/bank", tls_mode)
-        .unwrap();
+    let connector = ssl_config().unwrap();
+    let mut client =
+        Client::connect("postgresql://maxroach@localhost:26257/bank", connector).unwrap();
 
     // Run a transfer in a transaction.
-    execute_txn(&conn, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
+    execute_txn(&mut client, |txn| transfer_funds(txn, 1, 2, 100)).unwrap();
 
     // Check account balances after the transaction.
-    for row in &conn.query("SELECT id, balance FROM accounts", &[]).unwrap() {
+    for row in &client
+        .query("SELECT id, balance FROM accounts", &[])
+        .unwrap()
+    {
         let id: i64 = row.get(0);
         let balance: i64 = row.get(1);
         println!("{} {}", id, balance);

--- a/v19.2/build-a-rust-app-with-cockroachdb.md
+++ b/v19.2/build-a-rust-app-with-cockroachdb.md
@@ -13,11 +13,13 @@ We have tested the <a href="https://crates.io/crates/postgres/" data-proofer-ign
 
 {% include {{page.version.version}}/app/before-you-begin.md %}
 
-## Step 1. Install the Rust Postgres driver
-
-Install the Rust Postgres driver as described in the <a href="https://crates.io/crates/postgres/" data-proofer-ignore>official documentation</a>.
-
 <section class="filter-content" markdown="1" data-scope="secure">
+
+## Step 1. Specify the Rust Postgres driver as a dependency
+
+Update your `Cargo.toml` file to specify a dependency on the Rust Postgres driver, as described in the <a href="https://crates.io/crates/postgres/" data-proofer-ignore>official documentation</a>.
+
+Additionally, include the <a href="https://crates.io/crates/openssl" data-proofer-ignore>OpenSSL bindings</a> and <a href="https://crates.io/crates/postgres-openssl/" data-proofer-ignore>Rust Postgres OpenSSL</a> crates as dependencies.
 
 ## Step 2. Create the `maxroach` users and `bank` database
 
@@ -82,6 +84,10 @@ $ cockroach sql --certs-dir=certs -e 'SELECT id, balance FROM accounts' --databa
 </section>
 
 <section class="filter-content" markdown="1" data-scope="insecure">
+
+## Step 1. Specify the Rust Postgres driver as a dependency
+
+Update your `Cargo.toml` file to specify a dependency on the Rust Postgres driver, as described in the <a href="https://crates.io/crates/postgres/" data-proofer-ignore>official documentation</a>.
 
 ## Step 2. Create the `maxroach` users and `bank` database
 

--- a/v19.2/install-client-drivers.md
+++ b/v19.2/install-client-drivers.md
@@ -21,6 +21,7 @@ Applications may encounter incompatibilities when using advanced or obscure feat
   <button class="filter-button page-level" data-scope="c-sharp">C# (.NET)</button>
   <button class="filter-button page-level" data-scope="clojure">Clojure</button>
   <button class="filter-button page-level" data-scope="php">PHP</button>
+  <button class="filter-button page-level" data-scope="rust">Rust</button>
   <button class="filter-button page-level" data-scope="typescript">TypeScript</button>
 </div>
 
@@ -425,6 +426,20 @@ For a simple but complete "Hello World" example app, see [Build a Closure App wi
 Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
 
 For a simple but complete "Hello World" example app, see [Build a PHP App with CockroachDB and the PHP pgsql Driver](build-a-php-app-with-cockroachdb.html).
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="rust">
+
+## Drivers
+
+### postgres
+
+**Support level:** Beta
+
+Install the Rust Postgres driver as described in the [official documentation](https://crates.io/crates/postgres/).
+
+For a simple but complete "Hello World" example app, see [Build a Rust App with CockroachDB and the Rust Postgres Driver](build-a-rust-app-with-cockroachdb.html).
 
 </section>
 

--- a/v20.1/build-a-rust-app-with-cockroachdb.md
+++ b/v20.1/build-a-rust-app-with-cockroachdb.md
@@ -13,11 +13,13 @@ We have tested the <a href="https://crates.io/crates/postgres/" data-proofer-ign
 
 {% include {{page.version.version}}/app/before-you-begin.md %}
 
-## Step 1. Install the Rust Postgres driver
-
-Install the Rust Postgres driver as described in the <a href="https://crates.io/crates/postgres/" data-proofer-ignore>official documentation</a>.
-
 <section class="filter-content" markdown="1" data-scope="secure">
+
+## Step 1. Specify the Rust Postgres driver as a dependency
+
+Update your `Cargo.toml` file to specify a dependency on the Rust Postgres driver, as described in the <a href="https://crates.io/crates/postgres/" data-proofer-ignore>official documentation</a>.
+
+Additionally, include the <a href="https://crates.io/crates/openssl" data-proofer-ignore>OpenSSL bindings</a> and <a href="https://crates.io/crates/postgres-openssl/" data-proofer-ignore>Rust Postgres OpenSSL</a> crates as dependencies.
 
 ## Step 2. Create the `maxroach` users and `bank` database
 
@@ -82,6 +84,10 @@ $ cockroach sql --certs-dir=certs -e 'SELECT id, balance FROM accounts' --databa
 </section>
 
 <section class="filter-content" markdown="1" data-scope="insecure">
+
+## Step 1. Specify the Rust Postgres driver as a dependency
+
+Update your `Cargo.toml` file to specify a dependency on the Rust Postgres driver, as described in the <a href="https://crates.io/crates/postgres/" data-proofer-ignore>official documentation</a>.
 
 ## Step 2. Create the `maxroach` users and `bank` database
 

--- a/v20.1/install-client-drivers.md
+++ b/v20.1/install-client-drivers.md
@@ -428,6 +428,20 @@ For a simple but complete "Hello World" example app, see [Build a PHP App with C
 
 </section>
 
+<section class="filter-content" markdown="1" data-scope="rust">
+
+## Drivers
+
+### postgres
+
+**Support level:** Beta
+
+Install the Rust Postgres driver as described in the [official documentation](https://crates.io/crates/postgres/).
+
+For a simple but complete "Hello World" example app, see [Build a Rust App with CockroachDB and the Rust Postgres Driver](build-a-rust-app-with-cockroachdb.html).
+
+</section>
+
 <section class="filter-content" markdown="1" data-scope="typescript">
 
 ## ORMs


### PR DESCRIPTION
Fixes #5560.

- Update secure driver instructions to point to https://crates.io/crates/postgres-openssl/.
- Update secure basic samples for latest version of driver for v2.1-v20.1.
- Update secure txn samples for latest version of driver for v2.1-v20.1.
- Update insecure basic samples for latest version of driver for v2.1-v20.1.
- Update insecure txn samples for latest version of driver for v2.1-v20.1.
- Add Rust driver to Postgres Client listing page