### PR TITLE
Revert "Add list items to search indexing (Fixes 7351)"

### DIFF
--- a/jekyll-algolia-dev/lib/jekyll/algolia/configurator.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/configurator.rb
@@ -12,7 +12,7 @@ module Jekyll
       ALGOLIA_DEFAULTS = {
         'extensions_to_index' => nil,
         'files_to_exclude' => nil,
-        'nodes_to_index' => 'p,td,li',
+        'nodes_to_index' => 'p,td',
         'indexing_batch_size' => 1000,
         'max_record_size' => 20_000,
         'settings' => {


### PR DESCRIPTION
Reverts cockroachdb/docs#7352

Unfortunately adding list items to search indexing pushes certain pages over our Algolia size limit.

```
3:55:52 PM: [✗ Error] Record is too big                                                      
3:55:52 PM:                                                                                  
3:55:52 PM: The jekyll-algolia plugin detected that one of your records exceeds the 20.00 Kb 
3:55:52 PM: record size limit.                                                               
3:55:52 PM:                                                                                  
3:55:52 PM: title:    Low Latency Reads and Writes in a Multi-Region Cluster                 
3:55:52 PM: url:      https://www.cockroachlabs.com/docs/v20.1/demo-low-latency-multi-region-deployment.html 
3:55:52 PM: size:     26.09 Kb                                                               
3:55:52 PM:                                                                                  
3:55:52 PM: Most probable keys causing the issue:                                            
3:55:52 PM:    html (13.62 Kb), content (11.46 Kb), summary (0.09 Kb)                        
3:55:52 PM:                                                                                  
3:55:52 PM: Complete log of the record has been extracted to:                                
3:55:52 PM:    /opt/build/repo/jekyll-algolia-record-too-big.log  
```