### PR TITLE
IMPORT INTO edits

### DIFF
--- a/v19.2/import-into.md
+++ b/v19.2/import-into.md
@@ -10,6 +10,7 @@ toc: true
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges

--- a/v19.2/import-into.md
+++ b/v19.2/import-into.md
@@ -10,7 +10,7 @@ toc: true
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-- `IMPORT INTO` invalidates all [foreign keys](foreign-ke.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges

--- a/v19.2/import-into.md
+++ b/v19.2/import-into.md
@@ -10,7 +10,7 @@ toc: true
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-- `IMPORT INTO` invalidates all [foreign keys](foreign-key) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+- `IMPORT INTO` invalidates all [foreign keys](foreign-ke.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges

--- a/v19.2/import-into.md
+++ b/v19.2/import-into.md
@@ -4,15 +4,13 @@ summary: Import CSV data into an existing CockroachDB table.
 toc: true
 ---
 
-<span class="version-tag">New in v19.2:</span> The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an existing table. To create a table, use [`CREATE TABLE`](create-table.html).
+<span class="version-tag">New in v19.2:</span> The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [existing table](create-table.html). `IMPORT INTO` appends new rows onto the table.
 
-{{site.data.alerts.callout_success}}
-`IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
-{{site.data.alerts.end}}
+## Considerations
 
-{{site.data.alerts.callout_danger}}
-`IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-{{site.data.alerts.end}}
+- `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
+- `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
+- `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges
 

--- a/v20.1/import-into.md
+++ b/v20.1/import-into.md
@@ -10,7 +10,7 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [exi
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-- `IMPORT INTO` invalidates all [foreign keys](foreign-key) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges

--- a/v20.1/import-into.md
+++ b/v20.1/import-into.md
@@ -10,6 +10,7 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [exi
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges

--- a/v20.1/import-into.md
+++ b/v20.1/import-into.md
@@ -4,15 +4,13 @@ summary: Import CSV data into an existing CockroachDB table.
 toc: true
 ---
 
-The `IMPORT INTO` [statement](sql-statements.html) imports CSV and Avro data into an existing table. To create a table, use [`CREATE TABLE`](create-table.html).
+The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [existing table](create-table.html). `IMPORT INTO` appends new rows onto the table.
 
-{{site.data.alerts.callout_success}}
-`IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
-{{site.data.alerts.end}}
+## Considerations
 
-{{site.data.alerts.callout_danger}}
-`IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-{{site.data.alerts.end}}
+- `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
+- `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
+- `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges
 

--- a/v20.2/import-into.md
+++ b/v20.2/import-into.md
@@ -10,7 +10,7 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [exi
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-- `IMPORT INTO` invalidates all [foreign keys](foreign-key) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
 
 ## Required privileges

--- a/v20.2/import-into.md
+++ b/v20.2/import-into.md
@@ -4,15 +4,14 @@ summary: Import CSV data into an existing CockroachDB table.
 toc: true
 ---
 
-The `IMPORT INTO` [statement](sql-statements.html) imports CSV and Avro data into an existing table. To create a table, use [`CREATE TABLE`](create-table.html).
+The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [existing table](create-table.html). `IMPORT INTO` appends new rows onto the table.
 
-{{site.data.alerts.callout_success}}
-`IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
-{{site.data.alerts.end}}
+## Considerations
 
-{{site.data.alerts.callout_danger}}
-`IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
-{{site.data.alerts.end}}
+- `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
+- `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
+- `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
+
 
 ## Required privileges
 

--- a/v20.2/import-into.md
+++ b/v20.2/import-into.md
@@ -10,8 +10,8 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV data into an [exi
 
 - `IMPORT INTO` only works for existing tables. For information on how to import data into new tables, see [`IMPORT`](import.html).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
+- `IMPORT INTO` invalidates all [foreign keys](foreign-key) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` cannot be used to insert data into a column for an existing row. To do this, use [`INSERT`](insert.html).
-
 
 ## Required privileges
 


### PR DESCRIPTION
- Clarify that IMPORT INTO can't be used to insert data into existing row. Closes #7270
- Add note that IMPORT INTO invalidates foreign keys. Closes #7278.