### PR TITLE
Correct kv.range_split.load_qps_threshold default

### DIFF
--- a/v19.1/load-based-splitting.md
+++ b/v19.1/load-based-splitting.md
@@ -1,5 +1,5 @@
 ---
-title: Load-Based Splitting 
+title: Load-Based Splitting
 summary: To optimize your cluster's performance, CockroachDB can split frequently accessed keys into their own ranges.
 toc: true
 ---
@@ -22,7 +22,7 @@ Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.by_
 
 #### When to enable load-based splitting
 
-Load-based splitting is on by default and beneficial in almost all situations. 
+Load-based splitting is on by default and beneficial in almost all situations.
 
 #### When to disable load-based splitting
 
@@ -30,11 +30,11 @@ You might want to disable load-based splitting when troubleshooting range-relate
 
 ### Control load-based splitting threshold
 
-Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.load_qps_threshold` to the queries-per-second (QPS) at which you want to consider splitting a range (defaults to `250`):
+Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.load_qps_threshold` to the queries-per-second (QPS) at which you want to consider splitting a range (defaults to `2500`):
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SET CLUSTER SETTING kv.range_split.load_qps_threshold = 200;
+> SET CLUSTER SETTING kv.range_split.load_qps_threshold = 2000;
 ~~~
 
 #### When to modify the load-based splitting threshold

--- a/v19.2/load-based-splitting.md
+++ b/v19.2/load-based-splitting.md
@@ -1,5 +1,5 @@
 ---
-title: Load-Based Splitting 
+title: Load-Based Splitting
 summary: To optimize your cluster's performance, CockroachDB can split frequently accessed keys into their own ranges.
 toc: true
 ---
@@ -22,7 +22,7 @@ Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.by_
 
 #### When to enable load-based splitting
 
-Load-based splitting is on by default and beneficial in almost all situations. 
+Load-based splitting is on by default and beneficial in almost all situations.
 
 #### When to disable load-based splitting
 
@@ -30,11 +30,11 @@ You might want to disable load-based splitting when troubleshooting range-relate
 
 ### Control load-based splitting threshold
 
-Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.load_qps_threshold` to the queries-per-second (QPS) at which you want to consider splitting a range (defaults to `250`):
+Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.load_qps_threshold` to the queries-per-second (QPS) at which you want to consider splitting a range (defaults to `2500`):
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SET CLUSTER SETTING kv.range_split.load_qps_threshold = 200;
+> SET CLUSTER SETTING kv.range_split.load_qps_threshold = 2000;
 ~~~
 
 #### When to modify the load-based splitting threshold

--- a/v20.1/load-based-splitting.md
+++ b/v20.1/load-based-splitting.md
@@ -1,5 +1,5 @@
 ---
-title: Load-Based Splitting 
+title: Load-Based Splitting
 summary: To optimize your cluster's performance, CockroachDB can split frequently accessed keys into their own ranges.
 toc: true
 ---
@@ -22,7 +22,7 @@ Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.by_
 
 #### When to enable load-based splitting
 
-Load-based splitting is on by default and beneficial in almost all situations. 
+Load-based splitting is on by default and beneficial in almost all situations.
 
 #### When to disable load-based splitting
 
@@ -30,11 +30,11 @@ You might want to disable load-based splitting when troubleshooting range-relate
 
 ### Control load-based splitting threshold
 
-Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.load_qps_threshold` to the queries-per-second (QPS) at which you want to consider splitting a range (defaults to `250`):
+Use [`SET CLUSTER SETTING`](set-cluster-setting.html) to set `kv.range_split.load_qps_threshold` to the queries-per-second (QPS) at which you want to consider splitting a range (defaults to `2500`):
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SET CLUSTER SETTING kv.range_split.load_qps_threshold = 200;
+> SET CLUSTER SETTING kv.range_split.load_qps_threshold = 2000;
 ~~~
 
 #### When to modify the load-based splitting threshold


### PR DESCRIPTION
Corrects the default mentioned on the load-base splitting doc. However, this setting is excluded from the 20.1 auto-generated cluster settings docs (it's there in 19.2). I think this is due to the recent public/private setting distinction, but I'm not sure. I'll follow-up on that separately. I believe the setting should be included in the auto-generated doc if we're referencing it explicitly on a page like this.

Fixes #7108.