### PR TITLE
Updated CC Quickstart guide and sample app tutorial

### DIFF
--- a/v20.1/cockroachcloud-connect-to-your-cluster.md
+++ b/v20.1/cockroachcloud-connect-to-your-cluster.md
@@ -103,7 +103,7 @@ Use the Console to authorize networks:
 
 7. Click the name of the **ca.crt** file to download the CA certificate.
 
-8. Create a `certs` directory and move the `ca.crt` file to the `certs` directory. The `ca.crt` file must be available on every machine from which you want to connect the cluster and referenced in connection string.
+8. Create a `certs` directory and move the `ca.crt` file to the `certs` directory. The `ca.crt` file must be available on every machine from which you want to connect to the cluster and must be referenced in connection string.
 
     You will need to replace the `<certs_dir>` placeholders with the path to your certs directory in the CockroachDB client command or the connection string.
 

--- a/v20.1/cockroachcloud-quickstart.md
+++ b/v20.1/cockroachcloud-quickstart.md
@@ -48,12 +48,7 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 
 1. In the left navigation bar, click **Networking**.
 2. Click **Add Network**. The **Add Network** modal displays.
-3. From the **Network** dropdown, select **Public (Insecure)** to allow all networks.
-
-     {{site.data.alerts.callout_info}}
-     Use this with caution as your cluster will be vulnerable to denial-of-service and brute force password attacks.
-     {{site.data.alerts.end}}
-
+3. From the **Network** dropdown, select **Current Network** to auto-populate your local machine's IP address.
 4. To allow the network to access the cluster's Admin UI and to use the CockroachDB client to access the databases, select the **Admin UI to monitor the cluster** and **CockroachDB Client to access the databases** checkboxes.
 5. Click **Apply**.
 
@@ -64,6 +59,10 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 3. Verify that the `us-west2 GCP` region and `default_db` database are selected.
 4. Click **Continue**. The **Connect** tab is displayed.
 5. Click **Connection string** to get the connection string for your cluster.
+6. Create a `certs` directory on your local workstation.
+7. Click the name of the `ca.crt` file to download the CA certificate to your local machine.
+8. Move the downloaded `ca.crt` file to the `certs` directory.
+
 
 ## Connect to the cluster and run your first query
 
@@ -101,22 +100,18 @@ For this tutorial, we will use the [`movr` workload](movr.html) to run the first
 
 3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-3-get-the-connection-string).
 
-    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 1](#step-1-create-a-sql-user). For this tutorial, replace the `ca.crt` path placeholder with `sslmode=require`.
-
-    {{site.data.alerts.callout_info}}
-    If you are using the cluster in production, use the `sslmode=verify-full` mode. For details, see [Node identity verification](cockroachcloud-authentication.html#node-identity-verification).
-    {{site.data.alerts.end}}
+    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 1](#step-1-create-a-sql-user). Replace the `<certs_dir>` placeholder with the path to the `certs` directory that you created in [Step 3](#step-3-get-the-connection-string).
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach workload init movr 'postgres://<username>:<password>@<global host>:26257/movr?sslmode=require'
+    $ cockroach workload init movr 'postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
     ~~~
 
 4. Use the built-in SQL client to view the database:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --url='postgres://<username>:<password>@<global host>:26257/movr?sslmode=require'
+    $ cockroach sql --url='postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
     ~~~
 
     {% include copy-clipboard.html %}
@@ -157,7 +152,7 @@ For this tutorial, we will use the [`movr` workload](movr.html) to run the first
 
 ## Before you move into production
 
-Before using your free cluster in production, make sure you have [authorized your network](cockroachcloud-connect-to-your-cluster.html#step-1-authorize-your-network). Also, download the `ca.crt` file on every machine from which you want to [connect to the cluster](cockroachcloud-connect-to-your-cluster.html#step-3-select-a-connection-method) and reference it in the connection string.
+Before using your free cluster in production, make sure you have [authorized the network](cockroachcloud-connect-to-your-cluster.html#step-1-authorize-your-network) from which your app will access the cluster. Also, download the `ca.crt` file to every machine from which you want to [connect to the cluster](cockroachcloud-connect-to-your-cluster.html#step-3-select-a-connection-method).
 
 ## What's next
 

--- a/v20.1/cockroachcloud-quickstart.md
+++ b/v20.1/cockroachcloud-quickstart.md
@@ -13,14 +13,14 @@ If you haven't already, [sign up for a CockroachCloud account](https://cockroach
 
 ## Create a free CockroachCloud cluster
 
-For this quickstart, we will create a 3-node GCP cluster in the `us-west` region.
+For this tutorial, we will create a 3-node GCP cluster in the `us-west` region.
 
 1. [Log in](https://cockroachlabs.cloud/) to your CockroachCloud account.
 2. On the **Overview** page, click **Create Cluster**.
 3. On the **Create new cluster** page, for **Cloud provider**, select **Google Cloud**.
 4. For **Regions & nodes**, use the default selection of `California (us-west)` region and 3 nodes.
 5. For **Hardware per node**, select `Option 1` (2vCPU, 60 GB disk).
-6. For **Cluster name**,  enter `free-trial` in the text box.
+6. Name the cluster. The cluster name must be 6-20 characters in length, and can include lowercase letters, numbers, and dashes (but no leading or trailing dashes).
 7. Click **Next**.
 8. On the **Summary** page, enter your credit card details.
 
@@ -41,8 +41,7 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 
 1. In the left navigation bar, click **SQL Users**.
 2. Click **Add User**. The **Add User** modal displays.
-3. For **Username**, enter `trial_user`.
-4. For **Password**, enter `trial_password`.
+3. Enter a **Username** and **Password**.
 4. Click **Save**.
 
 ### Step 2. Authorize your network
@@ -61,13 +60,14 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 ### Step 3. Get the connection string
 
 1. In the top-right corner of the Console, click the **Connect** button. The **Connect** modal displays.
-2. The `trial_user`, `us-west2 GCP` region, and `default_db` database are selected by default.
-3. Click **Continue**. The **Connect** tab is displayed.
-4. Click **Connection string** to get the connection string for your cluster.
+2. From the **User** dropdown, select the SQL user you created in [Step 1. Create a SQL user](#step-1-create-a-sql-user).
+3. Verify that the `us-west2 GCP` region and `default_db` database are selected.
+4. Click **Continue**. The **Connect** tab is displayed.
+5. Click **Connection string** to get the connection string for your cluster.
 
 ## Connect to the cluster and run your first query
 
-For this quickstart, we will use the [`movr` workload](movr.html) to run the first query. On your local machine:
+For this tutorial, we will use the [`movr` workload](movr.html) to run the first query. On your local machine:
 
 1. [Download the CockroachDB binary](install-cockroachdb.html):
 
@@ -101,18 +101,22 @@ For this quickstart, we will use the [`movr` workload](movr.html) to run the fir
 
 3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-3-get-the-connection-string).
 
-    In the connection string, replace `<password>` with `trial_password` and the `ca.crt` path placeholder with `sslmode-require`:
+    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 1](#step-1-create-a-sql-user). For this tutorial, replace the `ca.crt` path placeholder with `sslmode=require`.
+
+    {{site.data.alerts.callout_info}}
+    If you are using the cluster in production, use the `sslmode=verify-full` mode. For details, see [Node identity verification](cockroachcloud-authentication.html#node-identity-verification).
+    {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach workload init movr 'postgres://trial_user:trial_password@<global host>:26257/movr?sslmode=require'
+    $ cockroach workload init movr 'postgres://<username>:<password>@<global host>:26257/movr?sslmode=require'
     ~~~
 
 4. Use the built-in SQL client to view the database:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --url='postgres://trial_user:trial_password@<global host>:26257/movr?sslmode=require'
+    $ cockroach sql --url='postgres://<username>:<password>@<global host>:26257/movr?sslmode=require'
     ~~~
 
     {% include copy-clipboard.html %}
@@ -150,6 +154,10 @@ For this quickstart, we will use the [`movr` workload](movr.html) to run the fir
       19999999-9999-4a00-8000-000000000005 | new york | Nicole Mcmahon   | 11540 Patton Extensions     | 0303726947
     (6 rows)
     ~~~
+
+## Before you move into production
+
+Before using your free cluster in production, make sure you have [authorized your network](cockroachcloud-connect-to-your-cluster.html#step-1-authorize-your-network). Also, download the `ca.crt` file on every machine from which you want to [connect to the cluster](cockroachcloud-connect-to-your-cluster.html#step-3-select-a-connection-method) and reference it in the connection string.
 
 ## What's next
 

--- a/v20.1/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.md
+++ b/v20.1/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.md
@@ -35,47 +35,31 @@ Before you connect to your CockroachCloud cluster, you need to authorize your ne
 
 Once you are [logged in](cockroachcloud-create-your-account.html#log-in), you can use the Console to authorize your network:
 
-1. Navigate to your cluster's **Networking** page.
-2. Click the **Add Network** button in the top right corner.
-
-    The **Add Network** modal displays.
-
-    <img src="{{ 'images/v20.1/cockroachcloud/add-network-modal.png' | relative_url }}" alt="Add network" style="border:1px solid #eee;max-width:100%" />
-
+1. In the left navigation bar, click **Networking**.
+2. Click the **Add Network** button in the right corner. The **Add Network** modal displays.
 3. (Optional) Enter a descriptive name for the network.
 4. From the **Network** dropdown, select **Current Network**. Your local machine's IP address will be auto-populated in the box.
-5. Select both networks: **UI** and **SQL** client.
+5. Select both networks: **Admin UI to monitor the cluster** and **CockroachDB Client to access the databases**.
 
-    The **UI** refers to the cluster's Admin UI, where you can observe your cluster's health and performance. For more information, see [Admin UI Overview](admin-ui-overview.html).
+    The **Admin UI** refers to the cluster's Admin UI, where you can observe your cluster's health and performance. For more information, see [Admin UI Overview](admin-ui-overview.html).
 
-6. Click **Save**.
+6. Click **Apply**.
 
 ### Step 2. Create a SQL user
 
 {% include {{ page.version.version }}/cockroachcloud-ask-admin.md %}
 
 1. Navigate to your cluster's **SQL Users** page.
-2. Click the **Add User** button in the top right corner.
-
-    The **Add User** modal displays.
-
-    <img src="{{ 'images/v20.1/cockroachcloud/add-user-modal.png' | relative_url }}" alt="Add user" style="border:1px solid #eee;max-width:100%" />
-
-3. In the **Username** field, enter `maxroach`.
-4. In the **Password** field, enter `Q7gc8rEdS`.
-5. Click **Create**.
+2. Click the **Add User** button in the top right corner. The **Add User** modal displays.
+3. Enter a **Username** and **Password**.
+4. Click **Save**.
 
     Currently, all new users are created with admin privileges. For more information and to change the default settings, see [Granting privileges](cockroachcloud-authorization.html#granting-privileges) and [Using roles](cockroachcloud-authorization.html#using-roles).
 
 ### Step 3. Generate the CockroachDB client connection string
 
-1. In the top right corner of the Console, click the **Connect** button.
-
-    The **Connect** modal displays.
-
-    <img src="{{ 'images/v20.1/cockroachcloud/connect-modal.png' | relative_url }}" alt="Connect to cluster" style="border:1px solid #eee;max-width:100%" />
-
-3. From the **User** dropdown, select `maxroach`.
+1. In the top right corner of the Console, click the **Connect** button. The **Connect** modal displays.
+3. From the **User** dropdown, select the user you created in [Step 2](#step-2-create-a-sql-user).
 4. Select a **Region** to connect to.
 5. From the **Database** dropdown, select `defaultdb`.
 6. Create a `certs` directory on your local workstation.
@@ -133,15 +117,10 @@ On your local workstation's terminal:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --url 'postgres://maxroach@<host>:26257/defaultdb?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
+    $ cockroach sql --url 'postgres://<username>@<host>:26257/defaultdb?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
     ~~~
 
-4. Enter the password you created for `maxroach`:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    Q7gc8rEdS
-    ~~~
+4. Enter the password you created for the SQL user in [Step 2](#step-2-create-a-sql-user).
 
 5. Create a database `todos`:
 
@@ -180,7 +159,7 @@ On your local workstation's terminal:
 
         <img src="{{ 'images/v20.1/cockroachcloud/connect-from-app.png' | relative_url }}" alt="Connect from app" style="border:1px solid #eee;max-width:100%" />
 
-  2. From the **User** dropdown, select `maxroach`.
+  2. From the **User** dropdown, select the SQL user you created in [Step 2](#step-2-create-a-sql-user).
   3. Select a **Region** to connect to.
   4. From the **Database** dropdown, select `todos`.
   5. On the **Connect Your App** tab, click **Copy connection string**.
@@ -214,7 +193,7 @@ In a new terminal:
 
     {% include copy-clipboard.html %}
     ~~~
-    SQLALCHEMY_DATABASE_URI = 'cockroachdb://maxroach:Q7gc8rEdS@<host>:26257/todos?sslmode=verify-full&sslrootcert=<absolute path to CA certificate>'
+    SQLALCHEMY_DATABASE_URI = 'cockroachdb://<username>:<password>@<host>:26257/todos?sslmode=verify-full&sslrootcert=<absolute path to CA certificate>'
     ~~~
 
     {{site.data.alerts.callout_info}}
@@ -278,7 +257,7 @@ Create a Kubernetes secret to store the CA certificate you downloaded earlier:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ kubectl create secret generic maxroach-secret --from-file <absolute path to the CA certificate>
+$ kubectl create secret generic <username>-secret --from-file <absolute path to the CA certificate>
 ~~~
 
 Verify the Kubernetes secret was created:
@@ -291,7 +270,7 @@ $ kubectl get secrets
 ~~~ shell
 NAME                  TYPE                                  DATA   AGE
 default-token-875zk   kubernetes.io/service-account-token   3      75s
-maxroach-secret       Opaque                                1      10s
+<username>-secret       Opaque                                1      10s
 ~~~
 
 ### Step 3. Change certificate directory path in configuration file
@@ -300,7 +279,7 @@ In the `hello.cfg` file in the `flask-alchemy` folder, replace the certificate d
 
 {% include copy-clipboard.html %}
 ~~~
-SQLALCHEMY_DATABASE_URI = 'cockroachdb://maxroach:Q7gc8rEdS@<host>:26257/todos?sslmode=verify-full&sslrootcert=/data/certs/<ca-cert file>'
+SQLALCHEMY_DATABASE_URI = 'cockroachdb://<username>:<password>@<host>:26257/todos?sslmode=verify-full&sslrootcert=/data/certs/<ca-cert file>'
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -358,7 +337,7 @@ You must use the `cockroachdb://` prefix in the URL passed to [`sqlalchemy.creat
 
 ### Step 5. Deploy the application
 
-1. In the `flask-alchemy` folder, create a file named `app-deployment.yaml` and copy the following code into the file:
+1. In the `flask-alchemy` folder, create a file named `app-deployment.yaml` and copy the following code into the file. Replace the `<username>` placeholder with the SQL user's username that you created  [while preparing the cluster](#step-2-create-a-sql-user):
 
     {% include copy-clipboard.html %}
     ~~~
@@ -393,7 +372,7 @@ You must use the `cockroachdb://` prefix in the URL passed to [`sqlalchemy.creat
           volumes:
           - name: ca-certs
             secret:
-              secretName: maxroach-secret
+              secretName: <username>-secret
     ---
     apiVersion: v1
     kind: Service
@@ -492,10 +471,8 @@ You must use the `cockroachdb://` prefix in the URL passed to [`sqlalchemy.creat
 1. On the Console, navigate to the cluster's **Monitoring** page and click **Open Admin UI**.
 
     You can also access the Admin UI by navigating to `https://<cluster-name>crdb.io:8080/#/metrics/overview/cluster`. Replace the `<cluster-name>` placeholder with the name of your cluster.
-
-2. In the **Username** field, enter `maxroach`.
-3. In the **Password** field, enter `Q7gc8rEdS`.
-4. Click **Log In**.
+2. Enter the SQL user's username and password you created while [preparing the cluster](#step-2-create-a-sql-user).
+3. Click **Log In**.
 
 ### Step 2. Monitor cluster health, metrics, and SQL statements
 


### PR DESCRIPTION
Summary of changes:

- Removed recommended username/password combinations from the Quickstart guide and sample app tutorial
- Cleaned up the sample app tutorial to match the current UI
- Added a "before you move into production section" to the Quickstart guide