### PR TITLE
Correct min cmake version required for building from source

### DIFF
--- a/v1.0/install-cockroachdb.html
+++ b/v1.0/install-cockroachdb.html
@@ -196,7 +196,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>CMake</td>
-        <td>Versions 3.81+ are known to work.</td>
+        <td>Versions 3.8+ are known to work.</td>
       </tr>
       <tr>
         <td>Autoconf</td>
@@ -391,7 +391,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>CMake</td>
-        <td>Versions 3.81+ are known to work.</td>
+        <td>Versions 3.8+ are known to work.</td>
       </tr>
       <tr>
         <td>Autoconf</td>

--- a/v1.1/install-cockroachdb.html
+++ b/v1.1/install-cockroachdb.html
@@ -157,7 +157,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>CMake</td>
-        <td>Versions 3.81+ are known to work.</td>
+        <td>Versions 3.8+ are known to work.</td>
       </tr>
       <tr>
         <td>Autoconf</td>
@@ -341,7 +341,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>CMake</td>
-        <td>Versions 3.81+ are known to work.</td>
+        <td>Versions 3.8+ are known to work.</td>
       </tr>
       <tr>
         <td>Autoconf</td>

--- a/v19.1/install-cockroachdb-linux.html
+++ b/v19.1/install-cockroachdb-linux.html
@@ -138,7 +138,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v19.1/install-cockroachdb-mac.html
+++ b/v19.1/install-cockroachdb-mac.html
@@ -127,7 +127,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v19.2/install-cockroachdb-linux.html
+++ b/v19.2/install-cockroachdb-linux.html
@@ -138,7 +138,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v19.2/install-cockroachdb-mac.html
+++ b/v19.2/install-cockroachdb-mac.html
@@ -127,7 +127,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v2.0/install-cockroachdb.html
+++ b/v2.0/install-cockroachdb.html
@@ -157,7 +157,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>CMake</td>
-        <td>Versions 3.81+ are known to work.</td>
+        <td>Versions 3.8+ are known to work.</td>
       </tr>
       <tr>
         <td>Autoconf</td>
@@ -345,7 +345,7 @@ $(document).ready(function(){
       </tr>
       <tr>
         <td>CMake</td>
-        <td>Versions 3.81+ are known to work.</td>
+        <td>Versions 3.8+ are known to work.</td>
       </tr>
       <tr>
         <td>Autoconf</td>

--- a/v2.1/install-cockroachdb-linux.html
+++ b/v2.1/install-cockroachdb-linux.html
@@ -138,7 +138,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v2.1/install-cockroachdb-mac.html
+++ b/v2.1/install-cockroachdb-mac.html
@@ -166,7 +166,7 @@ If you previously installed CockroachDB using a different method, you may need t
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v20.1/install-cockroachdb-linux.html
+++ b/v20.1/install-cockroachdb-linux.html
@@ -138,7 +138,7 @@ key: install-cockroachdb.html
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>

--- a/v20.1/install-cockroachdb-mac.html
+++ b/v20.1/install-cockroachdb-mac.html
@@ -164,7 +164,7 @@ If you previously installed CockroachDB via Homebrew before version v20.1, run <
         </tr>
         <tr>
           <td>CMake</td>
-          <td>Versions 3.81+ are known to work.</td>
+          <td>Versions 3.8+ are known to work.</td>
         </tr>
         <tr>
           <td>Autoconf</td>


### PR DESCRIPTION
Previously, it referenced 3.81+, but the latest release
is just 3.17.2. This was a typo. Change to 3.8+.

Fixes #7342.