### PR TITLE
Remove master/slave terminology

### DIFF
--- a/v1.0/simplified-deployment.md
+++ b/v1.0/simplified-deployment.md
@@ -4,7 +4,7 @@ summary: Deploying CockroachDB is simple and straightforward.
 toc: false
 ---
 
-Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like masters, slaves, primaries, or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
+Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like primaries or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
 
 -   No external dependencies
 -   Self-organizes using gossip network

--- a/v1.1/simplified-deployment.md
+++ b/v1.1/simplified-deployment.md
@@ -4,7 +4,7 @@ summary: Deploying CockroachDB is simple and straightforward.
 toc: false
 ---
 
-Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like masters, slaves, primaries, or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
+Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like primaries or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
 
 -   No external dependencies
 -   Self-organizes using gossip network

--- a/v2.0/simplified-deployment.md
+++ b/v2.0/simplified-deployment.md
@@ -4,7 +4,7 @@ summary: Deploying CockroachDB is simple and straightforward.
 toc: false
 ---
 
-Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like masters, slaves, primaries, or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
+Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like primaries or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
 
 -   No external dependencies
 -   Self-organizes using gossip network

--- a/v2.1/simplified-deployment.md
+++ b/v2.1/simplified-deployment.md
@@ -4,7 +4,7 @@ summary: Deploying CockroachDB is simple and straightforward.
 toc: false
 ---
 
-Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like masters, slaves, primaries, or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
+Deploying and maintaining databases has forever been a difficult and expensive prospect. Simplicity is one of our foremost design goals. CockroachDB is self contained and eschews external dependencies. There are no explicit roles like primaries or secondaries to get in the way. Instead, every CockroachDB node is symmetric and equally important, meaning no single points of failure in the architecture.
 
 -   No external dependencies
 -   Self-organizes using gossip network


### PR DESCRIPTION
Fixes #7534.

There are still many references to `master` in the docs repo, but they all refer to GitHub branch names. We should consider whether and how to change our main branch name as well. @jordanlewis, is this being discussed on the cockroach side as well?