### PR TITLE
Fix logic error in timestamp ordering remark

### DIFF
--- a/v20.1/transaction-retry-error-reference.md
+++ b/v20.1/transaction-retry-error-reference.md
@@ -69,7 +69,7 @@ TransactionRetryWithProtoRefreshError: ... RETRY_WRITE_TOO_OLD ...
 
 _Description_:
 
-The `RETRY_WRITE_TOO_OLD` error occurs when a transaction _A_ tries to write to a row _R_, but another transaction _B_ that was supposed to be serialized after _A_ (i.e., had been assigned a lower timestamp), has already written to that row _R_, and has already committed. This is a common error when you have too much contention in your workload.
+The `RETRY_WRITE_TOO_OLD` error occurs when a transaction _A_ tries to write to a row _R_, but another transaction _B_ that was supposed to be serialized after _A_ (i.e., had been assigned a higher timestamp), has already written to that row _R_, and has already committed. This is a common error when you have too much contention in your workload.
 
 _Action_:
 

--- a/v20.2/transaction-retry-error-reference.md
+++ b/v20.2/transaction-retry-error-reference.md
@@ -69,7 +69,7 @@ TransactionRetryWithProtoRefreshError: ... RETRY_WRITE_TOO_OLD ...
 
 _Description_:
 
-The `RETRY_WRITE_TOO_OLD` error occurs when a transaction _A_ tries to write to a row _R_, but another transaction _B_ that was supposed to be serialized after _A_ (i.e., had been assigned a lower timestamp), has already written to that row _R_, and has already committed. This is a common error when you have too much contention in your workload.
+The `RETRY_WRITE_TOO_OLD` error occurs when a transaction _A_ tries to write to a row _R_, but another transaction _B_ that was supposed to be serialized after _A_ (i.e., had been assigned a higher timestamp), has already written to that row _R_, and has already committed. This is a common error when you have too much contention in your workload.
 
 _Action_:
 


### PR DESCRIPTION
Summary of changes:

- In the section on `RETRY_WRITE_TOO_OLD`, we are talking about the
  ordering of two transactions A and B.  I had erroneously said that if
  B comes after A, then B has a lower timestamp than A.  In fact, if B
  comes after A, then B has a *higher* timestamp than A.  This PR fixes
  that error.