### PR TITLE
K8s multiregion eks

### DIFF
--- a/_includes/v20.1/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-insecure.md
@@ -8,15 +8,21 @@
     ~~~
 
     {{site.data.alerts.callout_danger}}
-    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset.yaml`. Their values should be identical.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes instance, you *must* set `resources.requests.memory` and `resources.limits.memory` to explicit values in the CockroachDB `containers` spec. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. 
 
-    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L146):
-    {{site.data.alerts.end}}
+    For example, to allocate 8Gi of memory to CockroachDB in each pod: 
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    --cache 2Gi --max-sql-memory 2Gi
     ~~~
+    containers:
+      - name: cockroachdb
+        ...
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+    ~~~
+    {{site.data.alerts.end}}
 
     Use the file to create the StatefulSet and start the cluster:
 

--- a/_includes/v20.1/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v20.1/orchestration/start-cockroachdb-secure.md
@@ -22,28 +22,19 @@ Some environments, such as Amazon EKS, do not support certificates signed by Kub
 
 Modify the values in the StatefulSet configuration.
 
-1. To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you *must* set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. In the `containers` specification, set this amount in both `resources.requests.memory` and `resources.limits.memory`.
+1. To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes instance, you *must* set `resources.requests.memory` and `resources.limits.memory` to explicit values in the CockroachDB `containers` spec. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. 
+
+    For example, to allocate 8Gi of memory to CockroachDB in each pod: 
 
     ~~~
-    resources:
-      requests:
-        memory: "8Gi"
-      limits:
-        memory: "8Gi"
-    ~~~
-
-    We recommend setting `cache` and `max-sql-memory` each to 1/4 of the memory allocation. These are defined as placeholder percentages in the StatefulSet command that creates the CockroachDB nodes:
-
-    ~~~
-    - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --advertise-host $(hostname -f) --http-addr 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
-    ~~~
-
-    {{site.data.alerts.callout_success}}
-    For example, if you are allocating 8Gi of `memory` to each CockroachDB node, allocate 2Gi to `cache` and 2Gi to `max-sql-memory`.
-    {{site.data.alerts.end}}
-
-    ~~~
-    --cache 2Gi --max-sql-memory 2Gi
+    containers:
+      - name: cockroachdb
+        ...
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
     ~~~
 
 2. In the `volumeClaimTemplates` specification, you may want to modify `resources.requests.storage` for your use case. This configuration defaults to 100Gi of disk space per pod. For more details on customizing disks for performance, see [these instructions](kubernetes-performance.html#disk-type).

--- a/_includes/v20.1/orchestration/start-kubernetes.md
+++ b/_includes/v20.1/orchestration/start-kubernetes.md
@@ -64,6 +64,10 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 2. From your local workstation, start the Kubernetes cluster:
 
+    {{site.data.alerts.callout_success}}
+    To ensure that all 3 nodes can be placed into a different availability zone, you may want to first [confirm that at least 3 zones are available in the region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe) for your account.
+    {{site.data.alerts.end}}
+
     {% include copy-clipboard.html %}
     ~~~ shell
     $ eksctl create cluster \

--- a/_includes/v20.1/prod-deployment/aws-inbound-rules.md
+++ b/_includes/v20.1/prod-deployment/aws-inbound-rules.md
@@ -20,12 +20,3 @@
  Source | Your network's IP ranges
 
 You can set your network IP by selecting "My IP" in the Source field.
-
-#### Load balancer-health check communication
-
- Field | Value
--------|-------------------
- Port Range | **8080**
- Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
-
- To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs.

--- a/_includes/v20.1/prod-deployment/aws-inbound-rules.md
+++ b/_includes/v20.1/prod-deployment/aws-inbound-rules.md
@@ -1,0 +1,31 @@
+#### Inter-node and load balancer-node communication
+
+ Field | Value
+-------|-------------------
+ Port Range | **26257**
+ Source | The ID of your security group (e.g., *sg-07ab277a*)
+
+#### Application data
+
+ Field | Value
+-------|-------------------
+ Port Range | **26257**
+ Source | Your application's IP ranges
+
+#### Admin UI
+
+ Field | Value
+-------|-------------------
+ Port Range | **8080**
+ Source | Your network's IP ranges
+
+You can set your network IP by selecting "My IP" in the Source field.
+
+#### Load balancer-health check communication
+
+ Field | Value
+-------|-------------------
+ Port Range | **8080**
+ Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
+
+ To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs.

--- a/_includes/v20.1/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v20.1/prod-deployment/insecure-test-load-balancing.md
@@ -1,8 +1,12 @@
 CockroachDB offers a pre-built `workload` binary for Linux that includes several load generators for simulating client traffic against your cluster. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
+{{site.data.alerts.callout_info}}
+Be sure that you have [set up an inbound rule](deploy-cockroachdb-on-aws-insecure.html#step-2-configure-your-network) that allows traffic from the application to the load balancer. In this case, you will run the sample workload on one of your instances. The traffic source for your inbound rule should therefore be the **internal (private)** IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}For comprehensive guidance on benchmarking CockroachDB with TPC-C, see our <a href="https://www.cockroachlabs.com/guides/cockroachdb-performance/">Performance Benchmarking white paper</a>.{{site.data.alerts.end}}
 
-1. SSH to the machine where you want the run the sample TPC-C workload.
+1. SSH to the machine where you want to run the sample TPC-C workload.
 
     This should be a machine that is not running a CockroachDB node.
 

--- a/_includes/v20.1/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v20.1/prod-deployment/secure-test-load-balancing.md
@@ -1,5 +1,9 @@
 CockroachDB offers a pre-built `workload` binary for Linux that includes several load generators for simulating client traffic against your cluster. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
+{{site.data.alerts.callout_info}}
+Be sure that you have [set up an inbound rule](deploy-cockroachdb-on-aws.html#step-2-configure-your-network) that allows traffic from the application to the load balancer. In this case, you will run the sample workload on one of your instances. The traffic source for your inbound rule should therefore be the **internal (private)** IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}For comprehensive guidance on benchmarking CockroachDB with TPC-C, see our <a href="https://www.cockroachlabs.com/guides/cockroachdb-performance/">Performance Benchmarking white paper</a>.{{site.data.alerts.end}}
 
 1. SSH to the machine where you want to run the sample TPC-C workload.

--- a/_includes/v20.2/orchestration/start-cockroachdb-insecure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-insecure.md
@@ -8,16 +8,22 @@
     ~~~
 
     {{site.data.alerts.callout_danger}}
-    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. Specify this amount by adjusting `resources.requests.memory` and `resources.limits.memory` in `cockroachdb-statefulset.yaml`. Their values should be identical.
+    To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes instance, you *must* set `resources.requests.memory` and `resources.limits.memory` to explicit values in the CockroachDB `containers` spec. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. 
 
-    We recommend setting `cache` and `max-sql-memory` each to 1/4 of your memory allocation. For example, if you are allocating 8Gi of memory to each CockroachDB node, substitute the following values in [this line](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/cockroachdb-statefulset.yaml#L146):
-    {{site.data.alerts.end}}
+    For example, to allocate 8Gi of memory to CockroachDB in each pod: 
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    --cache 2Gi --max-sql-memory 2Gi
     ~~~
-
+    containers:
+      - name: cockroachdb
+        ...
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+    ~~~
+    {{site.data.alerts.end}}
+    
     Use the file to create the StatefulSet and start the cluster:
 
     {% include copy-clipboard.html %}

--- a/_includes/v20.2/orchestration/start-cockroachdb-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-secure.md
@@ -22,30 +22,21 @@ Some environments, such as Amazon EKS, do not support certificates signed by Kub
 
 Modify the values in the StatefulSet configuration.
 
-1. To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you *must* set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. In the `containers` specification, set this amount in both `resources.requests.memory` and `resources.limits.memory`.
+1. To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes instance, you *must* set `resources.requests.memory` and `resources.limits.memory` to explicit values in the CockroachDB `containers` spec. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes. 
+
+    For example, to allocate 8Gi of memory to CockroachDB in each pod: 
 
     ~~~
-    resources:
-      requests:
-        memory: "8Gi"
-      limits:
-        memory: "8Gi"
+    containers:
+      - name: cockroachdb
+        ...
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
     ~~~
-
-    We recommend setting `cache` and `max-sql-memory` each to 1/4 of the memory allocation. These are defined as placeholder percentages in the StatefulSet command that creates the CockroachDB nodes:
-
-    ~~~
-    - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --advertise-host $(hostname -f) --http-addr 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
-    ~~~
-
-    {{site.data.alerts.callout_success}}
-    For example, if you are allocating 8Gi of `memory` to each CockroachDB node, allocate 2Gi to `cache` and 2Gi to `max-sql-memory`.
-    {{site.data.alerts.end}}
-
-    ~~~
-    --cache 2Gi --max-sql-memory 2Gi
-    ~~~
-
+    
 2. In the `volumeClaimTemplates` specification, you may want to modify `resources.requests.storage` for your use case. This configuration defaults to 100Gi of disk space per pod. For more details on customizing disks for performance, see [these instructions](kubernetes-performance.html#disk-type).
 
     ~~~

--- a/_includes/v20.2/orchestration/start-kubernetes.md
+++ b/_includes/v20.2/orchestration/start-kubernetes.md
@@ -64,6 +64,10 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 
 2. From your local workstation, start the Kubernetes cluster:
 
+    {{site.data.alerts.callout_success}}
+    To ensure that all 3 nodes can be placed into a different availability zone, you may want to first [confirm that at least 3 zones are available in the region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe) for your account.
+    {{site.data.alerts.end}}
+    
     {% include copy-clipboard.html %}
     ~~~ shell
     $ eksctl create cluster \

--- a/_includes/v20.2/prod-deployment/aws-inbound-rules.md
+++ b/_includes/v20.2/prod-deployment/aws-inbound-rules.md
@@ -1,0 +1,31 @@
+#### Inter-node and load balancer-node communication
+
+ Field | Value
+-------|-------------------
+ Port Range | **26257**
+ Source | The ID of your security group (e.g., *sg-07ab277a*)
+
+#### Application data
+
+ Field | Value
+-------|-------------------
+ Port Range | **26257**
+ Source | Your application's IP ranges
+
+#### Admin UI
+
+ Field | Value
+-------|-------------------
+ Port Range | **8080**
+ Source | Your network's IP ranges
+
+You can set your network IP by selecting "My IP" in the Source field.
+
+#### Load balancer-health check communication
+
+ Field | Value
+-------|-------------------
+ Port Range | **8080**
+ Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
+
+ To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs.

--- a/_includes/v20.2/prod-deployment/insecure-test-load-balancing.md
+++ b/_includes/v20.2/prod-deployment/insecure-test-load-balancing.md
@@ -1,5 +1,9 @@
 CockroachDB offers a pre-built `workload` binary for Linux that includes several load generators for simulating client traffic against your cluster. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
+{{site.data.alerts.callout_info}}
+Be sure that you have [set up an inbound rule](deploy-cockroachdb-on-aws-insecure.html#step-2-configure-your-network) that allows traffic from the application to the load balancer. In this case, you will run the sample workload on one of your instances. The traffic source for your inbound rule should therefore be the **internal (private)** IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}For comprehensive guidance on benchmarking CockroachDB with TPC-C, see our <a href="https://www.cockroachlabs.com/guides/cockroachdb-performance/">Performance Benchmarking white paper</a>.{{site.data.alerts.end}}
 
 1. SSH to the machine where you want the run the sample TPC-C workload.

--- a/_includes/v20.2/prod-deployment/secure-test-load-balancing.md
+++ b/_includes/v20.2/prod-deployment/secure-test-load-balancing.md
@@ -1,5 +1,9 @@
 CockroachDB offers a pre-built `workload` binary for Linux that includes several load generators for simulating client traffic against your cluster. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
+{{site.data.alerts.callout_info}}
+Be sure that you have [set up an inbound rule](deploy-cockroachdb-on-aws-insecure.html#step-2-configure-your-network) that allows traffic from the application to the load balancer. In this case, you will run the sample workload on one of your instances. The traffic source for your inbound rule should therefore be the **internal (private)** IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_success}}For comprehensive guidance on benchmarking CockroachDB with TPC-C, see our <a href="https://www.cockroachlabs.com/guides/cockroachdb-performance/">Performance Benchmarking white paper</a>.{{site.data.alerts.end}}
 
 1. SSH to the machine where you want to run the sample TPC-C workload.

--- a/v20.1/deploy-cockroachdb-on-aws-insecure.md
+++ b/v20.1/deploy-cockroachdb-on-aws-insecure.md
@@ -49,54 +49,12 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 ## Step 2. Configure your network
 
-CockroachDB requires TCP communication on two ports:
+[Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to your security group to allow TCP communication on two ports:
 
-- `26257` for inter-node communication (i.e., working as a cluster), for applications to connect to the load balancer, and for routing from the load balancer to nodes
-- `8080` for exposing your Admin UI, and for routing from the load balancer to the health check
+- `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
+- `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
 
-If you haven't already done so, [create inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) for your security group.
-
-#### Inter-node and load balancer-node communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **26257**
- Source | The ID of your security group (e.g., *sg-07ab277a*)
-
-#### Application data
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rules
- Protocol | TCP
- Port Range | **26257**
- Source | Your application's IP ranges
-
-If you plan to [run our sample workload](#step-8-run-a-sample-workload) on an instance, the traffic source is the internal (private) IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
-
-#### Admin UI
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | Your network's IP ranges
-
-You can set your network IP by selecting "My IP" in the Source field.
-
-#### Load balancer-health check communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
-
-To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs. You can also click on the VPC where it is listed in the EC2 console.
+{% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
 
 ## Step 3. Synchronize clocks
 

--- a/v20.1/deploy-cockroachdb-on-aws.md
+++ b/v20.1/deploy-cockroachdb-on-aws.md
@@ -52,54 +52,12 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 ## Step 2. Configure your network
 
-CockroachDB requires TCP communication on two ports:
+[Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to your security group to allow TCP communication on two ports:
 
-- `26257` for inter-node communication (i.e., working as a cluster), for applications to connect to the load balancer, and for routing from the load balancer to nodes
-- `8080` for exposing your Admin UI, and for routing from the load balancer to the health check
+- `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
+- `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
 
-If you haven't already done so, [create inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) for your security group.
-
-#### Inter-node and load balancer-node communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **26257**
- Source | The ID of your security group (e.g., *sg-07ab277a*)
-
-#### Application data
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rules
- Protocol | TCP
- Port Range | **26257**
- Source | Your application's IP ranges
-
-If you plan to [run our sample workload](#step-9-run-a-sample-workload) on an instance, the traffic source is the internal (private) IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
-
-#### Admin UI
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | Your network's IP ranges
-
-You can set your network IP by selecting "My IP" in the Source field.
-
-#### Load balancer-health check communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
-
-To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs. You can also click on the VPC where it is listed in the EC2 console.
+{% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
 
 ## Step 3. Synchronize clocks
 

--- a/v20.1/deploy-cockroachdb-on-aws.md
+++ b/v20.1/deploy-cockroachdb-on-aws.md
@@ -59,6 +59,15 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 {% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
 
+#### Load balancer-health check communication
+
+ Field | Value
+-------|-------------------
+ Port Range | **8080**
+ Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
+
+To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs.
+
 ## Step 3. Synchronize clocks
 
 {% include {{ page.version.version }}/prod-deployment/synchronize-clocks.md %}

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -41,16 +41,16 @@ Feature | Description
 
 ### UX differences from running in a single cluster
 
-These instructions create 3 StatefulSets that each run 3 CockroachDB pods in a separate Kubernetes cluster deployed in its own region. If you haven't often worked with multiple Kubernetes clusters, remember that `kubectl` commands are run against a cluster in a specific context. Either run `kubectl use-context <cluster-context>` frequently to switch contexts between commands, or append `--context=<cluster-context>` to the commands you run to ensure they are run against the correct cluster.
+These instructions create 3 StatefulSets that each run 3 CockroachDB pods in a separate Kubernetes cluster deployed in its own region. If you haven't often worked with multiple Kubernetes clusters, remember that `kubectl` commands are run against a cluster in a specific context. Either run `kubectl use-context <cluster-context>` frequently to switch contexts between commands, or append `--context <cluster-context>` to the commands you run to ensure they are run against the correct cluster.
 
 <section class="filter-content" markdown="1" data-scope="gke">
-Each Kubernetes cluster's DNS server is pointed at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., `*.us-west1-a.svc.cluster.local`) can be deferred to the appropriate cluster's DNS server. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
+Each Kubernetes cluster's DNS server is pointed at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., `*.us-west1-a.svc.cluster.local`) can be deferred to the appropriate cluster's DNS server. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace <cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace <namespace-name>` to set the default namespace for a context.
 
 Because the CockroachDB pods run in a non-default namespace, client applications wanting to talk to CockroachDB from the default namespace would need to use a zone-scoped service name (e.g., `cockroachdb-public.us-west1-a`) rather than `cockroachdb-public`, as in a single-cluster setting. However, the setup script used by these instructions sets up an additional [`ExternalName` service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) in the default namespace such that the clients in the default namespace can simply talk to the `cockroachdb-public` address.
 </section>
 
 <section class="filter-content" markdown="1" data-scope="eks">
-To enable the pods to communicate across regions, we peer the VPCs in all 3 regions with each other and configure a CoreDNS service in each region to route DNS traffic to the appropriate pods. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
+To enable the pods to communicate across regions, we peer the VPCs in all 3 regions with each other and configure a CoreDNS service in each region to route DNS traffic to the appropriate pods. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace <cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace <namespace-name>` to set the default namespace for a context.
 </section>
 
 ### Limitations
@@ -163,17 +163,17 @@ If you want to run on another cloud or on-premises, use this [basic network test
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-1>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-2>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-3>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context <cluster-context-3>
     ~~~
 </section>
 
@@ -188,6 +188,10 @@ If you want to run on another cloud or on-premises, use this [basic network test
     In order to enable VPC peering between the regions, the CIDR blocks of the VPCs **must not** overlap. This value cannot change once the cluster has been created, so be sure that your IP ranges do not overlap.
     {{site.data.alerts.end}}
 
+    {{site.data.alerts.callout_success}}
+    To ensure that all 3 nodes can be placed into a different availability zone, you may want to first [confirm that at least 3 zones are available in the region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe) for your account.
+    {{site.data.alerts.end}}
+
     {% include copy-clipboard.html %}
     ~~~ shell
     $ eksctl create cluster \
@@ -196,8 +200,8 @@ If you want to run on another cloud or on-premises, use this [basic network test
     --node-type m5.xlarge \
     --nodes 3 \
     --node-ami auto \
-    --region <aws-region-1>
-    --vpc-cidr=<ip-range-1>
+    --region <aws-region-1> \
+    --vpc-cidr <ip-range-1>
     ~~~
 
     {% include copy-clipboard.html %}
@@ -208,8 +212,8 @@ If you want to run on another cloud or on-premises, use this [basic network test
     --node-type m5.xlarge \
     --nodes 3 \
     --node-ami auto \
-    --region <aws-region-2>
-    --vpc-cidr=<ip-range-2>
+    --region <aws-region-2> \
+    --vpc-cidr <ip-range-2>
     ~~~
        
     {% include copy-clipboard.html %}
@@ -220,8 +224,8 @@ If you want to run on another cloud or on-premises, use this [basic network test
     --node-type m5.xlarge \
     --nodes 3 \
     --node-ami auto \
-    --region <aws-region-3>
-    --vpc-cidr=<ip-range-3>
+    --region <aws-region-3> \
+    --vpc-cidr <ip-range-3>
     ~~~
 
     Each command creates three EKS instances in a region, one for each CockroachDB node you will deploy. Note that each instance is assigned to a different availability zone in the region.
@@ -258,17 +262,17 @@ If you want to run on another cloud or on-premises, use this [basic network test
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl create namespace <cluster-namespace> --context=<cluster-context>
+    kubectl create namespace <cluster-namespace> --context <cluster-context>
     ~~~
 
     It's simplest for the namespace and region to have the same name, e.g.:
 
     ~~~ shell
-    kubectl create namespace eu-central-1 --context=maxroach@cockroachdb1.eu-central-1.eksctl.io
+    kubectl create namespace eu-central-1 --context maxroach@cockroachdb1.eu-central-1.eksctl.io
     ~~~
 
     {{site.data.alerts.callout_info}}
-    `kubectl` commands are run against the namespace named `default` by default. You can change the default namespace for a given context with `kubectl config set-context <context-name> --namespace=<namespace-name>`.
+    `kubectl` commands are run against the namespace named `default` by default. You can change the default namespace for a given context with `kubectl config set-context <context-name> --namespace <namespace-name>`.
 
     For clarity, every `kubectl` command in this tutorial uses the `--namespace` flag to indicate the proper namespace.
     {{site.data.alerts.end}}
@@ -281,10 +285,10 @@ For pods to communciate across three separate Kubernetes clusters, the VPCs in a
 
 1. Open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and note the ID of the VPC in each region. The VPC ID is found in the section called Your VPCs.
 
-1. Navigate to the Peering Connections section and [create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#create-vpc-peering-connection-local) between each of the 3 regions. When you create a peering connection, you will first select a requester VPC in the current region and then an accepter VPC in another region, specified by pasting the VPC ID.
+1. Navigate to the Peering Connections section and [create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#create-vpc-peering-connection-local) between each of the 3 regions. When you create a peering connection, you will first select a requester VPC in the current region and then an accepter VPC in a destination region, specified by pasting the VPC ID.
 
     {{site.data.alerts.callout_success}}
-    You should have a total of 3 VPC peering connections between your three VPCs. You will need to switch regions in the console to create one of the peering connections.
+    You need to create a total of 3 VPC peering connections between your 3 VPCs, which means switching regions at least once in the console. For example, if you are deploying in `eu-central-1`, `eu-north-1`, and `ca-central-1`, you can select `eu-central-1` in the console and create VPC peering connections to both `eu-north-1` and `ca-central-1`. Then switch to either `eu-north-1` or `ca-central-1` to create the VPC peering connection between those two regions.
     {{site.data.alerts.end}}
 
 1. To complete the VPC peering connections, switch to each destination region and [accept the pending connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#accept-vpc-peering-connection) in the VPC console. 
@@ -293,7 +297,7 @@ For pods to communciate across three separate Kubernetes clusters, the VPCs in a
 
 ### Create inbound rules
 
-For each region, navigate to the Security Groups section of the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and locate the security group that enables communication between nodes int he cluster. It should have a name like `ClusterSharedNodeSecurityGroup`. [Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to this security group to allow TCP communication on two ports:
+For each region, navigate to the Security Groups section of the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and locate the security group that enables communication between nodes in the cluster. It should have a name like `ClusterSharedNodeSecurityGroup`. [Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to this security group to allow TCP communication on two ports:
 
 - `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
 - `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
@@ -317,28 +321,28 @@ This important rule enables node communication between Kubernetes clusters in di
 
 The Kubernetes cluster in each region needs to have a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) pointed at its CoreDNS service, which you will configure in the next step.
 
-1. Upload our load balancer manifest [`dns-lb-eks.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml) to the Kubernetes clusters in all 3 regions:
+1. Upload our load balancer manifest [`dns-lb-eks.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml) to the Kubernetes clusters in all 3 regions:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-1>
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-2>
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-3>
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml --context <cluster-context-3>
     ~~~
 
     You should see the load balancer appear in the Load Balancers section of the EC2 console in each region. This load balancer will route traffic to CoreDNS in the region.
 
 1. For each region, navigate to the Load Balancer section of the [EC2 console](https://console.aws.amazon.com/ec2/) and get the DNS name of the Network Load Balancer you created in the previous step.
 
-1. For each region's load balancer, look up the IP addresses mapped to the load balancer:
+1. For each region's load balancer, look up the IP addresses mapped to the load balancer's DNS name:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -364,7 +368,12 @@ Each Kubernetes cluster has a [CoreDNS](https://coredns.io/) service that respon
 
 To enable traffic forwarding to CockroachDB pods in all 3 regions, you need to [modify the ConfigMap](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options) for the CoreDNS Corefile in each region.
 
-1. Download and open our ConfigMap template [`configmap.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/eks/configmap.yaml).
+1. Download and open our ConfigMap template [`configmap.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/eks/configmap.yaml):
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/configmap.yaml 
+    ~~~
 
 1. After [obtaining the IP addresses of EKS instances](#set-up-load-balancing) in all 3 regions, you can use this information to define a **separate ConfigMap for each region**. Each unique ConfigMap lists the forwarding addresses for the pods in the 2 other regions. 
 
@@ -411,14 +420,14 @@ To enable traffic forwarding to CockroachDB pods in all 3 regions, you need to [
 
     {% include copy-clipboard.html %}
     ~~~
-    kubectl apply -f <configmap-name> --context=<cluster-context>
+    kubectl apply -f <configmap-name> --context <cluster-context>
     ~~~
 
 1. For each region, check that your CoreDNS settings were applied:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl get -n kube-system cm/coredns --export -o yaml --context=<cluster-context>
+    kubectl get -n kube-system cm/coredns --export -o yaml --context <cluster-context>
     ~~~
 
 ### Exclude VPCs from SNAT
@@ -429,13 +438,13 @@ Set `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` to recognize the values of your 3 CIDR 
 
 {% include copy-clipboard.html %}
 ~~~
-kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS="cidr1,cidr2,cidr3" --context=<cluster-context>
+kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS="cidr1,cidr2,cidr3" --context <cluster-context>
 ~~~
 
 Remember that these are the CIDR blocks you chose when [starting your Kubernetes clusters](#step-1-start-kubernetes-clusters). You can also get the IP range of a VPC by opening the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and finding the VPC listed in the section called Your VPCs.
 
 {{site.data.alerts.callout_info}}
-If you plan to run your instances exclusively on private subnets, set the following environment variable instead on each region: `kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXTERNALSNAT=true --context=<cluster-context>`
+If you plan to run your instances exclusively on private subnets, set the following environment variable instead on each region: `kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXTERNALSNAT=true --context <cluster-context>`
 {{site.data.alerts.end}}
 </section>
 
@@ -508,7 +517,7 @@ If you plan to run your instances exclusively on private subnets, set the follow
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-1>
     ~~~
 
     ~~~
@@ -520,7 +529,7 @@ If you plan to run your instances exclusively on private subnets, set the follow
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-2>
     ~~~
 
     ~~~
@@ -532,7 +541,7 @@ If you plan to run your instances exclusively on private subnets, set the follow
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-3>
     ~~~
 
     ~~~
@@ -607,8 +616,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.client.root \
     --from-file=certs \
-    --context=<cluster-context-1> \
-    --namespace=<cluster-namespace-1>
+    --context <cluster-context-1> \
+    --namespace <cluster-namespace-1>
     ~~~
 
     {% include copy-clipboard.html %}
@@ -616,8 +625,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.client.root \
     --from-file=certs \
-    --context=<cluster-context-2> \
-    --namespace=<cluster-namespace-2>
+    --context <cluster-context-2> \
+    --namespace <cluster-namespace-2>
     ~~~
 
     {% include copy-clipboard.html %}
@@ -625,8 +634,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.client.root \
     --from-file=certs \
-    --context=<cluster-context-3> \
-    --namespace=<cluster-namespace-3>
+    --context <cluster-context-3> \
+    --namespace <cluster-namespace-3>
     ~~~
 
 1. Create the certificate and key pair for your CockroachDB nodes in one region, substituting `<cluster-namespace>` in this command with the appropriate namespace:
@@ -652,8 +661,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.node \
     --from-file=certs
-    --context=<cluster-context> \
-    --namespace=<cluster-namespace>    
+    --context <cluster-context> \
+    --namespace <cluster-namespace>    
     ~~~
     
 1. Repeat the previous 2 steps for your 2 remaining regions. You may need to delete the local `node.crt` and `node.key` in your `certs` directory before generating a new node certificate and key pair.
@@ -662,7 +671,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get secrets --context=<cluster-context>
+    $ kubectl get secrets --context <cluster-context>
     ~~~
 
     ~~~
@@ -675,7 +684,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
 ### Create StatefulSets
 
-1. Download and open our [multi-region StatefulSet configuration](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml). You'll save three versions of this file locally, one for each set of 3 CockroachDB nodes per region.
+1. Download and open our [multi-region StatefulSet configuration](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml). You'll save three versions of this file locally, one for each set of 3 CockroachDB nodes per region.
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -736,17 +745,17 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f <statefulset-1> --context=<cluster-context-1> --namespace=<cluster-namespace-1>
+    $ kubectl create -f <statefulset-1> --context <cluster-context-1> --namespace <cluster-namespace-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f <statefulset-2> --context=<cluster-context-2> --namespace=<cluster-namespace-2>
+    $ kubectl create -f <statefulset-2> --context <cluster-context-2> --namespace <cluster-namespace-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f <statefulset-3> --context=<cluster-context-3> --namespace=<cluster-namespace-3>
+    $ kubectl create -f <statefulset-3> --context <cluster-context-3> --namespace <cluster-namespace-3>
     ~~~
 
 1. Run `cockroach init` on one of the pods to complete the node startup process and have them join together as a cluster:
@@ -754,8 +763,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     {% include copy-clipboard.html %}
     ~~~
     kubectl exec \
-    --context=<cluster-context> \
-    --namespace=<cluster-namespace> \
+    --context <cluster-context> \
+    --namespace <cluster-namespace> \
     -it cockroachdb-0 \
     -- /cockroach/cockroach init \
     --certs-dir=/cockroach/cockroach-certs
@@ -769,7 +778,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl get pods --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -781,7 +790,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 </section>
 
 {{site.data.alerts.callout_success}}
-In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --context=<cluster-context> --namespace=<cluster-namespace>` rather than checking the log on the persistent volume.
+In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --context <cluster-context> --namespace <cluster-namespace>` rather than checking the log on the persistent volume.
 {{site.data.alerts.end}}
 
 <section class="filter-content" markdown="1" data-scope="gke">
@@ -791,7 +800,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f client-secure.yaml --context=<cluster-context>
+    $ kubectl create -f client-secure.yaml --context <cluster-context>
     ~~~
 
     ~~~
@@ -808,7 +817,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/client-secure.yaml --context=<cluster-context> --namespace=<cluster-namespace> 
+    kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/client-secure.yaml --context <cluster-context> --namespace <cluster-namespace> 
     ~~~
 
     ~~~
@@ -822,7 +831,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
     ~~~
@@ -892,7 +901,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
+    $ kubectl delete pod cockroachdb-client-secure --context <cluster-context>
     ~~~
 
 <section class="filter-content" markdown="1" data-scope="gke">
@@ -911,7 +920,7 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
 1.  Assign `roach` to the `admin` role (you only need to do this once):
@@ -932,7 +941,7 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl port-forward cockroachdb-0 8080 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl port-forward cockroachdb-0 8080 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -952,7 +961,7 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 </section>
 
 <section class="filter-content" markdown="1" data-scope="eks">
-## Step 6. Access the Admin UI
+## Step 6. Simulate datacenter failure
 </section>
 
 One of the major benefits of running a multi-region CockroachDB cluster is that an entire datacenter or region can go down without affecting the availability of the cluster as a whole.
@@ -963,7 +972,7 @@ To see this in action:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=0 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl scale statefulset cockroachdb --replicas=0 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -976,7 +985,7 @@ To see this in action:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=3 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl scale statefulset cockroachdb --replicas=3 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -1011,7 +1020,7 @@ Each of your Kubernetes clusters contains 3 instances that can run CockroachDB p
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=4 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl scale statefulset cockroachdb --replicas=4 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -1022,7 +1031,7 @@ Each of your Kubernetes clusters contains 3 instances that can run CockroachDB p
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl get pods --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -1052,7 +1061,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
@@ -1066,34 +1075,34 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster1> --context=<cluster-context-1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace <namespace-of-kubernetes-cluster1> --context <cluster-context-1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster2> --context=<cluster-context-2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace <namespace-of-kubernetes-cluster2> --context <cluster-context-2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster3> --context=<cluster-context-3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace <namespace-of-kubernetes-cluster3> --context <cluster-context-3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
 3. If you then check the status of the pods in each Kubernetes cluster, you should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-3>
     ~~~
 
     This will continue until all of the pods have restarted and are running the new image.
@@ -1110,7 +1119,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Re-enable auto-finalization:
@@ -1182,17 +1191,17 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-1>
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-2>
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-3>
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context <cluster-context-3>
     ~~~
 
     ~~~
@@ -1216,7 +1225,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
+    $ kubectl delete pod cockroachdb-client-secure --context <cluster-context>
     ~~~
 
     ~~~
@@ -1227,7 +1236,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get secrets --context=<cluster-context>
+    $ kubectl get secrets --context <cluster-context>
     ~~~
 
     ~~~
@@ -1241,17 +1250,17 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-1>
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-2>
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-3>
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context <cluster-context-3>
     ~~~
 
 1. Stop Kubernetes in each region:

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -1001,6 +1001,7 @@ Each of your Kubernetes clusters contains 3 instances that can run CockroachDB p
 
 <section class="filter-content" markdown="1" data-scope="gke">
 1. [Resize your Kubernetes cluster.](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster)
+</section>
 
 <section class="filter-content" markdown="1" data-scope="eks">
 1. [Resize your Kubernetes cluster.](https://eksctl.io/usage/managing-nodegroups/#scaling)

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -3,12 +3,19 @@ title: Orchestrate CockroachDB Across Multiple Kubernetes Clusters
 summary: How to use Kubernetes to orchestrate the deployment, management, and monitoring of an insecure CockroachDB cluster across multiple Kubernetes clusters in different regions.
 toc: true
 toc_not_nested: true
-redirect_from: orchetrate-cockroachdb-with-kubernetes-multi-region.html
+redirect_from: orchestrate-cockroachdb-with-kubernetes-multi-region.html
 ---
 
-This page shows you how to orchestrate a secure CockroachDB deployment across three [Kubernetes](http://kubernetes.io/) clusters, each in a different geographic region, using the [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) feature to manage the containers within each cluster and linking them together via DNS.
+<div class="filters filters-big clearfix">
+    <button class="filter-button" data-scope="gke">GKE</button>
+    <button class="filter-button" data-scope="eks">EKS</button>
+</div>
 
-To deploy in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
+This page shows you how to orchestrate a secure CockroachDB deployment across three [Kubernetes](http://kubernetes.io/) clusters, each in a different geographic region, using [StatefulSets](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) to manage the containers within each cluster and linking them together via DNS. This will result in a single, multi-region CockroachDB cluster running on Kubernetes.
+
+{{site.data.alerts.callout_success}}
+To deploy CockroachDB in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
+{{site.data.alerts.end}}
 
 ## Before you begin
 
@@ -22,29 +29,35 @@ Before getting started, it's helpful to review some Kubernetes-specific terminol
 
 Feature | Description
 --------|------------
-instance | A physical or virtual machine. In this tutorial, you'll run instances as part of three independent Kubernetes clusters, each in a different region.
-[pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one or more Docker containers. In this tutorial, each pod will run on a separate instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods in each region and grow to 4.
-[StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A StatefulSet is a group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
-[persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A persistent volume is a piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
-[RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) | RBAC, or Role-Based Access Control, is the system Kubernetes uses to manage permissions within the cluster. In order to take an action (e.g., `get` or `create`) on an API resource (e.g., a `pod`), the client must have a `Role` that allows it to do so.
-[namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) | A namespace provides a scope for resources and names within a Kubernetes cluster. Names of resources need to be unique within a namespace, but not across namespaces. Most Kubernetes client commands will use the `default` namespace by default, but can operate on resources in other namespaces as well if told to do so.
+[node](https://kubernetes.io/docs/concepts/architecture/nodes/) | A physical or virtual machine. In this tutorial, you'll run GKE or EKS instances and join them as worker nodes in three independent Kubernetes clusters, each in a different region.
+[pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one or more Docker containers. In this tutorial, each pod will run on a separate GKE or EKS instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods in each region and grow to 4.
+[StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
+[persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
+[CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) | A CSR, or certificate signing request, is a request to have a TLS certificate verified by a certificate authority (CA). A CSR is issued for the CockroachDB node running in each pod, as well as each client as it connects to the Kubernetes cluster.
+[RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) | RBAC, or role-based access control, is the system Kubernetes uses to manage permissions within the cluster. In order to take an action (e.g., `get` or `create`) on an API resource (e.g., a `pod`), the client must have a `Role` that allows it to do so.
+[namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) | A namespace provides a scope for resources and names within a Kubernetes cluster. Names of resources must be unique within a namespace, but not across namespaces. Most Kubernetes client commands will use the `default` namespace by default, but can operate on resources in other namespaces as well. In this tutorial, CockroachDB pods will be deployed in their own namespace in each Kubernetes cluster.
 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) | `kubectl` is the command-line interface for running commands against Kubernetes clusters.
-[kubectl context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration) | A `kubectl` "context" specifies a Kubernetes cluster to connect to and authentication for doing so. You can set a context as the default using the `kubectl use-context <context-name>` command such that all future `kubectl` commands will talk to that cluster, or you can specify the `--context=<context-name>` flag on almost any `kubectl` command to tell it which cluster you want to run the command against. We will make heavy use of the `--context` flag in these instructions in order to run commands against the different regions' Kubernetes clusters.
+[kubectl context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration) | When multiple Kubernetes clusters are deployed on your account, `kubectl` "context" specifies a cluster to connect to.
 
 ### UX differences from running in a single cluster
 
-These instructions create a StatefulSet that runs CockroachDB in each of the Kubernetes clusters you provide to the configuration scripts. These StatefulSets can be scaled independently of each other by running `kubectl` commands against the appropriate cluster. These steps will also point each Kubernetes cluster's DNS server at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., "*.us-west1-a.svc.cluster.local") can be deferred to the appropriate cluster's DNS server. However, in order to make this work, we create the StatefulSets in namespaces named after the zone in which the cluster is running. This means that in order to run a command against one of the pods, you have to run, e.g., `kubectl logs cockroachdb-0 --namespace=us-west1-a` instead of just `kubectl logs cockroachdb-0`. Alternatively, you can [configure your `kubectl` context to default to using that namespace for commands run against that cluster](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference).
+These instructions create 3 StatefulSets that each run 3 CockroachDB pods in a separate Kubernetes cluster deployed in its own region. If you haven't often worked with multiple Kubernetes clusters, remember that `kubectl` commands are run against a cluster in a specific context. Either run `kubectl use-context <cluster-context>` frequently to switch contexts between commands, or append `--context=<cluster-context>` to the commands you run to ensure they are run against the correct cluster.
 
-Note that the CockroachDB pods being in a non-default namespace means that if we didn't do anything about it then any client applications wanting to talk to CockroachDB from the default namespace would need to talk to a zone-scoped service name such as "cockroachdb-public.us-west1-a" rather than just the normal "cockroachdb-public" that they would use in a single-cluster setting. However, the setup script used by these instructions sets up an additional [`ExternalName` service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) in the default namespace such that the clients in the default namespace can simply talk to the "cockroachdb-public" address.
+<section class="filter-content" markdown="1" data-scope="gke">
+Each Kubernetes cluster's DNS server is pointed at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., `*.us-west1-a.svc.cluster.local`) can be deferred to the appropriate cluster's DNS server. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
 
-Finally, if you haven't worked with multiple Kubernetes clusters often before, you may find yourself forgetting to think about which cluster you want to run a given command against, and thus getting confusing results to your commands. Remember that you will either have to run `kubectl use-context <context-name>` frequently to switch contexts between commands or you will have to append `--context=<context-name>` on most commands you run to ensure they are run on the correct cluster.
+Because the CockroachDB pods run in a non-default namespace, client applications wanting to talk to CockroachDB from the default namespace would need to use a zone-scoped service name (e.g., `cockroachdb-public.us-west1-a`) rather than `cockroachdb-public`, as in a single-cluster setting. However, the setup script used by these instructions sets up an additional [`ExternalName` service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) in the default namespace such that the clients in the default namespace can simply talk to the `cockroachdb-public` address.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+To enable the pods to communicate across regions, we peer the VPCs in all 3 regions with each other and configure a CoreDNS service in each region to route DNS traffic to the appropriate pods. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
+</section>
 
 ### Limitations
 
-#### Kubernetes version
+{% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
 
-Kubernetes 1.8 or higher is required.
-
+<section class="filter-content" markdown="1" data-scope="gke">
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
@@ -52,18 +65,22 @@ Until December 2019, Google Cloud Platform restricted clients to using a load ba
 
 You can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access) on Google Cloud Platform to allow clients from one region to use an internal load balancer in another. We will update this tutorial accordingly.
 {{site.data.alerts.end}}
+</section>
 
 ## Step 1. Start Kubernetes clusters
 
-Our multi-region deployment approached relies on pod IP addresses being routable across three distinct Kubernetes clusters and regions. The hosted Google Kubernetes Engine (GKE) service satisfies this requirement, so that is the environment featured here. If you want to run on another cloud or on-premises, use this [basic network test](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/multiregion#pod-to-pod-connectivity) to see if it will work.
+Our multi-region deployment approach relies on pod IP addresses being routable across three distinct Kubernetes clusters and regions. Both the hosted Google Kubernetes Engine (GKE) and Amazon Elastic Kubernetes Service (EKS) satisfy this requirement. 
 
+If you want to run on another cloud or on-premises, use this [basic network test](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/multiregion#pod-to-pod-connectivity) to see if it will work.
+
+<section class="filter-content" markdown="1" data-scope="gke">
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.
 
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
 
     {{site.data.alerts.callout_success}}The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.{{site.data.alerts.end}}
 
-2. From your local workstation, start the first Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
+1. From your local workstation, start the first Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -76,9 +93,11 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     This creates GKE instances in the zone specified and joins them into a single Kubernetes cluster named `cockroachdb1`.
 
+    {{site.data.alerts.callout_info}}
     The process can take a few minutes, so do not move on to the next step until you see a `Creating cluster cockroachdb1...done` message and details about your cluster.
+    {{site.data.alerts.end}}
 
-3. Start the second Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
+1. Start the second Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -89,7 +108,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     Creating cluster cockroachdb2...done.
     ~~~
 
-4. Start the third Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
+1. Start the third Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -100,7 +119,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     Creating cluster cockroachdb3...done.
     ~~~
 
-5. Get the `kubectl` "contexts" for your clusters:
+1. Get the `kubectl` "contexts" for your clusters:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -115,12 +134,17 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     ~~~
 
     {{site.data.alerts.callout_info}}
-    All of the `kubectl` commands in this tutorial use the `--context` flag to tell `kubectl` which Kubernetes cluster to talk to. Each Kubernetes cluster operates independently; you have to tell each of them what to do separately, and when you want to get the status of something in a particular cluster, you have to make it clear to `kubectl` which cluster you're interested in.
+    `kubectl` commands are run against the `CURRENT` context by default. You can change the current context with this command:
 
-    The context with `*` in the `CURRENT` column indicates the cluster that `kubectl` will talk to by default if you do not specify the `--context` flag.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl config use-context <context-name>
+    ~~~
+    
+    When sending commands to another context, you need to use the `--context` flag to specify the context. For clarity, every `kubectl` command in this tutorial uses the `--context` flag to indicate the proper context. 
     {{site.data.alerts.end}}
 
-6. Get the email address associated with your Google Cloud account:
+1. Get the email address associated with your Google Cloud account:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -135,23 +159,287 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     This command returns your email address in all lowercase. However, in the next step, you must enter the address using the accurate capitalization. For example, if your address is YourName@example.com, you must use YourName@example.com and not yourname@example.com.
     {{site.data.alerts.end}}
 
-6. For each Kubernetes cluster, [create the RBAC roles](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control) CockroachDB needs for running on GKE, using the email address and relevant "context" name from the previous steps:
+1. For each Kubernetes cluster, [create the RBAC roles](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control) CockroachDB needs for running on GKE, using the email address and relevant "context" name from the previous steps:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<context-name-of-kubernetes-cluster2>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<context-name-of-kubernetes-cluster3>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-3>
+    ~~~
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+1. Complete the steps described in the [EKS Getting Started](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html) documentation.
+
+    This includes installing and configuring the AWS CLI and `eksctl`, which is the command-line tool used to create and delete Kubernetes clusters on EKS, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
+
+1. From your local workstation, create three Kubernetes clusters. For each cluster, specify a unique region and a **non-overlapping** IP range for the VPC in CIDR notation (e.g., 10.0.0.0/16). Refer to the AWS documentation for valid [regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) and [CIDR blocks](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#VPC_Sizing).
+
+    {{site.data.alerts.callout_danger}}
+    In order to enable VPC peering between the regions, the CIDR blocks of the VPCs **must not** overlap. This value cannot change once the cluster has been created, so be sure that your IP ranges do not overlap.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl create cluster \
+    --name cockroachdb1 \
+    --nodegroup-name standard-workers \
+    --node-type m5.xlarge \
+    --nodes 3 \
+    --node-ami auto \
+    --region <aws-region-1>
+    --vpc-cidr=<ip-range-1>
     ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl create cluster \
+    --name cockroachdb2 \
+    --nodegroup-name standard-workers \
+    --node-type m5.xlarge \
+    --nodes 3 \
+    --node-ami auto \
+    --region <aws-region-2>
+    --vpc-cidr=<ip-range-2>
+    ~~~
+       
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl create cluster \
+    --name cockroachdb3 \
+    --nodegroup-name standard-workers \
+    --node-type m5.xlarge \
+    --nodes 3 \
+    --node-ami auto \
+    --region <aws-region-3>
+    --vpc-cidr=<ip-range-3>
+    ~~~
+
+    Each command creates three EKS instances in a region, one for each CockroachDB node you will deploy. Note that the Kubernetes scheduler automatically assigns each instance to a different availability zone in the region.
+
+    In each region, the EKS instances are joined into a separate Kubernetes cluster: `cockroachdb1`, `cockroachdb2`, and `cockroachdb3`. The `--node-type` flag tells the node pool to use the [`m5.xlarge`](https://aws.amazon.com/ec2/instance-types/) instance type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
+
+    {{site.data.alerts.callout_info}}
+    Cluster provisioning usually takes between 10 and 15 minutes. Do not move on to the next step until you see a message like `[✔]  EKS cluster "cockroachdb1" in "us-east-1" region is ready` for each cluster.
+    {{site.data.alerts.end}}
+
+1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and verify that three instances, using the node group name you specified, are running in each region. You will need to toggle between each region in the console.
+
+1. Get the context name for each of the 3 regions. When running `kubectl` commands against each region's cluster, you will need to specify the context name for that region.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl config get-contexts
+    ~~~
+
+    ~~~
+    CURRENT   NAME                                           CLUSTER                               AUTHINFO                                       NAMESPACE
+    *         maxroach@cockroachdb1.eu-central-1.eksctl.io   cockroachdb1.eu-central-1.eksctl.io   maxroach@cockroachdb1.eu-central-1.eksctl.io
+              maxroach@cockroachdb2.ca-central-1.eksctl.io   cockroachdb2.ca-central-1.eksctl.io   maxroach@cockroachdb2.ca-central-1.eksctl.io
+              maxroach@cockroachdb3.eu-north-1.eksctl.io     cockroachdb3.eu-north-1.eksctl.io     maxroach@cockroachdb3.eu-north-1.eksctl.io
+    ~~~
+
+    {{site.data.alerts.callout_info}}
+    `kubectl` commands are run against the "current" context by default. You can change the current context with `kubectl config use-context <context-name>`.
+
+    When running commands on another region, you need to use the `--context` flag to specify that region's context. For clarity, every `kubectl` command in this tutorial uses the `--context` flag to indicate the proper context.
+    {{site.data.alerts.end}}
+
+1. Create three namespaces, one corresponding to each region. The CockroachDB cluster in each region will run in this namespace.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl create namespace <cluster-namespace> --context=<cluster-context>
+    ~~~
+
+    It's simplest for the namespace and region to have the same name, e.g.:
+
+    ~~~ shell
+    kubectl create namespace eu-central-1 --context=maxroach@cockroachdb1.eu-central-1.eksctl.io
+    ~~~
+
+    {{site.data.alerts.callout_info}}
+    `kubectl` commands are run against the namespace named `default` by default. You can change the default namespace for a given context with `kubectl config set-context <context-name> --namespace=<namespace-name>`.
+
+    For clarity, every `kubectl` command in this tutorial uses the `--namespace` flag to indicate the proper namespace.
+    {{site.data.alerts.end}}
+
+## Step 2. Configure your network
+
+### Set up VPC peering
+
+For pods to communciate across three separate Kubernetes clusters, the VPCs in all regions need to be peered. Network traffic can then be routed between the VPCs. For more information about VPC peering, see the [AWS documentation](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html).
+
+1. Open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and note the ID of the VPC in each region. The VPC ID is found in the section called Your VPCs.
+
+1. Navigate to the Peering Connections section and [create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#create-vpc-peering-connection-local) between each of the 3 regions. When you create a peering connection, you will first select a requester VPC in the current region and then an accepter VPC in another region, specified by pasting the VPC ID.
+
+    {{site.data.alerts.callout_success}}
+    You should have a total of 3 VPC peering connections between your three VPCs. You will need to switch regions in the console to create one of the peering connections.
+    {{site.data.alerts.end}}
+
+1. To complete the VPC peering connections, switch to each destination region and [accept the pending connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#accept-vpc-peering-connection) in the VPC console. 
+
+1. For all 3 regions, navigate to the Route Tables section and find `PublicRouteTable`. [Update this route table](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) with 2 new entries that point traffic to the other 2 peered VPCs. The **Destination** should be the CIDR block of a destination region, and the **Target** should be the VPC peering connection between the current and the destination region.
+
+### Create inbound rules
+
+For each region, navigate to the Security Groups section of the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and locate the security group that enables communication between nodes int he cluster. It should have a name like `ClusterSharedNodeSecurityGroup`. [Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to this security group to allow TCP communication on two ports:
+
+- `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
+- `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
+
+{{site.data.alerts.callout_info}}
+Remember to create these inbound rules in all 3 regions. This enables CockroachDB to communicate across each Kubernetes cluster.
+{{site.data.alerts.end}}
+
+#### Inter-region communciation
+
+ Field | Value
+-------|-------------------
+Port Range | **26257**
+Source | The IP range of each region's VPC in CIDR notation (e.g., 10.12.0.0/16)
+
+This important rule enables node communication between Kubernetes clusters in different regions. You need to create a separate rule for each region in your deployment.
+
+{% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
+
+### Set up load balancing
+
+The Kubernetes cluster in each region needs to have a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) pointed at its CoreDNS service, which you will configure in the next step.
+
+1. Upload our load balancer manifest [`dns-lb-eks.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/dns-lb-eks.yaml) to the Kubernetes clusters in all 3 regions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-3>
+    ~~~
+
+    You should see the load balancer appear in the Load Balancers section of the EC2 console in each region. This load balancer will route traffic to CoreDNS in the region.
+
+1. For each region, navigate to the Load Balancer section of the [EC2 console](https://console.aws.amazon.com/ec2/) and get the DNS name of the Network Load Balancer you created in the previous step.
+
+1. For each region's load balancer, look up the IP addresses mapped to the load balancer:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    dig <nlb-dns-name>
+    ~~~
+
+    ~~~
+    ...
+    
+    ;; ANSWER SECTION:
+    ac63a423fbf6231cba51235e1e51e6ec-132cf6c423e67123.elb.eu-central-1.amazonaws.com. 60 IN A ip1
+    ac63a423fbf6231cba51235e1e51e6ec-132cf6c423e67123.elb.eu-central-1.amazonaws.com. 60 IN A ip2
+    ac63a423fbf6231cba51235e1e51e6ec-132cf6c423e67123.elb.eu-central-1.amazonaws.com. 60 IN A ip3
+    
+    ...
+    ~~~
+
+    `ip1`, `ip2`, and `ip3` correspond to the 3 availability zones in the region where EKS instances are running. You will need these IP addresses when configuring your network in the next step.
+
+### Configure CoreDNS
+
+Each Kubernetes cluster has a [CoreDNS](https://coredns.io/) service that responds to DNS requests for pods in its region. CoreDNS can also forward DNS requests to pods in other regions.
+
+To enable traffic forwarding to CockroachDB pods in all 3 regions, you need to [modify the ConfigMap](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options) for the CoreDNS Corefile in each region.
+
+1. Download and open our ConfigMap template [`configmap.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/configmap.yaml).
+
+1. After [obtaining the IP addresses of EKS instances](#set-up-load-balancing) in all 3 regions, you can use this information to define a **separate ConfigMap for each region**. Each unique ConfigMap lists the forwarding addresses for the pods in the 2 other regions. 
+
+    ~~~
+    ...
+       region2.svc.cluster.local:53 {       # <---- Modify
+           log
+           errors
+           ready
+           cache 10
+           forward . ip1 ip2 ip3 {      # <---- Modify
+                force_tcp            # <---- Modify
+           }
+       }
+       region3.svc.cluster.local:53 {       # <---- Modify
+           log
+           errors
+           ready
+           cache 10
+           forward . ip1 ip2 ip3 {      # <---- Modify
+                force_tcp            # <---- Modify
+           }
+       }
+    ~~~
+
+    For each region, modify `configmap.yaml` by replacing:
+
+    <ul><li><code>region2</code> and <code>region3</code> with the namespaces in which the CockroachDB pods will run in the other 2 regions. You defined these namespaces after <a href="#step-1-start-kubernetes-clusters">starting the Kubernetes clusters</a>.</li><li><code>ip1</code>, <code>ip2</code>, and <code>ip3</code> with the IP addresses of the EKS instances in the region, which you looked up in the previous step.</li></ul>
+
+    You will end up with 3 different ConfigMaps. Give each ConfigMap a unique filename like `configmap-1.yaml`.
+
+    {{site.data.alerts.callout_info}}
+    If you configure your Network Load Balancer to support UDP traffic, you can drop the `force_tcp` line.
+    {{site.data.alerts.end}}
+
+1. For each region, first back up the existing ConfigMap:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl -n kube-system get configmap coredns -o yaml > <configmap-backup-name>
+    ~~~
+
+    Then apply the new ConfigMap:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    kubectl apply -f <configmap-name> --context=<cluster-context>
+    ~~~
+
+1. For each region, check that your CoreDNS settings were applied:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl get -n kube-system cm/coredns --export -o yaml --context=<cluster-context>
+    ~~~
+
+### Exclude VPCs from SNAT
+
+You will need to tell AWS to exclude your VPCs from [source network address translation (SNAT)](https://docs.aws.amazon.com/eks/latest/userguide/external-snat.html). This ensures that cross-VPC traffic is handled correctly by AWS while still allowing access to the public internet from the pods.
+
+Set `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` to recognize the values of your 3 CIDR blocks. Do this for all 3 regions:
+
+{% include copy-clipboard.html %}
+~~~
+kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS="cidr1,cidr2,cidr3" --context=<cluster-context>
+~~~
+
+Remember that these are the CIDR blocks you chose when [starting your Kubernetes clusters](#step-1-start-kubernetes-clusters). You can also get the IP range of a VPC by opening the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and finding the VPC listed in the section called Your VPCs.
+
+{{site.data.alerts.callout_info}}
+If you plan to run your instances exclusively on private subnets, set the following environment variable instead on each region: `kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXTERNALSNAT=true --context=<cluster-context>`
+{{site.data.alerts.end}}
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 2. Start CockroachDB
 
 1. Create a directory and download the required script and configuration files into it:
@@ -172,7 +460,14 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/{README.md,client-secure.yaml,cluster-init-secure.yaml,cockroachdb-statefulset-secure.yaml,dns-lb.yaml,example-app-secure.yaml,external-name-svc.yaml,setup.py,teardown.py}
     ~~~
 
-2. At the top of the `setup.py` script, fill in the `contexts` map with the zones of your clusters and their "context" names, for example:
+2. Retrieve the `kubectl` "contexts" for your clusters:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl config get-contexts
+    ~~~
+
+    At the top of the `setup.py` script, fill in the `contexts` map with the zones of your clusters and their "context" names, e.g.:
 
     ~~~
     context = {
@@ -180,13 +475,6 @@ Our multi-region deployment approached relies on pod IP addresses being routable
         'us-west1-a': 'gke_cockroach-shared_us-west1-a_cockroachdb2',
         'us-central1-a': 'gke_cockroach-shared_us-central1-a_cockroachdb3',
     }
-    ~~~
-
-    You retrieved the `kubectl` "contexts" in an earlier step. To get them again, run:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl config get-contexts
     ~~~
 
 3. In the `setup.py` script, fill in the `regions` map with the zones and corresponding regions of your clusters, for example:
@@ -199,7 +487,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     }
     ~~~
 
-    Setting regions is optional, but recommended, because it improves CockroachDB's ability to diversify data placement if you use more than one zone in the same region. If you aren't specifying regions, just leave the map empty.
+    Setting `regions` is optional, but recommended, because it improves CockroachDB's ability to diversify data placement if you use more than one zone in the same region. If you aren't specifying regions, just leave the map empty.
 
 4. If you haven't already, [install CockroachDB locally and add it to your `PATH`](install-cockroachdb.html). The `cockroach` binary will be used to generate certificates.
 
@@ -220,7 +508,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
     ~~~
 
     ~~~
@@ -232,7 +520,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster2>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
     ~~~
 
     ~~~
@@ -244,7 +532,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster3>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
     ~~~
 
     ~~~
@@ -266,11 +554,237 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     NAME                      NETWORK  DIRECTION  PRIORITY  ALLOW      DENY
     allow-cockroach-internal  default  INGRESS    1000      tcp:26257
     ~~~
+</section>
 
-{{site.data.alerts.callout_success}}
-In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --namespace=<cluster-namespace> --context=<cluster-context>` rather than checking the log on the persistent volume.
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 3. Start CockroachDB
+
+### Generate certificates
+
+{{site.data.alerts.callout_info}}
+Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly generate and sign the CockroachDB node and client certificates. Read our [Authentication](authentication.html#using-digital-certificates-with-cockroachdb) docs to learn about other methods of signing certificates.
 {{site.data.alerts.end}}
 
+1. Create two directories:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ mkdir certs my-safe-directory
+    ~~~
+
+    Directory | Description
+    ----------|------------
+    `certs` | You'll generate your CA certificate and all node and client certificates and keys in this directory.
+    `my-safe-directory` | You'll generate your CA key in this directory and then reference the key when generating node and client certificates.
+
+1. Create the CA certificate and key pair:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-ca \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+1. Create a client certificate and key pair for the root user:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+1. For all 3 regions, upload the client certificate and key to the Kubernetes cluster as a secret. 
+
+    {{site.data.alerts.callout_success}}
+    Specify the namespace in which the CockroachDB pods will run. You defined these namespaces after [starting your Kubernetes clusters](#step-1-start-kubernetes-clusters).
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.client.root \
+    --from-file=certs \
+    --context=<cluster-context-1> \
+    --namespace=<cluster-namespace-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.client.root \
+    --from-file=certs \
+    --context=<cluster-context-2> \
+    --namespace=<cluster-namespace-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.client.root \
+    --from-file=certs \
+    --context=<cluster-context-3> \
+    --namespace=<cluster-namespace-3>
+    ~~~
+
+1. Create the certificate and key pair for your CockroachDB nodes in one region, substituting `<cluster-namespace>` in this command with the appropriate namespace:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-node \
+    localhost 127.0.0.1 \
+    cockroachdb-public \
+    cockroachdb-public.<cluster-namespace> \
+    cockroachdb-public.<cluster-namespace>.svc.cluster.local \
+    *.cockroachdb \
+    *.cockroachdb.<cluster-namespace> \
+    *.cockroachdb.<cluster-namespace>.svc.cluster.local \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+1. Upload the node certificate and key to the Kubernetes cluster as a secret, specifying the appropriate context and namespace:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.node \
+    --from-file=certs
+    --context=<cluster-context> \
+    --namespace=<cluster-namespace>    
+    ~~~
+    
+1. Repeat the previous 2 steps for your 2 remaining regions. You may need to delete the local `node.crt` and `node.key` in your `certs` directory before generating a new node certificate and key pair.
+
+1. For all 3 regions, check that the secrets were created on the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get secrets --context=<cluster-context>
+    ~~~
+
+    ~~~
+    NAME                      TYPE                                  DATA   AGE
+    cockroachdb-token-db5wp   kubernetes.io/service-account-token   3      1m
+    cockroachdb.client.root   Opaque                                5      1m
+    cockroachdb.node          Opaque                                6      1m
+    default-token-65489       kubernetes.io/service-account-token   3      5m
+    ~~~
+
+### Create StatefulSets
+
+1. Download and open our [multi-region StatefulSet configuration](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure-eks.yaml). You'll save three versions of this file locally, one for each set of 3 CockroachDB nodes per region.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure-eks.yaml
+    ~~~
+
+    Look for **TODO** comments in the file. These highlight fields you need to define before deploying your StatefulSet.
+
+1. Fill in the namespace where CockroachDB nodes will run in region 1.
+
+    ~~~
+    namespace: <cluster-namespace>
+    ~~~
+
+1. Allocate a memory request and limit to CockroachDB on each pod, using the `resources` object in the CockroachDB `containers` spec. 
+
+    {{site.data.alerts.callout_success}}
+    These values should be appropriate for the instances that you have provisioned. Run `kubectl describe nodes` to see the available resources.
+    {{site.data.alerts.end}}
+
+    For example, to allocate 8Gi of memory to CockroachDB in each pod: 
+
+    ~~~
+    resources:
+      requests:
+        memory: "8Gi"
+      limits:
+        memory: "8Gi"
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    If you don't specify a memory request, no memory will be allocated to CockroachDB. If you don't specify a memory limit, the Kubernetes scheduler will allocate the maximum possible amount.
+    {{site.data.alerts.end}}
+
+1. The StatefulSet configuration includes a [`cockroach start`](cockroach-start.html) command that creates the nodes on the Kubernetes pods. 
+
+    In the `--locality` flag, name `region` after region 1. This can technically be an arbitrary value, but it's simplest to use the CockroachDB namespace in region 1.
+
+    ~~~
+    --locality=region=<cluster-namespace-1>,az=$(cat /etc/cockroach-env/zone),dns=$(hostname -f)
+    ~~~
+
+    In the `--join` flag, update the Cockroach node addresses in all 3 regions with their corresponding namespaces.
+
+    ~~~
+    --join cockroachdb-0.cockroachdb.<cluster-namespace-1>,cockroachdb-1.cockroachdb.<cluster-namespace-1>,cockroachdb-2.cockroachdb.<cluster-namespace-1>,cockroachdb-0.cockroachdb.<cluster-namespace-2>,cockroachdb-1.cockroachdb.<cluster-namespace-2>,cockroachdb-2.cockroachdb.<cluster-namespace-2>,cockroachdb-0.cockroachdb.<cluster-namespace-3>,cockroachdb-1.cockroachdb.<cluster-namespace-3>,cockroachdb-2.cockroachdb.<cluster-namespace-3>
+    ~~~
+
+1. Save this StatefulSet configuration, giving it a filename like `cockroachdb-statefulset-secure-eks-1.yaml`.
+
+    {{site.data.alerts.callout_success}}
+    If you change the StatefulSet name from the default `cockroachdb`, be sure to start and end with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+    {{site.data.alerts.end}}
+
+1. Create and save a StatefulSet configuration for each of the other 2 regions in the same way, being sure to use the correct namespaces for those regions in steps 2 and 4.
+
+1. Deploy the StatefulSets in each of your 3 regions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f <statefulset-1> --context=<cluster-context-1> --namespace=<cluster-namespace-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f <statefulset-2> --context=<cluster-context-2> --namespace=<cluster-namespace-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f <statefulset-3> --context=<cluster-context-3> --namespace=<cluster-namespace-3>
+    ~~~
+
+1. Run `cockroach init` on one of the pods to complete the node startup process and have them join together as a cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    kubectl exec \
+    --context=<cluster-context> \
+    --namespace=<cluster-namespace> \
+    -it cockroachdb-0 \
+    -- /cockroach/cockroach init \
+    --certs-dir=/cockroach/cockroach-certs
+    ~~~
+
+    ~~~
+    Cluster successfully initialized
+    ~~~
+
+1. Confirm that cluster initialization has completed successfully in each region. The job should be considered successful and the Kubernetes pods should soon be considered `Ready`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
+    ~~~
+
+    ~~~
+    NAMESPACE      NAME           READY   STATUS    RESTARTS   AGE
+    eu-central-1   cockroachdb-0  1/1     Running   0          12m
+    eu-central-1   cockroachdb-1  1/1     Running   0          12m
+    eu-central-1   cockroachdb-2  1/1     Running   0          12m
+    ~~~
+</section>
+
+{{site.data.alerts.callout_success}}
+In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --context=<cluster-context> --namespace=<cluster-namespace>` rather than checking the log on the persistent volume.
+{{site.data.alerts.end}}
+
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 3. Use the built-in SQL client
 
 1. Use the `client-secure.yaml` file to launch a pod and keep it running indefinitely, specifying the context of the Kubernetes cluster to run it in:
@@ -285,12 +799,30 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     ~~~
 
     The pod uses the `root` client certificate created earlier by the `setup.py` script. Note that this will work from any of the three Kubernetes clusters as long as you use the correct namespace and context combination.
+</section>
 
-2. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html), again specifying the namespace and context of the Kubernetes cluster where the pod is running:
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 4. Use the built-in SQL client
+
+1. Use the `client-secure.yaml` file to launch a pod and keep it running indefinitely, specifying the context of the Kubernetes cluster and namespace of the CockroachDB pods to run it in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/client-secure.yaml --context=<cluster-context> --namespace=<cluster-namespace> 
+    ~~~
+
+    ~~~
+    pod "cockroachdb-client-secure" created
+    ~~~
+
+    The pod uses the `root` client certificate you [generated earlier](#generate-certificates). Note that this will work from any of the three Kubernetes clusters as long as you use the correct namespace and context combination.
+</section>
+
+1. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html), again specifying the namespace and context of the Kubernetes cluster where the pod is running:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
     ~~~
@@ -307,7 +839,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     root@cockroachdb-public:26257/>
     ~~~
 
-3. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
+1. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -338,16 +870,16 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     (1 row)
     ~~~
 
-3. [Create a user with a password](create-user.html#create-a-user-with-a-password):
+1. [Create a user with a password](create-user.html#create-a-user-with-a-password):
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE USER roach WITH PASSWORD 'Q7gc8rEdS';
     ~~~
 
-      You will need this username and password to [access the Admin UI](#step-4-access-the-admin-ui) in Step 4.
+      You will need this username and password to access the Admin UI in the next step.
 
-4. Exit the SQL shell and pod:
+1. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -363,7 +895,13 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
     ~~~
 
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 4. Access the Admin UI
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 5. Access the Admin UI
+</section>
 
 To access the cluster's [Admin UI](admin-ui-overview.html):
 
@@ -373,28 +911,28 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
-2.  Assign `roach` to the `admin` role (you only need to do this once):
+1.  Assign `roach` to the `admin` role (you only need to do this once):
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > GRANT admin TO roach;
     ~~~
 
-3. Exit the SQL shell and pod:
+1. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > \q
     ~~~
 
-4. Port-forward from your local machine to a pod in one of your Kubernetes clusters:
+1. Port-forward from your local machine to a pod in one of your Kubernetes clusters:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl port-forward cockroachdb-0 8080 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl port-forward cockroachdb-0 8080 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
@@ -405,13 +943,19 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
     The `port-forward` command must be run on the same machine as the web browser in which you want to view the Admin UI. If you have been running these commands from a cloud instance or other non-local shell, you will not be able to view the UI without configuring `kubectl` locally and running the above `port-forward` command on your local machine.
     {{site.data.alerts.end}}
 
-5. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password created in the [Use the built-in SQL client](#step-3-use-the-built-in-sql-client) step.
+1. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password created in the [Use the built-in SQL client](#step-3-use-the-built-in-sql-client) step.
 
-6. In the UI, check the **Node List** to verify that all nodes are running, and then click the **Databases** tab on the left to verify that `bank` is listed.
+1. In the UI, check the [**Node List**](admin-ui-cluster-overview-page.html#node-list) to verify that all nodes are running, open the [**Databases** page](admin-ui-databases-page.html) to verify that `bank` is listed, and open the [**Network Latency** page](admin-ui-network-latency-page.html) to see the performance of your CockroachDB cluster across 3 regions.
 
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 5. Simulate datacenter failure
+</section>
 
-One of the major benefits of running a multi-region cluster is that an entire datacenter or region can go down without affecting the availability of the CockroachDB cluster as a whole.
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 6. Access the Admin UI
+</section>
+
+One of the major benefits of running a multi-region CockroachDB cluster is that an entire datacenter or region can go down without affecting the availability of the cluster as a whole.
 
 To see this in action:
 
@@ -419,27 +963,33 @@ To see this in action:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=0 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl scale statefulset cockroachdb --replicas=0 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
     statefulset "cockroachdb" scaled
     ~~~
 
-2. In the Admin UI, the **Cluster Overview** will soon show the three nodes from that region as **Suspect**. If you wait for 5 minutes or more, they will be listed as **Dead**. Note that even though there are three dead nodes, the other nodes are all healthy, and any clients using the database in the other regions will continue to work just fine.
+1. In the Admin UI, the **Cluster Overview** will soon show the three nodes from that region as **Suspect**. If you wait for 5 minutes or more, they will be listed as **Dead**. Note that even though there are three dead nodes, the other nodes are all healthy, and any clients using the database in the other regions will continue to work just fine.
 
-3. When you're done verifying that the cluster still fully functions with one of the regions down, you can bring the region back up by running:
+1. When you're done verifying that the cluster still fully functions with one of the regions down, you can bring the region back up by running:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=3 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl scale statefulset cockroachdb --replicas=3 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
     statefulset "cockroachdb" scaled
     ~~~
 
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 6. Maintain the cluster
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 7. Maintain the cluster
+</section>
 
 - [Scale the cluster](#scale-the-cluster)
 - [Upgrade the cluster](#upgrade-the-cluster)
@@ -447,26 +997,31 @@ To see this in action:
 
 ### Scale the cluster
 
-Each of your Kubernetes clusters contains 3 nodes that pods can run on. To ensure that you do not have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new worker node and then edit your StatefulSet configuration to add another pod.
+Each of your Kubernetes clusters contains 3 instances that can run CockroachDB pods. It's easy to scale a cluster to run more pods. To ensure that you do not have two CockroachDB pods on the same instance (as recommended in our [production best practices](recommended-production-settings.html)), you need to first add a new instance and then edit your StatefulSet configuration to add another pod.
 
-1. [Resize your cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster).
+<section class="filter-content" markdown="1" data-scope="gke">
+1. [Resize your Kubernetes cluster.](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster)
 
-2. Use the `kubectl scale` command to add a pod to the StatefulSet in the Kubernetes cluster where you want to add a CockroachDB node:
+<section class="filter-content" markdown="1" data-scope="eks">
+1. [Resize your Kubernetes cluster.](https://eksctl.io/usage/managing-nodegroups/#scaling)
+</section>
+
+1. Use the `kubectl scale` command to add a pod to the StatefulSet in the Kubernetes cluster where you want to add a CockroachDB node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=4 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl scale statefulset cockroachdb --replicas=4 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
     statefulset "cockroachdb" scaled
     ~~~
 
-3. Verify that a fourth pod was added successfully:
+1. Verify that a fourth pod was added successfully:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
@@ -486,9 +1041,9 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
 1. Decide how the upgrade will be finalized.
 
-    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v2.0.x to v2.1. For upgrades within the v2.1.x series, skip this step.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v19.2.x to v20.1. For upgrades within the v20.1.x series, skip this step.{{site.data.alerts.end}}
 
-    By default, after all nodes are running the new version, the upgrade process will be **auto-finalized**. This will enable certain performance improvements and bug fixes introduced in v2.1. After finalization, however, it will no longer be possible to perform a downgrade to v2.0. In the event of a catastrophic failure or corruption, the only option will be to start a new cluster using the old binary and then restore from one of the backups created prior to performing the upgrade.
+    By default, after all nodes are running the new version, the upgrade process will be **auto-finalized**. This will enable certain performance improvements and bug fixes introduced in v20.1. After finalization, however, it will no longer be possible to perform a downgrade to v19.2. In the event of a catastrophic failure or corruption, the only option will be to start a new cluster using the old binary and then restore from one of the backups created prior to performing the upgrade.
 
     We recommend disabling auto-finalization so you can monitor the stability and performance of the upgraded cluster before finalizing the upgrade:
 
@@ -496,55 +1051,55 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
 
         {% include copy-clipboard.html %}
         ~~~ sql
-        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '2.0';
+        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '19.2';
         ~~~
 
 2. For each Kubernetes cluster, kick off the upgrade process by changing the desired Docker image. To do so, pick the version that you want to upgrade to, then run the following command, replacing "VERSION" with your desired new version and specifying the relevant namespace and "context" name for the Kubernetes cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster1> --context=<context-name-of-kubernetes-cluster1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster1> --context=<cluster-context-1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster2> --context=<context-name-of-kubernetes-cluster2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster2> --context=<cluster-context-2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster3> --context=<context-name-of-kubernetes-cluster3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster3> --context=<cluster-context-3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
 3. If you then check the status of the pods in each Kubernetes cluster, you should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
     ~~~
 
     This will continue until all of the pods have restarted and are running the new image.
 
 4. Finish the upgrade.
 
-    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v2.0.x to v2.1. For upgrades within the v2.1.x series, skip this step.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v19.2.x to v20.1. For upgrades within the v20.1.x series, skip this step.{{site.data.alerts.end}}
 
     If you disabled auto-finalization in step 1 above, monitor the stability and performance of your cluster for as long as you require to feel comfortable with the upgrade (generally at least a day). If during this time you decide to roll back the upgrade, repeat the rolling restart procedure with the old binary.
 
@@ -554,7 +1109,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Re-enable auto-finalization:
@@ -566,6 +1121,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
 ### Stop the cluster
 
+<section class="filter-content" markdown="1" data-scope="gke">
 1. To delete all of the resources created in your clusters, copy the `contexts` map from `setup.py` into `teardown.py`, and then run `teardown.py`:
 
     ~~~ shell
@@ -618,6 +1174,108 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     ~~~
     Deleting cluster cockroachdb3...done.
     ~~~
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+1. In each region, delete all of the resources associated with the `cockroachdb` label, including the logs, and remote persistent volumes:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-3>
+    ~~~
+
+    ~~~
+    pod "cockroachdb-0" deleted
+    pod "cockroachdb-1" deleted
+    pod "cockroachdb-2" deleted
+    service "cockroachdb" deleted
+    service "cockroachdb-public" deleted
+    persistentvolumeclaim "datadir-cockroachdb-0" deleted
+    persistentvolumeclaim "datadir-cockroachdb-1" deleted
+    persistentvolumeclaim "datadir-cockroachdb-2" deleted
+    poddisruptionbudget.policy "cockroachdb-budget" deleted
+    rolebinding.rbac.authorization.k8s.io "cockroachdb" deleted
+    clusterrolebinding.rbac.authorization.k8s.io "cockroachdb" deleted
+    role.rbac.authorization.k8s.io "cockroachdb" deleted
+    clusterrole.rbac.authorization.k8s.io "cockroachdb" deleted
+    serviceaccount "cockroachdb" deleted
+    ~~~
+
+1. Delete the pod created for `cockroach` client commands, if you didn't do so earlier:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
+    ~~~
+
+    ~~~
+    pod "cockroachdb-client-secure" deleted
+    ~~~
+
+1. Get the names of the secrets you created on each cluster. These should be identical in all 3 regions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get secrets --context=<cluster-context>
+    ~~~
+
+    ~~~
+    NAME                      TYPE                                  DATA   AGE
+    cockroachdb.client.root   Opaque                                5      1d
+    cockroachdb.node          Opaque                                6      1d
+    ...
+    ~~~
+
+1. Delete the secrets that you created:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-3>
+    ~~~
+
+1. Stop Kubernetes in each region:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl delete cluster --name cockroachdb1 --region <aws-region-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl delete cluster --name cockroachdb2 --region <aws-region-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl delete cluster --name cockroachdb3 --region <aws-region-3>
+    ~~~
+
+1. Open the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home) to verify that the stacks were successfully deleted in each region.
+
+{{site.data.alerts.callout_danger}}
+If you stop Kubernetes without first deleting the persistent volumes, they will still exist in your cloud project.
+{{site.data.alerts.end}}
+</section>
 
 ## See also
 

--- a/v20.2/deploy-cockroachdb-on-aws-insecure.md
+++ b/v20.2/deploy-cockroachdb-on-aws-insecure.md
@@ -49,54 +49,12 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 ## Step 2. Configure your network
 
-CockroachDB requires TCP communication on two ports:
+[Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to your security group to allow TCP communication on two ports:
 
-- `26257` for inter-node communication (i.e., working as a cluster), for applications to connect to the load balancer, and for routing from the load balancer to nodes
-- `8080` for exposing your Admin UI, and for routing from the load balancer to the health check
+- `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
+- `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
 
-If you haven't already done so, [create inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) for your security group.
-
-#### Inter-node and load balancer-node communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **26257**
- Source | The ID of your security group (e.g., *sg-07ab277a*)
-
-#### Application data
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rules
- Protocol | TCP
- Port Range | **26257**
- Source | Your application's IP ranges
-
-If you plan to [run our sample workload](#step-8-run-a-sample-workload) on an instance, the traffic source is the internal (private) IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
-
-#### Admin UI
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | Your network's IP ranges
-
-You can set your network IP by selecting "My IP" in the Source field.
-
-#### Load balancer-health check communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
-
-To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs. You can also click on the VPC where it is listed in the EC2 console.
+{% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
 
 ## Step 3. Synchronize clocks
 

--- a/v20.2/deploy-cockroachdb-on-aws.md
+++ b/v20.2/deploy-cockroachdb-on-aws.md
@@ -52,54 +52,12 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 ## Step 2. Configure your network
 
-CockroachDB requires TCP communication on two ports:
+[Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to your security group to allow TCP communication on two ports:
 
-- `26257` for inter-node communication (i.e., working as a cluster), for applications to connect to the load balancer, and for routing from the load balancer to nodes
-- `8080` for exposing your Admin UI, and for routing from the load balancer to the health check
+- `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
+- `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
 
-If you haven't already done so, [create inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) for your security group.
-
-#### Inter-node and load balancer-node communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **26257**
- Source | The ID of your security group (e.g., *sg-07ab277a*)
-
-#### Application data
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rules
- Protocol | TCP
- Port Range | **26257**
- Source | Your application's IP ranges
-
-If you plan to [run our sample workload](#step-9-run-a-sample-workload) on an instance, the traffic source is the internal (private) IP address of that instance. To find this, open the Instances section of the Amazon EC2 console and click on the instance.
-
-#### Admin UI
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | Your network's IP ranges
-
-You can set your network IP by selecting "My IP" in the Source field.
-
-#### Load balancer-health check communication
-
- Field | Recommended Value
--------|-------------------
- Type | Custom TCP Rule
- Protocol | TCP
- Port Range | **8080**
- Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
-
-To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs. You can also click on the VPC where it is listed in the EC2 console.
+{% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
 
 ## Step 3. Synchronize clocks
 

--- a/v20.2/deploy-cockroachdb-on-aws.md
+++ b/v20.2/deploy-cockroachdb-on-aws.md
@@ -59,6 +59,15 @@ For more details, see [Hardware Recommendations](recommended-production-settings
 
 {% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
 
+#### Load balancer-health check communication
+
+ Field | Value
+-------|-------------------
+ Port Range | **8080**
+ Source | The IP range of your VPC in CIDR notation (e.g., 10.12.0.0/16)
+
+To get the IP range of a VPC, open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and find the VPC listed in the section called Your VPCs.
+
 ## Step 3. Synchronize clocks
 
 {% include {{ page.version.version }}/prod-deployment/synchronize-clocks.md %}

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -3,12 +3,19 @@ title: Orchestrate CockroachDB Across Multiple Kubernetes Clusters
 summary: How to use Kubernetes to orchestrate the deployment, management, and monitoring of an insecure CockroachDB cluster across multiple Kubernetes clusters in different regions.
 toc: true
 toc_not_nested: true
-redirect_from: orchetrate-cockroachdb-with-kubernetes-multi-region.html
+redirect_from: orchestrate-cockroachdb-with-kubernetes-multi-region.html
 ---
 
-This page shows you how to orchestrate a secure CockroachDB deployment across three [Kubernetes](http://kubernetes.io/) clusters, each in a different geographic region, using the [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) feature to manage the containers within each cluster and linking them together via DNS.
+<div class="filters filters-big clearfix">
+    <button class="filter-button" data-scope="gke">GKE</button>
+    <button class="filter-button" data-scope="eks">EKS</button>
+</div>
 
-To deploy in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
+This page shows you how to orchestrate a secure CockroachDB deployment across three [Kubernetes](http://kubernetes.io/) clusters, each in a different geographic region, using [StatefulSets](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) to manage the containers within each cluster and linking them together via DNS. This will result in a single, multi-region CockroachDB cluster running on Kubernetes.
+
+{{site.data.alerts.callout_success}}
+To deploy CockroachDB in a single Kubernetes cluster instead, see [Kubernetes Single-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
+{{site.data.alerts.end}}
 
 ## Before you begin
 
@@ -22,29 +29,35 @@ Before getting started, it's helpful to review some Kubernetes-specific terminol
 
 Feature | Description
 --------|------------
-instance | A physical or virtual machine. In this tutorial, you'll run instances as part of three independent Kubernetes clusters, each in a different region.
-[pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one or more Docker containers. In this tutorial, each pod will run on a separate instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods in each region and grow to 4.
-[StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A StatefulSet is a group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
-[persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A persistent volume is a piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
-[RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) | RBAC, or Role-Based Access Control, is the system Kubernetes uses to manage permissions within the cluster. In order to take an action (e.g., `get` or `create`) on an API resource (e.g., a `pod`), the client must have a `Role` that allows it to do so.
-[namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) | A namespace provides a scope for resources and names within a Kubernetes cluster. Names of resources need to be unique within a namespace, but not across namespaces. Most Kubernetes client commands will use the `default` namespace by default, but can operate on resources in other namespaces as well if told to do so.
+[node](https://kubernetes.io/docs/concepts/architecture/nodes/) | A physical or virtual machine. In this tutorial, you'll run GKE or EKS instances and join them as worker nodes in three independent Kubernetes clusters, each in a different region.
+[pod](http://kubernetes.io/docs/user-guide/pods/) | A pod is a group of one or more Docker containers. In this tutorial, each pod will run on a separate GKE or EKS instance and include one Docker container running a single CockroachDB node. You'll start with 3 pods in each region and grow to 4.
+[StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) | A group of pods treated as stateful units, where each pod has distinguishable network identity and always binds back to the same persistent storage on restart. StatefulSets are considered stable as of Kubernetes version 1.9 after reaching beta in version 1.5.
+[persistent volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) | A piece of networked storage (Persistent Disk on GCE, Elastic Block Store on AWS) mounted into a pod. The lifetime of a persistent volume is decoupled from the lifetime of the pod that's using it, ensuring that each CockroachDB node binds back to the same storage on restart.<br><br>This tutorial assumes that dynamic volume provisioning is available. When that is not the case, [persistent volume claims](http://kubernetes.io/docs/user-guide/persistent-volumes/#persistentvolumeclaims) need to be created manually.
+[CSR](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/) | A CSR, or certificate signing request, is a request to have a TLS certificate verified by a certificate authority (CA). A CSR is issued for the CockroachDB node running in each pod, as well as each client as it connects to the Kubernetes cluster.
+[RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) | RBAC, or role-based access control, is the system Kubernetes uses to manage permissions within the cluster. In order to take an action (e.g., `get` or `create`) on an API resource (e.g., a `pod`), the client must have a `Role` that allows it to do so.
+[namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) | A namespace provides a scope for resources and names within a Kubernetes cluster. Names of resources must be unique within a namespace, but not across namespaces. Most Kubernetes client commands will use the `default` namespace by default, but can operate on resources in other namespaces as well. In this tutorial, CockroachDB pods will be deployed in their own namespace in each Kubernetes cluster.
 [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) | `kubectl` is the command-line interface for running commands against Kubernetes clusters.
-[kubectl context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration) | A `kubectl` "context" specifies a Kubernetes cluster to connect to and authentication for doing so. You can set a context as the default using the `kubectl use-context <context-name>` command such that all future `kubectl` commands will talk to that cluster, or you can specify the `--context=<context-name>` flag on almost any `kubectl` command to tell it which cluster you want to run the command against. We will make heavy use of the `--context` flag in these instructions in order to run commands against the different regions' Kubernetes clusters.
+[kubectl context](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-context-and-configuration) | When multiple Kubernetes clusters are deployed on your account, `kubectl` "context" specifies a cluster to connect to.
 
 ### UX differences from running in a single cluster
 
-These instructions create a StatefulSet that runs CockroachDB in each of the Kubernetes clusters you provide to the configuration scripts. These StatefulSets can be scaled independently of each other by running `kubectl` commands against the appropriate cluster. These steps will also point each Kubernetes cluster's DNS server at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., "*.us-west1-a.svc.cluster.local") can be deferred to the appropriate cluster's DNS server. However, in order to make this work, we create the StatefulSets in namespaces named after the zone in which the cluster is running. This means that in order to run a command against one of the pods, you have to run, e.g., `kubectl logs cockroachdb-0 --namespace=us-west1-a` instead of just `kubectl logs cockroachdb-0`. Alternatively, you can [configure your `kubectl` context to default to using that namespace for commands run against that cluster](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#setting-the-namespace-preference).
+These instructions create 3 StatefulSets that each run 3 CockroachDB pods in a separate Kubernetes cluster deployed in its own region. If you haven't often worked with multiple Kubernetes clusters, remember that `kubectl` commands are run against a cluster in a specific context. Either run `kubectl use-context <cluster-context>` frequently to switch contexts between commands, or append `--context=<cluster-context>` to the commands you run to ensure they are run against the correct cluster.
 
-Note that the CockroachDB pods being in a non-default namespace means that if we didn't do anything about it then any client applications wanting to talk to CockroachDB from the default namespace would need to talk to a zone-scoped service name such as "cockroachdb-public.us-west1-a" rather than just the normal "cockroachdb-public" that they would use in a single-cluster setting. However, the setup script used by these instructions sets up an additional [`ExternalName` service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) in the default namespace such that the clients in the default namespace can simply talk to the "cockroachdb-public" address.
+<section class="filter-content" markdown="1" data-scope="gke">
+Each Kubernetes cluster's DNS server is pointed at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., `*.us-west1-a.svc.cluster.local`) can be deferred to the appropriate cluster's DNS server. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
 
-Finally, if you haven't worked with multiple Kubernetes clusters often before, you may find yourself forgetting to think about which cluster you want to run a given command against, and thus getting confusing results to your commands. Remember that you will either have to run `kubectl use-context <context-name>` frequently to switch contexts between commands or you will have to append `--context=<context-name>` on most commands you run to ensure they are run on the correct cluster.
+Because the CockroachDB pods run in a non-default namespace, client applications wanting to talk to CockroachDB from the default namespace would need to use a zone-scoped service name (e.g., `cockroachdb-public.us-west1-a`) rather than `cockroachdb-public`, as in a single-cluster setting. However, the setup script used by these instructions sets up an additional [`ExternalName` service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) in the default namespace such that the clients in the default namespace can simply talk to the `cockroachdb-public` address.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+To enable the pods to communicate across regions, we peer the VPCs in all 3 regions with each other and configure a CoreDNS service in each region to route DNS traffic to the appropriate pods. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
+</section>
 
 ### Limitations
 
-#### Kubernetes version
+{% include {{ page.version.version }}/orchestration/kubernetes-limitations.md %}
 
-Kubernetes 1.8 or higher is required.
-
+<section class="filter-content" markdown="1" data-scope="gke">
 #### Exposing DNS servers
 
 {{site.data.alerts.callout_danger}}
@@ -52,18 +65,22 @@ Until December 2019, Google Cloud Platform restricted clients to using a load ba
 
 You can now [enable global access](https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#ilb-global-access) on Google Cloud Platform to allow clients from one region to use an internal load balancer in another. We will update this tutorial accordingly.
 {{site.data.alerts.end}}
+</section>
 
 ## Step 1. Start Kubernetes clusters
 
-Our multi-region deployment approached relies on pod IP addresses being routable across three distinct Kubernetes clusters and regions. The hosted Google Kubernetes Engine (GKE) service satisfies this requirement, so that is the environment featured here. If you want to run on another cloud or on-premises, use this [basic network test](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/multiregion#pod-to-pod-connectivity) to see if it will work.
+Our multi-region deployment approach relies on pod IP addresses being routable across three distinct Kubernetes clusters and regions. Both the hosted Google Kubernetes Engine (GKE) and Amazon Elastic Kubernetes Service (EKS) satisfy this requirement. 
 
+If you want to run on another cloud or on-premises, use this [basic network test](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/multiregion#pod-to-pod-connectivity) to see if it will work.
+
+<section class="filter-content" markdown="1" data-scope="gke">
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.
 
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
 
     {{site.data.alerts.callout_success}}The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.{{site.data.alerts.end}}
 
-2. From your local workstation, start the first Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
+1. From your local workstation, start the first Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -76,9 +93,11 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     This creates GKE instances in the zone specified and joins them into a single Kubernetes cluster named `cockroachdb1`.
 
+    {{site.data.alerts.callout_info}}
     The process can take a few minutes, so do not move on to the next step until you see a `Creating cluster cockroachdb1...done` message and details about your cluster.
+    {{site.data.alerts.end}}
 
-3. Start the second Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
+1. Start the second Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -89,7 +108,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     Creating cluster cockroachdb2...done.
     ~~~
 
-4. Start the third Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
+1. Start the third Kubernetes cluster, specifying the [zone](https://cloud.google.com/compute/docs/regions-zones/) it should run in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -100,7 +119,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     Creating cluster cockroachdb3...done.
     ~~~
 
-5. Get the `kubectl` "contexts" for your clusters:
+1. Get the `kubectl` "contexts" for your clusters:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -115,12 +134,17 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     ~~~
 
     {{site.data.alerts.callout_info}}
-    All of the `kubectl` commands in this tutorial use the `--context` flag to tell `kubectl` which Kubernetes cluster to talk to. Each Kubernetes cluster operates independently; you have to tell each of them what to do separately, and when you want to get the status of something in a particular cluster, you have to make it clear to `kubectl` which cluster you're interested in.
+    `kubectl` commands are run against the `CURRENT` context by default. You can change the current context with this command:
 
-    The context with `*` in the `CURRENT` column indicates the cluster that `kubectl` will talk to by default if you do not specify the `--context` flag.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl config use-context <context-name>
+    ~~~
+    
+    When sending commands to another context, you need to use the `--context` flag to specify the context. For clarity, every `kubectl` command in this tutorial uses the `--context` flag to indicate the proper context. 
     {{site.data.alerts.end}}
 
-6. Get the email address associated with your Google Cloud account:
+1. Get the email address associated with your Google Cloud account:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -135,23 +159,287 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     This command returns your email address in all lowercase. However, in the next step, you must enter the address using the accurate capitalization. For example, if your address is YourName@example.com, you must use YourName@example.com and not yourname@example.com.
     {{site.data.alerts.end}}
 
-6. For each Kubernetes cluster, [create the RBAC roles](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control) CockroachDB needs for running on GKE, using the email address and relevant "context" name from the previous steps:
+1. For each Kubernetes cluster, [create the RBAC roles](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control) CockroachDB needs for running on GKE, using the email address and relevant "context" name from the previous steps:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<context-name-of-kubernetes-cluster2>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<context-name-of-kubernetes-cluster3>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-3>
+    ~~~
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+1. Complete the steps described in the [EKS Getting Started](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html) documentation.
+
+    This includes installing and configuring the AWS CLI and `eksctl`, which is the command-line tool used to create and delete Kubernetes clusters on EKS, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
+
+1. From your local workstation, create three Kubernetes clusters. For each cluster, specify a unique region and a **non-overlapping** IP range for the VPC in CIDR notation (e.g., 10.0.0.0/16). Refer to the AWS documentation for valid [regions](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) and [CIDR blocks](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#VPC_Sizing).
+
+    {{site.data.alerts.callout_danger}}
+    In order to enable VPC peering between the regions, the CIDR blocks of the VPCs **must not** overlap. This value cannot change once the cluster has been created, so be sure that your IP ranges do not overlap.
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl create cluster \
+    --name cockroachdb1 \
+    --nodegroup-name standard-workers \
+    --node-type m5.xlarge \
+    --nodes 3 \
+    --node-ami auto \
+    --region <aws-region-1>
+    --vpc-cidr=<ip-range-1>
     ~~~
 
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl create cluster \
+    --name cockroachdb2 \
+    --nodegroup-name standard-workers \
+    --node-type m5.xlarge \
+    --nodes 3 \
+    --node-ami auto \
+    --region <aws-region-2>
+    --vpc-cidr=<ip-range-2>
+    ~~~
+       
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl create cluster \
+    --name cockroachdb3 \
+    --nodegroup-name standard-workers \
+    --node-type m5.xlarge \
+    --nodes 3 \
+    --node-ami auto \
+    --region <aws-region-3>
+    --vpc-cidr=<ip-range-3>
+    ~~~
+
+    Each command creates three EKS instances in a region, one for each CockroachDB node you will deploy. Note that the Kubernetes scheduler automatically assigns each instance to a different availability zone in the region.
+
+    In each region, the EKS instances are joined into a separate Kubernetes cluster: `cockroachdb1`, `cockroachdb2`, and `cockroachdb3`. The `--node-type` flag tells the node pool to use the [`m5.xlarge`](https://aws.amazon.com/ec2/instance-types/) instance type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
+
+    {{site.data.alerts.callout_info}}
+    Cluster provisioning usually takes between 10 and 15 minutes. Do not move on to the next step until you see a message like `[✔]  EKS cluster "cockroachdb1" in "us-east-1" region is ready` for each cluster.
+    {{site.data.alerts.end}}
+
+1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and verify that three instances, using the node group name you specified, are running in each region. You will need to toggle between each region in the console.
+
+1. Get the context name for each of the 3 regions. When running `kubectl` commands against each region's cluster, you will need to specify the context name for that region.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl config get-contexts
+    ~~~
+
+    ~~~
+    CURRENT   NAME                                           CLUSTER                               AUTHINFO                                       NAMESPACE
+    *         maxroach@cockroachdb1.eu-central-1.eksctl.io   cockroachdb1.eu-central-1.eksctl.io   maxroach@cockroachdb1.eu-central-1.eksctl.io
+              maxroach@cockroachdb2.ca-central-1.eksctl.io   cockroachdb2.ca-central-1.eksctl.io   maxroach@cockroachdb2.ca-central-1.eksctl.io
+              maxroach@cockroachdb3.eu-north-1.eksctl.io     cockroachdb3.eu-north-1.eksctl.io     maxroach@cockroachdb3.eu-north-1.eksctl.io
+    ~~~
+
+    {{site.data.alerts.callout_info}}
+    `kubectl` commands are run against the "current" context by default. You can change the current context with `kubectl config use-context <context-name>`.
+
+    When running commands on another region, you need to use the `--context` flag to specify that region's context. For clarity, every `kubectl` command in this tutorial uses the `--context` flag to indicate the proper context.
+    {{site.data.alerts.end}}
+
+1. Create three namespaces, one corresponding to each region. The CockroachDB cluster in each region will run in this namespace.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl create namespace <cluster-namespace> --context=<cluster-context>
+    ~~~
+
+    It's simplest for the namespace and region to have the same name, e.g.:
+
+    ~~~ shell
+    kubectl create namespace eu-central-1 --context=maxroach@cockroachdb1.eu-central-1.eksctl.io
+    ~~~
+
+    {{site.data.alerts.callout_info}}
+    `kubectl` commands are run against the namespace named `default` by default. You can change the default namespace for a given context with `kubectl config set-context <context-name> --namespace=<namespace-name>`.
+
+    For clarity, every `kubectl` command in this tutorial uses the `--namespace` flag to indicate the proper namespace.
+    {{site.data.alerts.end}}
+
+## Step 2. Configure your network
+
+### Set up VPC peering
+
+For pods to communciate across three separate Kubernetes clusters, the VPCs in all regions need to be peered. Network traffic can then be routed between the VPCs. For more information about VPC peering, see the [AWS documentation](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html).
+
+1. Open the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and note the ID of the VPC in each region. The VPC ID is found in the section called Your VPCs.
+
+1. Navigate to the Peering Connections section and [create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#create-vpc-peering-connection-local) between each of the 3 regions. When you create a peering connection, you will first select a requester VPC in the current region and then an accepter VPC in another region, specified by pasting the VPC ID.
+
+    {{site.data.alerts.callout_success}}
+    You should have a total of 3 VPC peering connections between your three VPCs. You will need to switch regions in the console to create one of the peering connections.
+    {{site.data.alerts.end}}
+
+1. To complete the VPC peering connections, switch to each destination region and [accept the pending connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#accept-vpc-peering-connection) in the VPC console. 
+
+1. For all 3 regions, navigate to the Route Tables section and find `PublicRouteTable`. [Update this route table](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html) with 2 new entries that point traffic to the other 2 peered VPCs. The **Destination** should be the CIDR block of a destination region, and the **Target** should be the VPC peering connection between the current and the destination region.
+
+### Create inbound rules
+
+For each region, navigate to the Security Groups section of the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and locate the security group that enables communication between nodes int he cluster. It should have a name like `ClusterSharedNodeSecurityGroup`. [Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to this security group to allow TCP communication on two ports:
+
+- `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
+- `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
+
+{{site.data.alerts.callout_info}}
+Remember to create these inbound rules in all 3 regions. This enables CockroachDB to communicate across each Kubernetes cluster.
+{{site.data.alerts.end}}
+
+#### Inter-region communciation
+
+ Field | Value
+-------|-------------------
+Port Range | **26257**
+Source | The IP range of each region's VPC in CIDR notation (e.g., 10.12.0.0/16)
+
+This important rule enables node communication between Kubernetes clusters in different regions. You need to create a separate rule for each region in your deployment.
+
+{% include {{ page.version.version }}/prod-deployment/aws-inbound-rules.md %}
+
+### Set up load balancing
+
+The Kubernetes cluster in each region needs to have a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) pointed at its CoreDNS service, which you will configure in the next step.
+
+1. Upload our load balancer manifest [`dns-lb-eks.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/dns-lb-eks.yaml) to the Kubernetes clusters in all 3 regions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-3>
+    ~~~
+
+    You should see the load balancer appear in the Load Balancers section of the EC2 console in each region. This load balancer will route traffic to CoreDNS in the region.
+
+1. For each region, navigate to the Load Balancer section of the [EC2 console](https://console.aws.amazon.com/ec2/) and get the DNS name of the Network Load Balancer you created in the previous step.
+
+1. For each region's load balancer, look up the IP addresses mapped to the load balancer:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    dig <nlb-dns-name>
+    ~~~
+
+    ~~~
+    ...
+    
+    ;; ANSWER SECTION:
+    ac63a423fbf6231cba51235e1e51e6ec-132cf6c423e67123.elb.eu-central-1.amazonaws.com. 60 IN A ip1
+    ac63a423fbf6231cba51235e1e51e6ec-132cf6c423e67123.elb.eu-central-1.amazonaws.com. 60 IN A ip2
+    ac63a423fbf6231cba51235e1e51e6ec-132cf6c423e67123.elb.eu-central-1.amazonaws.com. 60 IN A ip3
+    
+    ...
+    ~~~
+
+    `ip1`, `ip2`, and `ip3` correspond to the 3 availability zones in the region where EKS instances are running. You will need these IP addresses when configuring your network in the next step.
+
+### Configure CoreDNS
+
+Each Kubernetes cluster has a [CoreDNS](https://coredns.io/) service that responds to DNS requests for pods in its region. CoreDNS can also forward DNS requests to pods in other regions.
+
+To enable traffic forwarding to CockroachDB pods in all 3 regions, you need to [modify the ConfigMap](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options) for the CoreDNS Corefile in each region.
+
+1. Download and open our ConfigMap template [`configmap.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/configmap.yaml).
+
+1. After [obtaining the IP addresses of EKS instances](#set-up-load-balancing) in all 3 regions, you can use this information to define a **separate ConfigMap for each region**. Each unique ConfigMap lists the forwarding addresses for the pods in the 2 other regions. 
+
+    ~~~
+    ...
+       region2.svc.cluster.local:53 {       # <---- Modify
+           log
+           errors
+           ready
+           cache 10
+           forward . ip1 ip2 ip3 {      # <---- Modify
+                force_tcp            # <---- Modify
+           }
+       }
+       region3.svc.cluster.local:53 {       # <---- Modify
+           log
+           errors
+           ready
+           cache 10
+           forward . ip1 ip2 ip3 {      # <---- Modify
+                force_tcp            # <---- Modify
+           }
+       }
+    ~~~
+
+    For each region, modify `configmap.yaml` by replacing:
+
+    <ul><li><code>region2</code> and <code>region3</code> with the namespaces in which the CockroachDB pods will run in the other 2 regions. You defined these namespaces after <a href="#step-1-start-kubernetes-clusters">starting the Kubernetes clusters</a>.</li><li><code>ip1</code>, <code>ip2</code>, and <code>ip3</code> with the IP addresses of the EKS instances in the region, which you looked up in the previous step.</li></ul>
+
+    You will end up with 3 different ConfigMaps. Give each ConfigMap a unique filename like `configmap-1.yaml`.
+
+    {{site.data.alerts.callout_info}}
+    If you configure your Network Load Balancer to support UDP traffic, you can drop the `force_tcp` line.
+    {{site.data.alerts.end}}
+
+1. For each region, first back up the existing ConfigMap:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl -n kube-system get configmap coredns -o yaml > <configmap-backup-name>
+    ~~~
+
+    Then apply the new ConfigMap:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    kubectl apply -f <configmap-name> --context=<cluster-context>
+    ~~~
+
+1. For each region, check that your CoreDNS settings were applied:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    kubectl get -n kube-system cm/coredns --export -o yaml --context=<cluster-context>
+    ~~~
+
+### Exclude VPCs from SNAT
+
+You will need to tell AWS to exclude your VPCs from [source network address translation (SNAT)](https://docs.aws.amazon.com/eks/latest/userguide/external-snat.html). This ensures that cross-VPC traffic is handled correctly by AWS while still allowing access to the public internet from the pods.
+
+Set `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` to recognize the values of your 3 CIDR blocks. Do this for all 3 regions:
+
+{% include copy-clipboard.html %}
+~~~
+kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS="cidr1,cidr2,cidr3" --context=<cluster-context>
+~~~
+
+Remember that these are the CIDR blocks you chose when [starting your Kubernetes clusters](#step-1-start-kubernetes-clusters). You can also get the IP range of a VPC by opening the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and finding the VPC listed in the section called Your VPCs.
+
+{{site.data.alerts.callout_info}}
+If you plan to run your instances exclusively on private subnets, set the following environment variable instead on each region: `kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXTERNALSNAT=true --context=<cluster-context>`
+{{site.data.alerts.end}}
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 2. Start CockroachDB
 
 1. Create a directory and download the required script and configuration files into it:
@@ -172,7 +460,14 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/{README.md,client-secure.yaml,cluster-init-secure.yaml,cockroachdb-statefulset-secure.yaml,dns-lb.yaml,example-app-secure.yaml,external-name-svc.yaml,setup.py,teardown.py}
     ~~~
 
-2. At the top of the `setup.py` script, fill in the `contexts` map with the zones of your clusters and their "context" names, for example:
+2. Retrieve the `kubectl` "contexts" for your clusters:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl config get-contexts
+    ~~~
+
+    At the top of the `setup.py` script, fill in the `contexts` map with the zones of your clusters and their "context" names, e.g.:
 
     ~~~
     context = {
@@ -180,13 +475,6 @@ Our multi-region deployment approached relies on pod IP addresses being routable
         'us-west1-a': 'gke_cockroach-shared_us-west1-a_cockroachdb2',
         'us-central1-a': 'gke_cockroach-shared_us-central1-a_cockroachdb3',
     }
-    ~~~
-
-    You retrieved the `kubectl` "contexts" in an earlier step. To get them again, run:
-
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ kubectl config get-contexts
     ~~~
 
 3. In the `setup.py` script, fill in the `regions` map with the zones and corresponding regions of your clusters, for example:
@@ -199,7 +487,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     }
     ~~~
 
-    Setting regions is optional, but recommended, because it improves CockroachDB's ability to diversify data placement if you use more than one zone in the same region. If you aren't specifying regions, just leave the map empty.
+    Setting `regions` is optional, but recommended, because it improves CockroachDB's ability to diversify data placement if you use more than one zone in the same region. If you aren't specifying regions, just leave the map empty.
 
 4. If you haven't already, [install CockroachDB locally and add it to your `PATH`](install-cockroachdb.html). The `cockroach` binary will be used to generate certificates.
 
@@ -220,7 +508,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
     ~~~
 
     ~~~
@@ -232,7 +520,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster2>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
     ~~~
 
     ~~~
@@ -244,7 +532,7 @@ Our multi-region deployment approached relies on pod IP addresses being routable
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster3>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
     ~~~
 
     ~~~
@@ -266,11 +554,237 @@ Our multi-region deployment approached relies on pod IP addresses being routable
     NAME                      NETWORK  DIRECTION  PRIORITY  ALLOW      DENY
     allow-cockroach-internal  default  INGRESS    1000      tcp:26257
     ~~~
+</section>
 
-{{site.data.alerts.callout_success}}
-In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --namespace=<cluster-namespace> --context=<cluster-context>` rather than checking the log on the persistent volume.
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 3. Start CockroachDB
+
+### Generate certificates
+
+{{site.data.alerts.callout_info}}
+Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The below steps use [`cockroach cert` commands](cockroach-cert.html) to quickly generate and sign the CockroachDB node and client certificates. Read our [Authentication](authentication.html#using-digital-certificates-with-cockroachdb) docs to learn about other methods of signing certificates.
 {{site.data.alerts.end}}
 
+1. Create two directories:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ mkdir certs my-safe-directory
+    ~~~
+
+    Directory | Description
+    ----------|------------
+    `certs` | You'll generate your CA certificate and all node and client certificates and keys in this directory.
+    `my-safe-directory` | You'll generate your CA key in this directory and then reference the key when generating node and client certificates.
+
+1. Create the CA certificate and key pair:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-ca \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+1. Create a client certificate and key pair for the root user:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-client \
+    root \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+1. For all 3 regions, upload the client certificate and key to the Kubernetes cluster as a secret. 
+
+    {{site.data.alerts.callout_success}}
+    Specify the namespace in which the CockroachDB pods will run. You defined these namespaces after [starting your Kubernetes clusters](#step-1-start-kubernetes-clusters).
+    {{site.data.alerts.end}}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.client.root \
+    --from-file=certs \
+    --context=<cluster-context-1> \
+    --namespace=<cluster-namespace-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.client.root \
+    --from-file=certs \
+    --context=<cluster-context-2> \
+    --namespace=<cluster-namespace-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.client.root \
+    --from-file=certs \
+    --context=<cluster-context-3> \
+    --namespace=<cluster-namespace-3>
+    ~~~
+
+1. Create the certificate and key pair for your CockroachDB nodes in one region, substituting `<cluster-namespace>` in this command with the appropriate namespace:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach cert create-node \
+    localhost 127.0.0.1 \
+    cockroachdb-public \
+    cockroachdb-public.<cluster-namespace> \
+    cockroachdb-public.<cluster-namespace>.svc.cluster.local \
+    *.cockroachdb \
+    *.cockroachdb.<cluster-namespace> \
+    *.cockroachdb.<cluster-namespace>.svc.cluster.local \
+    --certs-dir=certs \
+    --ca-key=my-safe-directory/ca.key
+    ~~~
+
+1. Upload the node certificate and key to the Kubernetes cluster as a secret, specifying the appropriate context and namespace:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create secret \
+    generic cockroachdb.node \
+    --from-file=certs
+    --context=<cluster-context> \
+    --namespace=<cluster-namespace>    
+    ~~~
+    
+1. Repeat the previous 2 steps for your 2 remaining regions. You may need to delete the local `node.crt` and `node.key` in your `certs` directory before generating a new node certificate and key pair.
+
+1. For all 3 regions, check that the secrets were created on the cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get secrets --context=<cluster-context>
+    ~~~
+
+    ~~~
+    NAME                      TYPE                                  DATA   AGE
+    cockroachdb-token-db5wp   kubernetes.io/service-account-token   3      1m
+    cockroachdb.client.root   Opaque                                5      1m
+    cockroachdb.node          Opaque                                6      1m
+    default-token-65489       kubernetes.io/service-account-token   3      5m
+    ~~~
+
+### Create StatefulSets
+
+1. Download and open our [multi-region StatefulSet configuration](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure-eks.yaml). You'll save three versions of this file locally, one for each set of 3 CockroachDB nodes per region.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/cockroachdb-statefulset-secure-eks.yaml
+    ~~~
+
+    Look for **TODO** comments in the file. These highlight fields you need to define before deploying your StatefulSet.
+
+1. Fill in the namespace where CockroachDB nodes will run in region 1.
+
+    ~~~
+    namespace: <cluster-namespace>
+    ~~~
+
+1. Allocate a memory request and limit to CockroachDB on each pod, using the `resources` object in the CockroachDB `containers` spec. 
+
+    {{site.data.alerts.callout_success}}
+    These values should be appropriate for the instances that you have provisioned. Run `kubectl describe nodes` to see the available resources.
+    {{site.data.alerts.end}}
+
+    For example, to allocate 8Gi of memory to CockroachDB in each pod: 
+
+    ~~~
+    resources:
+      requests:
+        memory: "8Gi"
+      limits:
+        memory: "8Gi"
+    ~~~
+
+    {{site.data.alerts.callout_danger}}
+    If you don't specify a memory request, no memory will be allocated to CockroachDB. If you don't specify a memory limit, the Kubernetes scheduler will allocate the maximum possible amount.
+    {{site.data.alerts.end}}
+
+1. The StatefulSet configuration includes a [`cockroach start`](cockroach-start.html) command that creates the nodes on the Kubernetes pods. 
+
+    In the `--locality` flag, name `region` after region 1. This can technically be an arbitrary value, but it's simplest to use the CockroachDB namespace in region 1.
+
+    ~~~
+    --locality=region=<cluster-namespace-1>,az=$(cat /etc/cockroach-env/zone),dns=$(hostname -f)
+    ~~~
+
+    In the `--join` flag, update the Cockroach node addresses in all 3 regions with their corresponding namespaces.
+
+    ~~~
+    --join cockroachdb-0.cockroachdb.<cluster-namespace-1>,cockroachdb-1.cockroachdb.<cluster-namespace-1>,cockroachdb-2.cockroachdb.<cluster-namespace-1>,cockroachdb-0.cockroachdb.<cluster-namespace-2>,cockroachdb-1.cockroachdb.<cluster-namespace-2>,cockroachdb-2.cockroachdb.<cluster-namespace-2>,cockroachdb-0.cockroachdb.<cluster-namespace-3>,cockroachdb-1.cockroachdb.<cluster-namespace-3>,cockroachdb-2.cockroachdb.<cluster-namespace-3>
+    ~~~
+
+1. Save this StatefulSet configuration, giving it a filename like `cockroachdb-statefulset-secure-eks-1.yaml`.
+
+    {{site.data.alerts.callout_success}}
+    If you change the StatefulSet name from the default `cockroachdb`, be sure to start and end with an alphanumeric character and otherwise use lowercase alphanumeric characters, `-`, or `.` so as to comply with [CSR naming requirements](orchestrate-cockroachdb-with-kubernetes.html#csr-names).
+    {{site.data.alerts.end}}
+
+1. Create and save a StatefulSet configuration for each of the other 2 regions in the same way, being sure to use the correct namespaces for those regions in steps 2 and 4.
+
+1. Deploy the StatefulSets in each of your 3 regions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f <statefulset-1> --context=<cluster-context-1> --namespace=<cluster-namespace-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f <statefulset-2> --context=<cluster-context-2> --namespace=<cluster-namespace-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl create -f <statefulset-3> --context=<cluster-context-3> --namespace=<cluster-namespace-3>
+    ~~~
+
+1. Run `cockroach init` on one of the pods to complete the node startup process and have them join together as a cluster:
+
+    {% include copy-clipboard.html %}
+    ~~~
+    kubectl exec \
+    --context=<cluster-context> \
+    --namespace=<cluster-namespace> \
+    -it cockroachdb-0 \
+    -- /cockroach/cockroach init \
+    --certs-dir=/cockroach/cockroach-certs
+    ~~~
+
+    ~~~
+    Cluster successfully initialized
+    ~~~
+
+1. Confirm that cluster initialization has completed successfully in each region. The job should be considered successful and the Kubernetes pods should soon be considered `Ready`:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
+    ~~~
+
+    ~~~
+    NAMESPACE      NAME           READY   STATUS    RESTARTS   AGE
+    eu-central-1   cockroachdb-0  1/1     Running   0          12m
+    eu-central-1   cockroachdb-1  1/1     Running   0          12m
+    eu-central-1   cockroachdb-2  1/1     Running   0          12m
+    ~~~
+</section>
+
+{{site.data.alerts.callout_success}}
+In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --context=<cluster-context> --namespace=<cluster-namespace>` rather than checking the log on the persistent volume.
+{{site.data.alerts.end}}
+
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 3. Use the built-in SQL client
 
 1. Use the `client-secure.yaml` file to launch a pod and keep it running indefinitely, specifying the context of the Kubernetes cluster to run it in:
@@ -285,12 +799,30 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     ~~~
 
     The pod uses the `root` client certificate created earlier by the `setup.py` script. Note that this will work from any of the three Kubernetes clusters as long as you use the correct namespace and context combination.
+</section>
 
-2. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html), again specifying the namespace and context of the Kubernetes cluster where the pod is running:
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 4. Use the built-in SQL client
+
+1. Use the `client-secure.yaml` file to launch a pod and keep it running indefinitely, specifying the context of the Kubernetes cluster and namespace of the CockroachDB pods to run it in:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/client-secure.yaml --context=<cluster-context> --namespace=<cluster-namespace> 
+    ~~~
+
+    ~~~
+    pod "cockroachdb-client-secure" created
+    ~~~
+
+    The pod uses the `root` client certificate you [generated earlier](#generate-certificates). Note that this will work from any of the three Kubernetes clusters as long as you use the correct namespace and context combination.
+</section>
+
+1. Get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html), again specifying the namespace and context of the Kubernetes cluster where the pod is running:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
     ~~~
@@ -307,7 +839,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     root@cockroachdb-public:26257/>
     ~~~
 
-3. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
+1. Run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -338,16 +870,16 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     (1 row)
     ~~~
 
-3. [Create a user with a password](create-user.html#create-a-user-with-a-password):
+1. [Create a user with a password](create-user.html#create-a-user-with-a-password):
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE USER roach WITH PASSWORD 'Q7gc8rEdS';
     ~~~
 
-      You will need this username and password to [access the Admin UI](#step-4-access-the-admin-ui) in Step 4.
+      You will need this username and password to access the Admin UI in the next step.
 
-4. Exit the SQL shell and pod:
+1. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
@@ -363,7 +895,13 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
     $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
     ~~~
 
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 4. Access the Admin UI
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 5. Access the Admin UI
+</section>
 
 To access the cluster's [Admin UI](admin-ui-overview.html):
 
@@ -373,28 +911,28 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
-2.  Assign `roach` to the `admin` role (you only need to do this once):
+1.  Assign `roach` to the `admin` role (you only need to do this once):
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > GRANT admin TO roach;
     ~~~
 
-3. Exit the SQL shell and pod:
+1. Exit the SQL shell and pod:
 
     {% include copy-clipboard.html %}
     ~~~ sql
     > \q
     ~~~
 
-4. Port-forward from your local machine to a pod in one of your Kubernetes clusters:
+1. Port-forward from your local machine to a pod in one of your Kubernetes clusters:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl port-forward cockroachdb-0 8080 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl port-forward cockroachdb-0 8080 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
@@ -405,13 +943,19 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
     The `port-forward` command must be run on the same machine as the web browser in which you want to view the Admin UI. If you have been running these commands from a cloud instance or other non-local shell, you will not be able to view the UI without configuring `kubectl` locally and running the above `port-forward` command on your local machine.
     {{site.data.alerts.end}}
 
-5. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password created in the [Use the built-in SQL client](#step-3-use-the-built-in-sql-client) step.
+1. Go to <a href="https://localhost:8080/" data-proofer-ignore>https://localhost:8080</a> and log in with the username and password created in the [Use the built-in SQL client](#step-3-use-the-built-in-sql-client) step.
 
-6. In the UI, check the **Node List** to verify that all nodes are running, and then click the **Databases** tab on the left to verify that `bank` is listed.
+1. In the UI, check the [**Node List**](admin-ui-cluster-overview-page.html#node-list) to verify that all nodes are running, open the [**Databases** page](admin-ui-databases-page.html) to verify that `bank` is listed, and open the [**Network Latency** page](admin-ui-network-latency-page.html) to see the performance of your CockroachDB cluster across 3 regions.
 
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 5. Simulate datacenter failure
+</section>
 
-One of the major benefits of running a multi-region cluster is that an entire datacenter or region can go down without affecting the availability of the CockroachDB cluster as a whole.
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 6. Access the Admin UI
+</section>
+
+One of the major benefits of running a multi-region CockroachDB cluster is that an entire datacenter or region can go down without affecting the availability of the cluster as a whole.
 
 To see this in action:
 
@@ -419,27 +963,33 @@ To see this in action:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=0 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl scale statefulset cockroachdb --replicas=0 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
     statefulset "cockroachdb" scaled
     ~~~
 
-2. In the Admin UI, the **Cluster Overview** will soon show the three nodes from that region as **Suspect**. If you wait for 5 minutes or more, they will be listed as **Dead**. Note that even though there are three dead nodes, the other nodes are all healthy, and any clients using the database in the other regions will continue to work just fine.
+1. In the Admin UI, the **Cluster Overview** will soon show the three nodes from that region as **Suspect**. If you wait for 5 minutes or more, they will be listed as **Dead**. Note that even though there are three dead nodes, the other nodes are all healthy, and any clients using the database in the other regions will continue to work just fine.
 
-3. When you're done verifying that the cluster still fully functions with one of the regions down, you can bring the region back up by running:
+1. When you're done verifying that the cluster still fully functions with one of the regions down, you can bring the region back up by running:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=3 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl scale statefulset cockroachdb --replicas=3 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
     statefulset "cockroachdb" scaled
     ~~~
 
+<section class="filter-content" markdown="1" data-scope="gke">
 ## Step 6. Maintain the cluster
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+## Step 7. Maintain the cluster
+</section>
 
 - [Scale the cluster](#scale-the-cluster)
 - [Upgrade the cluster](#upgrade-the-cluster)
@@ -447,26 +997,31 @@ To see this in action:
 
 ### Scale the cluster
 
-Each of your Kubernetes clusters contains 3 nodes that pods can run on. To ensure that you do not have two pods on the same node (as recommended in our [production best practices](recommended-production-settings.html)), you need to add a new worker node and then edit your StatefulSet configuration to add another pod.
+Each of your Kubernetes clusters contains 3 instances that can run CockroachDB pods. It's easy to scale a cluster to run more pods. To ensure that you do not have two CockroachDB pods on the same instance (as recommended in our [production best practices](recommended-production-settings.html)), you need to first add a new instance and then edit your StatefulSet configuration to add another pod.
 
-1. [Resize your cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster).
+<section class="filter-content" markdown="1" data-scope="gke">
+1. [Resize your Kubernetes cluster.](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster)
 
-2. Use the `kubectl scale` command to add a pod to the StatefulSet in the Kubernetes cluster where you want to add a CockroachDB node:
+<section class="filter-content" markdown="1" data-scope="eks">
+1. [Resize your Kubernetes cluster.](https://eksctl.io/usage/managing-nodegroups/#scaling)
+</section>
+
+1. Use the `kubectl scale` command to add a pod to the StatefulSet in the Kubernetes cluster where you want to add a CockroachDB node:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=4 --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl scale statefulset cockroachdb --replicas=4 --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
     statefulset "cockroachdb" scaled
     ~~~
 
-3. Verify that a fourth pod was added successfully:
+1. Verify that a fourth pod was added successfully:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --namespace=<cluster-namespace> --context=<cluster-context>
+    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
     ~~~
 
     ~~~
@@ -486,9 +1041,9 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
 1. Decide how the upgrade will be finalized.
 
-    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v2.0.x to v2.1. For upgrades within the v2.1.x series, skip this step.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.{{site.data.alerts.end}}
 
-    By default, after all nodes are running the new version, the upgrade process will be **auto-finalized**. This will enable certain performance improvements and bug fixes introduced in v2.1. After finalization, however, it will no longer be possible to perform a downgrade to v2.0. In the event of a catastrophic failure or corruption, the only option will be to start a new cluster using the old binary and then restore from one of the backups created prior to performing the upgrade.
+    By default, after all nodes are running the new version, the upgrade process will be **auto-finalized**. This will enable certain performance improvements and bug fixes introduced in v20.2. After finalization, however, it will no longer be possible to perform a downgrade to v20.1. In the event of a catastrophic failure or corruption, the only option will be to start a new cluster using the old binary and then restore from one of the backups created prior to performing the upgrade.
 
     We recommend disabling auto-finalization so you can monitor the stability and performance of the upgraded cluster before finalizing the upgrade:
 
@@ -496,55 +1051,55 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
 
         {% include copy-clipboard.html %}
         ~~~ sql
-        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '2.0';
+        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '20.1';
         ~~~
 
 2. For each Kubernetes cluster, kick off the upgrade process by changing the desired Docker image. To do so, pick the version that you want to upgrade to, then run the following command, replacing "VERSION" with your desired new version and specifying the relevant namespace and "context" name for the Kubernetes cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster1> --context=<context-name-of-kubernetes-cluster1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster1> --context=<cluster-context-1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster2> --context=<context-name-of-kubernetes-cluster2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster2> --context=<cluster-context-2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster3> --context=<context-name-of-kubernetes-cluster3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster3> --context=<cluster-context-3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
 3. If you then check the status of the pods in each Kubernetes cluster, you should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<context-name-of-kubernetes-cluster1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
     ~~~
 
     This will continue until all of the pods have restarted and are running the new image.
 
 4. Finish the upgrade.
 
-    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v2.0.x to v2.1. For upgrades within the v2.1.x series, skip this step.{{site.data.alerts.end}}
+    {{site.data.alerts.callout_info}}This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.{{site.data.alerts.end}}
 
     If you disabled auto-finalization in step 1 above, monitor the stability and performance of your cluster for as long as you require to feel comfortable with the upgrade (generally at least a day). If during this time you decide to roll back the upgrade, repeat the rolling restart procedure with the old binary.
 
@@ -554,7 +1109,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Re-enable auto-finalization:
@@ -566,6 +1121,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
 ### Stop the cluster
 
+<section class="filter-content" markdown="1" data-scope="gke">
 1. To delete all of the resources created in your clusters, copy the `contexts` map from `setup.py` into `teardown.py`, and then run `teardown.py`:
 
     ~~~ shell
@@ -618,6 +1174,108 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     ~~~
     Deleting cluster cockroachdb3...done.
     ~~~
+</section>
+
+<section class="filter-content" markdown="1" data-scope="eks">
+1. In each region, delete all of the resources associated with the `cockroachdb` label, including the logs, and remote persistent volumes:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-3>
+    ~~~
+
+    ~~~
+    pod "cockroachdb-0" deleted
+    pod "cockroachdb-1" deleted
+    pod "cockroachdb-2" deleted
+    service "cockroachdb" deleted
+    service "cockroachdb-public" deleted
+    persistentvolumeclaim "datadir-cockroachdb-0" deleted
+    persistentvolumeclaim "datadir-cockroachdb-1" deleted
+    persistentvolumeclaim "datadir-cockroachdb-2" deleted
+    poddisruptionbudget.policy "cockroachdb-budget" deleted
+    rolebinding.rbac.authorization.k8s.io "cockroachdb" deleted
+    clusterrolebinding.rbac.authorization.k8s.io "cockroachdb" deleted
+    role.rbac.authorization.k8s.io "cockroachdb" deleted
+    clusterrole.rbac.authorization.k8s.io "cockroachdb" deleted
+    serviceaccount "cockroachdb" deleted
+    ~~~
+
+1. Delete the pod created for `cockroach` client commands, if you didn't do so earlier:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
+    ~~~
+
+    ~~~
+    pod "cockroachdb-client-secure" deleted
+    ~~~
+
+1. Get the names of the secrets you created on each cluster. These should be identical in all 3 regions:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get secrets --context=<cluster-context>
+    ~~~
+
+    ~~~
+    NAME                      TYPE                                  DATA   AGE
+    cockroachdb.client.root   Opaque                                5      1d
+    cockroachdb.node          Opaque                                6      1d
+    ...
+    ~~~
+
+1. Delete the secrets that you created:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-3>
+    ~~~
+
+1. Stop Kubernetes in each region:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl delete cluster --name cockroachdb1 --region <aws-region-1>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl delete cluster --name cockroachdb2 --region <aws-region-2>
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ eksctl delete cluster --name cockroachdb3 --region <aws-region-3>
+    ~~~
+
+1. Open the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home) to verify that the stacks were successfully deleted in each region.
+
+{{site.data.alerts.callout_danger}}
+If you stop Kubernetes without first deleting the persistent volumes, they will still exist in your cloud project.
+{{site.data.alerts.end}}
+</section>
 
 ## See also
 

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -1001,6 +1001,7 @@ Each of your Kubernetes clusters contains 3 instances that can run CockroachDB p
 
 <section class="filter-content" markdown="1" data-scope="gke">
 1. [Resize your Kubernetes cluster.](https://cloud.google.com/kubernetes-engine/docs/how-to/resizing-a-cluster)
+</section>
 
 <section class="filter-content" markdown="1" data-scope="eks">
 1. [Resize your Kubernetes cluster.](https://eksctl.io/usage/managing-nodegroups/#scaling)

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -41,16 +41,16 @@ Feature | Description
 
 ### UX differences from running in a single cluster
 
-These instructions create 3 StatefulSets that each run 3 CockroachDB pods in a separate Kubernetes cluster deployed in its own region. If you haven't often worked with multiple Kubernetes clusters, remember that `kubectl` commands are run against a cluster in a specific context. Either run `kubectl use-context <cluster-context>` frequently to switch contexts between commands, or append `--context=<cluster-context>` to the commands you run to ensure they are run against the correct cluster.
+These instructions create 3 StatefulSets that each run 3 CockroachDB pods in a separate Kubernetes cluster deployed in its own region. If you haven't often worked with multiple Kubernetes clusters, remember that `kubectl` commands are run against a cluster in a specific context. Either run `kubectl use-context <cluster-context>` frequently to switch contexts between commands, or append `--context <cluster-context>` to the commands you run to ensure they are run against the correct cluster.
 
 <section class="filter-content" markdown="1" data-scope="gke">
-Each Kubernetes cluster's DNS server is pointed at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., `*.us-west1-a.svc.cluster.local`) can be deferred to the appropriate cluster's DNS server. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
+Each Kubernetes cluster's DNS server is pointed at the other clusters' DNS servers so that DNS lookups for certain zone-scoped suffixes (e.g., `*.us-west1-a.svc.cluster.local`) can be deferred to the appropriate cluster's DNS server. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace <cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace <namespace-name>` to set the default namespace for a context.
 
 Because the CockroachDB pods run in a non-default namespace, client applications wanting to talk to CockroachDB from the default namespace would need to use a zone-scoped service name (e.g., `cockroachdb-public.us-west1-a`) rather than `cockroachdb-public`, as in a single-cluster setting. However, the setup script used by these instructions sets up an additional [`ExternalName` service](https://kubernetes.io/docs/concepts/services-networking/service/#externalname) in the default namespace such that the clients in the default namespace can simply talk to the `cockroachdb-public` address.
 </section>
 
 <section class="filter-content" markdown="1" data-scope="eks">
-To enable the pods to communicate across regions, we peer the VPCs in all 3 regions with each other and configure a CoreDNS service in each region to route DNS traffic to the appropriate pods. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace=<cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace=<namespace-name>` to set the default namespace for a context.
+To enable the pods to communicate across regions, we peer the VPCs in all 3 regions with each other and configure a CoreDNS service in each region to route DNS traffic to the appropriate pods. To make this work, we create the StatefulSets in namespaces named after the region in which each Kubernetes cluster is deployed. To run a command against one of the pods, append `--namespace <cluster-namespace>` to your commands. Alternatively, run `kubectl config set-context <context-name> --namespace <namespace-name>` to set the default namespace for a context.
 </section>
 
 ### Limitations
@@ -163,17 +163,17 @@ If you want to run on another cloud or on-premises, use this [basic network test
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-1>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-2>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context=<cluster-context-3>
+    $ kubectl create clusterrolebinding $USER-cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org> --context <cluster-context-3>
     ~~~
 </section>
 
@@ -188,6 +188,10 @@ If you want to run on another cloud or on-premises, use this [basic network test
     In order to enable VPC peering between the regions, the CIDR blocks of the VPCs **must not** overlap. This value cannot change once the cluster has been created, so be sure that your IP ranges do not overlap.
     {{site.data.alerts.end}}
 
+    {{site.data.alerts.callout_success}}
+    To ensure that all 3 nodes can be placed into a different availability zone, you may want to first [confirm that at least 3 zones are available in the region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe) for your account.
+    {{site.data.alerts.end}}
+
     {% include copy-clipboard.html %}
     ~~~ shell
     $ eksctl create cluster \
@@ -196,8 +200,8 @@ If you want to run on another cloud or on-premises, use this [basic network test
     --node-type m5.xlarge \
     --nodes 3 \
     --node-ami auto \
-    --region <aws-region-1>
-    --vpc-cidr=<ip-range-1>
+    --region <aws-region-1> \
+    --vpc-cidr <ip-range-1>
     ~~~
 
     {% include copy-clipboard.html %}
@@ -208,8 +212,8 @@ If you want to run on another cloud or on-premises, use this [basic network test
     --node-type m5.xlarge \
     --nodes 3 \
     --node-ami auto \
-    --region <aws-region-2>
-    --vpc-cidr=<ip-range-2>
+    --region <aws-region-2> \
+    --vpc-cidr <ip-range-2>
     ~~~
        
     {% include copy-clipboard.html %}
@@ -220,8 +224,8 @@ If you want to run on another cloud or on-premises, use this [basic network test
     --node-type m5.xlarge \
     --nodes 3 \
     --node-ami auto \
-    --region <aws-region-3>
-    --vpc-cidr=<ip-range-3>
+    --region <aws-region-3> \
+    --vpc-cidr <ip-range-3>
     ~~~
 
     Each command creates three EKS instances in a region, one for each CockroachDB node you will deploy. Note that each instance is assigned to a different availability zone in the region.
@@ -258,17 +262,17 @@ If you want to run on another cloud or on-premises, use this [basic network test
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl create namespace <cluster-namespace> --context=<cluster-context>
+    kubectl create namespace <cluster-namespace> --context <cluster-context>
     ~~~
 
     It's simplest for the namespace and region to have the same name, e.g.:
 
     ~~~ shell
-    kubectl create namespace eu-central-1 --context=maxroach@cockroachdb1.eu-central-1.eksctl.io
+    kubectl create namespace eu-central-1 --context maxroach@cockroachdb1.eu-central-1.eksctl.io
     ~~~
 
     {{site.data.alerts.callout_info}}
-    `kubectl` commands are run against the namespace named `default` by default. You can change the default namespace for a given context with `kubectl config set-context <context-name> --namespace=<namespace-name>`.
+    `kubectl` commands are run against the namespace named `default` by default. You can change the default namespace for a given context with `kubectl config set-context <context-name> --namespace <namespace-name>`.
 
     For clarity, every `kubectl` command in this tutorial uses the `--namespace` flag to indicate the proper namespace.
     {{site.data.alerts.end}}
@@ -284,7 +288,7 @@ For pods to communciate across three separate Kubernetes clusters, the VPCs in a
 1. Navigate to the Peering Connections section and [create a VPC peering connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#create-vpc-peering-connection-local) between each of the 3 regions. When you create a peering connection, you will first select a requester VPC in the current region and then an accepter VPC in another region, specified by pasting the VPC ID.
 
     {{site.data.alerts.callout_success}}
-    You should have a total of 3 VPC peering connections between your three VPCs. You will need to switch regions in the console to create one of the peering connections.
+    You need to create a total of 3 VPC peering connections between your 3 VPCs, which means switching regions at least once in the console. For example, if you are deploying in `eu-central-1`, `eu-north-1`, and `ca-central-1`, you can select `eu-central-1` in the console and create VPC peering connections to both `eu-north-1` and `ca-central-1`. Then switch to either `eu-north-1` or `ca-central-1` to create the VPC peering connection between those two regions.
     {{site.data.alerts.end}}
 
 1. To complete the VPC peering connections, switch to each destination region and [accept the pending connection](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html#accept-vpc-peering-connection) in the VPC console. 
@@ -293,7 +297,7 @@ For pods to communciate across three separate Kubernetes clusters, the VPCs in a
 
 ### Create inbound rules
 
-For each region, navigate to the Security Groups section of the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and locate the security group that enables communication between nodes int he cluster. It should have a name like `ClusterSharedNodeSecurityGroup`. [Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to this security group to allow TCP communication on two ports:
+For each region, navigate to the Security Groups section of the [Amazon EC2 console](https://console.aws.amazon.com/ec2/) and locate the security group that enables communication between nodes in the cluster. It should have a name like `ClusterSharedNodeSecurityGroup`. [Add Custom TCP inbound rules](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule) to this security group to allow TCP communication on two ports:
 
 - `26257` for inter-node and client-node communication. This enables the nodes to work as a cluster, the load balancer to route traffic to the nodes, and applications to connect to the load balancer.
 - `8080` for exposing the Admin UI to the user, and for routing the load balancer to the health check endpoint.
@@ -317,28 +321,28 @@ This important rule enables node communication between Kubernetes clusters in di
 
 The Kubernetes cluster in each region needs to have a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) pointed at its CoreDNS service, which you will configure in the next step.
 
-1. Upload our load balancer manifest [`dns-lb-eks.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml) to the Kubernetes clusters in all 3 regions:
+1. Upload our load balancer manifest [`dns-lb-eks.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml) to the Kubernetes clusters in all 3 regions:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-1>
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-2>
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/dns-lb-eks.yaml --context=<cluster-context-3>
+    kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/dns-lb-eks.yaml --context <cluster-context-3>
     ~~~
 
     You should see the load balancer appear in the Load Balancers section of the EC2 console in each region. This load balancer will route traffic to CoreDNS in the region.
 
 1. For each region, navigate to the Load Balancer section of the [EC2 console](https://console.aws.amazon.com/ec2/) and get the DNS name of the Network Load Balancer you created in the previous step.
 
-1. For each region's load balancer, look up the IP addresses mapped to the load balancer:
+1. For each region's load balancer, look up the IP addresses mapped to the load balancer's DNS name:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -364,7 +368,12 @@ Each Kubernetes cluster has a [CoreDNS](https://coredns.io/) service that respon
 
 To enable traffic forwarding to CockroachDB pods in all 3 regions, you need to [modify the ConfigMap](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options) for the CoreDNS Corefile in each region.
 
-1. Download and open our ConfigMap template [`configmap.yaml`](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/eks/configmap.yaml).
+1. Download and open our ConfigMap template [`configmap.yaml`](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/eks/configmap.yaml):
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    curl -O https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/eks/configmap.yaml 
+    ~~~
 
 1. After [obtaining the IP addresses of EKS instances](#set-up-load-balancing) in all 3 regions, you can use this information to define a **separate ConfigMap for each region**. Each unique ConfigMap lists the forwarding addresses for the pods in the 2 other regions. 
 
@@ -411,14 +420,14 @@ To enable traffic forwarding to CockroachDB pods in all 3 regions, you need to [
 
     {% include copy-clipboard.html %}
     ~~~
-    kubectl apply -f <configmap-name> --context=<cluster-context>
+    kubectl apply -f <configmap-name> --context <cluster-context>
     ~~~
 
 1. For each region, check that your CoreDNS settings were applied:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl get -n kube-system cm/coredns --export -o yaml --context=<cluster-context>
+    kubectl get -n kube-system cm/coredns --export -o yaml --context <cluster-context>
     ~~~
 
 ### Exclude VPCs from SNAT
@@ -429,13 +438,13 @@ Set `AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS` to recognize the values of your 3 CIDR 
 
 {% include copy-clipboard.html %}
 ~~~
-kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS="cidr1,cidr2,cidr3" --context=<cluster-context>
+kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS="cidr1,cidr2,cidr3" --context <cluster-context>
 ~~~
 
 Remember that these are the CIDR blocks you chose when [starting your Kubernetes clusters](#step-1-start-kubernetes-clusters). You can also get the IP range of a VPC by opening the [Amazon VPC console](https://console.aws.amazon.com/vpc/) and finding the VPC listed in the section called Your VPCs.
 
 {{site.data.alerts.callout_info}}
-If you plan to run your instances exclusively on private subnets, set the following environment variable instead on each region: `kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXTERNALSNAT=true --context=<cluster-context>`
+If you plan to run your instances exclusively on private subnets, set the following environment variable instead on each region: `kubectl set env ds aws-node -n kube-system AWS_VPC_K8S_CNI_EXTERNALSNAT=true --context <cluster-context>`
 {{site.data.alerts.end}}
 </section>
 
@@ -508,7 +517,7 @@ If you plan to run your instances exclusively on private subnets, set the follow
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-1>
     ~~~
 
     ~~~
@@ -520,7 +529,7 @@ If you plan to run your instances exclusively on private subnets, set the follow
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-2>
     ~~~
 
     ~~~
@@ -532,7 +541,7 @@ If you plan to run your instances exclusively on private subnets, set the follow
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-3>
     ~~~
 
     ~~~
@@ -607,8 +616,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.client.root \
     --from-file=certs \
-    --context=<cluster-context-1> \
-    --namespace=<cluster-namespace-1>
+    --context <cluster-context-1> \
+    --namespace <cluster-namespace-1>
     ~~~
 
     {% include copy-clipboard.html %}
@@ -616,8 +625,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.client.root \
     --from-file=certs \
-    --context=<cluster-context-2> \
-    --namespace=<cluster-namespace-2>
+    --context <cluster-context-2> \
+    --namespace <cluster-namespace-2>
     ~~~
 
     {% include copy-clipboard.html %}
@@ -625,8 +634,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.client.root \
     --from-file=certs \
-    --context=<cluster-context-3> \
-    --namespace=<cluster-namespace-3>
+    --context <cluster-context-3> \
+    --namespace <cluster-namespace-3>
     ~~~
 
 1. Create the certificate and key pair for your CockroachDB nodes in one region, substituting `<cluster-namespace>` in this command with the appropriate namespace:
@@ -652,8 +661,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     $ kubectl create secret \
     generic cockroachdb.node \
     --from-file=certs
-    --context=<cluster-context> \
-    --namespace=<cluster-namespace>    
+    --context <cluster-context> \
+    --namespace <cluster-namespace>    
     ~~~
     
 1. Repeat the previous 2 steps for your 2 remaining regions. You may need to delete the local `node.crt` and `node.key` in your `certs` directory before generating a new node certificate and key pair.
@@ -662,7 +671,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get secrets --context=<cluster-context>
+    $ kubectl get secrets --context <cluster-context>
     ~~~
 
     ~~~
@@ -675,7 +684,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
 ### Create StatefulSets
 
-1. Download and open our [multi-region StatefulSet configuration](https://github.com/cockroachdb/cockroach/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml). You'll save three versions of this file locally, one for each set of 3 CockroachDB nodes per region.
+1. Download and open our [multi-region StatefulSet configuration](https://github.com/cockroachdb/cockroach/blob/master/cloud/kubernetes/multiregion/eks/cockroachdb-statefulset-secure-eks.yaml). You'll save three versions of this file locally, one for each set of 3 CockroachDB nodes per region.
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -736,17 +745,17 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f <statefulset-1> --context=<cluster-context-1> --namespace=<cluster-namespace-1>
+    $ kubectl create -f <statefulset-1> --context <cluster-context-1> --namespace <cluster-namespace-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f <statefulset-2> --context=<cluster-context-2> --namespace=<cluster-namespace-2>
+    $ kubectl create -f <statefulset-2> --context <cluster-context-2> --namespace <cluster-namespace-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f <statefulset-3> --context=<cluster-context-3> --namespace=<cluster-namespace-3>
+    $ kubectl create -f <statefulset-3> --context <cluster-context-3> --namespace <cluster-namespace-3>
     ~~~
 
 1. Run `cockroach init` on one of the pods to complete the node startup process and have them join together as a cluster:
@@ -754,8 +763,8 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
     {% include copy-clipboard.html %}
     ~~~
     kubectl exec \
-    --context=<cluster-context> \
-    --namespace=<cluster-namespace> \
+    --context <cluster-context> \
+    --namespace <cluster-namespace> \
     -it cockroachdb-0 \
     -- /cockroach/cockroach init \
     --certs-dir=/cockroach/cockroach-certs
@@ -769,7 +778,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl get pods --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -781,7 +790,7 @@ Amazon EKS does not support certificates signed by Kubernetes' built-in CA. The 
 </section>
 
 {{site.data.alerts.callout_success}}
-In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --context=<cluster-context> --namespace=<cluster-namespace>` rather than checking the log on the persistent volume.
+In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB nodes to write to `stderr`, so if you ever need access to a pod/node's logs to troubleshoot, use `kubectl logs <podname> --context <cluster-context> --namespace <cluster-namespace>` rather than checking the log on the persistent volume.
 {{site.data.alerts.end}}
 
 <section class="filter-content" markdown="1" data-scope="gke">
@@ -791,7 +800,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl create -f client-secure.yaml --context=<cluster-context>
+    $ kubectl create -f client-secure.yaml --context <cluster-context>
     ~~~
 
     ~~~
@@ -808,7 +817,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/client-secure.yaml --context=<cluster-context> --namespace=<cluster-namespace> 
+    kubectl create -f https://raw.githubusercontent.com/cockroachdb/cockroach/master/cloud/kubernetes/multiregion/client-secure.yaml --context <cluster-context> --namespace <cluster-namespace> 
     ~~~
 
     ~~~
@@ -822,7 +831,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
     ~~~
@@ -892,7 +901,7 @@ In each Kubernetes cluster, the StatefulSet configuration sets all CockroachDB n
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
+    $ kubectl delete pod cockroachdb-client-secure --context <cluster-context>
     ~~~
 
 <section class="filter-content" markdown="1" data-scope="gke">
@@ -911,7 +920,7 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+    $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
     ~~~
 
 1.  Assign `roach` to the `admin` role (you only need to do this once):
@@ -932,7 +941,7 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl port-forward cockroachdb-0 8080 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl port-forward cockroachdb-0 8080 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -952,7 +961,7 @@ To access the cluster's [Admin UI](admin-ui-overview.html):
 </section>
 
 <section class="filter-content" markdown="1" data-scope="eks">
-## Step 6. Access the Admin UI
+## Step 6. Simulate datacenter failure
 </section>
 
 One of the major benefits of running a multi-region CockroachDB cluster is that an entire datacenter or region can go down without affecting the availability of the cluster as a whole.
@@ -963,7 +972,7 @@ To see this in action:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=0 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl scale statefulset cockroachdb --replicas=0 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -976,7 +985,7 @@ To see this in action:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=3 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl scale statefulset cockroachdb --replicas=3 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -1011,7 +1020,7 @@ Each of your Kubernetes clusters contains 3 instances that can run CockroachDB p
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl scale statefulset cockroachdb --replicas=4 --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl scale statefulset cockroachdb --replicas=4 --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -1022,7 +1031,7 @@ Each of your Kubernetes clusters contains 3 instances that can run CockroachDB p
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --context=<cluster-context> --namespace=<cluster-namespace>
+    $ kubectl get pods --context <cluster-context> --namespace <cluster-namespace>
     ~~~
 
     ~~~
@@ -1052,7 +1061,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
@@ -1066,34 +1075,34 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster1> --context=<cluster-context-1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace <namespace-of-kubernetes-cluster1> --context <cluster-context-1> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster2> --context=<cluster-context-2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace <namespace-of-kubernetes-cluster2> --context <cluster-context-2> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl patch statefulset cockroachdb --namespace=<namespace-of-kubernetes-cluster3> --context=<cluster-context-3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
+    $ kubectl patch statefulset cockroachdb --namespace <namespace-of-kubernetes-cluster3> --context <cluster-context-3> --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value":"cockroachdb/cockroach:VERSION"}]'
     ~~~
 
 3. If you then check the status of the pods in each Kubernetes cluster, you should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-1>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-2>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context=<cluster-context-3>
+    $ kubectl get pods --selector app=cockroachdb --all-namespaces --context <cluster-context-3>
     ~~~
 
     This will continue until all of the pods have restarted and are running the new image.
@@ -1110,7 +1119,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure --context=<cluster-context> --namespace=<cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+        $ kubectl exec -it cockroachdb-client-secure --context <cluster-context> --namespace <cluster-namespace> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
         ~~~
 
     2. Re-enable auto-finalization:
@@ -1182,17 +1191,17 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-1>
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-2>
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context=<cluster-context-3>
+    $ kubectl delete pods,statefulsets,services,persistentvolumeclaims,persistentvolumes,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb --context <cluster-context-3>
     ~~~
 
     ~~~
@@ -1216,7 +1225,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete pod cockroachdb-client-secure --context=<cluster-context>
+    $ kubectl delete pod cockroachdb-client-secure --context <cluster-context>
     ~~~
 
     ~~~
@@ -1227,7 +1236,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl get secrets --context=<cluster-context>
+    $ kubectl get secrets --context <cluster-context>
     ~~~
 
     ~~~
@@ -1241,17 +1250,17 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-1>
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context <cluster-context-1>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-2>
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context <cluster-context-2>
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context=<cluster-context-3>
+    $ kubectl delete secrets cockroachdb.client.root cockroachdb.node  --context <cluster-context-3>
     ~~~
 
 1. Stop Kubernetes in each region:


### PR DESCRIPTION
Fixes #4314.
Relates to https://github.com/cockroachdb/cockroach/pull/51775, which adds `cockroachdb-statefulset-secure-eks.yaml`, `dnb-lb-eks.yaml`, and `configmap.yaml` to the `multiregion` repo.
Also addresses https://github.com/cockroachdb/cockroach/pull/51471.

- Draft EKS multi-region deployment (manual steps; no script)
- Under **Create inbound rules**, I'm not sure if the "Inter-node and load balancer-node communication" still fits for this rule on multi-region. It seems the load balancer points at CoreDNS on port 53, and CoreDNS provides the load balancer-node communication. Is this right?
- Since #5922 appears to still be unresolved, there is no guidance here on setting a CPU request and/or limit.
- Bob's [PR](https://github.com/cockroachdb/cockroach/pull/51471) implied (to me) that `--cache` and `--max-sql-memory` are now dynamically set in the `cockroach start` command, so I removed this from the multi- and single-region guides.
  - Also, I am not sure if the line "To avoid running out of memory when CockroachDB is not the only pod on a Kubernetes node, you must set memory limits explicitly. This is because CockroachDB does not detect the amount of memory allocated to its pod when run in Kubernetes." is still accurate after that PR. I have an instruction here to add a memory request & limit, but am not clear on whether there is still a risk of OOM, after Bob's changes, if you don't set limits.