### PR TITLE
Follow-up to https://github.com/cockroachdb/docs/pull/7550

### DIFF
--- a/releases/v19.1.1.md
+++ b/releases/v19.1.1.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.1 since version v19.
 
 ## May 20, 2019
 
+This page lists additions and changes in v19.1.1 since v19.1.0.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.2.md
+++ b/releases/v19.1.2.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.2 since version v19.
 
 ## June 17, 2019
 
+This page lists additions and changes in v19.1.2 since v19.1.1.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.3.md
+++ b/releases/v19.1.3.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.3 since version v19.
 
 ## July 15, 2019
 
+This page lists additions and changes in v19.1.3 since v19.1.2.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.4.md
+++ b/releases/v19.1.4.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.4 since version v19.
 
 ## August 13, 2019
 
+This page lists additions and changes in v19.1.4 since v19.1.3.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.5.md
+++ b/releases/v19.1.5.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.5 since version v19.
 
 ## September 30, 2019
 
+This page lists additions and changes in v19.1.5 since v19.1.4.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.6.md
+++ b/releases/v19.1.6.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.6 since version v19.
 
 ## December 16, 2019
 
+This page lists additions and changes in v19.1.6 since v19.1.5.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.7.md
+++ b/releases/v19.1.7.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.7 since version v19.
 
 ## January 27, 2020
 
+This page lists additions and changes in v19.1.7 since v19.1.6.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.8.md
+++ b/releases/v19.1.8.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.8 since version v19.
 
 ## February 11, 2020
 
+This page lists additions and changes in v19.1.8 since v19.1.7.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.1.9.md
+++ b/releases/v19.1.9.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.1.9 since version v19.
 
 ## May 12, 2020
 
+This page lists additions and changes in v19.1.9 since v19.1.8.
+
+- For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
+- To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.2.1.md
+++ b/releases/v19.2.1.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.1 since version v19.
 
 ## November 25, 2019
 
+This page lists additions and changes in v19.2.1 since v19.2.0.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.2.2.md
+++ b/releases/v19.2.2.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.2 since version v19.
 
 ## December 16, 2019
 
+This page lists additions and changes in v19.2.2 since v19.2.1.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.2.3.md
+++ b/releases/v19.2.3.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.3 since version v19.
 
 ## February 05, 2020
 
+This page lists additions and changes in v19.2.3 since v19.2.2.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.2.4.md
+++ b/releases/v19.2.4.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.4 since version v19.
 
 ## February 11, 2020
 
+This page lists additions and changes in v19.2.4 since v19.2.3.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -68,4 +73,3 @@ This release includes 15 merged PRs by 10 authors.
 [#44749]: https://github.com/cockroachdb/cockroach/pull/44749
 [#44810]: https://github.com/cockroachdb/cockroach/pull/44810
 [#44818]: https://github.com/cockroachdb/cockroach/pull/44818
-

--- a/releases/v19.2.5.md
+++ b/releases/v19.2.5.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.5 since version v19.
 
 ## March 23, 2020
 
+This page lists additions and changes in v19.2.5 since v19.2.4.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.2.6.md
+++ b/releases/v19.2.6.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.6 since version v19.
 
 ## April 13, 2020
 
+This page lists additions and changes in v19.2.6 since v19.2.5.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v19.2.7.md
+++ b/releases/v19.2.7.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.7 since version v19.
 
 ## May 20, 2020
 
+This page lists additions and changes in v19.2.7 since v19.2.6.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to v19.2, see [Upgrade to CockroachDB v19.2](../v19.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -146,4 +151,3 @@ We would like to thank the following contributors from the CockroachDB community
 [#48752]: https://github.com/cockroachdb/cockroach/pull/48752
 [#48767]: https://github.com/cockroachdb/cockroach/pull/48767
 [#48777]: https://github.com/cockroachdb/cockroach/pull/48777
-

--- a/releases/v20.1.1.md
+++ b/releases/v20.1.1.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.1 since version v20.
 
 ## May 26, 2020
 
+This page lists additions and changes in v20.1.1 since v20.1.0.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to v20.1, see [Upgrade to CockroachDB v20.1](../v20.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v20.1.2.md
+++ b/releases/v20.1.2.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.2 since version v20.
 
 ## June 17, 2020
 
+This page lists additions and changes in v20.1.2 since v20.1.1.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to v20.1, see [Upgrade to CockroachDB v20.1](../v20.1/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">


### PR DESCRIPTION
Forgot to include this part in 7550:

Add intro to all prod patch release notes linking users
to GA release notes for full feature summaries and upgrade
instructions. With this, we can remove GA release notes
from sidenav.