### PR TITLE
Add list items to search indexing + changes to meet Algolia max record size (Fixes #7351)

### DIFF
--- a/jekyll-algolia-dev/lib/jekyll/algolia/configurator.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/configurator.rb
@@ -12,7 +12,7 @@ module Jekyll
       ALGOLIA_DEFAULTS = {
         'extensions_to_index' => nil,
         'files_to_exclude' => nil,
-        'nodes_to_index' => 'p,td',
+        'nodes_to_index' => 'p,td,li',
         'indexing_batch_size' => 1000,
         'max_record_size' => 20_000,
         'settings' => {

--- a/jekyll-algolia-dev/lib/jekyll/algolia/extractor.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/extractor.rb
@@ -58,7 +58,7 @@ module Jekyll
           content,
           options: {
             css_selector: Configurator.algolia('nodes_to_index'),
-            tags_to_exclude: 'script,style,iframe'
+            tags_to_exclude: 'script,style,iframe,svg,pre'
           }
         )
         # We remove objectIDs, as the will be added at the very end, after all

--- a/jekyll-algolia-dev/lib/jekyll/algolia/shrinker.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/shrinker.rb
@@ -20,7 +20,9 @@ module Jekyll
       # - max_size: The max size to achieve in bytes
       #
       # The excerpts are the attributes most subject to being reduced. We'll go
-      # as far as removing them if there is no other choice.
+      # as far as removing them if there is no other choice. The last resort
+      # is to remove the html attribute from Algolia records (note that this
+      # will not affect generated doc pages).
       def self.fit_to_size(raw_record, max_size)
         return raw_record if size(raw_record) <= max_size
 
@@ -35,7 +37,7 @@ module Jekyll
         record[:excerpt_html] = record[:excerpt_text]
         return record if size(record) <= max_size
 
-        # We half the excerpts
+        # We halve the excerpts
         excerpt_words = record[:excerpt_text].split(/\s+/)
         shortened_excerpt = excerpt_words[0...excerpt_words.size / 2].join(' ')
         record[:excerpt_text] = shortened_excerpt
@@ -46,6 +48,12 @@ module Jekyll
         record.delete(:excerpt_text)
         record.delete(:excerpt_html)
         return record if size(record) <= max_size
+
+        # Remove html 
+        if raw_record.key?(:html)
+          record.delete(:html)
+          return record if size(record) <= max_size
+        end
 
         # Still too big, we fail
         stop_with_error(record)


### PR DESCRIPTION
Attempt #2 to add list items to search indexing (previous attempt had to be rolled back because we generated files over Algolia's max record size).

This change adds list items to search indexing, and works around the max record size issue by:
- Shrinking records via removing html attributes
- Excluding \<svg\> diagrams and \<pre\> code blocks from search indexing

Exclusion of code blocks is based on previous discussion with @jseldess, where we agreed they can be excluded because they are not the "meat" of documents.

This change has been tested to make sure we now successfully come under Algolia's max record limit.