### PR TITLE
add known limitation: Admin UI CPU metric

### DIFF
--- a/v19.1/known-limitations.md
+++ b/v19.1/known-limitations.md
@@ -157,6 +157,12 @@ For multi-core systems, the user CPU percent can be greater than 100%. Full util
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/28724)
 
+### Admin UI: CPU count in containerized environments
+
+When CockroachDB is run in a containerized environment (e.g., Kubernetes), the Admin UI does not detect CPU limits applied to a container. Instead, the UI displays the actual number of CPUs provisioned on a VM.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/34988)
+
 ### `GROUP BY` referring to `SELECT` aliases
 
 Applications developed for PostgreSQL that use `GROUP BY` to refer to column aliases _produced_ in the same `SELECT` clause must be changed to use the full underlying expression instead. For example, `SELECT x+y AS z ... GROUP BY z` must be changed to `SELECT x+y AS z ... GROUP BY x+y`. Otherwise, CockroachDB will produce either a planning error or, in some cases, invalid results.

--- a/v19.2/known-limitations.md
+++ b/v19.2/known-limitations.md
@@ -203,6 +203,12 @@ For multi-core systems, the user CPU percent can be greater than 100%. Full util
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/28724)
 
+### Admin UI: CPU count in containerized environments
+
+When CockroachDB is run in a containerized environment (e.g., Kubernetes), the Admin UI does not detect CPU limits applied to a container. Instead, the UI displays the actual number of CPUs provisioned on a VM.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/34988)
+
 ### `GROUP BY` referring to `SELECT` aliases
 
 Applications developed for PostgreSQL that use `GROUP BY` to refer to column aliases _produced_ in the same `SELECT` clause must be changed to use the full underlying expression instead. For example, `SELECT x+y AS z ... GROUP BY z` must be changed to `SELECT x+y AS z ... GROUP BY x+y`. Otherwise, CockroachDB will produce either a planning error or, in some cases, invalid results.

--- a/v2.1/known-limitations.md
+++ b/v2.1/known-limitations.md
@@ -73,6 +73,12 @@ For multi-core systems, the user CPU percent can be greater than 100%. Full util
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/28724)
 
+### Admin UI: CPU count in containerized environments
+
+When CockroachDB is run in a containerized environment (e.g., Kubernetes), the Admin UI does not detect CPU limits applied to a container. Instead, the UI displays the actual number of CPUs provisioned on a VM.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/34988)
+
 ### `GROUP BY` referring to `SELECT` aliases
 
 Applications developed for PostgreSQL that use `GROUP BY` to refer to column aliases _produced_ in the same `SELECT` clause must be changed to use the full underlying expression instead. For example, `SELECT x+y AS z ... GROUP BY z` must be changed to `SELECT x+y AS z ... GROUP BY x+y`. Otherwise, CockroachDB will produce either a planning error or, in some cases, invalid results.

--- a/v20.1/known-limitations.md
+++ b/v20.1/known-limitations.md
@@ -319,6 +319,12 @@ For multi-core systems, the user CPU percent can be greater than 100%. Full util
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/28724)
 
+### Admin UI: CPU count in containerized environments
+
+When CockroachDB is run in a containerized environment (e.g., Kubernetes), the Admin UI does not detect CPU limits applied to a container. Instead, the UI displays the actual number of CPUs provisioned on a VM.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/34988)
+
 ### `TRUNCATE` does not behave like `DELETE`
 
 `TRUNCATE` is not a DML statement, but instead works as a DDL statement. Its limitations are the same as other DDL statements, which are outlined in [Online Schema Changes: Limitations](online-schema-changes.html#limitations)

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -268,6 +268,12 @@ For multi-core systems, the user CPU percent can be greater than 100%. Full util
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/28724)
 
+### Admin UI: CPU count in containerized environments
+
+When CockroachDB is run in a containerized environment (e.g., Kubernetes), the Admin UI does not detect CPU limits applied to a container. Instead, the UI displays the actual number of CPUs provisioned on a VM.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/34988)
+
 ### `TRUNCATE` does not behave like `DELETE`
 
 `TRUNCATE` is not a DML statement, but instead works as a DDL statement. Its limitations are the same as other DDL statements, which are outlined in [Online Schema Changes: Limitations](online-schema-changes.html#limitations)


### PR DESCRIPTION
Fixes #7719. Covers v2.1 - 20.2.

Questions:

- Should this known limitation also apply to memory limits (based on [this comment](https://github.com/cockroachdb/cockroach/issues/34988#issuecomment-648283843))? 
- Should CPU technically be called vCPU?