### PR TITLE
Remove CDC correctness warning

### DIFF
--- a/_includes/v20.1/known-limitations/cdc.md
+++ b/_includes/v20.1/known-limitations/cdc.md
@@ -5,6 +5,5 @@
 - Partial or intermittent sink unavailability may impact changefeed stability; however, [ordering guarantees](change-data-capture.html#ordering-guarantees) will still hold for as long as a changefeed [remains active](change-data-capture.html#monitor-a-changefeed).
 - Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).
 - Additional target options will be added, including partitions and ranges of primary key rows.
-- There is an open correctness issue with changefeeds connected to cloud storage sinks where new row information will display with a lower timestamp than what has already been emitted, which violates our [ordering guarantees](change-data-capture.html#ordering-guarantees).
 - Changefeeds do not pick up data ingested with the [`IMPORT INTO`](import-into.html) statement.
 - Using a [cloud storage sink](create-changefeed.html#cloud-storage-sink) only works with `JSON` and emits [newline-delimited json](http://ndjson.org) files.

--- a/_includes/v20.2/known-limitations/cdc.md
+++ b/_includes/v20.2/known-limitations/cdc.md
@@ -5,6 +5,5 @@
 - Partial or intermittent sink unavailability may impact changefeed stability; however, [ordering guarantees](change-data-capture.html#ordering-guarantees) will still hold for as long as a changefeed [remains active](change-data-capture.html#monitor-a-changefeed).
 - Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).
 - Additional target options will be added, including partitions and ranges of primary key rows.
-- There is an open correctness issue with changefeeds connected to cloud storage sinks where new row information will display with a lower timestamp than what has already been emitted, which violates our [ordering guarantees](change-data-capture.html#ordering-guarantees).
 - Changefeeds do not pick up data ingested with the [`IMPORT INTO`](import-into.html) statement.
 - Using a [cloud storage sink](create-changefeed.html#cloud-storage-sink) only works with `JSON` and emits [newline-delimited json](http://ndjson.org) files.

--- a/v20.1/create-changefeed.md
+++ b/v20.1/create-changefeed.md
@@ -247,8 +247,6 @@ For more information on how to create a changefeed that emits an [Avro](https://
 
 {{site.data.alerts.callout_danger}}
 **This is an experimental feature.** The interface and output are subject to change.
-
-There is an open correctness issue with changefeeds connected to cloud storage sinks where new row information will display with a lower timestamp than what has already been emitted, which violates our [ordering guarantees](change-data-capture.html#ordering-guarantees).
 {{site.data.alerts.end}}
 
 {% include copy-clipboard.html %}

--- a/v20.2/create-changefeed.md
+++ b/v20.2/create-changefeed.md
@@ -243,8 +243,6 @@ For more information on how to create a changefeed that emits an [Avro](https://
 
 {{site.data.alerts.callout_danger}}
 **This is an experimental feature.** The interface and output are subject to change.
-
-There is an open correctness issue with changefeeds connected to cloud storage sinks where new row information will display with a lower timestamp than what has already been emitted, which violates our [ordering guarantees](change-data-capture.html#ordering-guarantees).
 {{site.data.alerts.end}}
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
The "open correctness issue with changefeeds connected to cloud storage 
sinks where new row information will display with a lower timestamp than 
what has already been emitted, which violates our ordering guarantees" 
was fixed in v20.1