### PR TITLE
Improve visibility of Spring tutorial

### DIFF
--- a/v20.1/build-a-java-app-with-cockroachdb.md
+++ b/v20.1/build-a-java-app-with-cockroachdb.md
@@ -13,6 +13,10 @@ twitter: false
 
 This tutorial shows you how to build a simple Java application with CockroachDB and the Java JDBC driver.
 
+{{site.data.alerts.callout_success}}
+For a sample app and tutorial that uses Spring Data JDBC and CockroachDB, see [Build a Spring App with CockroachDB and JDBC](build-a-spring-app-with-cockroachdb-jdbc.html).
+{{site.data.alerts.end}}
+
 ## Before you begin
 
 {% include {{page.version.version}}/app/before-you-begin.md %}

--- a/v20.1/developer-guide-overview.md
+++ b/v20.1/developer-guide-overview.md
@@ -22,6 +22,8 @@ This guide shows you how to do common tasks that come up when you build an appli
 
 For simple but complete sample apps and tutorials, see [Hello World](hello-world-example-apps.html).
 
+For more advanced sample apps and tutorials, see [Build a Spring App with CockroachDB](build-a-spring-app-with-cockroachdb-jdbc.html) and [Develop and Deploy a Multi-Region Web Application](multi-region-overview.html).
+
 ## See also
 
 - [Migrate to CockroachDB](migration-overview.html)

--- a/v20.2/build-a-java-app-with-cockroachdb.md
+++ b/v20.2/build-a-java-app-with-cockroachdb.md
@@ -13,6 +13,10 @@ twitter: false
 
 This tutorial shows you how to build a simple Java application with CockroachDB and the Java JDBC driver.
 
+{{site.data.alerts.callout_success}}
+For a sample app and tutorial that uses Spring Data JDBC and CockroachDB, see [Build a Spring App with CockroachDB and JDBC](build-a-spring-app-with-cockroachdb-jdbc.html).
+{{site.data.alerts.end}}
+
 ## Before you begin
 
 {% include {{page.version.version}}/app/before-you-begin.md %}

--- a/v20.2/developer-guide-overview.md
+++ b/v20.2/developer-guide-overview.md
@@ -22,6 +22,8 @@ This guide shows you how to do common tasks that come up when you build an appli
 
 For simple but complete sample apps and tutorials, see [Hello World](hello-world-example-apps.html).
 
+For more advanced sample apps and tutorials, see [Build a Spring App with CockroachDB](build-a-spring-app-with-cockroachdb-jdbc.html) and [Develop and Deploy a Multi-Region Web Application](multi-region-overview.html).
+
 ## See also
 
 - [Migrate to CockroachDB](migration-overview.html)


### PR DESCRIPTION
This PR adds links to the Spring tutorial in two places:
- The overview of the Develop guide
- The JDBC Java docs

As we add more Spring tutorials, I'll add links to the tutorials in the corresponding ORM tutorial.