### PR TITLE
upgrade Production Checklist with "rules of thumb"

### DIFF
--- a/v19.2/recommended-production-settings.md
+++ b/v19.2/recommended-production-settings.md
@@ -36,55 +36,53 @@ This hardware guidance is meant to be platform agnostic and can apply to bare-me
 | IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
 | MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
 
-{{site.data.alerts.callout_danger}}
 Before deploying to production, test and tune your hardware setup for your application workload. For example, read-heavy and write-heavy workloads will place different emphases on [CPU](#cpu-and-memory), [RAM](#cpu-and-memory), [storage](#storage), [I/O](#disk-i-o), and [network](#networking) capacity.
-{{site.data.alerts.end}}
 
 #### CPU and memory
 
-Each node should have at least **2 vCPUs** and at least **4 GB of RAM per vCPU**. More data, complex workloads, higher concurrency, and faster performance require additional resources. 
+Each node should have **at least 2 vCPUs**, and for best performance we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
-{{site.data.alerts.callout_danger}}
-Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
-{{site.data.alerts.end}}
+- To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
-- Select the fastest available processors. 
+      {{site.data.alerts.callout_info}}
+      Note that the benefits to having more RAM decrease as the number of vCPUs increases.
+      {{site.data.alerts.end}}
 
-- To optimize for throughput, use larger nodes with up to 32 vCPUs (the sweet spot for OLTP workloads, based on internal testing results). See [Disk I/O](#disk-i-o) for additional throughput guidelines.
+- To optimize for resiliency, use many smaller nodes instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
-    To further increase throughput, add more nodes to the cluster instead of increasing node size. Nodes with more than 32 vCPUs will have [NUMA](https://en.wikipedia.org/wiki/Non-uniform_memory_access) (non-uniform memory access) implications leading to performance downgrades.
-
-    {{site.data.alerts.callout_info}}
-    Note that the benefits to having more RAM decrease as the number of vCPUs increases.
-    {{site.data.alerts.end}}
-
-- To optimize for resiliency, use many smaller nodes (e.g., 4 vCPUs per node) instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
+- Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
 
 - To ensure consistent SQL performance, make sure all nodes have a uniform configuration.
 
+{{site.data.alerts.callout_info}}
+Underprovisioning RAM results in reduced performance (due to reduced caching and increased spilling to disk), and in some cases can cause OOM crashes. Underprovisioning CPU generally results in poor performance, and in extreme cases can lead to cluster unavailability. For more information, see [capacity planning issues](cluster-setup-troubleshooting.html#capacity-planning-issues) and [memory issues](cluster-setup-troubleshooting.html#memory-issues).
+{{site.data.alerts.end}}
+
 #### Storage
 
-Provision volumes with up to **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The recommended disk capacity is 300 GiB to 2 TiB per node. 
+- The maximum recommended storage capacity per node is 2 TB, regardless of the number of vCPUs.
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 
-    It is critical to store CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
 
-- The recommended Linux filesystem is [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page).
+- The recommended Linux filesystems are [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page) and [XFS](https://xfs.wiki.kernel.org/).
 
-- Avoid using shared storage such as NFS, CIFS, and CEPH storage. These do not meet our [disk I/O](#disk-i-o) requirements.
+- Always keep some of your disk capacity free on production. Doing so accommodates fluctuations in routine database operations and supports continuous data growth. 
 
-- For the best performance results, use SSD or NVMe devices.
-
-- Always keep at least 40% of disk capacity free on production. This accommodates fluctuations in routine database operations and supports continuous data growth.
+    We strongly recommend [monitoring](monitoring-and-alerting.html#node-is-running-low-on-disk-space) your storage utilization and rate of growth, and taking action to add capacity well before you hit the limit.
 
 - Place a [ballast file](cockroach-debug-ballast.html) in each node's storage directory. In the unlikely case that a node runs out of disk space and shuts down, you can delete the ballast file to free up enough space to be able to restart the node.
 
 - Use [zone configs](configure-replication-zones.html) to increase the replication factor from 3 (the default) to 5 (across at least 5 nodes).
 
     This is especially recommended if you are using local disks with no RAID protection rather than a cloud provider's network-attached disks that are often replicated under the hood, because local disks have a greater risk of failure. You can do this for the [entire cluster](configure-replication-zones.html#edit-the-default-replication-zone) or for specific [databases](configure-replication-zones.html#create-a-replication-zone-for-a-database), [tables](configure-replication-zones.html#create-a-replication-zone-for-a-table), or [rows](configure-replication-zones.html#create-a-replication-zone-for-a-partition) (enterprise-only).
+
+{{site.data.alerts.callout_info}}
+Underprovisioning storage leads to node crashes when the disks fill up. Once this has happened, it is difficult to recover from. To prevent your disks from filling up, provision enough storage for your workload, monitor your disk usage, and use a ballast file as described above. For more information, see [capacity planning issues](cluster-setup-troubleshooting.html#capacity-planning-issues) and [storage issues](cluster-setup-troubleshooting.html#storage-issues).
+{{site.data.alerts.end}}
 
 ##### Disk I/O
 

--- a/v19.2/recommended-production-settings.md
+++ b/v19.2/recommended-production-settings.md
@@ -31,8 +31,8 @@ This hardware guidance is meant to be platform agnostic and can apply to bare-me
 
 | Value | Recommendation | Reference
 |-------|----------------|----------
-| RAM per vCPU | 4 GB | [CPU and memory](#cpu-and-memory)
-| Capacity per vCPU | 60 GB | [Storage](#storage)
+| RAM per vCPU | 4 GiB | [CPU and memory](#cpu-and-memory)
+| Capacity per vCPU | 60 GiB | [Storage](#storage)
 | IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
 | MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
 
@@ -40,7 +40,7 @@ Before deploying to production, test and tune your hardware setup for your appli
 
 #### CPU and memory
 
-Each node should have **at least 2 vCPUs**, and for best performance we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
+Each node should have **at least 2 vCPUs**. For best performance, we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
@@ -60,13 +60,13 @@ Underprovisioning RAM results in reduced performance (due to reduced caching and
 
 #### Storage
 
-We recommend provisioning volumes with **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **60 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The maximum recommended storage capacity per node is 2 TB, regardless of the number of vCPUs.
+- The maximum recommended storage capacity per node is 2 TiB, regardless of the number of vCPUs.
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 
-    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling.
 
 - The recommended Linux filesystems are [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page) and [XFS](https://xfs.wiki.kernel.org/).
 
@@ -131,13 +131,13 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 #### Digital Ocean
 
-- Use any [droplets](https://www.digitalocean.com/pricing/) except standard droplets with only 1 GB of RAM, which is below our minimum requirement. All Digital Ocean droplets use SSD storage.
+- Use any [droplets](https://www.digitalocean.com/pricing/) except standard droplets with only 1 GiB of RAM, which is below our minimum requirement. All Digital Ocean droplets use SSD storage.
 
 #### GCP
 
 - Use `n1-standard` or `n1-highcpu` [predefined VMs](https://cloud.google.com/compute/pricing#predefined_machine_types), or [custom VMs](https://cloud.google.com/compute/pricing#custommachinetypepricing).
 
-    For example, Cockroach Labs has used `n1-standard-16` (16 vCPUs and 60 GB of RAM per VM, local SSD) for [performance benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
+    For example, Cockroach Labs has used `n1-standard-16` (16 vCPUs and 60 GiB of RAM per VM, local SSD) for [performance benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
     Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.

--- a/v19.2/recommended-production-settings.md
+++ b/v19.2/recommended-production-settings.md
@@ -15,6 +15,10 @@ Also keep in mind some basic topology recommendations:
 
 {% include {{ page.version.version }}/prod-deployment/topology-recommendations.md %}
 
+## Software
+
+We recommend running a [glibc](https://www.gnu.org/software/libc/)-based Linux distribution and Linux kernel version from the last 5 years, such as [Ubuntu](https://ubuntu.com/), [Red Hat Enterprise Linux (RHEL)](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux), [CentOS](https://www.centos.org/), or [Container-Optimized OS](https://cloud.google.com/container-optimized-os/docs).
+
 ## Hardware
 
 {{site.data.alerts.callout_info}}
@@ -23,41 +27,76 @@ Mentions of "CPU resources" refer to vCPUs, which are also known as hyperthreads
 
 ### Basic hardware recommendations
 
-Nodes should have sufficient CPU, RAM, network, and storage capacity to handle your workload. It's important to test and tune your hardware setup before deploying to production.
+This hardware guidance is meant to be platform agnostic and can apply to bare-metal, containerized, and orchestrated deployments. Also see our [cloud-specific](#cloud-specific-recommendations) recommendations.
+
+| Value | Recommendation | Reference
+|-------|----------------|----------
+| RAM per vCPU | 4 GB | [CPU and memory](#cpu-and-memory)
+| Capacity per vCPU | 60 GB | [Storage](#storage)
+| IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
+| MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
+
+{{site.data.alerts.callout_danger}}
+Before deploying to production, test and tune your hardware setup for your application workload. For example, read-heavy and write-heavy workloads will place different emphases on [CPU](#cpu-and-memory), [RAM](#cpu-and-memory), [storage](#storage), [I/O](#disk-i-o), and [network](#networking) capacity.
+{{site.data.alerts.end}}
 
 #### CPU and memory
 
-- At a bare minimum, each node should have **2 vCPUs and 2 GB of RAM**. More data, complex workloads, higher concurrency, and faster performance require additional resources.
+Each node should have at least **2 vCPUs** and at least **4 GB of RAM per vCPU**. More data, complex workloads, higher concurrency, and faster performance require additional resources. 
 
-    {{site.data.alerts.callout_danger}}
-    Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
+{{site.data.alerts.callout_danger}}
+Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
+{{site.data.alerts.end}}
+
+- Select the fastest available processors. 
+
+- To optimize for throughput, use larger nodes with up to 32 vCPUs (the sweet spot for OLTP workloads, based on internal testing results). See [Disk I/O](#disk-i-o) for additional throughput guidelines.
+
+    To further increase throughput, add more nodes to the cluster instead of increasing node size. Nodes with more than 32 vCPUs will have [NUMA](https://en.wikipedia.org/wiki/Non-uniform_memory_access) (non-uniform memory access) implications leading to performance downgrades.
+
+    {{site.data.alerts.callout_info}}
+    Note that the benefits to having more RAM decrease as the number of vCPUs increases.
     {{site.data.alerts.end}}
 
-- To optimize for throughput, use larger nodes, up to 32 vCPUs. Based on internal testing results, 32 vCPUs is the sweet spot for OLTP workloads. For RAM, aim for a ratio of 2 GB per vCPU.
+- To optimize for resiliency, use many smaller nodes (e.g., 4 vCPUs per node) instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
-    To increase throughput further, add more nodes to the cluster instead of increasing node size; higher vCPUs will have [NUMA](https://en.wikipedia.org/wiki/Non-uniform_memory_access) (non-uniform memory access) implications.
-
-- To optimize for resiliency, use many smaller nodes (e.g., 4 vCPUs per node) instead of fewer larger ones. Recovery from a failed node is faster when data is spread across more nodes.
-
-- In all cases, make sure nodes are uniform to ensure consistent SQL performance.
+- To ensure consistent SQL performance, make sure all nodes have a uniform configuration.
 
 #### Storage
 
+Provision volumes with up to **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+
+- The recommended disk capacity is 300 GiB to 2 TiB per node. 
+
+- Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
+
+    It is critical to store CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+
 - The recommended Linux filesystem is [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page).
 
-- Avoid using shared storage such as NFS, CIFS, and CEPH storage.
+- Avoid using shared storage such as NFS, CIFS, and CEPH storage. These do not meet our [disk I/O](#disk-i-o) requirements.
 
-- For the best performance results, use SSD or NVMe devices. The recommended volume size is 300-500 GB.
+- For the best performance results, use SSD or NVMe devices.
 
-    Monitor IOPS for higher service times. If they exceed 1-5 ms, you will need to add more devices or expand the cluster to reduce the disk latency. To monitor IOPS, use tools such as `iostat` (part of `sysstat`).
-
-- To calculate IOPS, use [sysbench](https://github.com/akopytov/sysbench). If IOPS decrease, add more nodes to your cluster to increase IOPS.
+- Always keep at least 40% of disk capacity free on production. This accommodates fluctuations in routine database operations and supports continuous data growth.
 
 - Place a [ballast file](cockroach-debug-ballast.html) in each node's storage directory. In the unlikely case that a node runs out of disk space and shuts down, you can delete the ballast file to free up enough space to be able to restart the node.
 
 - Use [zone configs](configure-replication-zones.html) to increase the replication factor from 3 (the default) to 5 (across at least 5 nodes).
 
     This is especially recommended if you are using local disks with no RAID protection rather than a cloud provider's network-attached disks that are often replicated under the hood, because local disks have a greater risk of failure. You can do this for the [entire cluster](configure-replication-zones.html#edit-the-default-replication-zone) or for specific [databases](configure-replication-zones.html#create-a-replication-zone-for-a-database), [tables](configure-replication-zones.html#create-a-replication-zone-for-a-table), or [rows](configure-replication-zones.html#create-a-replication-zone-for-a-partition) (enterprise-only).
+
+##### Disk I/O
+
+Disks must be able to achieve **500 IOPS and 30 MB/s per vCPU**.
+
+{{site.data.alerts.callout_info}}
+Disk I/O especially affects performance on write-heavy workloads. For more context, see [Reads and Writes in CockroachDB](architecture/reads-and-writes-overview.html#write-scenario).
+{{site.data.alerts.end}}
+
+- Monitor IOPS for higher service times. If they exceed 1-5 ms, you will need to add more devices or expand the cluster to reduce the disk latency. To monitor IOPS, use tools such as `iostat` (part of `sysstat`).
+
+- To calculate IOPS, use [sysbench](https://github.com/akopytov/sysbench). If IOPS decrease, add more nodes to your cluster to increase IOPS.
 
 - The optimal configuration for striping more than one device is [RAID 10](https://en.wikipedia.org/wiki/Nested_RAID_levels#RAID_10_(RAID_1+0)). RAID 0 and 1 are also acceptable from a performance perspective.
 

--- a/v20.1/recommended-production-settings.md
+++ b/v20.1/recommended-production-settings.md
@@ -31,64 +31,58 @@ This hardware guidance is meant to be platform agnostic and can apply to bare-me
 
 | Value | Recommendation | Reference
 |-------|----------------|----------
-| RAM per vCPU | 4 GB | [CPU and memory](#cpu-and-memory)
-| Capacity per vCPU | Up to 250 GB | [Storage](#storage)
+| RAM per vCPU | 4 GiB | [CPU and memory](#cpu-and-memory)
+| Capacity per vCPU | 60 GB | [Storage](#storage)
 | IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
 | MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
 
-{{site.data.alerts.callout_danger}}
 Before deploying to production, test and tune your hardware setup for your application workload. For example, read-heavy and write-heavy workloads will place different emphases on [CPU](#cpu-and-memory), [RAM](#cpu-and-memory), [storage](#storage), [I/O](#disk-i-o), and [network](#networking) capacity.
-{{site.data.alerts.end}}
 
 #### CPU and memory
 
-Each node should have at least **2 vCPUs** and at least **4 GB of RAM per vCPU**. More data, complex workloads, higher concurrency, and faster performance require additional resources. 
+Each node should have **at least 2 vCPUs**, and for best performance we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
-{{site.data.alerts.callout_danger}}
-Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
-{{site.data.alerts.end}}
+- To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
-- Select the fastest available processors. 
+      {{site.data.alerts.callout_info}}
+      Note that the benefits to having more RAM decrease as the number of vCPUs increases.
+      {{site.data.alerts.end}}
 
-- To optimize for throughput, use larger nodes with up to 32 vCPUs (the sweet spot for OLTP workloads, based on internal testing results). See [Disk I/O](#disk-i-o) for additional throughput guidelines.
+- To optimize for resiliency, use many smaller nodes instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
-    To further increase throughput, add more nodes to the cluster instead of increasing node size. Nodes with more than 32 vCPUs will have [NUMA](https://en.wikipedia.org/wiki/Non-uniform_memory_access) (non-uniform memory access) implications leading to performance downgrades.
-
-    {{site.data.alerts.callout_info}}
-    Note that the benefits to having more RAM decrease as the number of vCPUs increases.
-    {{site.data.alerts.end}}
-
-- To optimize for resiliency, use many smaller nodes (e.g., 4 vCPUs per node) instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
+- Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
 
 - To ensure consistent SQL performance, make sure all nodes have a uniform configuration.
 
+{{site.data.alerts.callout_info}}
+Underprovisioning RAM results in reduced performance (due to reduced caching and increased spilling to disk), and in some cases can cause OOM crashes. Underprovisioning CPU generally results in poor performance, and in extreme cases can lead to cluster unavailability. For more information, see [capacity planning issues](cluster-setup-troubleshooting.html#capacity-planning-issues) and [memory issues](cluster-setup-troubleshooting.html#memory-issues).
+{{site.data.alerts.end}}
+
 #### Storage
 
-Provision volumes with up to **250 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The recommended disk capacity is 300 GiB to 4 TiB per node. 
-
-    {{site.data.alerts.callout_info}}
-    For more context on these numbers, see [Node density testing configuration](#node-density-testing-configuration).
-    {{site.data.alerts.end}}
+- The maximum recommended storage capacity per node is 4 TB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 
-    It is critical to store CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
 
-- The recommended Linux filesystem is [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page).
+- The recommended Linux filesystems are [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page) and [XFS](https://xfs.wiki.kernel.org/).
 
-- Avoid using shared storage such as NFS, CIFS, and CEPH storage. These do not meet our [disk I/O](#disk-i-o) requirements.
+- Always keep some of your disk capacity free on production. Doing so accommodates fluctuations in routine database operations and supports continuous data growth. 
 
-- For the best performance results, use SSD or NVMe devices.
-
-- Always keep at least 40% of disk capacity free on production. This accommodates fluctuations in routine database operations and supports continuous data growth.
+    We strongly recommend [monitoring](monitoring-and-alerting.html#node-is-running-low-on-disk-space) your storage utilization and rate of growth, and taking action to add capacity well before you hit the limit.
 
 - Place a [ballast file](cockroach-debug-ballast.html) in each node's storage directory. In the unlikely case that a node runs out of disk space and shuts down, you can delete the ballast file to free up enough space to be able to restart the node.
 
 - Use [zone configs](configure-replication-zones.html) to increase the replication factor from 3 (the default) to 5 (across at least 5 nodes).
 
     This is especially recommended if you are using local disks with no RAID protection rather than a cloud provider's network-attached disks that are often replicated under the hood, because local disks have a greater risk of failure. You can do this for the [entire cluster](configure-replication-zones.html#edit-the-default-replication-zone) or for specific [databases](configure-replication-zones.html#create-a-replication-zone-for-a-database), [tables](configure-replication-zones.html#create-a-replication-zone-for-a-table), or [rows](configure-replication-zones.html#create-a-replication-zone-for-a-partition) (enterprise-only).
+
+{{site.data.alerts.callout_info}}
+Underprovisioning storage leads to node crashes when the disks fill up. Once this has happened, it is difficult to recover from. To prevent your disks from filling up, provision enough storage for your workload, monitor your disk usage, and use a ballast file as described above. For more information, see [capacity planning issues](cluster-setup-troubleshooting.html#capacity-planning-issues) and [storage issues](cluster-setup-troubleshooting.html#storage-issues).
+{{site.data.alerts.end}}
 
 ##### Disk I/O
 
@@ -153,13 +147,13 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 #### Digital Ocean
 
-- Use any [droplets](https://www.digitalocean.com/pricing/) except standard droplets with only 1 GB of RAM, which is below our minimum requirement. All Digital Ocean droplets use SSD storage.
+- Use any [droplets](https://www.digitalocean.com/pricing/) except standard droplets with only 1 GiB of RAM, which is below our minimum requirement. All Digital Ocean droplets use SSD storage.
 
 #### GCP
 
 - Use `n1-standard` or `n1-highcpu` [predefined VMs](https://cloud.google.com/compute/pricing#predefined_machine_types), or [custom VMs](https://cloud.google.com/compute/pricing#custommachinetypepricing).
 
-    For example, Cockroach Labs has used `n1-standard-16` (16 vCPUs and 60 GB of RAM per VM, local SSD) for [performance benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
+    For example, Cockroach Labs has used `n1-standard-16` (16 vCPUs and 60 GiB of RAM per VM, local SSD) for [performance benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
     Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.

--- a/v20.1/recommended-production-settings.md
+++ b/v20.1/recommended-production-settings.md
@@ -32,7 +32,7 @@ This hardware guidance is meant to be platform agnostic and can apply to bare-me
 | Value | Recommendation | Reference
 |-------|----------------|----------
 | RAM per vCPU | 4 GiB | [CPU and memory](#cpu-and-memory)
-| Capacity per vCPU | 60 GB | [Storage](#storage)
+| Capacity per vCPU | 60 GiB | [Storage](#storage)
 | IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
 | MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
 
@@ -40,7 +40,7 @@ Before deploying to production, test and tune your hardware setup for your appli
 
 #### CPU and memory
 
-Each node should have **at least 2 vCPUs**, and for best performance we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
+Each node should have **at least 2 vCPUs**. For best performance, we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
@@ -60,13 +60,13 @@ Underprovisioning RAM results in reduced performance (due to reduced caching and
 
 #### Storage
 
-We recommend provisioning volumes with **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **60 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The maximum recommended storage capacity per node is 4 TB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
+- The maximum recommended storage capacity per node is 4 TiB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 
-    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling.
 
 - The recommended Linux filesystems are [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page) and [XFS](https://xfs.wiki.kernel.org/).
 

--- a/v20.2/recommended-production-settings.md
+++ b/v20.2/recommended-production-settings.md
@@ -31,64 +31,58 @@ This hardware guidance is meant to be platform agnostic and can apply to bare-me
 
 | Value | Recommendation | Reference
 |-------|----------------|----------
-| RAM per vCPU | 4 GB | [CPU and memory](#cpu-and-memory)
-| Capacity per vCPU | Up to 250 GB | [Storage](#storage)
+| RAM per vCPU | 4 GiB | [CPU and memory](#cpu-and-memory)
+| Capacity per vCPU | 60 GB | [Storage](#storage)
 | IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
 | MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
 
-{{site.data.alerts.callout_danger}}
 Before deploying to production, test and tune your hardware setup for your application workload. For example, read-heavy and write-heavy workloads will place different emphases on [CPU](#cpu-and-memory), [RAM](#cpu-and-memory), [storage](#storage), [I/O](#disk-i-o), and [network](#networking) capacity.
-{{site.data.alerts.end}}
 
 #### CPU and memory
 
-Each node should have at least **2 vCPUs** and at least **4 GB of RAM per vCPU**. More data, complex workloads, higher concurrency, and faster performance require additional resources. 
+Each node should have **at least 2 vCPUs**, and for best performance we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
-{{site.data.alerts.callout_danger}}
-Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
-{{site.data.alerts.end}}
+- To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
-- Select the fastest available processors. 
+      {{site.data.alerts.callout_info}}
+      Note that the benefits to having more RAM decrease as the number of vCPUs increases.
+      {{site.data.alerts.end}}
 
-- To optimize for throughput, use larger nodes with up to 32 vCPUs (the sweet spot for OLTP workloads, based on internal testing results). See [Disk I/O](#disk-i-o) for additional throughput guidelines.
+- To optimize for resiliency, use many smaller nodes instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
-    To further increase throughput, add more nodes to the cluster instead of increasing node size. Nodes with more than 32 vCPUs will have [NUMA](https://en.wikipedia.org/wiki/Non-uniform_memory_access) (non-uniform memory access) implications leading to performance downgrades.
-
-    {{site.data.alerts.callout_info}}
-    Note that the benefits to having more RAM decrease as the number of vCPUs increases.
-    {{site.data.alerts.end}}
-
-- To optimize for resiliency, use many smaller nodes (e.g., 4 vCPUs per node) instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
+- Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
 
 - To ensure consistent SQL performance, make sure all nodes have a uniform configuration.
 
+{{site.data.alerts.callout_info}}
+Underprovisioning RAM results in reduced performance (due to reduced caching and increased spilling to disk), and in some cases can cause OOM crashes. Underprovisioning CPU generally results in poor performance, and in extreme cases can lead to cluster unavailability. For more information, see [capacity planning issues](cluster-setup-troubleshooting.html#capacity-planning-issues) and [memory issues](cluster-setup-troubleshooting.html#memory-issues).
+{{site.data.alerts.end}}
+
 #### Storage
 
-Provision volumes with up to **250 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The recommended disk capacity is 300 GiB to 4 TiB per node. 
-
-    {{site.data.alerts.callout_info}}
-    For more context on these numbers, see [Node density testing configuration](#node-density-testing-configuration).
-    {{site.data.alerts.end}}
+- The maximum recommended storage capacity per node is 4 TB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 
-    It is critical to store CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
 
-- The recommended Linux filesystem is [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page).
+- The recommended Linux filesystems are [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page) and [XFS](https://xfs.wiki.kernel.org/).
 
-- Avoid using shared storage such as NFS, CIFS, and CEPH storage. These do not meet our [disk I/O](#disk-i-o) requirements.
+- Always keep some of your disk capacity free on production. Doing so accommodates fluctuations in routine database operations and supports continuous data growth. 
 
-- For the best performance results, use SSD or NVMe devices.
-
-- Always keep at least 40% of disk capacity free on production. This accommodates fluctuations in routine database operations and supports continuous data growth.
+    We strongly recommend [monitoring](monitoring-and-alerting.html#node-is-running-low-on-disk-space) your storage utilization and rate of growth, and taking action to add capacity well before you hit the limit.
 
 - Place a [ballast file](cockroach-debug-ballast.html) in each node's storage directory. In the unlikely case that a node runs out of disk space and shuts down, you can delete the ballast file to free up enough space to be able to restart the node.
 
 - Use [zone configs](configure-replication-zones.html) to increase the replication factor from 3 (the default) to 5 (across at least 5 nodes).
 
     This is especially recommended if you are using local disks with no RAID protection rather than a cloud provider's network-attached disks that are often replicated under the hood, because local disks have a greater risk of failure. You can do this for the [entire cluster](configure-replication-zones.html#edit-the-default-replication-zone) or for specific [databases](configure-replication-zones.html#create-a-replication-zone-for-a-database), [tables](configure-replication-zones.html#create-a-replication-zone-for-a-table), or [rows](configure-replication-zones.html#create-a-replication-zone-for-a-partition) (enterprise-only).
+
+{{site.data.alerts.callout_info}}
+Underprovisioning storage leads to node crashes when the disks fill up. Once this has happened, it is difficult to recover from. To prevent your disks from filling up, provision enough storage for your workload, monitor your disk usage, and use a ballast file as described above. For more information, see [capacity planning issues](cluster-setup-troubleshooting.html#capacity-planning-issues) and [storage issues](cluster-setup-troubleshooting.html#storage-issues).
+{{site.data.alerts.end}}
 
 ##### Disk I/O
 
@@ -153,13 +147,13 @@ Cockroach Labs recommends the following cloud-specific configurations based on o
 
 #### Digital Ocean
 
-- Use any [droplets](https://www.digitalocean.com/pricing/) except standard droplets with only 1 GB of RAM, which is below our minimum requirement. All Digital Ocean droplets use SSD storage.
+- Use any [droplets](https://www.digitalocean.com/pricing/) except standard droplets with only 1 GiB of RAM, which is below our minimum requirement. All Digital Ocean droplets use SSD storage.
 
 #### GCP
 
 - Use `n1-standard` or `n1-highcpu` [predefined VMs](https://cloud.google.com/compute/pricing#predefined_machine_types), or [custom VMs](https://cloud.google.com/compute/pricing#custommachinetypepricing).
 
-    For example, Cockroach Labs has used `n1-standard-16` (16 vCPUs and 60 GB of RAM per VM, local SSD) for [performance benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
+    For example, Cockroach Labs has used `n1-standard-16` (16 vCPUs and 60 GiB of RAM per VM, local SSD) for [performance benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html). We have also found benefits in using the [Skylake platform](https://cloud.google.com/compute/docs/cpu-platforms).
 
     {{site.data.alerts.callout_danger}}
     Do not use `f1` or `g1` [shared-core machines](https://cloud.google.com/compute/docs/machine-types#sharedcore), which limit the load on CPU resources.

--- a/v20.2/recommended-production-settings.md
+++ b/v20.2/recommended-production-settings.md
@@ -32,7 +32,7 @@ This hardware guidance is meant to be platform agnostic and can apply to bare-me
 | Value | Recommendation | Reference
 |-------|----------------|----------
 | RAM per vCPU | 4 GiB | [CPU and memory](#cpu-and-memory)
-| Capacity per vCPU | 60 GB | [Storage](#storage)
+| Capacity per vCPU | 60 GiB | [Storage](#storage)
 | IOPS per vCPU | 500 | [Disk I/O](#disk-i-o)
 | MB/s per vCPU | 30 | [Disk I/O](#disk-i-o)
 
@@ -40,7 +40,7 @@ Before deploying to production, test and tune your hardware setup for your appli
 
 #### CPU and memory
 
-Each node should have **at least 2 vCPUs**, and for best performance we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
+Each node should have **at least 2 vCPUs**. For best performance, we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
@@ -60,13 +60,13 @@ Underprovisioning RAM results in reduced performance (due to reduced caching and
 
 #### Storage
 
-We recommend provisioning volumes with **60 GB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **60 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The maximum recommended storage capacity per node is 4 TB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
+- The maximum recommended storage capacity per node is 4 TiB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 
-    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling. This can cause unwanted behavior on the cluster.
+    We suggest storing CockroachDB [log files](debug-and-error-logs.html) in a separate volume from CockroachDB data so that logging is not impacted by I/O throttling.
 
 - The recommended Linux filesystems are [ext4](https://ext4.wiki.kernel.org/index.php/Main_Page) and [XFS](https://xfs.wiki.kernel.org/).
 


### PR DESCRIPTION
Fixes #7096.
Fixes #6702.

- As Raphael noted, selecting the number of nodes for fault tolerance comes before selecting the number of CPUs per node. We don't currently have a docs reference specifically about determining node count for a production deployment, but this is in progress. I'm discussing with @jseldess how best to add this to our deployment guidance.
- On the storage capacity issue (60 GB -> 250 GB), I was unclear on whether this capacity equates to the max `store` size and whether that in turn equates to the total disk capacity. Since we advise operators to always leave a certain amount (listed in this update as 40%) free, should they account for this 40% when provisioning volumes so that they can benefit from the full supported 60/250 GB?
  - For now I've conflated the recommended max storage with the disk capacity, and left the 40% free capacity as a separate consideration.
  - 250 GB is a value I made up that gives 4 TB / 16 vCPUs, based on the node density test. Is this too ambitious?
- There is discrepancy throughout between MB/GB/TB (used in [Alex's doc](https://docs.google.com/document/d/1eYbjhoyY4HgpmPUilYBDhRCn1vOtXiV2RlbSog7ZXhU/edit#)) and MiB/GiB/TiB (used elsewhere in the published doc). Should the units all match?
- Also, I am unclear whether the I/O unit is MB/s or Mbps. 
- There is currently no information about the specific effects of under-provisioning CPU, RAM, or disk, as requested by @petermattis. @bdarnell any insight on this would be helpful!