### PR TITLE
make docs footer consistent with wordpress

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,6 +24,9 @@
             <a href="https://www.cockroachlabs.com/pricing/">Pricing</a>
           </li>
           <li>
+            <a href="https://www.cockroachlabs.com/product/whats-new/">What's New</a>
+          </li>
+          <li>
             <a href="https://www.cockroachlabs.com/get-cockroachdb/">Get CockroachDB</a>
           </li>
           <li>
@@ -73,6 +76,9 @@
         </li>
         <ul class="footer-sub-nav">
           <li><a href="https://forum.cockroachlabs.com/">Forum</a></li>
+          <li>
+            <a href="https://cockroa.ch/slack">Slack</a>
+          </li>
           <li>
             <a href="https://support.cockroachlabs.com/hc/en-us">Support Portal</a>
           </li>


### PR DESCRIPTION
The slack URL under "Support Channels" is in https://www.cockroachlabs.com/contact/
but is not in any of the docs pages. This adds it in there for
consistency.