### PR TITLE
Removed the -p option from the roach2/roach3 docker cli example

### DIFF
--- a/v20.1/start-a-local-cluster-in-docker-windows.md
+++ b/v20.1/start-a-local-cluster-in-docker-windows.md
@@ -69,7 +69,6 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
     --name=roach2 `
     --hostname=roach2 `
     --net=roachnet `
-    -p 26257:26257 -p 8080:8080  `
     -v "//c/Users/<username>/cockroach-data/roach2:/cockroach/cockroach-data"  `
     {{page.release_info.docker_image}}:{{page.release_info.version}} start `
     --insecure `
@@ -81,7 +80,6 @@ We've used `roachnet` as the network name here and in subsequent steps, but feel
     --name=roach3 `
     --hostname=roach3 `
     --net=roachnet `
-    -p 26257:26257 -p 8080:8080  `
     -v "//c/Users/<username>/cockroach-data/roach3:/cockroach/cockroach-data"  `
     {{page.release_info.docker_image}}:{{page.release_info.version}} start `
     --insecure `


### PR DESCRIPTION
There is not a need to expose the other two nodes and you can't expose them on the same port anyway, so just remove this option from the second and third nodes when starting the containers.