### PR TITLE
Update sidebar to better expose latest prod and testing releases

### DIFF
--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -3,45 +3,49 @@
   "is_top_level": true,
   "items": [
     {
-      "title": "v20.1.2",
-      "urls": [
-        "/releases/v20.1.2.html"
+      "title": "Production Releases",
+      "items": [
+        {
+          "title": "Latest v20.1",
+          "urls": [
+            "/releases/v20.1.2.html"
+          ]
+        },
+        {
+          "title": "Latest v19.2",
+          "urls": [
+            "/releases/v19.2.7.html"
+          ]
+        },
+        {
+          "title": "Latest v19.1",
+          "urls": [
+            "/releases/v19.1.9.html"
+          ]
+        },
+        {
+          "title": "All Production Releases",
+          "urls": [
+            "/releases/#production-releases"
+          ]
+        }
       ]
     },
     {
-      "title": "v20.1",
-      "urls": [
-        "/releases/v20.1.0.html"
-      ]
-    },
-    {
-      "title": "v19.2.7",
-      "urls": [
-        "/releases/v19.2.7.html"
-      ]
-    },
-    {
-      "title": "v19.2",
-      "urls": [
-        "/releases/v19.2.0.html"
-      ]
-    },
-    {
-      "title": "v19.1.9",
-      "urls": [
-        "/releases/v19.1.9.html"
-      ]
-    },
-    {
-      "title": "v19.1",
-      "urls": [
-        "/releases/v19.1.0.html"
-      ]
-    },
-    {
-      "title": "All Releases",
-      "urls": [
-        "/releases/"
+      "title": "Testing Releases",
+      "items": [
+        {
+          "title": "Latest v20.2 Alpha",
+          "urls": [
+            "/releases/v20.2.0-alpha.1.html"
+          ]
+        },
+        {
+          "title": "All Testing Releases",
+          "urls": [
+            "/releases/#testing-releases"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
- Create prod and testing sections.
- Expose latest release under each. Last 3 for prod. Only one
  for testing.
- Add intro to all prod patch release notes linking users
  to GA release notes for full feature summaries and upgrade
  instructions. With this, we can remove GA release notes
  from sidenav.

Fixes #7547.
Fixes #7506.