### PR TITLE
Updated stmt_block diagram

### DIFF
--- a/_includes/v20.2/sql/diagrams/stmt_block.html
+++ b/_includes/v20.2/sql/diagrams/stmt_block.html
@@ -16,7 +16,7 @@
          <polygon points="97 17 89 13 89 21"></polygon>
       </svg>
       <p>no references</p><br/><p style="font-size: 14px; font-weight:bold"><a name="stmt" href="#stmt">stmt:</a></p>
-      <svg width="274" height="628">
+      <svg width="274" height="716">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
@@ -28,67 +28,77 @@
             <rect x="49" y="65" width="124" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="85">preparable_stmt</text>
          </a>
+         <a xlink:href="#analyze_stmt" xlink:title="analyze_stmt">
+            <rect x="51" y="111" width="104" height="32"></rect>
+            <rect x="49" y="109" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="129">analyze_stmt</text>
+         </a>
          <a xlink:href="#copy_from_stmt" xlink:title="copy_from_stmt">
-            <rect x="51" y="111" width="120" height="32"></rect>
-            <rect x="49" y="109" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="129">copy_from_stmt</text>
+            <rect x="51" y="155" width="120" height="32"></rect>
+            <rect x="49" y="153" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="173">copy_from_stmt</text>
          </a>
          <a xlink:href="#comment_stmt" xlink:title="comment_stmt">
-            <rect x="51" y="155" width="112" height="32"></rect>
-            <rect x="49" y="153" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="173">comment_stmt</text>
+            <rect x="51" y="199" width="112" height="32"></rect>
+            <rect x="49" y="197" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="217">comment_stmt</text>
          </a>
          <a xlink:href="#execute_stmt" xlink:title="execute_stmt">
-            <rect x="51" y="199" width="106" height="32"></rect>
-            <rect x="49" y="197" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="217">execute_stmt</text>
+            <rect x="51" y="243" width="106" height="32"></rect>
+            <rect x="49" y="241" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="261">execute_stmt</text>
          </a>
          <a xlink:href="#deallocate_stmt" xlink:title="deallocate_stmt">
-            <rect x="51" y="243" width="120" height="32"></rect>
-            <rect x="49" y="241" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="261">deallocate_stmt</text>
+            <rect x="51" y="287" width="120" height="32"></rect>
+            <rect x="49" y="285" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="305">deallocate_stmt</text>
          </a>
          <a xlink:href="#discard_stmt" xlink:title="discard_stmt">
-            <rect x="51" y="287" width="100" height="32"></rect>
-            <rect x="49" y="285" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="305">discard_stmt</text>
+            <rect x="51" y="331" width="100" height="32"></rect>
+            <rect x="49" y="329" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="349">discard_stmt</text>
          </a>
          <a xlink:href="#grant_stmt" xlink:title="grant_stmt">
-            <rect x="51" y="331" width="90" height="32"></rect>
-            <rect x="49" y="329" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="349">grant_stmt</text>
+            <rect x="51" y="375" width="90" height="32"></rect>
+            <rect x="49" y="373" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="393">grant_stmt</text>
          </a>
          <a xlink:href="#prepare_stmt" xlink:title="prepare_stmt">
-            <rect x="51" y="375" width="106" height="32"></rect>
-            <rect x="49" y="373" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="393">prepare_stmt</text>
+            <rect x="51" y="419" width="106" height="32"></rect>
+            <rect x="49" y="417" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="437">prepare_stmt</text>
          </a>
          <a xlink:href="#revoke_stmt" xlink:title="revoke_stmt">
-            <rect x="51" y="419" width="98" height="32"></rect>
-            <rect x="49" y="417" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="437">revoke_stmt</text>
+            <rect x="51" y="463" width="98" height="32"></rect>
+            <rect x="49" y="461" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="481">revoke_stmt</text>
          </a>
          <a xlink:href="#savepoint_stmt" xlink:title="savepoint_stmt">
-            <rect x="51" y="463" width="118" height="32"></rect>
-            <rect x="49" y="461" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="481">savepoint_stmt</text>
+            <rect x="51" y="507" width="118" height="32"></rect>
+            <rect x="49" y="505" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="525">savepoint_stmt</text>
          </a>
          <a xlink:href="#release_stmt" xlink:title="release_stmt">
-            <rect x="51" y="507" width="102" height="32"></rect>
-            <rect x="49" y="505" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="525">release_stmt</text>
+            <rect x="51" y="551" width="102" height="32"></rect>
+            <rect x="49" y="549" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="569">release_stmt</text>
          </a>
          <a xlink:href="#nonpreparable_set_stmt" xlink:title="nonpreparable_set_stmt">
-            <rect x="51" y="551" width="176" height="32"></rect>
-            <rect x="49" y="549" width="176" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="569">nonpreparable_set_stmt</text>
+            <rect x="51" y="595" width="176" height="32"></rect>
+            <rect x="49" y="593" width="176" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="613">nonpreparable_set_stmt</text>
          </a>
          <a xlink:href="#transaction_stmt" xlink:title="transaction_stmt">
-            <rect x="51" y="595" width="126" height="32"></rect>
-            <rect x="49" y="593" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="613">transaction_stmt</text>
+            <rect x="51" y="639" width="126" height="32"></rect>
+            <rect x="49" y="637" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="657">transaction_stmt</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m124 0 h10 m0 0 h52 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m112 0 h10 m0 0 h64 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m90 0 h10 m0 0 h86 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m98 0 h10 m0 0 h78 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m118 0 h10 m0 0 h58 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m102 0 h10 m0 0 h74 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m176 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m126 0 h10 m0 0 h50 m23 -604 h-3"></path>
+         <a xlink:href="#close_cursor_stmt" xlink:title="close_cursor_stmt">
+            <rect x="51" y="683" width="134" height="32"></rect>
+            <rect x="49" y="681" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="701">close_cursor_stmt</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m124 0 h10 m0 0 h52 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m104 0 h10 m0 0 h72 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m112 0 h10 m0 0 h64 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m90 0 h10 m0 0 h86 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m98 0 h10 m0 0 h78 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m118 0 h10 m0 0 h58 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m102 0 h10 m0 0 h74 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m176 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m126 0 h10 m0 0 h50 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m134 0 h10 m0 0 h42 m23 -692 h-3"></path>
          <polygon points="265 5 273 1 273 9"></polygon>
          <polygon points="265 5 257 1 257 9"></polygon>
       </svg>
@@ -215,6 +225,30 @@
             <li><a href="#common_table_expr" title="common_table_expr">common_table_expr</a></li>
             <li><a href="#explain_stmt" title="explain_stmt">explain_stmt</a></li>
             <li><a href="#prepare_stmt" title="prepare_stmt">prepare_stmt</a></li>
+            <li><a href="#stmt" title="stmt">stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="analyze_stmt" href="#analyze_stmt">analyze_stmt:</a></p>
+      <svg width="316" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ANALYZE</text>
+         <rect x="51" y="47" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">ANALYSE</text>
+         <a xlink:href="#analyze_target" xlink:title="analyze_target">
+            <rect x="173" y="3" width="116" height="32"></rect>
+            <rect x="171" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="181" y="21">analyze_target</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m82 0 h10 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -44 h10 m116 0 h10 m3 0 h-3"></path>
+         <polygon points="307 17 315 13 315 21"></polygon>
+         <polygon points="307 17 299 13 299 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="copy_from_stmt" href="#copy_from_stmt">copy_from_stmt:</a></p>
@@ -622,6 +656,25 @@
          </p><ul>
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="close_cursor_stmt" href="#close_cursor_stmt">close_cursor_stmt:</a></p>
+      <svg width="186" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CLOSE</text>
+         <rect x="115" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">ALL</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m44 0 h10 m3 0 h-3"></path>
+         <polygon points="177 17 185 13 185 21"></polygon>
+         <polygon points="177 17 169 13 169 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#stmt" title="stmt">stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_stmt" href="#alter_stmt">alter_stmt:</a></p>
       <svg width="214" height="80">
          
@@ -646,44 +699,63 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="backup_stmt" href="#backup_stmt">backup_stmt:</a></p>
-      <svg width="624" height="134">
+      <svg width="710" height="244">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="74" height="32" rx="10"></rect>
          <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">BACKUP</text>
-         <a xlink:href="#targets" xlink:title="targets">
-            <rect x="145" y="35" width="66" height="32"></rect>
-            <rect x="143" y="33" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="153" y="53">targets</text>
+         <a xlink:href="#opt_backup_targets" xlink:title="opt_backup_targets">
+            <rect x="125" y="3" width="148" height="32"></rect>
+            <rect x="123" y="1" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="133" y="21">opt_backup_targets</text>
          </a>
-         <rect x="251" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="249" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="259" y="21">TO</text>
-         <a xlink:href="#partitioned_backup" xlink:title="partitioned_backup">
-            <rect x="309" y="3" width="142" height="32"></rect>
-            <rect x="307" y="1" width="142" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="317" y="21">partitioned_backup</text>
+         <rect x="45" y="69" width="54" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">INTO</text>
+         <rect x="139" y="101" width="70" height="32" rx="10"></rect>
+         <rect x="137" y="99" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="119">LATEST</text>
+         <rect x="229" y="101" width="36" height="32" rx="10"></rect>
+         <rect x="227" y="99" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="237" y="119">IN</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="305" y="69" width="212" height="32"></rect>
+            <rect x="303" y="67" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="313" y="87">string_or_placeholder_opt_list</text>
          </a>
          <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
-            <rect x="471" y="3" width="132" height="32"></rect>
-            <rect x="469" y="1" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="479" y="21">opt_as_of_clause</text>
+            <rect x="537" y="69" width="132" height="32"></rect>
+            <rect x="535" y="67" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="545" y="87">opt_as_of_clause</text>
+         </a>
+         <rect x="45" y="145" width="38" height="32" rx="10"></rect>
+         <rect x="43" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="163">TO</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="103" y="145" width="212" height="32"></rect>
+            <rect x="101" y="143" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="111" y="163">string_or_placeholder_opt_list</text>
+         </a>
+         <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
+            <rect x="335" y="145" width="132" height="32"></rect>
+            <rect x="333" y="143" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="343" y="163">opt_as_of_clause</text>
          </a>
          <a xlink:href="#opt_incremental" xlink:title="opt_incremental">
-            <rect x="325" y="101" width="122" height="32"></rect>
-            <rect x="323" y="99" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="333" y="119">opt_incremental</text>
+            <rect x="487" y="145" width="122" height="32"></rect>
+            <rect x="485" y="143" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="495" y="163">opt_incremental</text>
          </a>
-         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
-            <rect x="467" y="101" width="130" height="32"></rect>
-            <rect x="465" y="99" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="475" y="119">opt_with_options</text>
+         <a xlink:href="#opt_with_backup_options" xlink:title="opt_with_backup_options">
+            <rect x="499" y="211" width="184" height="32"></rect>
+            <rect x="497" y="209" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="507" y="229">opt_with_backup_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m20 -32 h10 m38 0 h10 m0 0 h10 m142 0 h10 m0 0 h10 m132 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-322 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m122 0 h10 m0 0 h10 m130 0 h10 m3 0 h-3"></path>
-         <polygon points="615 115 623 111 623 119"></polygon>
-         <polygon points="615 115 607 111 607 119"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m54 0 h10 m20 0 h10 m0 0 h136 m-166 0 h20 m146 0 h20 m-186 0 q10 0 10 10 m166 0 q0 -10 10 -10 m-176 10 v12 m166 0 v-12 m-166 12 q0 10 10 10 m146 0 q10 0 10 -10 m-156 10 h10 m70 0 h10 m0 0 h10 m36 0 h10 m20 -32 h10 m212 0 h10 m0 0 h10 m132 0 h10 m-664 0 h20 m644 0 h20 m-684 0 q10 0 10 10 m664 0 q0 -10 10 -10 m-674 10 v56 m664 0 v-56 m-664 56 q0 10 10 10 m644 0 q10 0 10 -10 m-654 10 h10 m38 0 h10 m0 0 h10 m212 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m122 0 h10 m0 0 h60 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-234 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m184 0 h10 m3 0 h-3"></path>
+         <polygon points="701 225 709 221 709 229"></polygon>
+         <polygon points="701 225 693 221 693 229"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -718,7 +790,7 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_stmt" href="#create_stmt">create_stmt:</a></p>
-      <svg width="234" height="124">
+      <svg width="336" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -737,9 +809,14 @@
             <rect x="49" y="89" width="136" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="109">create_stats_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m128 0 h10 m0 0 h8 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m122 0 h10 m0 0 h14 m-166 -10 v20 m176 0 v-20 m-176 20 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m136 0 h10 m23 -88 h-3"></path>
-         <polygon points="225 17 233 13 233 21"></polygon>
-         <polygon points="225 17 217 13 217 21"></polygon>
+         <a xlink:href="#create_schedule_for_backup_stmt" xlink:title="create_schedule_for_backup_stmt">
+            <rect x="51" y="135" width="238" height="32"></rect>
+            <rect x="49" y="133" width="238" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">create_schedule_for_backup_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m128 0 h10 m0 0 h110 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m122 0 h10 m0 0 h116 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m136 0 h10 m0 0 h102 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m238 0 h10 m23 -132 h-3"></path>
+         <polygon points="327 17 335 13 335 21"></polygon>
+         <polygon points="327 17 319 13 319 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -796,7 +873,7 @@
             <li><a href="#row_source_extension_stmt" title="row_source_extension_stmt">row_source_extension_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_stmt" href="#drop_stmt">drop_stmt:</a></p>
-      <svg width="214" height="80">
+      <svg width="246" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -810,9 +887,14 @@
             <rect x="49" y="45" width="116" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="65">drop_role_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m112 0 h10 m0 0 h4 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m23 -44 h-3"></path>
-         <polygon points="205 17 213 13 213 21"></polygon>
-         <polygon points="205 17 197 13 197 21"></polygon>
+         <a xlink:href="#drop_schedule_stmt" xlink:title="drop_schedule_stmt">
+            <rect x="51" y="91" width="148" height="32"></rect>
+            <rect x="49" y="89" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">drop_schedule_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m112 0 h10 m0 0 h36 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m116 0 h10 m0 0 h32 m-178 -10 v20 m188 0 v-20 m-188 20 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m148 0 h10 m23 -88 h-3"></path>
+         <polygon points="237 17 245 13 245 21"></polygon>
+         <polygon points="237 17 229 13 229 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1034,32 +1116,23 @@
             <li><a href="#row_source_extension_stmt" title="row_source_extension_stmt">row_source_extension_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="pause_stmt" href="#pause_stmt">pause_stmt:</a></p>
-      <svg width="350" height="80">
+      <svg width="264" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">PAUSE</text>
-         <rect x="135" y="3" width="46" height="32" rx="10"></rect>
-         <rect x="133" y="1" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="21">JOB</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="201" y="3" width="64" height="32"></rect>
-            <rect x="199" y="1" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="209" y="21">a_expr</text>
+         <a xlink:href="#pause_jobs_stmt" xlink:title="pause_jobs_stmt">
+            <rect x="51" y="3" width="130" height="32"></rect>
+            <rect x="49" y="1" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">pause_jobs_stmt</text>
          </a>
-         <rect x="135" y="47" width="56" height="32" rx="10"></rect>
-         <rect x="133" y="45" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="65">JOBS</text>
-         <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="211" y="47" width="92" height="32"></rect>
-            <rect x="209" y="45" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="219" y="65">select_stmt</text>
+         <a xlink:href="#pause_schedules_stmt" xlink:title="pause_schedules_stmt">
+            <rect x="51" y="47" width="166" height="32"></rect>
+            <rect x="49" y="45" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">pause_schedules_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h38 m-208 0 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v24 m208 0 v-24 m-208 24 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m56 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"></path>
-         <polygon points="341 17 349 13 349 21"></polygon>
-         <polygon points="341 17 333 13 333 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m130 0 h10 m0 0 h36 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m166 0 h10 m23 -44 h-3"></path>
+         <polygon points="255 17 263 13 263 21"></polygon>
+         <polygon points="255 17 247 13 247 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1089,71 +1162,73 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="restore_stmt" href="#restore_stmt">restore_stmt:</a></p>
-      <svg width="678" height="134">
+      <svg width="612" height="178">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="82" height="32" rx="10"></rect>
          <rect x="29" y="1" width="82" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">RESTORE</text>
+         <rect x="153" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="151" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="21">FROM</text>
          <a xlink:href="#targets" xlink:title="targets">
-            <rect x="153" y="35" width="66" height="32"></rect>
-            <rect x="151" y="33" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="161" y="53">targets</text>
+            <rect x="153" y="47" width="66" height="32"></rect>
+            <rect x="151" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="161" y="65">targets</text>
          </a>
-         <rect x="259" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="257" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="267" y="21">FROM</text>
-         <a xlink:href="#partitioned_backup_list" xlink:title="partitioned_backup_list">
-            <rect x="337" y="3" width="168" height="32"></rect>
-            <rect x="335" y="1" width="168" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="345" y="21">partitioned_backup_list</text>
+         <rect x="239" y="47" width="58" height="32" rx="10"></rect>
+         <rect x="237" y="45" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="247" y="65">FROM</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="337" y="79" width="158" height="32"></rect>
+            <rect x="335" y="77" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="97">string_or_placeholder</text>
+         </a>
+         <rect x="515" y="79" width="36" height="32" rx="10"></rect>
+         <rect x="513" y="77" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="523" y="97">IN</text>
+         <a xlink:href="#list_of_string_or_placeholder_opt_list" xlink:title="list_of_string_or_placeholder_opt_list">
+            <rect x="25" y="145" width="258" height="32"></rect>
+            <rect x="23" y="143" width="258" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="33" y="163">list_of_string_or_placeholder_opt_list</text>
          </a>
          <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
-            <rect x="525" y="3" width="132" height="32"></rect>
-            <rect x="523" y="1" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="533" y="21">opt_as_of_clause</text>
+            <rect x="303" y="145" width="132" height="32"></rect>
+            <rect x="301" y="143" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="311" y="163">opt_as_of_clause</text>
          </a>
          <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
-            <rect x="521" y="101" width="130" height="32"></rect>
-            <rect x="519" y="99" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="529" y="119">opt_with_options</text>
+            <rect x="455" y="145" width="130" height="32"></rect>
+            <rect x="453" y="143" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="463" y="163">opt_with_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m20 -32 h10 m58 0 h10 m0 0 h10 m168 0 h10 m0 0 h10 m132 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m130 0 h10 m3 0 h-3"></path>
-         <polygon points="669 115 677 111 677 119"></polygon>
-         <polygon points="669 115 661 111 661 119"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h360 m-458 0 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m66 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-610 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m258 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m130 0 h10 m3 0 h-3"></path>
+         <polygon points="603 159 611 155 611 163"></polygon>
+         <polygon points="603 159 595 155 595 163"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="resume_stmt" href="#resume_stmt">resume_stmt:</a></p>
-      <svg width="360" height="80">
+      <svg width="272" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">RESUME</text>
-         <rect x="145" y="3" width="46" height="32" rx="10"></rect>
-         <rect x="143" y="1" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="153" y="21">JOB</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="211" y="3" width="64" height="32"></rect>
-            <rect x="209" y="1" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="219" y="21">a_expr</text>
+         <a xlink:href="#resume_jobs_stmt" xlink:title="resume_jobs_stmt">
+            <rect x="51" y="3" width="138" height="32"></rect>
+            <rect x="49" y="1" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">resume_jobs_stmt</text>
          </a>
-         <rect x="145" y="47" width="56" height="32" rx="10"></rect>
-         <rect x="143" y="45" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="153" y="65">JOBS</text>
-         <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="221" y="47" width="92" height="32"></rect>
-            <rect x="219" y="45" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="229" y="65">select_stmt</text>
+         <a xlink:href="#resume_schedules_stmt" xlink:title="resume_schedules_stmt">
+            <rect x="51" y="47" width="174" height="32"></rect>
+            <rect x="49" y="45" width="174" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">resume_schedules_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h38 m-208 0 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v24 m208 0 v-24 m-208 24 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m56 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"></path>
-         <polygon points="351 17 359 13 359 21"></polygon>
-         <polygon points="351 17 343 13 343 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m138 0 h10 m0 0 h36 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v24 m214 0 v-24 m-214 24 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m174 0 h10 m23 -44 h-3"></path>
+         <polygon points="263 17 271 13 271 21"></polygon>
+         <polygon points="263 17 255 13 255 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1254,11 +1329,15 @@
             <li><a href="#cancel_sessions_stmt" title="cancel_sessions_stmt">cancel_sessions_stmt</a></li>
             <li><a href="#create_table_as_stmt" title="create_table_as_stmt">create_table_as_stmt</a></li>
             <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
+            <li><a href="#drop_schedule_stmt" title="drop_schedule_stmt">drop_schedule_stmt</a></li>
             <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
+            <li><a href="#for_schedules_clause" title="for_schedules_clause">for_schedules_clause</a></li>
             <li><a href="#insert_rest" title="insert_rest">insert_rest</a></li>
-            <li><a href="#pause_stmt" title="pause_stmt">pause_stmt</a></li>
+            <li><a href="#pause_jobs_stmt" title="pause_jobs_stmt">pause_jobs_stmt</a></li>
+            <li><a href="#pause_schedules_stmt" title="pause_schedules_stmt">pause_schedules_stmt</a></li>
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
-            <li><a href="#resume_stmt" title="resume_stmt">resume_stmt</a></li>
+            <li><a href="#resume_jobs_stmt" title="resume_jobs_stmt">resume_jobs_stmt</a></li>
+            <li><a href="#resume_schedules_stmt" title="resume_schedules_stmt">resume_schedules_stmt</a></li>
             <li><a href="#row_source_extension_stmt" title="row_source_extension_stmt">row_source_extension_stmt</a></li>
             <li><a href="#show_jobs_stmt" title="show_jobs_stmt">show_jobs_stmt</a></li>
          </ul>
@@ -1291,7 +1370,7 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stmt" href="#show_stmt">show_stmt:</a></p>
-      <svg width="290" height="1048">
+      <svg width="290" height="1136">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1325,97 +1404,107 @@
             <rect x="49" y="221" width="164" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="241">show_databases_stmt</text>
          </a>
+         <a xlink:href="#show_enums_stmt" xlink:title="show_enums_stmt">
+            <rect x="51" y="267" width="140" height="32"></rect>
+            <rect x="49" y="265" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">show_enums_stmt</text>
+         </a>
          <a xlink:href="#show_grants_stmt" xlink:title="show_grants_stmt">
-            <rect x="51" y="267" width="138" height="32"></rect>
-            <rect x="49" y="265" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="285">show_grants_stmt</text>
+            <rect x="51" y="311" width="138" height="32"></rect>
+            <rect x="49" y="309" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">show_grants_stmt</text>
          </a>
          <a xlink:href="#show_indexes_stmt" xlink:title="show_indexes_stmt">
-            <rect x="51" y="311" width="146" height="32"></rect>
-            <rect x="49" y="309" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="329">show_indexes_stmt</text>
+            <rect x="51" y="355" width="146" height="32"></rect>
+            <rect x="49" y="353" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">show_indexes_stmt</text>
          </a>
          <a xlink:href="#show_partitions_stmt" xlink:title="show_partitions_stmt">
-            <rect x="51" y="355" width="158" height="32"></rect>
-            <rect x="49" y="353" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="373">show_partitions_stmt</text>
+            <rect x="51" y="399" width="158" height="32"></rect>
+            <rect x="49" y="397" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="417">show_partitions_stmt</text>
          </a>
          <a xlink:href="#show_jobs_stmt" xlink:title="show_jobs_stmt">
-            <rect x="51" y="399" width="124" height="32"></rect>
-            <rect x="49" y="397" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="417">show_jobs_stmt</text>
+            <rect x="51" y="443" width="124" height="32"></rect>
+            <rect x="49" y="441" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="461">show_jobs_stmt</text>
+         </a>
+         <a xlink:href="#show_schedules_stmt" xlink:title="show_schedules_stmt">
+            <rect x="51" y="487" width="160" height="32"></rect>
+            <rect x="49" y="485" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="505">show_schedules_stmt</text>
          </a>
          <a xlink:href="#show_queries_stmt" xlink:title="show_queries_stmt">
-            <rect x="51" y="443" width="144" height="32"></rect>
-            <rect x="49" y="441" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="461">show_queries_stmt</text>
+            <rect x="51" y="531" width="144" height="32"></rect>
+            <rect x="49" y="529" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="549">show_queries_stmt</text>
          </a>
          <a xlink:href="#show_ranges_stmt" xlink:title="show_ranges_stmt">
-            <rect x="51" y="487" width="142" height="32"></rect>
-            <rect x="49" y="485" width="142" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="505">show_ranges_stmt</text>
+            <rect x="51" y="575" width="142" height="32"></rect>
+            <rect x="49" y="573" width="142" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="593">show_ranges_stmt</text>
          </a>
          <a xlink:href="#show_range_for_row_stmt" xlink:title="show_range_for_row_stmt">
-            <rect x="51" y="531" width="192" height="32"></rect>
-            <rect x="49" y="529" width="192" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="549">show_range_for_row_stmt</text>
+            <rect x="51" y="619" width="192" height="32"></rect>
+            <rect x="49" y="617" width="192" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="637">show_range_for_row_stmt</text>
          </a>
          <a xlink:href="#show_roles_stmt" xlink:title="show_roles_stmt">
-            <rect x="51" y="575" width="128" height="32"></rect>
-            <rect x="49" y="573" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="593">show_roles_stmt</text>
+            <rect x="51" y="663" width="128" height="32"></rect>
+            <rect x="49" y="661" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="681">show_roles_stmt</text>
          </a>
          <a xlink:href="#show_savepoint_stmt" xlink:title="show_savepoint_stmt">
-            <rect x="51" y="619" width="160" height="32"></rect>
-            <rect x="49" y="617" width="160" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="637">show_savepoint_stmt</text>
+            <rect x="51" y="707" width="160" height="32"></rect>
+            <rect x="49" y="705" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="725">show_savepoint_stmt</text>
          </a>
          <a xlink:href="#show_schemas_stmt" xlink:title="show_schemas_stmt">
-            <rect x="51" y="663" width="152" height="32"></rect>
-            <rect x="49" y="661" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="681">show_schemas_stmt</text>
+            <rect x="51" y="751" width="152" height="32"></rect>
+            <rect x="49" y="749" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="769">show_schemas_stmt</text>
          </a>
          <a xlink:href="#show_sequences_stmt" xlink:title="show_sequences_stmt">
-            <rect x="51" y="707" width="166" height="32"></rect>
-            <rect x="49" y="705" width="166" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="725">show_sequences_stmt</text>
+            <rect x="51" y="795" width="166" height="32"></rect>
+            <rect x="49" y="793" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="813">show_sequences_stmt</text>
          </a>
          <a xlink:href="#show_session_stmt" xlink:title="show_session_stmt">
-            <rect x="51" y="751" width="146" height="32"></rect>
-            <rect x="49" y="749" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="769">show_session_stmt</text>
+            <rect x="51" y="839" width="146" height="32"></rect>
+            <rect x="49" y="837" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="857">show_session_stmt</text>
          </a>
          <a xlink:href="#show_sessions_stmt" xlink:title="show_sessions_stmt">
-            <rect x="51" y="795" width="152" height="32"></rect>
-            <rect x="49" y="793" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="813">show_sessions_stmt</text>
+            <rect x="51" y="883" width="152" height="32"></rect>
+            <rect x="49" y="881" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="901">show_sessions_stmt</text>
          </a>
          <a xlink:href="#show_stats_stmt" xlink:title="show_stats_stmt">
-            <rect x="51" y="839" width="130" height="32"></rect>
-            <rect x="49" y="837" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="857">show_stats_stmt</text>
-         </a>
-         <a xlink:href="#show_tables_stmt" xlink:title="show_tables_stmt">
-            <rect x="51" y="883" width="136" height="32"></rect>
-            <rect x="49" y="881" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="901">show_tables_stmt</text>
-         </a>
-         <a xlink:href="#show_trace_stmt" xlink:title="show_trace_stmt">
             <rect x="51" y="927" width="130" height="32"></rect>
             <rect x="49" y="925" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="945">show_trace_stmt</text>
+            <text class="nonterminal" x="59" y="945">show_stats_stmt</text>
+         </a>
+         <a xlink:href="#show_tables_stmt" xlink:title="show_tables_stmt">
+            <rect x="51" y="971" width="136" height="32"></rect>
+            <rect x="49" y="969" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="989">show_tables_stmt</text>
+         </a>
+         <a xlink:href="#show_trace_stmt" xlink:title="show_trace_stmt">
+            <rect x="51" y="1015" width="130" height="32"></rect>
+            <rect x="49" y="1013" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1033">show_trace_stmt</text>
          </a>
          <a xlink:href="#show_users_stmt" xlink:title="show_users_stmt">
-            <rect x="51" y="971" width="132" height="32"></rect>
-            <rect x="49" y="969" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="989">show_users_stmt</text>
+            <rect x="51" y="1059" width="132" height="32"></rect>
+            <rect x="49" y="1057" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1077">show_users_stmt</text>
          </a>
          <a xlink:href="#show_zone_stmt" xlink:title="show_zone_stmt">
-            <rect x="51" y="1015" width="128" height="32"></rect>
-            <rect x="49" y="1013" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1033">show_zone_stmt</text>
+            <rect x="51" y="1103" width="128" height="32"></rect>
+            <rect x="49" y="1101" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1121">show_zone_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h50 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m148 0 h10 m0 0 h44 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m168 0 h10 m0 0 h24 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m154 0 h10 m0 0 h38 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m164 0 h10 m0 0 h28 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m158 0 h10 m0 0 h34 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m124 0 h10 m0 0 h68 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m144 0 h10 m0 0 h48 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m142 0 h10 m0 0 h50 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m192 0 h10 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m166 0 h10 m0 0 h26 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m136 0 h10 m0 0 h56 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m23 -1012 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h50 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m148 0 h10 m0 0 h44 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m168 0 h10 m0 0 h24 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m154 0 h10 m0 0 h38 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m164 0 h10 m0 0 h28 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m140 0 h10 m0 0 h52 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m158 0 h10 m0 0 h34 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m124 0 h10 m0 0 h68 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m144 0 h10 m0 0 h48 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m142 0 h10 m0 0 h50 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m192 0 h10 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m166 0 h10 m0 0 h26 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m136 0 h10 m0 0 h56 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m23 -1100 h-3"></path>
          <polygon points="281 17 289 13 289 21"></polygon>
          <polygon points="281 17 273 13 273 21"></polygon>
       </svg>
@@ -1555,6 +1644,24 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
             <li><a href="#row_source_extension_stmt" title="row_source_extension_stmt">row_source_extension_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="analyze_target" href="#analyze_target">analyze_target:</a></p>
+      <svg width="152" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="31" y="3" width="94" height="32"></rect>
+            <rect x="29" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">table_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m3 0 h-3"></path>
+         <polygon points="143 17 151 13 151 21"></polygon>
+         <polygon points="143 17 135 13 135 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#analyze_stmt" title="analyze_stmt">analyze_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_name" href="#table_name">table_name:</a></p>
       <svg width="184" height="36">
          
@@ -1577,6 +1684,7 @@
             <li><a href="#alter_unsplit_stmt" title="alter_unsplit_stmt">alter_unsplit_stmt</a></li>
             <li><a href="#alter_zone_partition_stmt" title="alter_zone_partition_stmt">alter_zone_partition_stmt</a></li>
             <li><a href="#alter_zone_table_stmt" title="alter_zone_table_stmt">alter_zone_table_stmt</a></li>
+            <li><a href="#analyze_target" title="analyze_target">analyze_target</a></li>
             <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
             <li><a href="#comment_stmt" title="comment_stmt">comment_stmt</a></li>
             <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
@@ -1601,6 +1709,7 @@
             <li><a href="#show_zone_stmt" title="show_zone_stmt">show_zone_stmt</a></li>
             <li><a href="#single_table_pattern_list" title="single_table_pattern_list">single_table_pattern_list</a></li>
             <li><a href="#sortby" title="sortby">sortby</a></li>
+            <li><a href="#table_elem" title="table_elem">table_elem</a></li>
             <li><a href="#table_index_name" title="table_index_name">table_index_name</a></li>
             <li><a href="#table_name_list" title="table_name_list">table_name_list</a></li>
             <li><a href="#table_name_opt_idx" title="table_name_opt_idx">table_name_opt_idx</a></li>
@@ -1667,7 +1776,6 @@
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#copy_from_stmt" title="copy_from_stmt">copy_from_stmt</a></li>
             <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
             <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
@@ -1860,6 +1968,7 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
             <li><a href="#column_name" title="column_name">column_name</a></li>
             <li><a href="#column_path" title="column_path">column_path</a></li>
             <li><a href="#constraint_name" title="constraint_name">constraint_name</a></li>
@@ -1909,7 +2018,7 @@
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="targets" href="#targets">targets:</a></p>
-      <svg width="440" height="300">
+      <svg width="440" height="344">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1947,22 +2056,28 @@
             <rect x="259" y="177" width="132" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="269" y="197">table_pattern_list</text>
          </a>
-         <rect x="51" y="267" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">DATABASE</text>
+         <rect x="51" y="267" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">TENANT</text>
+         <rect x="143" y="267" width="72" height="32" rx="10"></rect>
+         <rect x="141" y="265" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="151" y="285">ICONST</text>
+         <rect x="51" y="311" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">DATABASE</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="161" y="267" width="80" height="32"></rect>
-            <rect x="159" y="265" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="169" y="285">name_list</text>
+            <rect x="161" y="311" width="80" height="32"></rect>
+            <rect x="159" y="309" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="169" y="329">name_list</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m80 0 h10 m0 0 h262 m-382 0 h20 m362 0 h20 m-402 0 q10 0 10 10 m382 0 q0 -10 10 -10 m-392 10 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m142 0 h10 m0 0 h200 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m154 0 h10 m0 0 h188 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m166 0 h10 m0 0 h176 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-352 10 h10 m106 0 h10 m0 0 h10 m24 0 h10 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v24 m190 0 v-24 m-190 24 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m62 0 h10 m0 0 h88 m20 -44 h10 m132 0 h10 m-372 -10 v20 m382 0 v-20 m-382 20 v68 m382 0 v-68 m-382 68 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m90 0 h10 m0 0 h10 m80 0 h10 m0 0 h152 m23 -264 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m80 0 h10 m0 0 h262 m-382 0 h20 m362 0 h20 m-402 0 q10 0 10 10 m382 0 q0 -10 10 -10 m-392 10 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m142 0 h10 m0 0 h200 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m154 0 h10 m0 0 h188 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m166 0 h10 m0 0 h176 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-352 10 h10 m106 0 h10 m0 0 h10 m24 0 h10 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v24 m190 0 v-24 m-190 24 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m62 0 h10 m0 0 h88 m20 -44 h10 m132 0 h10 m-372 -10 v20 m382 0 v-20 m-382 20 v68 m382 0 v-68 m-382 68 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m72 0 h10 m0 0 h10 m72 0 h10 m0 0 h178 m-372 -10 v20 m382 0 v-20 m-382 20 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m90 0 h10 m0 0 h10 m80 0 h10 m0 0 h152 m23 -308 h-3"></path>
          <polygon points="431 17 439 13 439 21"></polygon>
          <polygon points="431 17 423 13 423 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
+            <li><a href="#opt_backup_targets" title="opt_backup_targets">opt_backup_targets</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
             <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
@@ -2206,7 +2321,7 @@
             <li><a href="#transaction_stmt" title="transaction_stmt">transaction_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_ddl_stmt" href="#alter_ddl_stmt">alter_ddl_stmt:</a></p>
-      <svg width="252" height="300">
+      <svg width="252" height="388">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -2245,7 +2360,17 @@
             <rect x="49" y="265" width="146" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="285">alter_partition_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m124 0 h10 m0 0 h30 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m126 0 h10 m0 0 h28 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m122 0 h10 m0 0 h32 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m154 0 h10 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m152 0 h10 m0 0 h2 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m130 0 h10 m0 0 h24 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m146 0 h10 m0 0 h8 m23 -264 h-3"></path>
+         <a xlink:href="#alter_schema_stmt" xlink:title="alter_schema_stmt">
+            <rect x="51" y="311" width="140" height="32"></rect>
+            <rect x="49" y="309" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">alter_schema_stmt</text>
+         </a>
+         <a xlink:href="#alter_type_stmt" xlink:title="alter_type_stmt">
+            <rect x="51" y="355" width="120" height="32"></rect>
+            <rect x="49" y="353" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">alter_type_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m124 0 h10 m0 0 h30 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m126 0 h10 m0 0 h28 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m122 0 h10 m0 0 h32 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m154 0 h10 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m152 0 h10 m0 0 h2 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m130 0 h10 m0 0 h24 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m146 0 h10 m0 0 h8 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m140 0 h10 m0 0 h14 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m120 0 h10 m0 0 h34 m23 -352 h-3"></path>
          <polygon points="243 17 251 13 251 21"></polygon>
          <polygon points="243 17 235 13 235 21"></polygon>
       </svg>
@@ -2290,7 +2415,26 @@
          </p><ul>
             <li><a href="#alter_stmt" title="alter_stmt">alter_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="partitioned_backup" href="#partitioned_backup">partitioned_backup:</a></p>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_backup_targets" href="#opt_backup_targets">opt_backup_targets:</a></p>
+      <svg width="124" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#targets" xlink:title="targets">
+            <rect x="31" y="3" width="66" height="32"></rect>
+            <rect x="29" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">targets</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m3 0 h-3"></path>
+         <polygon points="115 17 123 13 123 21"></polygon>
+         <polygon points="115 17 107 13 107 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="string_or_placeholder_opt_list" href="#string_or_placeholder_opt_list">string_or_placeholder_opt_list:</a></p>
       <svg width="374" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
@@ -2317,8 +2461,10 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#backup_options" title="backup_options">backup_options</a></li>
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
-            <li><a href="#partitioned_backup_list" title="partitioned_backup_list">partitioned_backup_list</a></li>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
+            <li><a href="#list_of_string_or_placeholder_opt_list" title="list_of_string_or_placeholder_opt_list">list_of_string_or_placeholder_opt_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_as_of_clause" href="#opt_as_of_clause">opt_as_of_clause:</a></p>
       <svg width="200" height="56">
@@ -2341,6 +2487,42 @@
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
             <li><a href="#scrub_database_stmt" title="scrub_database_stmt">scrub_database_stmt</a></li>
             <li><a href="#scrub_table_stmt" title="scrub_table_stmt">scrub_table_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_backup_options" href="#opt_with_backup_options">opt_with_backup_options:</a></p>
+      <svg width="558" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <a xlink:href="#backup_options_list" xlink:title="backup_options_list">
+            <rect x="149" y="23" width="146" height="32"></rect>
+            <rect x="147" y="21" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="41">backup_options_list</text>
+         </a>
+         <rect x="149" y="67" width="84" height="32" rx="10"></rect>
+         <rect x="147" y="65" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="85">OPTIONS</text>
+         <rect x="253" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="251" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="85">(</text>
+         <a xlink:href="#backup_options_list" xlink:title="backup_options_list">
+            <rect x="299" y="67" width="146" height="32"></rect>
+            <rect x="297" y="65" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="85">backup_options_list</text>
+         </a>
+         <rect x="465" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="463" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="473" y="85">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h470 m-500 0 h20 m480 0 h20 m-520 0 q10 0 10 10 m500 0 q0 -10 10 -10 m-510 10 v12 m500 0 v-12 m-500 12 q0 10 10 10 m480 0 q10 0 10 -10 m-490 10 h10 m58 0 h10 m20 0 h10 m146 0 h10 m0 0 h196 m-382 0 h20 m362 0 h20 m-402 0 q10 0 10 10 m382 0 q0 -10 10 -10 m-392 10 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m146 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"></path>
+         <polygon points="549 5 557 1 557 9"></polygon>
+         <polygon points="549 5 541 1 541 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_incremental" href="#opt_incremental">opt_incremental:</a></p>
       <svg width="496" height="56">
@@ -2367,7 +2549,7 @@
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cancel_jobs_stmt" href="#cancel_jobs_stmt">cancel_jobs_stmt:</a></p>
-      <svg width="358" height="80">
+      <svg width="462" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -2386,13 +2568,18 @@
          <rect x="141" y="45" width="56" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="151" y="65">JOBS</text>
          <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="219" y="47" width="92" height="32"></rect>
-            <rect x="217" y="45" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="227" y="65">select_stmt</text>
+            <rect x="239" y="47" width="92" height="32"></rect>
+            <rect x="237" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="65">select_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h38 m-208 0 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v24 m208 0 v-24 m-208 24 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m56 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"></path>
-         <polygon points="349 17 357 13 357 21"></polygon>
-         <polygon points="349 17 341 13 341 21"></polygon>
+         <a xlink:href="#for_schedules_clause" xlink:title="for_schedules_clause">
+            <rect x="239" y="91" width="156" height="32"></rect>
+            <rect x="237" y="89" width="156" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="109">for_schedules_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h142 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m56 0 h10 m20 0 h10 m92 0 h10 m0 0 h64 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v24 m196 0 v-24 m-196 24 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m156 0 h10 m43 -88 h-3"></path>
+         <polygon points="453 17 461 13 461 21"></polygon>
+         <polygon points="453 17 445 13 445 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -2527,7 +2714,7 @@
             <li><a href="#create_stmt" title="create_stmt">create_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_ddl_stmt" href="#create_ddl_stmt">create_ddl_stmt:</a></p>
-      <svg width="276" height="344">
+      <svg width="276" height="388">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -2561,17 +2748,22 @@
             <rect x="49" y="221" width="158" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="241">create_table_as_stmt</text>
          </a>
-         <a xlink:href="#create_view_stmt" xlink:title="create_view_stmt">
+         <a xlink:href="#create_type_stmt" xlink:title="create_type_stmt">
             <rect x="51" y="267" width="132" height="32"></rect>
             <rect x="49" y="265" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="285">create_view_stmt</text>
+            <text class="nonterminal" x="59" y="285">create_type_stmt</text>
+         </a>
+         <a xlink:href="#create_view_stmt" xlink:title="create_view_stmt">
+            <rect x="51" y="311" width="132" height="32"></rect>
+            <rect x="49" y="309" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">create_view_stmt</text>
          </a>
          <a xlink:href="#create_sequence_stmt" xlink:title="create_sequence_stmt">
-            <rect x="51" y="311" width="164" height="32"></rect>
-            <rect x="49" y="309" width="164" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="329">create_sequence_stmt</text>
+            <rect x="51" y="355" width="164" height="32"></rect>
+            <rect x="49" y="353" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">create_sequence_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m164 0 h10 m0 0 h14 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m138 0 h10 m0 0 h40 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m152 0 h10 m0 0 h26 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m136 0 h10 m0 0 h42 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m158 0 h10 m0 0 h20 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m132 0 h10 m0 0 h46 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m164 0 h10 m0 0 h14 m23 -308 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m164 0 h10 m0 0 h14 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m138 0 h10 m0 0 h40 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m152 0 h10 m0 0 h26 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m136 0 h10 m0 0 h42 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m158 0 h10 m0 0 h20 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m132 0 h10 m0 0 h46 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m132 0 h10 m0 0 h46 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m164 0 h10 m0 0 h14 m23 -352 h-3"></path>
          <polygon points="267 17 275 13 275 21"></polygon>
          <polygon points="267 17 259 13 259 21"></polygon>
       </svg>
@@ -2616,6 +2808,69 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-400 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m146 0 h10 m0 0 h10 m184 0 h10 m3 0 h-3"></path>
          <polygon points="609 83 617 79 617 87"></polygon>
          <polygon points="609 83 601 79 601 87"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_stmt" title="create_stmt">create_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_schedule_for_backup_stmt" href="#create_schedule_for_backup_stmt">create_schedule_for_backup_stmt:</a></p>
+      <svg width="760" height="168">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE</text>
+         <rect x="121" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="119" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="21">SCHEDULE</text>
+         <a xlink:href="#opt_description" xlink:title="opt_description">
+            <rect x="233" y="3" width="118" height="32"></rect>
+            <rect x="231" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="241" y="21">opt_description</text>
+         </a>
+         <rect x="371" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="369" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="379" y="21">FOR</text>
+         <rect x="439" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="437" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="21">BACKUP</text>
+         <a xlink:href="#opt_backup_targets" xlink:title="opt_backup_targets">
+            <rect x="533" y="3" width="148" height="32"></rect>
+            <rect x="531" y="1" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="541" y="21">opt_backup_targets</text>
+         </a>
+         <rect x="701" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="699" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="709" y="21">TO</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="29" y="69" width="212" height="32"></rect>
+            <rect x="27" y="67" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="37" y="87">string_or_placeholder_opt_list</text>
+         </a>
+         <a xlink:href="#opt_with_backup_options" xlink:title="opt_with_backup_options">
+            <rect x="261" y="69" width="184" height="32"></rect>
+            <rect x="259" y="67" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="269" y="87">opt_with_backup_options</text>
+         </a>
+         <a xlink:href="#cron_expr" xlink:title="cron_expr">
+            <rect x="465" y="69" width="82" height="32"></rect>
+            <rect x="463" y="67" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="473" y="87">cron_expr</text>
+         </a>
+         <a xlink:href="#opt_full_backup_clause" xlink:title="opt_full_backup_clause">
+            <rect x="567" y="69" width="168" height="32"></rect>
+            <rect x="565" y="67" width="168" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="575" y="87">opt_full_backup_clause</text>
+         </a>
+         <a xlink:href="#opt_with_schedule_options" xlink:title="opt_with_schedule_options">
+            <rect x="539" y="135" width="194" height="32"></rect>
+            <rect x="537" y="133" width="194" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="547" y="153">opt_with_schedule_options</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-754 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m212 0 h10 m0 0 h10 m184 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m194 0 h10 m3 0 h-3"></path>
+         <polygon points="751 149 759 145 759 153"></polygon>
+         <polygon points="751 149 743 145 743 153"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -2685,7 +2940,10 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
+            <li><a href="#create_index_stmt" title="create_index_stmt">create_index_stmt</a></li>
             <li><a href="#delete_stmt" title="delete_stmt">delete_stmt</a></li>
+            <li><a href="#index_def" title="index_def">index_def</a></li>
             <li><a href="#on_conflict" title="on_conflict">on_conflict</a></li>
             <li><a href="#simple_select_clause" title="simple_select_clause">simple_select_clause</a></li>
             <li><a href="#update_stmt" title="update_stmt">update_stmt</a></li>
@@ -2759,7 +3017,7 @@
             <li><a href="#upsert_stmt" title="upsert_stmt">upsert_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_ddl_stmt" href="#drop_ddl_stmt">drop_ddl_stmt:</a></p>
-      <svg width="252" height="212">
+      <svg width="252" height="300">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -2788,7 +3046,17 @@
             <rect x="49" y="177" width="154" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="197">drop_sequence_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m152 0 h10 m0 0 h2 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m126 0 h10 m0 0 h28 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m124 0 h10 m0 0 h30 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m122 0 h10 m0 0 h32 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m154 0 h10 m23 -176 h-3"></path>
+         <a xlink:href="#drop_schema_stmt" xlink:title="drop_schema_stmt">
+            <rect x="51" y="223" width="140" height="32"></rect>
+            <rect x="49" y="221" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">drop_schema_stmt</text>
+         </a>
+         <a xlink:href="#drop_type_stmt" xlink:title="drop_type_stmt">
+            <rect x="51" y="267" width="120" height="32"></rect>
+            <rect x="49" y="265" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">drop_type_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m152 0 h10 m0 0 h2 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m126 0 h10 m0 0 h28 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m124 0 h10 m0 0 h30 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m122 0 h10 m0 0 h32 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m154 0 h10 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m140 0 h10 m0 0 h14 m-184 -10 v20 m194 0 v-20 m-194 20 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m120 0 h10 m0 0 h34 m23 -264 h-3"></path>
          <polygon points="243 17 251 13 251 21"></polygon>
          <polygon points="243 17 235 13 235 21"></polygon>
       </svg>
@@ -2823,6 +3091,38 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m166 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m184 0 h10 m3 0 h-3"></path>
          <polygon points="679 17 687 13 687 21"></polygon>
          <polygon points="679 17 671 13 671 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_stmt" title="drop_stmt">drop_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_schedule_stmt" href="#drop_schedule_stmt">drop_schedule_stmt:</a></p>
+      <svg width="388" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">DROP</text>
+         <rect x="129" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="127" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="21">SCHEDULE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="241" y="3" width="64" height="32"></rect>
+            <rect x="239" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="21">a_expr</text>
+         </a>
+         <rect x="129" y="47" width="100" height="32" rx="10"></rect>
+         <rect x="127" y="45" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="65">SCHEDULES</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="249" y="47" width="92" height="32"></rect>
+            <rect x="247" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="257" y="65">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h36 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v24 m252 0 v-24 m-252 24 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m100 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"></path>
+         <polygon points="379 17 387 13 387 21"></polygon>
+         <polygon points="379 17 371 13 371 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -2888,15 +3188,18 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_role_stmt" title="alter_role_stmt">alter_role_stmt</a></li>
+            <li><a href="#backup_options" title="backup_options">backup_options</a></li>
             <li><a href="#create_role_stmt" title="create_role_stmt">create_role_stmt</a></li>
             <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
             <li><a href="#kv_option" title="kv_option">kv_option</a></li>
             <li><a href="#opt_changefeed_sink" title="opt_changefeed_sink">opt_changefeed_sink</a></li>
-            <li><a href="#partitioned_backup" title="partitioned_backup">partitioned_backup</a></li>
+            <li><a href="#opt_description" title="opt_description">opt_description</a></li>
             <li><a href="#password_clause" title="password_clause">password_clause</a></li>
+            <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
             <li><a href="#show_backup_stmt" title="show_backup_stmt">show_backup_stmt</a></li>
             <li><a href="#string_or_placeholder_list" title="string_or_placeholder_list">string_or_placeholder_list</a></li>
+            <li><a href="#string_or_placeholder_opt_list" title="string_or_placeholder_opt_list">string_or_placeholder_opt_list</a></li>
             <li><a href="#valid_until_clause" title="valid_until_clause">valid_until_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="string_or_placeholder_list" href="#string_or_placeholder_list">string_or_placeholder_list:</a></p>
@@ -2921,7 +3224,7 @@
             <li><a href="#drop_role_stmt" title="drop_role_stmt">drop_role_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
             <li><a href="#opt_incremental" title="opt_incremental">opt_incremental</a></li>
-            <li><a href="#partitioned_backup" title="partitioned_backup">partitioned_backup</a></li>
+            <li><a href="#string_or_placeholder_opt_list" title="string_or_placeholder_opt_list">string_or_placeholder_opt_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_elem_list" href="#table_elem_list">table_elem_list:</a></p>
       <svg width="188" height="80">
@@ -3077,872 +3380,74 @@
          </p><ul>
             <li><a href="#insert_stmt" title="insert_stmt">insert_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="a_expr" href="#a_expr">a_expr:</a></p>
-      <svg width="700" height="3698">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="pause_jobs_stmt" href="#pause_jobs_stmt">pause_jobs_stmt:</a></p>
+      <svg width="454" height="124">
          
-         <polygon points="11 17 3 13 3 21"></polygon>
-         <polygon points="19 17 11 13 11 21"></polygon>
-         <a xlink:href="#c_expr" xlink:title="c_expr">
-            <rect x="53" y="3" width="62" height="32"></rect>
-            <rect x="51" y="1" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="61" y="21">c_expr</text>
-         </a>
-         <rect x="73" y="47" width="30" height="32" rx="10"></rect>
-         <rect x="71" y="45" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="65">+</text>
-         <rect x="73" y="91" width="26" height="32" rx="10"></rect>
-         <rect x="71" y="89" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="109">-</text>
-         <rect x="73" y="135" width="30" height="32" rx="10"></rect>
-         <rect x="71" y="133" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="153">~</text>
-         <rect x="73" y="179" width="48" height="32" rx="10"></rect>
-         <rect x="71" y="177" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="197">NOT</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="161" y="47" width="64" height="32"></rect>
-            <rect x="159" y="45" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="169" y="65">a_expr</text>
-         </a>
-         <rect x="53" y="223" width="80" height="32" rx="10"></rect>
-         <rect x="51" y="221" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="61" y="241">DEFAULT</text>
-         <rect x="85" y="305" width="90" height="32" rx="10"></rect>
-         <rect x="83" y="303" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="323">TYPECAST</text>
-         <a xlink:href="#cast_target" xlink:title="cast_target">
-            <rect x="195" y="305" width="92" height="32"></rect>
-            <rect x="193" y="303" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="323">cast_target</text>
-         </a>
-         <rect x="85" y="349" width="128" height="32" rx="10"></rect>
-         <rect x="83" y="347" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="367">TYPEANNOTATE</text>
-         <a xlink:href="#typename" xlink:title="typename">
-            <rect x="233" y="349" width="82" height="32"></rect>
-            <rect x="231" y="347" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="241" y="367">typename</text>
-         </a>
-         <rect x="85" y="393" width="80" height="32" rx="10"></rect>
-         <rect x="83" y="391" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="411">COLLATE</text>
-         <a xlink:href="#collation_name" xlink:title="collation_name">
-            <rect x="185" y="393" width="114" height="32"></rect>
-            <rect x="183" y="391" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="193" y="411">collation_name</text>
-         </a>
-         <rect x="85" y="437" width="36" height="32" rx="10"></rect>
-         <rect x="83" y="435" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="455">AT</text>
-         <rect x="141" y="437" width="52" height="32" rx="10"></rect>
-         <rect x="139" y="435" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="149" y="455">TIME</text>
-         <rect x="213" y="437" width="56" height="32" rx="10"></rect>
-         <rect x="211" y="435" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="221" y="455">ZONE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="289" y="437" width="64" height="32"></rect>
-            <rect x="287" y="435" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="297" y="455">a_expr</text>
-         </a>
-         <rect x="85" y="481" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="479" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="499">+</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="481" width="64" height="32"></rect>
-            <rect x="133" y="479" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="499">a_expr</text>
-         </a>
-         <rect x="85" y="525" width="26" height="32" rx="10"></rect>
-         <rect x="83" y="523" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="543">-</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="131" y="525" width="64" height="32"></rect>
-            <rect x="129" y="523" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="139" y="543">a_expr</text>
-         </a>
-         <rect x="85" y="569" width="28" height="32" rx="10"></rect>
-         <rect x="83" y="567" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="587">*</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="133" y="569" width="64" height="32"></rect>
-            <rect x="131" y="567" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="141" y="587">a_expr</text>
-         </a>
-         <rect x="85" y="613" width="28" height="32" rx="10"></rect>
-         <rect x="83" y="611" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="631">/</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="133" y="613" width="64" height="32"></rect>
-            <rect x="131" y="611" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="141" y="631">a_expr</text>
-         </a>
-         <rect x="85" y="657" width="92" height="32" rx="10"></rect>
-         <rect x="83" y="655" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="675">FLOORDIV</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="197" y="657" width="64" height="32"></rect>
-            <rect x="195" y="655" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="205" y="675">a_expr</text>
-         </a>
-         <rect x="85" y="701" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="699" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="719">%</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="139" y="701" width="64" height="32"></rect>
-            <rect x="137" y="699" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="147" y="719">a_expr</text>
-         </a>
-         <rect x="85" y="745" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="743" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="763">^</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="745" width="64" height="32"></rect>
-            <rect x="133" y="743" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="763">a_expr</text>
-         </a>
-         <rect x="85" y="789" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="787" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="807">#</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="789" width="64" height="32"></rect>
-            <rect x="133" y="787" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="807">a_expr</text>
-         </a>
-         <rect x="85" y="833" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="831" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="851">&amp;</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="833" width="64" height="32"></rect>
-            <rect x="133" y="831" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="851">a_expr</text>
-         </a>
-         <rect x="85" y="877" width="26" height="32" rx="10"></rect>
-         <rect x="83" y="875" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="895">|</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="131" y="877" width="64" height="32"></rect>
-            <rect x="129" y="875" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="139" y="895">a_expr</text>
-         </a>
-         <rect x="85" y="921" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="919" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="939">&lt;</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="921" width="64" height="32"></rect>
-            <rect x="133" y="919" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="939">a_expr</text>
-         </a>
-         <rect x="85" y="965" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="963" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="983">&gt;</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="965" width="64" height="32"></rect>
-            <rect x="133" y="963" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="983">a_expr</text>
-         </a>
-         <rect x="85" y="1009" width="26" height="32" rx="10"></rect>
-         <rect x="83" y="1007" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1027">?</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="131" y="1009" width="64" height="32"></rect>
-            <rect x="129" y="1007" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="139" y="1027">a_expr</text>
-         </a>
-         <rect x="85" y="1053" width="162" height="32" rx="10"></rect>
-         <rect x="83" y="1051" width="162" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1071">JSON_SOME_EXISTS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="267" y="1053" width="64" height="32"></rect>
-            <rect x="265" y="1051" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="275" y="1071">a_expr</text>
-         </a>
-         <rect x="85" y="1097" width="148" height="32" rx="10"></rect>
-         <rect x="83" y="1095" width="148" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1115">JSON_ALL_EXISTS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="253" y="1097" width="64" height="32"></rect>
-            <rect x="251" y="1095" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="261" y="1115">a_expr</text>
-         </a>
-         <rect x="85" y="1141" width="92" height="32" rx="10"></rect>
-         <rect x="83" y="1139" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1159">CONTAINS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="197" y="1141" width="64" height="32"></rect>
-            <rect x="195" y="1139" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="205" y="1159">a_expr</text>
-         </a>
-         <rect x="85" y="1185" width="128" height="32" rx="10"></rect>
-         <rect x="83" y="1183" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1203">CONTAINED_BY</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="233" y="1185" width="64" height="32"></rect>
-            <rect x="231" y="1183" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="241" y="1203">a_expr</text>
-         </a>
-         <rect x="85" y="1229" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="1227" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1247">=</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="1229" width="64" height="32"></rect>
-            <rect x="133" y="1227" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="1247">a_expr</text>
-         </a>
-         <rect x="85" y="1273" width="76" height="32" rx="10"></rect>
-         <rect x="83" y="1271" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1291">CONCAT</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="181" y="1273" width="64" height="32"></rect>
-            <rect x="179" y="1271" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="189" y="1291">a_expr</text>
-         </a>
-         <rect x="85" y="1317" width="68" height="32" rx="10"></rect>
-         <rect x="83" y="1315" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1335">LSHIFT</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="173" y="1317" width="64" height="32"></rect>
-            <rect x="171" y="1315" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="181" y="1335">a_expr</text>
-         </a>
-         <rect x="85" y="1361" width="70" height="32" rx="10"></rect>
-         <rect x="83" y="1359" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1379">RSHIFT</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="175" y="1361" width="64" height="32"></rect>
-            <rect x="173" y="1359" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="183" y="1379">a_expr</text>
-         </a>
-         <rect x="85" y="1405" width="88" height="32" rx="10"></rect>
-         <rect x="83" y="1403" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1423">FETCHVAL</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="193" y="1405" width="64" height="32"></rect>
-            <rect x="191" y="1403" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="201" y="1423">a_expr</text>
-         </a>
-         <rect x="85" y="1449" width="96" height="32" rx="10"></rect>
-         <rect x="83" y="1447" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1467">FETCHTEXT</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="201" y="1449" width="64" height="32"></rect>
-            <rect x="199" y="1447" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="209" y="1467">a_expr</text>
-         </a>
-         <rect x="85" y="1493" width="134" height="32" rx="10"></rect>
-         <rect x="83" y="1491" width="134" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1511">FETCHVAL_PATH</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="239" y="1493" width="64" height="32"></rect>
-            <rect x="237" y="1491" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="247" y="1511">a_expr</text>
-         </a>
-         <rect x="85" y="1537" width="140" height="32" rx="10"></rect>
-         <rect x="83" y="1535" width="140" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1555">FETCHTEXT_PATH</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="245" y="1537" width="64" height="32"></rect>
-            <rect x="243" y="1535" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="253" y="1555">a_expr</text>
-         </a>
-         <rect x="85" y="1581" width="120" height="32" rx="10"></rect>
-         <rect x="83" y="1579" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1599">REMOVE_PATH</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="225" y="1581" width="64" height="32"></rect>
-            <rect x="223" y="1579" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="233" y="1599">a_expr</text>
-         </a>
-         <rect x="85" y="1625" width="262" height="32" rx="10"></rect>
-         <rect x="83" y="1623" width="262" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1643">INET_CONTAINED_BY_OR_EQUALS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="367" y="1625" width="64" height="32"></rect>
-            <rect x="365" y="1623" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="375" y="1643">a_expr</text>
-         </a>
-         <rect x="85" y="1669" width="86" height="32" rx="10"></rect>
-         <rect x="83" y="1667" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1687">AND_AND</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="191" y="1669" width="64" height="32"></rect>
-            <rect x="189" y="1667" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="199" y="1687">a_expr</text>
-         </a>
-         <rect x="85" y="1713" width="226" height="32" rx="10"></rect>
-         <rect x="83" y="1711" width="226" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1731">INET_CONTAINS_OR_EQUALS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="331" y="1713" width="64" height="32"></rect>
-            <rect x="329" y="1711" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="339" y="1731">a_expr</text>
-         </a>
-         <rect x="85" y="1757" width="118" height="32" rx="10"></rect>
-         <rect x="83" y="1755" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1775">LESS_EQUALS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="223" y="1757" width="64" height="32"></rect>
-            <rect x="221" y="1755" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="231" y="1775">a_expr</text>
-         </a>
-         <rect x="85" y="1801" width="144" height="32" rx="10"></rect>
-         <rect x="83" y="1799" width="144" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1819">GREATER_EQUALS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="249" y="1801" width="64" height="32"></rect>
-            <rect x="247" y="1799" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="257" y="1819">a_expr</text>
-         </a>
-         <rect x="85" y="1845" width="112" height="32" rx="10"></rect>
-         <rect x="83" y="1843" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1863">NOT_EQUALS</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="217" y="1845" width="64" height="32"></rect>
-            <rect x="215" y="1843" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="225" y="1863">a_expr</text>
-         </a>
-         <rect x="85" y="1889" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="1887" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1907">AND</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="153" y="1889" width="64" height="32"></rect>
-            <rect x="151" y="1887" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="161" y="1907">a_expr</text>
-         </a>
-         <rect x="85" y="1933" width="40" height="32" rx="10"></rect>
-         <rect x="83" y="1931" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1951">OR</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="145" y="1933" width="64" height="32"></rect>
-            <rect x="143" y="1931" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="153" y="1951">a_expr</text>
-         </a>
-         <rect x="85" y="1977" width="50" height="32" rx="10"></rect>
-         <rect x="83" y="1975" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1995">LIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="155" y="1977" width="64" height="32"></rect>
-            <rect x="153" y="1975" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="163" y="1995">a_expr</text>
-         </a>
-         <rect x="85" y="2021" width="50" height="32" rx="10"></rect>
-         <rect x="83" y="2019" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2039">LIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="155" y="2021" width="64" height="32"></rect>
-            <rect x="153" y="2019" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="163" y="2039">a_expr</text>
-         </a>
-         <rect x="239" y="2021" width="72" height="32" rx="10"></rect>
-         <rect x="237" y="2019" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="247" y="2039">ESCAPE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="331" y="2021" width="64" height="32"></rect>
-            <rect x="329" y="2019" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="339" y="2039">a_expr</text>
-         </a>
-         <rect x="85" y="2065" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="2063" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2083">NOT</text>
-         <rect x="153" y="2065" width="50" height="32" rx="10"></rect>
-         <rect x="151" y="2063" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="2083">LIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="223" y="2065" width="64" height="32"></rect>
-            <rect x="221" y="2063" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="231" y="2083">a_expr</text>
-         </a>
-         <rect x="85" y="2109" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="2107" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2127">NOT</text>
-         <rect x="153" y="2109" width="50" height="32" rx="10"></rect>
-         <rect x="151" y="2107" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="2127">LIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="223" y="2109" width="64" height="32"></rect>
-            <rect x="221" y="2107" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="231" y="2127">a_expr</text>
-         </a>
-         <rect x="307" y="2109" width="72" height="32" rx="10"></rect>
-         <rect x="305" y="2107" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="315" y="2127">ESCAPE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="399" y="2109" width="64" height="32"></rect>
-            <rect x="397" y="2107" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="407" y="2127">a_expr</text>
-         </a>
-         <rect x="85" y="2153" width="56" height="32" rx="10"></rect>
-         <rect x="83" y="2151" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2171">ILIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="161" y="2153" width="64" height="32"></rect>
-            <rect x="159" y="2151" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="169" y="2171">a_expr</text>
-         </a>
-         <rect x="85" y="2197" width="56" height="32" rx="10"></rect>
-         <rect x="83" y="2195" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2215">ILIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="161" y="2197" width="64" height="32"></rect>
-            <rect x="159" y="2195" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="169" y="2215">a_expr</text>
-         </a>
-         <rect x="245" y="2197" width="72" height="32" rx="10"></rect>
-         <rect x="243" y="2195" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="253" y="2215">ESCAPE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="337" y="2197" width="64" height="32"></rect>
-            <rect x="335" y="2195" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="345" y="2215">a_expr</text>
-         </a>
-         <rect x="85" y="2241" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="2239" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2259">NOT</text>
-         <rect x="153" y="2241" width="56" height="32" rx="10"></rect>
-         <rect x="151" y="2239" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="2259">ILIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="229" y="2241" width="64" height="32"></rect>
-            <rect x="227" y="2239" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="237" y="2259">a_expr</text>
-         </a>
-         <rect x="85" y="2285" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="2283" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2303">NOT</text>
-         <rect x="153" y="2285" width="56" height="32" rx="10"></rect>
-         <rect x="151" y="2283" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="2303">ILIKE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="229" y="2285" width="64" height="32"></rect>
-            <rect x="227" y="2283" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="237" y="2303">a_expr</text>
-         </a>
-         <rect x="313" y="2285" width="72" height="32" rx="10"></rect>
-         <rect x="311" y="2283" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="321" y="2303">ESCAPE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="405" y="2285" width="64" height="32"></rect>
-            <rect x="403" y="2283" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="413" y="2303">a_expr</text>
-         </a>
-         <rect x="85" y="2329" width="78" height="32" rx="10"></rect>
-         <rect x="83" y="2327" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2347">SIMILAR</text>
-         <rect x="183" y="2329" width="38" height="32" rx="10"></rect>
-         <rect x="181" y="2327" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="191" y="2347">TO</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="241" y="2329" width="64" height="32"></rect>
-            <rect x="239" y="2327" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="249" y="2347">a_expr</text>
-         </a>
-         <rect x="85" y="2373" width="78" height="32" rx="10"></rect>
-         <rect x="83" y="2371" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2391">SIMILAR</text>
-         <rect x="183" y="2373" width="38" height="32" rx="10"></rect>
-         <rect x="181" y="2371" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="191" y="2391">TO</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="241" y="2373" width="64" height="32"></rect>
-            <rect x="239" y="2371" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="249" y="2391">a_expr</text>
-         </a>
-         <rect x="325" y="2373" width="72" height="32" rx="10"></rect>
-         <rect x="323" y="2371" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="2391">ESCAPE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="417" y="2373" width="64" height="32"></rect>
-            <rect x="415" y="2371" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="425" y="2391">a_expr</text>
-         </a>
-         <rect x="85" y="2417" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="2415" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2435">NOT</text>
-         <rect x="153" y="2417" width="78" height="32" rx="10"></rect>
-         <rect x="151" y="2415" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="2435">SIMILAR</text>
-         <rect x="251" y="2417" width="38" height="32" rx="10"></rect>
-         <rect x="249" y="2415" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="259" y="2435">TO</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="309" y="2417" width="64" height="32"></rect>
-            <rect x="307" y="2415" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="317" y="2435">a_expr</text>
-         </a>
-         <rect x="85" y="2461" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="2459" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2479">NOT</text>
-         <rect x="153" y="2461" width="78" height="32" rx="10"></rect>
-         <rect x="151" y="2459" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="2479">SIMILAR</text>
-         <rect x="251" y="2461" width="38" height="32" rx="10"></rect>
-         <rect x="249" y="2459" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="259" y="2479">TO</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="309" y="2461" width="64" height="32"></rect>
-            <rect x="307" y="2459" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="317" y="2479">a_expr</text>
-         </a>
-         <rect x="393" y="2461" width="72" height="32" rx="10"></rect>
-         <rect x="391" y="2459" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="401" y="2479">ESCAPE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="485" y="2461" width="64" height="32"></rect>
-            <rect x="483" y="2459" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="493" y="2479">a_expr</text>
-         </a>
-         <rect x="85" y="2505" width="30" height="32" rx="10"></rect>
-         <rect x="83" y="2503" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2523">~</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="2505" width="64" height="32"></rect>
-            <rect x="133" y="2503" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="2523">a_expr</text>
-         </a>
-         <rect x="85" y="2549" width="132" height="32" rx="10"></rect>
-         <rect x="83" y="2547" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2567">NOT_REGMATCH</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="237" y="2549" width="64" height="32"></rect>
-            <rect x="235" y="2547" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="245" y="2567">a_expr</text>
-         </a>
-         <rect x="85" y="2593" width="100" height="32" rx="10"></rect>
-         <rect x="83" y="2591" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2611">REGIMATCH</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="205" y="2593" width="64" height="32"></rect>
-            <rect x="203" y="2591" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="213" y="2611">a_expr</text>
-         </a>
-         <rect x="85" y="2637" width="138" height="32" rx="10"></rect>
-         <rect x="83" y="2635" width="138" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2655">NOT_REGIMATCH</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="243" y="2637" width="64" height="32"></rect>
-            <rect x="241" y="2635" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="251" y="2655">a_expr</text>
-         </a>
-         <rect x="85" y="2681" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="2679" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2699">IS</text>
-         <rect x="139" y="2681" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="2679" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="2699">NAN</text>
-         <rect x="85" y="2725" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="2723" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2743">IS</text>
-         <rect x="139" y="2725" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="2723" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="2743">NOT</text>
-         <rect x="207" y="2725" width="48" height="32" rx="10"></rect>
-         <rect x="205" y="2723" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="2743">NAN</text>
-         <rect x="85" y="2769" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="2767" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2787">IS</text>
-         <rect x="139" y="2769" width="56" height="32" rx="10"></rect>
-         <rect x="137" y="2767" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="2787">NULL</text>
-         <rect x="85" y="2813" width="70" height="32" rx="10"></rect>
-         <rect x="83" y="2811" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2831">ISNULL</text>
-         <rect x="85" y="2857" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="2855" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2875">IS</text>
-         <rect x="139" y="2857" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="2855" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="2875">NOT</text>
-         <rect x="207" y="2857" width="56" height="32" rx="10"></rect>
-         <rect x="205" y="2855" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="2875">NULL</text>
-         <rect x="85" y="2901" width="84" height="32" rx="10"></rect>
-         <rect x="83" y="2899" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2919">NOTNULL</text>
-         <rect x="85" y="2945" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="2943" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="2963">IS</text>
-         <rect x="139" y="2945" width="54" height="32" rx="10"></rect>
-         <rect x="137" y="2943" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="2963">TRUE</text>
-         <rect x="85" y="2989" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="2987" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3007">IS</text>
-         <rect x="139" y="2989" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="2987" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3007">NOT</text>
-         <rect x="207" y="2989" width="54" height="32" rx="10"></rect>
-         <rect x="205" y="2987" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="3007">TRUE</text>
-         <rect x="85" y="3033" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3031" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3051">IS</text>
-         <rect x="139" y="3033" width="62" height="32" rx="10"></rect>
-         <rect x="137" y="3031" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3051">FALSE</text>
-         <rect x="85" y="3077" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3075" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3095">IS</text>
-         <rect x="139" y="3077" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="3075" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3095">NOT</text>
-         <rect x="207" y="3077" width="62" height="32" rx="10"></rect>
-         <rect x="205" y="3075" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="3095">FALSE</text>
-         <rect x="85" y="3121" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3119" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3139">IS</text>
-         <rect x="139" y="3121" width="94" height="32" rx="10"></rect>
-         <rect x="137" y="3119" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3139">UNKNOWN</text>
-         <rect x="85" y="3165" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3163" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3183">IS</text>
-         <rect x="139" y="3165" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="3163" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3183">NOT</text>
-         <rect x="207" y="3165" width="94" height="32" rx="10"></rect>
-         <rect x="205" y="3163" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="3183">UNKNOWN</text>
-         <rect x="85" y="3209" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3207" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3227">IS</text>
-         <rect x="139" y="3209" width="86" height="32" rx="10"></rect>
-         <rect x="137" y="3207" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3227">DISTINCT</text>
-         <rect x="245" y="3209" width="58" height="32" rx="10"></rect>
-         <rect x="243" y="3207" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="253" y="3227">FROM</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="323" y="3209" width="64" height="32"></rect>
-            <rect x="321" y="3207" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="331" y="3227">a_expr</text>
-         </a>
-         <rect x="85" y="3253" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3251" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3271">IS</text>
-         <rect x="139" y="3253" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="3251" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3271">NOT</text>
-         <rect x="207" y="3253" width="86" height="32" rx="10"></rect>
-         <rect x="205" y="3251" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="3271">DISTINCT</text>
-         <rect x="313" y="3253" width="58" height="32" rx="10"></rect>
-         <rect x="311" y="3251" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="321" y="3271">FROM</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="391" y="3253" width="64" height="32"></rect>
-            <rect x="389" y="3251" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="399" y="3271">a_expr</text>
-         </a>
-         <rect x="85" y="3297" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3295" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3315">IS</text>
-         <rect x="139" y="3297" width="38" height="32" rx="10"></rect>
-         <rect x="137" y="3295" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3315">OF</text>
-         <rect x="197" y="3297" width="26" height="32" rx="10"></rect>
-         <rect x="195" y="3295" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="205" y="3315">(</text>
-         <a xlink:href="#type_list" xlink:title="type_list">
-            <rect x="243" y="3297" width="74" height="32"></rect>
-            <rect x="241" y="3295" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="251" y="3315">type_list</text>
-         </a>
-         <rect x="337" y="3297" width="26" height="32" rx="10"></rect>
-         <rect x="335" y="3295" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="345" y="3315">)</text>
-         <rect x="85" y="3341" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="3339" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3359">IS</text>
-         <rect x="139" y="3341" width="48" height="32" rx="10"></rect>
-         <rect x="137" y="3339" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="3359">NOT</text>
-         <rect x="207" y="3341" width="38" height="32" rx="10"></rect>
-         <rect x="205" y="3339" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="3359">OF</text>
-         <rect x="265" y="3341" width="26" height="32" rx="10"></rect>
-         <rect x="263" y="3339" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="273" y="3359">(</text>
-         <a xlink:href="#type_list" xlink:title="type_list">
-            <rect x="311" y="3341" width="74" height="32"></rect>
-            <rect x="309" y="3339" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="319" y="3359">type_list</text>
-         </a>
-         <rect x="405" y="3341" width="26" height="32" rx="10"></rect>
-         <rect x="403" y="3339" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="413" y="3359">)</text>
-         <rect x="85" y="3385" width="84" height="32" rx="10"></rect>
-         <rect x="83" y="3383" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3403">BETWEEN</text>
-         <a xlink:href="#opt_asymmetric" xlink:title="opt_asymmetric">
-            <rect x="189" y="3385" width="120" height="32"></rect>
-            <rect x="187" y="3383" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="197" y="3403">opt_asymmetric</text>
-         </a>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="329" y="3385" width="64" height="32"></rect>
-            <rect x="327" y="3383" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="337" y="3403">b_expr</text>
-         </a>
-         <rect x="413" y="3385" width="48" height="32" rx="10"></rect>
-         <rect x="411" y="3383" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="421" y="3403">AND</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="481" y="3385" width="64" height="32"></rect>
-            <rect x="479" y="3383" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="489" y="3403">a_expr</text>
-         </a>
-         <rect x="85" y="3429" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="3427" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3447">NOT</text>
-         <rect x="153" y="3429" width="84" height="32" rx="10"></rect>
-         <rect x="151" y="3427" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="3447">BETWEEN</text>
-         <a xlink:href="#opt_asymmetric" xlink:title="opt_asymmetric">
-            <rect x="257" y="3429" width="120" height="32"></rect>
-            <rect x="255" y="3427" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="265" y="3447">opt_asymmetric</text>
-         </a>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="397" y="3429" width="64" height="32"></rect>
-            <rect x="395" y="3427" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="405" y="3447">b_expr</text>
-         </a>
-         <rect x="481" y="3429" width="48" height="32" rx="10"></rect>
-         <rect x="479" y="3427" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="489" y="3447">AND</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="549" y="3429" width="64" height="32"></rect>
-            <rect x="547" y="3427" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="557" y="3447">a_expr</text>
-         </a>
-         <rect x="85" y="3473" width="84" height="32" rx="10"></rect>
-         <rect x="83" y="3471" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3491">BETWEEN</text>
-         <rect x="189" y="3473" width="100" height="32" rx="10"></rect>
-         <rect x="187" y="3471" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="197" y="3491">SYMMETRIC</text>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="309" y="3473" width="64" height="32"></rect>
-            <rect x="307" y="3471" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="317" y="3491">b_expr</text>
-         </a>
-         <rect x="393" y="3473" width="48" height="32" rx="10"></rect>
-         <rect x="391" y="3471" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="401" y="3491">AND</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="461" y="3473" width="64" height="32"></rect>
-            <rect x="459" y="3471" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="469" y="3491">a_expr</text>
-         </a>
-         <rect x="85" y="3517" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="3515" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3535">NOT</text>
-         <rect x="153" y="3517" width="84" height="32" rx="10"></rect>
-         <rect x="151" y="3515" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="3535">BETWEEN</text>
-         <rect x="257" y="3517" width="100" height="32" rx="10"></rect>
-         <rect x="255" y="3515" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="265" y="3535">SYMMETRIC</text>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="377" y="3517" width="64" height="32"></rect>
-            <rect x="375" y="3515" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="385" y="3535">b_expr</text>
-         </a>
-         <rect x="461" y="3517" width="48" height="32" rx="10"></rect>
-         <rect x="459" y="3515" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="469" y="3535">AND</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="529" y="3517" width="64" height="32"></rect>
-            <rect x="527" y="3515" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="3535">a_expr</text>
-         </a>
-         <rect x="85" y="3561" width="36" height="32" rx="10"></rect>
-         <rect x="83" y="3559" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3579">IN</text>
-         <a xlink:href="#in_expr" xlink:title="in_expr">
-            <rect x="141" y="3561" width="66" height="32"></rect>
-            <rect x="139" y="3559" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="149" y="3579">in_expr</text>
-         </a>
-         <rect x="85" y="3605" width="48" height="32" rx="10"></rect>
-         <rect x="83" y="3603" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="3623">NOT</text>
-         <rect x="153" y="3605" width="36" height="32" rx="10"></rect>
-         <rect x="151" y="3603" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="3623">IN</text>
-         <a xlink:href="#in_expr" xlink:title="in_expr">
-            <rect x="209" y="3605" width="66" height="32"></rect>
-            <rect x="207" y="3603" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="217" y="3623">in_expr</text>
-         </a>
-         <a xlink:href="#subquery_op" xlink:title="subquery_op">
-            <rect x="85" y="3649" width="102" height="32"></rect>
-            <rect x="83" y="3647" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="93" y="3667">subquery_op</text>
-         </a>
-         <a xlink:href="#sub_type" xlink:title="sub_type">
-            <rect x="207" y="3649" width="78" height="32"></rect>
-            <rect x="205" y="3647" width="78" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="215" y="3667">sub_type</text>
-         </a>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="305" y="3649" width="64" height="32"></rect>
-            <rect x="303" y="3647" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="313" y="3667">a_expr</text>
-         </a>
-         <path class="line" d="m19 17 h2 m20 0 h10 m62 0 h10 m0 0 h110 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-182 10 h10 m30 0 h10 m0 0 h18 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v24 m88 0 v-24 m-88 24 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m26 0 h10 m0 0 h22 m-78 -10 v20 m88 0 v-20 m-88 20 v24 m88 0 v-24 m-88 24 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m30 0 h10 m0 0 h18 m-78 -10 v20 m88 0 v-20 m-88 20 v24 m88 0 v-24 m-88 24 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -132 h10 m64 0 h10 m-202 -10 v20 m212 0 v-20 m-212 20 v156 m212 0 v-156 m-212 156 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m80 0 h10 m0 0 h92 m22 -220 l2 0 m2 0 l2 0 m2 0 l2 0 m-264 302 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m90 0 h10 m0 0 h10 m92 0 h10 m0 0 h326 m-568 0 h20 m548 0 h20 m-588 0 q10 0 10 10 m568 0 q0 -10 10 -10 m-578 10 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m128 0 h10 m0 0 h10 m82 0 h10 m0 0 h298 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m80 0 h10 m0 0 h10 m114 0 h10 m0 0 h314 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m36 0 h10 m0 0 h10 m52 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h260 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m28 0 h10 m0 0 h10 m64 0 h10 m0 0 h416 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m28 0 h10 m0 0 h10 m64 0 h10 m0 0 h416 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h352 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m64 0 h10 m0 0 h410 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m162 0 h10 m0 0 h10 m64 0 h10 m0 0 h282 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m148 0 h10 m0 0 h10 m64 0 h10 m0 0 h296 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h352 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m128 0 h10 m0 0 h10 m64 0 h10 m0 0 h316 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m76 0 h10 m0 0 h10 m64 0 h10 m0 0 h368 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m68 0 h10 m0 0 h10 m64 0 h10 m0 0 h376 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m70 0 h10 m0 0 h10 m64 0 h10 m0 0 h374 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m88 0 h10 m0 0 h10 m64 0 h10 m0 0 h356 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m96 0 h10 m0 0 h10 m64 0 h10 m0 0 h348 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m134 0 h10 m0 0 h10 m64 0 h10 m0 0 h310 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m140 0 h10 m0 0 h10 m64 0 h10 m0 0 h304 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m120 0 h10 m0 0 h10 m64 0 h10 m0 0 h324 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m262 0 h10 m0 0 h10 m64 0 h10 m0 0 h182 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m86 0 h10 m0 0 h10 m64 0 h10 m0 0 h358 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m226 0 h10 m0 0 h10 m64 0 h10 m0 0 h218 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m118 0 h10 m0 0 h10 m64 0 h10 m0 0 h326 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m144 0 h10 m0 0 h10 m64 0 h10 m0 0 h300 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m112 0 h10 m0 0 h10 m64 0 h10 m0 0 h332 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h396 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m40 0 h10 m0 0 h10 m64 0 h10 m0 0 h404 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h394 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h218 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h326 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h150 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h388 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h212 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h320 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h144 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h308 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h132 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h240 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h64 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m132 0 h10 m0 0 h10 m64 0 h10 m0 0 h312 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m100 0 h10 m0 0 h10 m64 0 h10 m0 0 h344 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m138 0 h10 m0 0 h10 m64 0 h10 m0 0 h306 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h426 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m48 0 h10 m0 0 h358 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m56 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m70 0 h10 m0 0 h458 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h350 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m84 0 h10 m0 0 h444 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m54 0 h10 m0 0 h420 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m54 0 h10 m0 0 h352 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m62 0 h10 m0 0 h412 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m62 0 h10 m0 0 h344 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m94 0 h10 m0 0 h380 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m94 0 h10 m0 0 h312 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m0 0 h226 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m0 0 h158 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h250 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h182 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m84 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h68 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m84 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h88 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h20 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m36 0 h10 m0 0 h10 m66 0 h10 m0 0 h406 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m66 0 h10 m0 0 h338 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m102 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m64 0 h10 m0 0 h244 m-588 -3344 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m588 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-588 0 h10 m0 0 h578 m-628 32 h20 m628 0 h20 m-668 0 q10 0 10 10 m648 0 q0 -10 10 -10 m-658 10 v3358 m648 0 v-3358 m-648 3358 q0 10 10 10 m628 0 q10 0 10 -10 m-638 10 h10 m0 0 h618 m23 -3378 h-3"></path>
-         <polygon points="691 319 699 315 699 323"></polygon>
-         <polygon points="691 319 683 315 683 323"></polygon>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">PAUSE</text>
+         <rect x="135" y="3" width="46" height="32" rx="10"></rect>
+         <rect x="133" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="21">JOB</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="201" y="3" width="64" height="32"></rect>
+            <rect x="199" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="209" y="21">a_expr</text>
+         </a>
+         <rect x="135" y="47" width="56" height="32" rx="10"></rect>
+         <rect x="133" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="65">JOBS</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="231" y="47" width="92" height="32"></rect>
+            <rect x="229" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="65">select_stmt</text>
+         </a>
+         <a xlink:href="#for_schedules_clause" xlink:title="for_schedules_clause">
+            <rect x="231" y="91" width="156" height="32"></rect>
+            <rect x="229" y="89" width="156" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="109">for_schedules_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h142 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m56 0 h10 m20 0 h10 m92 0 h10 m0 0 h64 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v24 m196 0 v-24 m-196 24 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m156 0 h10 m43 -88 h-3"></path>
+         <polygon points="445 17 453 13 453 21"></polygon>
+         <polygon points="445 17 437 13 437 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#alter_column_default" title="alter_column_default">alter_column_default</a></li>
-            <li><a href="#alter_split_index_stmt" title="alter_split_index_stmt">alter_split_index_stmt</a></li>
-            <li><a href="#alter_split_stmt" title="alter_split_stmt">alter_split_stmt</a></li>
-            <li><a href="#array_subscript" title="array_subscript">array_subscript</a></li>
-            <li><a href="#as_of_clause" title="as_of_clause">as_of_clause</a></li>
-            <li><a href="#cancel_jobs_stmt" title="cancel_jobs_stmt">cancel_jobs_stmt</a></li>
-            <li><a href="#cancel_queries_stmt" title="cancel_queries_stmt">cancel_queries_stmt</a></li>
-            <li><a href="#cancel_sessions_stmt" title="cancel_sessions_stmt">cancel_sessions_stmt</a></li>
-            <li><a href="#case_arg" title="case_arg">case_arg</a></li>
-            <li><a href="#case_default" title="case_default">case_default</a></li>
-            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
-            <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-            <li><a href="#expr_list" title="expr_list">expr_list</a></li>
-            <li><a href="#extract_list" title="extract_list">extract_list</a></li>
-            <li><a href="#filter_clause" title="filter_clause">filter_clause</a></li>
-            <li><a href="#frame_bound" title="frame_bound">frame_bound</a></li>
-            <li><a href="#func_expr_common_subexpr" title="func_expr_common_subexpr">func_expr_common_subexpr</a></li>
-            <li><a href="#having_clause" title="having_clause">having_clause</a></li>
-            <li><a href="#index_elem" title="index_elem">index_elem</a></li>
-            <li><a href="#join_qual" title="join_qual">join_qual</a></li>
-            <li><a href="#limit_clause" title="limit_clause">limit_clause</a></li>
-            <li><a href="#offset_clause" title="offset_clause">offset_clause</a></li>
-            <li><a href="#opt_alter_column_using" title="opt_alter_column_using">opt_alter_column_using</a></li>
-            <li><a href="#opt_hash_sharded" title="opt_hash_sharded">opt_hash_sharded</a></li>
-            <li><a href="#opt_slice_bound" title="opt_slice_bound">opt_slice_bound</a></li>
-            <li><a href="#overlay_list" title="overlay_list">overlay_list</a></li>
-            <li><a href="#overlay_placing" title="overlay_placing">overlay_placing</a></li>
             <li><a href="#pause_stmt" title="pause_stmt">pause_stmt</a></li>
-            <li><a href="#resume_stmt" title="resume_stmt">resume_stmt</a></li>
-            <li><a href="#show_jobs_stmt" title="show_jobs_stmt">show_jobs_stmt</a></li>
-            <li><a href="#single_set_clause" title="single_set_clause">single_set_clause</a></li>
-            <li><a href="#sortby" title="sortby">sortby</a></li>
-            <li><a href="#special_function" title="special_function">special_function</a></li>
-            <li><a href="#substr_for" title="substr_for">substr_for</a></li>
-            <li><a href="#substr_from" title="substr_from">substr_from</a></li>
-            <li><a href="#substr_list" title="substr_list">substr_list</a></li>
-            <li><a href="#target_elem" title="target_elem">target_elem</a></li>
-            <li><a href="#trim_list" title="trim_list">trim_list</a></li>
-            <li><a href="#tuple1_ambiguous_values" title="tuple1_ambiguous_values">tuple1_ambiguous_values</a></li>
-            <li><a href="#tuple1_unambiguous_values" title="tuple1_unambiguous_values">tuple1_unambiguous_values</a></li>
-            <li><a href="#var_value" title="var_value">var_value</a></li>
-            <li><a href="#when_clause" title="when_clause">when_clause</a></li>
-            <li><a href="#where_clause" title="where_clause">where_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="pause_schedules_stmt" href="#pause_schedules_stmt">pause_schedules_stmt:</a></p>
+      <svg width="394" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">PAUSE</text>
+         <rect x="135" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="133" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="21">SCHEDULE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="247" y="3" width="64" height="32"></rect>
+            <rect x="245" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="255" y="21">a_expr</text>
+         </a>
+         <rect x="135" y="47" width="100" height="32" rx="10"></rect>
+         <rect x="133" y="45" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="65">SCHEDULES</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="255" y="47" width="92" height="32"></rect>
+            <rect x="253" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="263" y="65">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h36 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v24 m252 0 v-24 m-252 24 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m100 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"></path>
+         <polygon points="385 17 393 13 393 21"></polygon>
+         <polygon points="385 17 377 13 377 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#pause_stmt" title="pause_stmt">pause_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="reset_session_stmt" href="#reset_session_stmt">reset_session_stmt:</a></p>
       <svg width="378" height="68">
@@ -3995,26 +3500,95 @@
          </p><ul>
             <li><a href="#reset_stmt" title="reset_stmt">reset_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="partitioned_backup_list" href="#partitioned_backup_list">partitioned_backup_list:</a></p>
-      <svg width="240" height="80">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="list_of_string_or_placeholder_opt_list" href="#list_of_string_or_placeholder_opt_list">list_of_string_or_placeholder_opt_list:</a></p>
+      <svg width="310" height="80">
          
          <polygon points="9 61 1 57 1 65"></polygon>
          <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#partitioned_backup" xlink:title="partitioned_backup">
-            <rect x="51" y="47" width="142" height="32"></rect>
-            <rect x="49" y="45" width="142" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">partitioned_backup</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="51" y="47" width="212" height="32"></rect>
+            <rect x="49" y="45" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">string_or_placeholder_opt_list</text>
          </a>
          <rect x="51" y="3" width="24" height="32" rx="10"></rect>
          <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m142 0 h10 m-182 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m162 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-162 0 h10 m24 0 h10 m0 0 h118 m23 44 h-3"></path>
-         <polygon points="231 61 239 57 239 65"></polygon>
-         <polygon points="231 61 223 57 223 65"></polygon>
+         <path class="line" d="m17 61 h2 m20 0 h10 m212 0 h10 m-252 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m232 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-232 0 h10 m24 0 h10 m0 0 h188 m23 44 h-3"></path>
+         <polygon points="301 61 309 57 309 65"></polygon>
+         <polygon points="301 61 293 57 293 65"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="resume_jobs_stmt" href="#resume_jobs_stmt">resume_jobs_stmt:</a></p>
+      <svg width="464" height="124">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">RESUME</text>
+         <rect x="145" y="3" width="46" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">JOB</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="211" y="3" width="64" height="32"></rect>
+            <rect x="209" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="219" y="21">a_expr</text>
+         </a>
+         <rect x="145" y="47" width="56" height="32" rx="10"></rect>
+         <rect x="143" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="65">JOBS</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="241" y="47" width="92" height="32"></rect>
+            <rect x="239" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="65">select_stmt</text>
+         </a>
+         <a xlink:href="#for_schedules_clause" xlink:title="for_schedules_clause">
+            <rect x="241" y="91" width="156" height="32"></rect>
+            <rect x="239" y="89" width="156" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="109">for_schedules_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h142 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m56 0 h10 m20 0 h10 m92 0 h10 m0 0 h64 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v24 m196 0 v-24 m-196 24 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m156 0 h10 m43 -88 h-3"></path>
+         <polygon points="455 17 463 13 463 21"></polygon>
+         <polygon points="455 17 447 13 447 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#resume_stmt" title="resume_stmt">resume_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="resume_schedules_stmt" href="#resume_schedules_stmt">resume_schedules_stmt:</a></p>
+      <svg width="404" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">RESUME</text>
+         <rect x="145" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="143" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="21">SCHEDULE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="257" y="3" width="64" height="32"></rect>
+            <rect x="255" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="265" y="21">a_expr</text>
+         </a>
+         <rect x="145" y="47" width="100" height="32" rx="10"></rect>
+         <rect x="143" y="45" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="65">SCHEDULES</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="265" y="47" width="92" height="32"></rect>
+            <rect x="263" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="273" y="65">select_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h36 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v24 m252 0 v-24 m-252 24 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m100 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"></path>
+         <polygon points="395 17 403 13 403 21"></polygon>
+         <polygon points="395 17 387 13 387 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#resume_stmt" title="resume_stmt">resume_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="scrub_table_stmt" href="#scrub_table_stmt">scrub_table_stmt:</a></p>
       <svg width="608" height="102">
@@ -4502,6 +4076,25 @@
          </p><ul>
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_enums_stmt" href="#show_enums_stmt">show_enums_stmt:</a></p>
+      <svg width="210" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="115" y="3" width="68" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">ENUMS</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m68 0 h10 m3 0 h-3"></path>
+         <polygon points="201 17 209 13 209 21"></polygon>
+         <polygon points="201 17 193 13 193 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_grants_stmt" href="#show_grants_stmt">show_grants_stmt:</a></p>
       <svg width="556" height="36">
          
@@ -4635,7 +4228,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_jobs_stmt" href="#show_jobs_stmt">show_jobs_stmt:</a></p>
-      <svg width="624" height="220">
+      <svg width="624" height="264">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -4662,23 +4255,65 @@
             <rect x="463" y="77" width="92" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="473" y="97">select_stmt</text>
          </a>
-         <rect x="135" y="155" width="46" height="32" rx="10"></rect>
-         <rect x="133" y="153" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="173">JOB</text>
-         <rect x="221" y="187" width="62" height="32" rx="10"></rect>
-         <rect x="219" y="185" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="229" y="205">WHEN</text>
-         <rect x="303" y="187" width="92" height="32" rx="10"></rect>
-         <rect x="301" y="185" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="311" y="205">COMPLETE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="435" y="155" width="64" height="32"></rect>
-            <rect x="433" y="153" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="443" y="173">a_expr</text>
+         <a xlink:href="#for_schedules_clause" xlink:title="for_schedules_clause">
+            <rect x="231" y="155" width="156" height="32"></rect>
+            <rect x="229" y="153" width="156" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="173">for_schedules_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m100 0 h10 m0 0 h10 m56 0 h10 m0 0 h266 m-482 0 h20 m462 0 h20 m-502 0 q10 0 10 10 m482 0 q0 -10 10 -10 m-492 10 v24 m482 0 v-24 m-482 24 q0 10 10 10 m462 0 q10 0 10 -10 m-472 10 h10 m56 0 h10 m20 0 h10 m0 0 h336 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v12 m366 0 v-12 m-366 12 q0 10 10 10 m346 0 q10 0 10 -10 m-336 10 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m92 0 h10 m-452 -42 v20 m482 0 v-20 m-482 20 v88 m482 0 v-88 m-482 88 q0 10 10 10 m462 0 q10 0 10 -10 m-472 10 h10 m46 0 h10 m20 0 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m64 0 h10 m0 0 h78 m23 -152 h-3"></path>
+         <rect x="135" y="199" width="46" height="32" rx="10"></rect>
+         <rect x="133" y="197" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="217">JOB</text>
+         <rect x="221" y="231" width="62" height="32" rx="10"></rect>
+         <rect x="219" y="229" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="229" y="249">WHEN</text>
+         <rect x="303" y="231" width="92" height="32" rx="10"></rect>
+         <rect x="301" y="229" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="311" y="249">COMPLETE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="435" y="199" width="64" height="32"></rect>
+            <rect x="433" y="197" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="443" y="217">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m100 0 h10 m0 0 h10 m56 0 h10 m0 0 h266 m-482 0 h20 m462 0 h20 m-502 0 q10 0 10 10 m482 0 q0 -10 10 -10 m-492 10 v24 m482 0 v-24 m-482 24 q0 10 10 10 m462 0 q10 0 10 -10 m-472 10 h10 m56 0 h10 m20 0 h10 m0 0 h336 m-366 0 h20 m346 0 h20 m-386 0 q10 0 10 10 m366 0 q0 -10 10 -10 m-376 10 v12 m366 0 v-12 m-366 12 q0 10 10 10 m346 0 q10 0 10 -10 m-336 10 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m92 0 h10 m-356 -10 v20 m366 0 v-20 m-366 20 v56 m366 0 v-56 m-366 56 q0 10 10 10 m346 0 q10 0 10 -10 m-356 10 h10 m156 0 h10 m0 0 h170 m-452 -118 v20 m482 0 v-20 m-482 20 v132 m482 0 v-132 m-482 132 q0 10 10 10 m462 0 q10 0 10 -10 m-472 10 h10 m46 0 h10 m20 0 h10 m0 0 h184 m-214 0 h20 m194 0 h20 m-234 0 q10 0 10 10 m214 0 q0 -10 10 -10 m-224 10 v12 m214 0 v-12 m-214 12 q0 10 10 10 m194 0 q10 0 10 -10 m-204 10 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 -32 h10 m64 0 h10 m0 0 h78 m23 -196 h-3"></path>
          <polygon points="615 17 623 13 623 21"></polygon>
          <polygon points="615 17 607 13 607 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_schedules_stmt" href="#show_schedules_stmt">show_schedules_stmt:</a></p>
+      <svg width="682" height="112">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <a xlink:href="#schedule_state" xlink:title="schedule_state">
+            <rect x="155" y="35" width="116" height="32"></rect>
+            <rect x="153" y="33" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="163" y="53">schedule_state</text>
+         </a>
+         <rect x="311" y="3" width="100" height="32" rx="10"></rect>
+         <rect x="309" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="319" y="21">SCHEDULES</text>
+         <a xlink:href="#opt_schedule_executor_type" xlink:title="opt_schedule_executor_type">
+            <rect x="431" y="3" width="204" height="32"></rect>
+            <rect x="429" y="1" width="204" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="439" y="21">opt_schedule_executor_type</text>
+         </a>
+         <rect x="135" y="79" width="92" height="32" rx="10"></rect>
+         <rect x="133" y="77" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="97">SCHEDULE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="247" y="79" width="64" height="32"></rect>
+            <rect x="245" y="77" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="255" y="97">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m40 0 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m20 -32 h10 m100 0 h10 m0 0 h10 m204 0 h10 m-540 0 h20 m520 0 h20 m-560 0 q10 0 10 10 m540 0 q0 -10 10 -10 m-550 10 v56 m540 0 v-56 m-540 56 q0 10 10 10 m520 0 q10 0 10 -10 m-530 10 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h324 m23 -76 h-3"></path>
+         <polygon points="673 17 681 13 681 21"></polygon>
+         <polygon points="673 17 665 13 665 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -5238,8 +4873,10 @@
             <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
             <li><a href="#drop_database_stmt" title="drop_database_stmt">drop_database_stmt</a></li>
             <li><a href="#drop_index_stmt" title="drop_index_stmt">drop_index_stmt</a></li>
+            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
             <li><a href="#drop_sequence_stmt" title="drop_sequence_stmt">drop_sequence_stmt</a></li>
             <li><a href="#drop_table_stmt" title="drop_table_stmt">drop_table_stmt</a></li>
+            <li><a href="#drop_type_stmt" title="drop_type_stmt">drop_type_stmt</a></li>
             <li><a href="#drop_view_stmt" title="drop_view_stmt">drop_view_stmt</a></li>
             <li><a href="#truncate_stmt" title="truncate_stmt">truncate_stmt</a></li>
          </ul>
@@ -5310,6 +4947,7 @@
             <li><a href="#sequence_name" title="sequence_name">sequence_name</a></li>
             <li><a href="#standalone_index_name" title="standalone_index_name">standalone_index_name</a></li>
             <li><a href="#table_name" title="table_name">table_name</a></li>
+            <li><a href="#type_name" title="type_name">type_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="kv_option_list" href="#kv_option_list">kv_option_list:</a></p>
       <svg width="180" height="80">
@@ -5331,6 +4969,7 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#opt_with_options" title="opt_with_options">opt_with_options</a></li>
+            <li><a href="#opt_with_schedule_options" title="opt_with_schedule_options">opt_with_schedule_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="prefixed_column_path" href="#prefixed_column_path">prefixed_column_path:</a></p>
       <svg width="516" height="154">
@@ -5374,6 +5013,7 @@
          </p><ul>
             <li><a href="#column_path" title="column_path">column_path</a></li>
             <li><a href="#func_name" title="func_name">func_name</a></li>
+            <li><a href="#func_name_no_crdb_extra" title="func_name_no_crdb_extra">func_name_no_crdb_extra</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="index_name" href="#index_name">index_name:</a></p>
       <svg width="196" height="36">
@@ -5456,7 +5096,7 @@
             <li><a href="#values_clause" title="values_clause">values_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
-      <svg width="332" height="11872">
+      <svg width="332" height="12048">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -5472,63 +5112,63 @@
          <rect x="51" y="135" width="66" height="32" rx="10"></rect>
          <rect x="49" y="133" width="66" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="153">ADMIN</text>
-         <rect x="51" y="179" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">AGGREGATE</text>
-         <rect x="51" y="223" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">ALTER</text>
-         <rect x="51" y="267" width="36" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">AT</text>
-         <rect x="51" y="311" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">AUTOMATIC</text>
-         <rect x="51" y="355" width="134" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="134" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">AUTHORIZATION</text>
-         <rect x="51" y="399" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">BACKUP</text>
-         <rect x="51" y="443" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">BEGIN</text>
-         <rect x="51" y="487" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">BIGSERIAL</text>
-         <rect x="51" y="531" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">BLOB</text>
-         <rect x="51" y="575" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">BOOL</text>
-         <rect x="51" y="619" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">BUCKET_COUNT</text>
-         <rect x="51" y="663" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">BUNDLE</text>
-         <rect x="51" y="707" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">BY</text>
-         <rect x="51" y="751" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">BYTEA</text>
+         <rect x="51" y="179" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">AFTER</text>
+         <rect x="51" y="223" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">AGGREGATE</text>
+         <rect x="51" y="267" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">ALTER</text>
+         <rect x="51" y="311" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">ALWAYS</text>
+         <rect x="51" y="355" width="36" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">AT</text>
+         <rect x="51" y="399" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">ATTRIBUTE</text>
+         <rect x="51" y="443" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">AUTOMATIC</text>
+         <rect x="51" y="487" width="134" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">AUTHORIZATION</text>
+         <rect x="51" y="531" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">BACKUP</text>
+         <rect x="51" y="575" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">BEFORE</text>
+         <rect x="51" y="619" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">BEGIN</text>
+         <rect x="51" y="663" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">BUCKET_COUNT</text>
+         <rect x="51" y="707" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">BUNDLE</text>
+         <rect x="51" y="751" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">BY</text>
          <rect x="51" y="795" width="64" height="32" rx="10"></rect>
          <rect x="49" y="793" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">BYTES</text>
-         <rect x="51" y="839" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">CACHE</text>
-         <rect x="51" y="883" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">CANCEL</text>
-         <rect x="51" y="927" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">CASCADE</text>
-         <rect x="51" y="971" width="110" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="110" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">CHANGEFEED</text>
+         <text class="terminal" x="59" y="813">CACHE</text>
+         <rect x="51" y="839" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">CANCEL</text>
+         <rect x="51" y="883" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">CASCADE</text>
+         <rect x="51" y="927" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">CHANGEFEED</text>
+         <rect x="51" y="971" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">CLOSE</text>
          <rect x="51" y="1015" width="80" height="32" rx="10"></rect>
          <rect x="49" y="1013" width="80" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="1033">CLUSTER</text>
@@ -5538,739 +5178,751 @@
          <rect x="51" y="1103" width="88" height="32" rx="10"></rect>
          <rect x="49" y="1101" width="88" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="1121">COMMENT</text>
-         <rect x="51" y="1147" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">COMMIT</text>
-         <rect x="51" y="1191" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">COMMITTED</text>
-         <rect x="51" y="1235" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">COMPACT</text>
-         <rect x="51" y="1279" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">COMPLETE</text>
-         <rect x="51" y="1323" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">CONFLICT</text>
-         <rect x="51" y="1367" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">CONFIGURATION</text>
-         <rect x="51" y="1411" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">CONFIGURATIONS</text>
-         <rect x="51" y="1455" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">CONFIGURE</text>
-         <rect x="51" y="1499" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">CONSTRAINTS</text>
-         <rect x="51" y="1543" width="112" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">CONVERSION</text>
-         <rect x="51" y="1587" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">COPY</text>
-         <rect x="51" y="1631" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">COVERING</text>
-         <rect x="51" y="1675" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">CREATEROLE</text>
-         <rect x="51" y="1719" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">CUBE</text>
-         <rect x="51" y="1763" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">CURRENT</text>
-         <rect x="51" y="1807" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">CYCLE</text>
-         <rect x="51" y="1851" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">DATA</text>
-         <rect x="51" y="1895" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">DATABASE</text>
-         <rect x="51" y="1939" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">DATABASES</text>
-         <rect x="51" y="1983" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">DATE</text>
+         <rect x="51" y="1147" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">COMMENTS</text>
+         <rect x="51" y="1191" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">COMMIT</text>
+         <rect x="51" y="1235" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">COMMITTED</text>
+         <rect x="51" y="1279" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">COMPACT</text>
+         <rect x="51" y="1323" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">COMPLETE</text>
+         <rect x="51" y="1367" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">CONFLICT</text>
+         <rect x="51" y="1411" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">CONFIGURATION</text>
+         <rect x="51" y="1455" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">CONFIGURATIONS</text>
+         <rect x="51" y="1499" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">CONFIGURE</text>
+         <rect x="51" y="1543" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">CONSTRAINTS</text>
+         <rect x="51" y="1587" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">CONVERSION</text>
+         <rect x="51" y="1631" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">COPY</text>
+         <rect x="51" y="1675" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">COVERING</text>
+         <rect x="51" y="1719" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">CREATEROLE</text>
+         <rect x="51" y="1763" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">CUBE</text>
+         <rect x="51" y="1807" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">CURRENT</text>
+         <rect x="51" y="1851" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1849" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1869">CYCLE</text>
+         <rect x="51" y="1895" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">DATA</text>
+         <rect x="51" y="1939" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">DATABASE</text>
+         <rect x="51" y="1983" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">DATABASES</text>
          <rect x="51" y="2027" width="48" height="32" rx="10"></rect>
          <rect x="49" y="2025" width="48" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="2045">DAY</text>
          <rect x="51" y="2071" width="108" height="32" rx="10"></rect>
          <rect x="49" y="2069" width="108" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="2089">DEALLOCATE</text>
-         <rect x="51" y="2115" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">DELETE</text>
-         <rect x="51" y="2159" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">DEFERRED</text>
-         <rect x="51" y="2203" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">DISCARD</text>
-         <rect x="51" y="2247" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">DOMAIN</text>
-         <rect x="51" y="2291" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">DOUBLE</text>
-         <rect x="51" y="2335" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">DROP</text>
-         <rect x="51" y="2379" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">ENCODING</text>
-         <rect x="51" y="2423" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">ENUM</text>
-         <rect x="51" y="2467" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">ESCAPE</text>
-         <rect x="51" y="2511" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">EXCLUDE</text>
-         <rect x="51" y="2555" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">EXECUTE</text>
-         <rect x="51" y="2599" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">EXPERIMENTAL</text>
-         <rect x="51" y="2643" width="174" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="174" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">EXPERIMENTAL_AUDIT</text>
-         <rect x="51" y="2687" width="234" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="234" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">EXPERIMENTAL_FINGERPRINTS</text>
-         <rect x="51" y="2731" width="202" height="32" rx="10"></rect>
-         <rect x="49" y="2729" width="202" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">EXPERIMENTAL_RELOCATE</text>
-         <rect x="51" y="2775" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">EXPERIMENTAL_REPLICA</text>
-         <rect x="51" y="2819" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">EXPIRATION</text>
-         <rect x="51" y="2863" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">EXPLAIN</text>
-         <rect x="51" y="2907" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">EXPORT</text>
-         <rect x="51" y="2951" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">EXTENSION</text>
-         <rect x="51" y="2995" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">FILES</text>
-         <rect x="51" y="3039" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">FILTER</text>
-         <rect x="51" y="3083" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">FIRST</text>
-         <rect x="51" y="3127" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">FLOAT4</text>
-         <rect x="51" y="3171" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">FLOAT8</text>
-         <rect x="51" y="3215" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">FOLLOWING</text>
-         <rect x="51" y="3259" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="3257" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">FORCE_INDEX</text>
-         <rect x="51" y="3303" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">FUNCTION</text>
-         <rect x="51" y="3347" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">GLOBAL</text>
-         <rect x="51" y="3391" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">GRANTS</text>
-         <rect x="51" y="3435" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">GROUPS</text>
-         <rect x="51" y="3479" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">HASH</text>
-         <rect x="51" y="3523" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">HIGH</text>
-         <rect x="51" y="3567" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">HISTOGRAM</text>
-         <rect x="51" y="3611" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">HOUR</text>
-         <rect x="51" y="3655" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">IMMEDIATE</text>
+         <rect x="51" y="2115" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">DECLARE</text>
+         <rect x="51" y="2159" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">DELETE</text>
+         <rect x="51" y="2203" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">DEFAULTS</text>
+         <rect x="51" y="2247" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2245" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2265">DEFERRED</text>
+         <rect x="51" y="2291" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="2289" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2309">DETACHED</text>
+         <rect x="51" y="2335" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="2333" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2353">DISCARD</text>
+         <rect x="51" y="2379" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="2377" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2397">DOMAIN</text>
+         <rect x="51" y="2423" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="2421" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2441">DOUBLE</text>
+         <rect x="51" y="2467" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2465" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2485">DROP</text>
+         <rect x="51" y="2511" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="2509" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2529">ENCODING</text>
+         <rect x="51" y="2555" width="208" height="32" rx="10"></rect>
+         <rect x="49" y="2553" width="208" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2573">ENCRYPTION_PASSPHRASE</text>
+         <rect x="51" y="2599" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2597" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2617">ENUM</text>
+         <rect x="51" y="2643" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="2641" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2661">ENUMS</text>
+         <rect x="51" y="2687" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2685" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2705">ESCAPE</text>
+         <rect x="51" y="2731" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="2729" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2749">EXCLUDE</text>
+         <rect x="51" y="2775" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">EXCLUDING</text>
+         <rect x="51" y="2819" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">EXECUTE</text>
+         <rect x="51" y="2863" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">EXECUTION</text>
+         <rect x="51" y="2907" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">EXPERIMENTAL</text>
+         <rect x="51" y="2951" width="174" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="174" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">EXPERIMENTAL_AUDIT</text>
+         <rect x="51" y="2995" width="234" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="234" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">EXPERIMENTAL_FINGERPRINTS</text>
+         <rect x="51" y="3039" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">EXPERIMENTAL_RELOCATE</text>
+         <rect x="51" y="3083" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">EXPERIMENTAL_REPLICA</text>
+         <rect x="51" y="3127" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">EXPIRATION</text>
+         <rect x="51" y="3171" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">EXPLAIN</text>
+         <rect x="51" y="3215" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">EXPORT</text>
+         <rect x="51" y="3259" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="3257" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3277">EXTENSION</text>
+         <rect x="51" y="3303" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">FILES</text>
+         <rect x="51" y="3347" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">FILTER</text>
+         <rect x="51" y="3391" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">FIRST</text>
+         <rect x="51" y="3435" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">FOLLOWING</text>
+         <rect x="51" y="3479" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">FORCE_INDEX</text>
+         <rect x="51" y="3523" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">FUNCTION</text>
+         <rect x="51" y="3567" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">GENERATED</text>
+         <rect x="51" y="3611" width="182" height="32" rx="10"></rect>
+         <rect x="49" y="3609" width="182" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3629">GEOMETRYCOLLECTION</text>
+         <rect x="51" y="3655" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3653" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3673">GLOBAL</text>
          <rect x="51" y="3699" width="74" height="32" rx="10"></rect>
          <rect x="49" y="3697" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">IMPORT</text>
-         <rect x="51" y="3743" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="3741" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3761">INCLUDE</text>
-         <rect x="51" y="3787" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="3785" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3805">INCREMENT</text>
-         <rect x="51" y="3831" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="3829" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3849">INCREMENTAL</text>
-         <rect x="51" y="3875" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="3873" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3893">INDEXES</text>
-         <rect x="51" y="3919" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="3917" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3937">INET</text>
-         <rect x="51" y="3963" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3961" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3981">INJECT</text>
-         <rect x="51" y="4007" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="4005" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4025">INSERT</text>
-         <rect x="51" y="4051" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="4049" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4069">INT2</text>
-         <rect x="51" y="4095" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="4093" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4113">INT2VECTOR</text>
-         <rect x="51" y="4139" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="4137" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4157">INT4</text>
-         <rect x="51" y="4183" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="4181" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4201">INT8</text>
-         <rect x="51" y="4227" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="4225" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4245">INT64</text>
-         <rect x="51" y="4271" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="4269" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4289">INTERLEAVE</text>
-         <rect x="51" y="4315" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="4313" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4333">INVERTED</text>
-         <rect x="51" y="4359" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4357" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4377">ISOLATION</text>
-         <rect x="51" y="4403" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="4401" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4421">JOB</text>
-         <rect x="51" y="4447" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4445" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4465">JOBS</text>
-         <rect x="51" y="4491" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4489" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4509">JSON</text>
-         <rect x="51" y="4535" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="4533" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4553">JSONB</text>
-         <rect x="51" y="4579" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="4577" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4597">KEY</text>
+         <text class="terminal" x="59" y="3717">GRANTS</text>
+         <rect x="51" y="3743" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3741" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3761">GROUPS</text>
+         <rect x="51" y="3787" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3785" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3805">HASH</text>
+         <rect x="51" y="3831" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="3829" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3849">HIGH</text>
+         <rect x="51" y="3875" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="3873" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3893">HISTOGRAM</text>
+         <rect x="51" y="3919" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="3917" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3937">HOUR</text>
+         <rect x="51" y="3963" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="3961" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3981">IDENTITY</text>
+         <rect x="51" y="4007" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="4005" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4025">IMMEDIATE</text>
+         <rect x="51" y="4051" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4049" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4069">IMPORT</text>
+         <rect x="51" y="4095" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="4093" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4113">INCLUDE</text>
+         <rect x="51" y="4139" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="4137" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4157">INCLUDING</text>
+         <rect x="51" y="4183" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="4181" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4201">INCREMENT</text>
+         <rect x="51" y="4227" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="4225" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4245">INCREMENTAL</text>
+         <rect x="51" y="4271" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="4269" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4289">INDEXES</text>
+         <rect x="51" y="4315" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="4313" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4333">INJECT</text>
+         <rect x="51" y="4359" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="4357" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4377">INSERT</text>
+         <rect x="51" y="4403" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="4401" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4421">INTERLEAVE</text>
+         <rect x="51" y="4447" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="4445" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4465">INVERTED</text>
+         <rect x="51" y="4491" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="4489" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4509">ISOLATION</text>
+         <rect x="51" y="4535" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4533" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4553">JOB</text>
+         <rect x="51" y="4579" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="4577" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4597">JOBS</text>
          <rect x="51" y="4623" width="56" height="32" rx="10"></rect>
          <rect x="49" y="4621" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4641">KEYS</text>
-         <rect x="51" y="4667" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="4665" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4685">KV</text>
-         <rect x="51" y="4711" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="4709" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4729">LANGUAGE</text>
-         <rect x="51" y="4755" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="4753" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4773">LAST</text>
-         <rect x="51" y="4799" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="4797" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4817">LC_COLLATE</text>
-         <rect x="51" y="4843" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="4841" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4861">LC_CTYPE</text>
-         <rect x="51" y="4887" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="4885" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4905">LEASE</text>
-         <rect x="51" y="4931" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="4929" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4949">LESS</text>
-         <rect x="51" y="4975" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="4973" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4993">LEVEL</text>
-         <rect x="51" y="5019" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="5017" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5037">LIST</text>
-         <rect x="51" y="5063" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="5061" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5081">LOCAL</text>
-         <rect x="51" y="5107" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5105" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5125">LOCKED</text>
-         <rect x="51" y="5151" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="5149" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5169">LOGIN</text>
-         <rect x="51" y="5195" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="5193" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5213">LOOKUP</text>
-         <rect x="51" y="5239" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="5237" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5257">LOW</text>
-         <rect x="51" y="5283" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5281" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5301">MATCH</text>
-         <rect x="51" y="5327" width="120" height="32" rx="10"></rect>
-         <rect x="49" y="5325" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5345">MATERIALIZED</text>
-         <rect x="51" y="5371" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="5369" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5389">MAXVALUE</text>
-         <rect x="51" y="5415" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5413" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5433">MERGE</text>
-         <rect x="51" y="5459" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="5457" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5477">MINUTE</text>
-         <rect x="51" y="5503" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="5501" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5521">MINVALUE</text>
-         <rect x="51" y="5547" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="5545" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5565">MONTH</text>
-         <rect x="51" y="5591" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5589" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5609">NAMES</text>
-         <rect x="51" y="5635" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="5633" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5653">NAN</text>
-         <rect x="51" y="5679" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="5677" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5697">NAME</text>
-         <rect x="51" y="5723" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="5721" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5741">NEXT</text>
-         <rect x="51" y="5767" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="5765" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5785">NO</text>
-         <rect x="51" y="5811" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="5809" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5829">NORMAL</text>
-         <rect x="51" y="5855" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="5853" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5873">NO_INDEX_JOIN</text>
-         <rect x="51" y="5899" width="128" height="32" rx="10"></rect>
-         <rect x="49" y="5897" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5917">NOCREATEROLE</text>
-         <rect x="51" y="5943" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="5941" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5961">NOLOGIN</text>
-         <rect x="51" y="5987" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="5985" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6005">NOWAIT</text>
+         <text class="terminal" x="59" y="4641">JSON</text>
+         <rect x="51" y="4667" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4665" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4685">KEY</text>
+         <rect x="51" y="4711" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="4709" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4729">KEYS</text>
+         <rect x="51" y="4755" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="4753" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4773">KMS</text>
+         <rect x="51" y="4799" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="4797" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4817">KV</text>
+         <rect x="51" y="4843" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="4841" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4861">LANGUAGE</text>
+         <rect x="51" y="4887" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="4885" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4905">LAST</text>
+         <rect x="51" y="4931" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="4929" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4949">LATEST</text>
+         <rect x="51" y="4975" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="4973" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4993">LC_COLLATE</text>
+         <rect x="51" y="5019" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="5017" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5037">LC_CTYPE</text>
+         <rect x="51" y="5063" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="5061" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5081">LEASE</text>
+         <rect x="51" y="5107" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="5105" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5125">LESS</text>
+         <rect x="51" y="5151" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="5149" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5169">LEVEL</text>
+         <rect x="51" y="5195" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="5193" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5213">LINESTRING</text>
+         <rect x="51" y="5239" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="5237" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5257">LIST</text>
+         <rect x="51" y="5283" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5281" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5301">LOCAL</text>
+         <rect x="51" y="5327" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="5325" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5345">LOCKED</text>
+         <rect x="51" y="5371" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5369" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5389">LOGIN</text>
+         <rect x="51" y="5415" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="5413" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5433">LOOKUP</text>
+         <rect x="51" y="5459" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="5457" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5477">LOW</text>
+         <rect x="51" y="5503" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5501" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5521">MATCH</text>
+         <rect x="51" y="5547" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="5545" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5565">MATERIALIZED</text>
+         <rect x="51" y="5591" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="5589" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5609">MAXVALUE</text>
+         <rect x="51" y="5635" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5633" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5653">MERGE</text>
+         <rect x="51" y="5679" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="5677" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5697">MINUTE</text>
+         <rect x="51" y="5723" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="5721" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5741">MINVALUE</text>
+         <rect x="51" y="5767" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="5765" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5785">MULTILINESTRING</text>
+         <rect x="51" y="5811" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="5809" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5829">MULTIPOINT</text>
+         <rect x="51" y="5855" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="5853" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5873">MULTIPOLYGON</text>
+         <rect x="51" y="5899" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="5897" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5917">MONTH</text>
+         <rect x="51" y="5943" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="5941" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5961">NAMES</text>
+         <rect x="51" y="5987" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="5985" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6005">NAN</text>
          <rect x="51" y="6031" width="64" height="32" rx="10"></rect>
          <rect x="49" y="6029" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6049">NULLS</text>
-         <rect x="51" y="6075" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="6073" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6093">IGNORE_FOREIGN_KEYS</text>
-         <rect x="51" y="6119" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="6117" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6137">OF</text>
-         <rect x="51" y="6163" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="6161" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6181">OFF</text>
-         <rect x="51" y="6207" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="6205" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6225">OID</text>
-         <rect x="51" y="6251" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6249" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6269">OIDS</text>
-         <rect x="51" y="6295" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="6293" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6313">OIDVECTOR</text>
-         <rect x="51" y="6339" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="6337" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6357">OPERATOR</text>
-         <rect x="51" y="6383" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="6381" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6401">OPT</text>
-         <rect x="51" y="6427" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6425" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6445">OPTION</text>
-         <rect x="51" y="6471" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="6469" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6489">OPTIONS</text>
-         <rect x="51" y="6515" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="6513" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6533">ORDINALITY</text>
-         <rect x="51" y="6559" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6557" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6577">OTHERS</text>
-         <rect x="51" y="6603" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6601" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6621">OVER</text>
-         <rect x="51" y="6647" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="6645" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6665">OWNED</text>
-         <rect x="51" y="6691" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="6689" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6709">PARENT</text>
-         <rect x="51" y="6735" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="6733" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6753">PARTIAL</text>
-         <rect x="51" y="6779" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="6777" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6797">PARTITION</text>
-         <rect x="51" y="6823" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="6821" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6841">PARTITIONS</text>
-         <rect x="51" y="6867" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="6865" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6885">PASSWORD</text>
-         <rect x="51" y="6911" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6909" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6929">PAUSE</text>
-         <rect x="51" y="6955" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6953" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6973">PHYSICAL</text>
-         <rect x="51" y="6999" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6997" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7017">PLAN</text>
-         <rect x="51" y="7043" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7041" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7061">PLANS</text>
-         <rect x="51" y="7087" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="7085" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7105">PRECEDING</text>
-         <rect x="51" y="7131" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="7129" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7149">PREPARE</text>
-         <rect x="51" y="7175" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="7173" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7193">PRESERVE</text>
-         <rect x="51" y="7219" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="7217" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7237">PRIORITY</text>
-         <rect x="51" y="7263" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="7261" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7281">PUBLIC</text>
-         <rect x="51" y="7307" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="7305" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7325">PUBLICATION</text>
-         <rect x="51" y="7351" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="7349" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7369">QUERIES</text>
-         <rect x="51" y="7395" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="7393" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7413">QUERY</text>
-         <rect x="51" y="7439" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="7437" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7457">RANGE</text>
-         <rect x="51" y="7483" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="7481" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7501">RANGES</text>
-         <rect x="51" y="7527" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="7525" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7545">READ</text>
-         <rect x="51" y="7571" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="7569" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7589">RECURSIVE</text>
-         <rect x="51" y="7615" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="7613" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7633">REF</text>
-         <rect x="51" y="7659" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="7657" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7677">REGCLASS</text>
-         <rect x="51" y="7703" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="7701" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7721">REGPROC</text>
-         <rect x="51" y="7747" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="7745" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7765">REGPROCEDURE</text>
-         <rect x="51" y="7791" width="128" height="32" rx="10"></rect>
-         <rect x="49" y="7789" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7809">REGNAMESPACE</text>
-         <rect x="51" y="7835" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="7833" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7853">REGTYPE</text>
-         <rect x="51" y="7879" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="7877" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7897">REINDEX</text>
-         <rect x="51" y="7923" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="7921" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7941">RELEASE</text>
-         <rect x="51" y="7967" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="7965" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7985">RENAME</text>
-         <rect x="51" y="8011" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="8009" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8029">REPEATABLE</text>
+         <text class="terminal" x="59" y="6049">NEVER</text>
+         <rect x="51" y="6075" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="6073" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6093">NEXT</text>
+         <rect x="51" y="6119" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="6117" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6137">NO</text>
+         <rect x="51" y="6163" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6161" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6181">NORMAL</text>
+         <rect x="51" y="6207" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="6205" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6225">NO_INDEX_JOIN</text>
+         <rect x="51" y="6251" width="128" height="32" rx="10"></rect>
+         <rect x="49" y="6249" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6269">NOCREATEROLE</text>
+         <rect x="51" y="6295" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="6293" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6313">NOLOGIN</text>
+         <rect x="51" y="6339" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6337" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6357">NOWAIT</text>
+         <rect x="51" y="6383" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="6381" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6401">NULLS</text>
+         <rect x="51" y="6427" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="6425" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6445">IGNORE_FOREIGN_KEYS</text>
+         <rect x="51" y="6471" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="6469" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6489">OF</text>
+         <rect x="51" y="6515" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="6513" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6533">OFF</text>
+         <rect x="51" y="6559" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="6557" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6577">OIDS</text>
+         <rect x="51" y="6603" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="6601" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6621">OPERATOR</text>
+         <rect x="51" y="6647" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="6645" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6665">OPT</text>
+         <rect x="51" y="6691" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6689" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6709">OPTION</text>
+         <rect x="51" y="6735" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="6733" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6753">OPTIONS</text>
+         <rect x="51" y="6779" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="6777" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6797">ORDINALITY</text>
+         <rect x="51" y="6823" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6821" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6841">OTHERS</text>
+         <rect x="51" y="6867" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="6865" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6885">OVER</text>
+         <rect x="51" y="6911" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6909" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6929">OWNED</text>
+         <rect x="51" y="6955" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6953" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6973">OWNER</text>
+         <rect x="51" y="6999" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6997" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7017">PARENT</text>
+         <rect x="51" y="7043" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7041" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7061">PARTIAL</text>
+         <rect x="51" y="7087" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="7085" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7105">PARTITION</text>
+         <rect x="51" y="7131" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="7129" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7149">PARTITIONS</text>
+         <rect x="51" y="7175" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="7173" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7193">PASSWORD</text>
+         <rect x="51" y="7219" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7217" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7237">PAUSE</text>
+         <rect x="51" y="7263" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="7261" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7281">PAUSED</text>
+         <rect x="51" y="7307" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="7305" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7325">PHYSICAL</text>
+         <rect x="51" y="7351" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="7349" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7369">PLAN</text>
+         <rect x="51" y="7395" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7393" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7413">PLANS</text>
+         <rect x="51" y="7439" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="7437" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7457">PRECEDING</text>
+         <rect x="51" y="7483" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="7481" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7501">PREPARE</text>
+         <rect x="51" y="7527" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="7525" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7545">PRESERVE</text>
+         <rect x="51" y="7571" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="7569" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7589">PRIORITY</text>
+         <rect x="51" y="7615" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7613" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7633">PUBLIC</text>
+         <rect x="51" y="7659" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="7657" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7677">PUBLICATION</text>
+         <rect x="51" y="7703" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="7701" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7721">QUERIES</text>
+         <rect x="51" y="7747" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="7745" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7765">QUERY</text>
+         <rect x="51" y="7791" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="7789" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7809">RANGE</text>
+         <rect x="51" y="7835" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="7833" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7853">RANGES</text>
+         <rect x="51" y="7879" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="7877" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7897">READ</text>
+         <rect x="51" y="7923" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="7921" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7941">RECURRING</text>
+         <rect x="51" y="7967" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="7965" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7985">RECURSIVE</text>
+         <rect x="51" y="8011" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="8009" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8029">REF</text>
          <rect x="51" y="8055" width="80" height="32" rx="10"></rect>
          <rect x="49" y="8053" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8073">REPLACE</text>
-         <rect x="51" y="8099" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="8097" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8117">RESET</text>
-         <rect x="51" y="8143" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="8141" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8161">RESTORE</text>
-         <rect x="51" y="8187" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="8185" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8205">RESTRICT</text>
-         <rect x="51" y="8231" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8229" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8249">RESUME</text>
-         <rect x="51" y="8275" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8273" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8293">REVOKE</text>
-         <rect x="51" y="8319" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8317" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8337">ROLE</text>
-         <rect x="51" y="8363" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8361" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8381">ROLES</text>
-         <rect x="51" y="8407" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="8405" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8425">ROLLBACK</text>
-         <rect x="51" y="8451" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8449" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8469">ROLLUP</text>
-         <rect x="51" y="8495" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="8493" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8513">ROWS</text>
-         <rect x="51" y="8539" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="8537" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8557">RULE</text>
-         <rect x="51" y="8583" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="8581" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8601">SETTING</text>
-         <rect x="51" y="8627" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="8625" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8645">SETTINGS</text>
-         <rect x="51" y="8671" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="8669" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8689">STATUS</text>
-         <rect x="51" y="8715" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="8713" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8733">SAVEPOINT</text>
-         <rect x="51" y="8759" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="8757" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8777">SCATTER</text>
-         <rect x="51" y="8803" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="8801" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8821">SCHEMA</text>
+         <text class="terminal" x="59" y="8073">REINDEX</text>
+         <rect x="51" y="8099" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="8097" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8117">RELEASE</text>
+         <rect x="51" y="8143" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8141" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8161">RENAME</text>
+         <rect x="51" y="8187" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="8185" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8205">REPEATABLE</text>
+         <rect x="51" y="8231" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="8229" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8249">REPLACE</text>
+         <rect x="51" y="8275" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="8273" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8293">RESET</text>
+         <rect x="51" y="8319" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="8317" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8337">RESTORE</text>
+         <rect x="51" y="8363" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="8361" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8381">RESTRICT</text>
+         <rect x="51" y="8407" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8405" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8425">RESUME</text>
+         <rect x="51" y="8451" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="8449" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8469">RETRY</text>
+         <rect x="51" y="8495" width="160" height="32" rx="10"></rect>
+         <rect x="49" y="8493" width="160" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8513">REVISION_HISTORY</text>
+         <rect x="51" y="8539" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8537" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8557">REVOKE</text>
+         <rect x="51" y="8583" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8581" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8601">ROLE</text>
+         <rect x="51" y="8627" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="8625" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8645">ROLES</text>
+         <rect x="51" y="8671" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="8669" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8689">ROLLBACK</text>
+         <rect x="51" y="8715" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8713" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8733">ROLLUP</text>
+         <rect x="51" y="8759" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="8757" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8777">ROWS</text>
+         <rect x="51" y="8803" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="8801" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8821">RULE</text>
          <rect x="51" y="8847" width="84" height="32" rx="10"></rect>
          <rect x="49" y="8845" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8865">SCHEMAS</text>
-         <rect x="51" y="8891" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="8889" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8909">SCRUB</text>
-         <rect x="51" y="8935" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8933" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8953">SEARCH</text>
-         <rect x="51" y="8979" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="8977" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8997">SECOND</text>
-         <rect x="51" y="9023" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="9021" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9041">SERIAL</text>
-         <rect x="51" y="9067" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="9065" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9085">SERIALIZABLE</text>
-         <rect x="51" y="9111" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="9109" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9129">SERIAL2</text>
-         <rect x="51" y="9155" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="9153" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9173">SERIAL4</text>
-         <rect x="51" y="9199" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="9197" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9217">SERIAL8</text>
-         <rect x="51" y="9243" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="9241" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9261">SEQUENCE</text>
-         <rect x="51" y="9287" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="9285" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9305">SEQUENCES</text>
-         <rect x="51" y="9331" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="9329" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9349">SERVER</text>
-         <rect x="51" y="9375" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="9373" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9393">SESSION</text>
-         <rect x="51" y="9419" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="9417" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9437">SESSIONS</text>
-         <rect x="51" y="9463" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="9461" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9481">SET</text>
-         <rect x="51" y="9507" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="9505" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9525">SHARE</text>
-         <rect x="51" y="9551" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="9549" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9569">SHOW</text>
-         <rect x="51" y="9595" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="9593" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9613">SIMPLE</text>
-         <rect x="51" y="9639" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="9637" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9657">SKIP</text>
-         <rect x="51" y="9683" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="9681" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9701">SMALLSERIAL</text>
-         <rect x="51" y="9727" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="9725" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9745">SNAPSHOT</text>
-         <rect x="51" y="9771" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="9769" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9789">SPLIT</text>
-         <rect x="51" y="9815" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="9813" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9833">SQL</text>
-         <rect x="51" y="9859" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="9857" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9877">START</text>
-         <rect x="51" y="9903" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="9901" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9921">STATISTICS</text>
-         <rect x="51" y="9947" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="9945" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9965">STDIN</text>
-         <rect x="51" y="9991" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="9989" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10009">STORE</text>
-         <rect x="51" y="10035" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10033" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10053">STORED</text>
-         <rect x="51" y="10079" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="10077" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10097">STORING</text>
-         <rect x="51" y="10123" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="10121" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10141">STRICT</text>
-         <rect x="51" y="10167" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="10165" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10185">STRING</text>
-         <rect x="51" y="10211" width="124" height="32" rx="10"></rect>
-         <rect x="49" y="10209" width="124" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10229">SUBSCRIPTION</text>
+         <text class="terminal" x="59" y="8865">RUNNING</text>
+         <rect x="51" y="8891" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="8889" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8909">SCHEDULE</text>
+         <rect x="51" y="8935" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="8933" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8953">SCHEDULES</text>
+         <rect x="51" y="8979" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="8977" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8997">SETTING</text>
+         <rect x="51" y="9023" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="9021" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9041">SETTINGS</text>
+         <rect x="51" y="9067" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="9065" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9085">STATUS</text>
+         <rect x="51" y="9111" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="9109" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9129">SAVEPOINT</text>
+         <rect x="51" y="9155" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="9153" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9173">SCATTER</text>
+         <rect x="51" y="9199" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="9197" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9217">SCHEMA</text>
+         <rect x="51" y="9243" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="9241" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9261">SCHEMAS</text>
+         <rect x="51" y="9287" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="9285" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9305">SCRUB</text>
+         <rect x="51" y="9331" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="9329" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9349">SEARCH</text>
+         <rect x="51" y="9375" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="9373" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9393">SECOND</text>
+         <rect x="51" y="9419" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="9417" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9437">SERIALIZABLE</text>
+         <rect x="51" y="9463" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="9461" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9481">SEQUENCE</text>
+         <rect x="51" y="9507" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="9505" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9525">SEQUENCES</text>
+         <rect x="51" y="9551" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="9549" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9569">SERVER</text>
+         <rect x="51" y="9595" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="9593" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9613">SESSION</text>
+         <rect x="51" y="9639" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="9637" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9657">SESSIONS</text>
+         <rect x="51" y="9683" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="9681" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9701">SET</text>
+         <rect x="51" y="9727" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9725" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9745">SHARE</text>
+         <rect x="51" y="9771" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9769" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9789">SHOW</text>
+         <rect x="51" y="9815" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="9813" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9833">SIMPLE</text>
+         <rect x="51" y="9859" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="9857" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9877">SKIP</text>
+         <rect x="51" y="9903" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="9901" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9921">SNAPSHOT</text>
+         <rect x="51" y="9947" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="9945" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9965">SPLIT</text>
+         <rect x="51" y="9991" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="9989" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10009">SQL</text>
+         <rect x="51" y="10035" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="10033" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10053">START</text>
+         <rect x="51" y="10079" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="10077" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10097">STATISTICS</text>
+         <rect x="51" y="10123" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="10121" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10141">STDIN</text>
+         <rect x="51" y="10167" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="10165" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10185">STORAGE</text>
+         <rect x="51" y="10211" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="10209" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10229">STORE</text>
          <rect x="51" y="10255" width="74" height="32" rx="10"></rect>
          <rect x="49" y="10253" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10273">SYNTAX</text>
-         <rect x="51" y="10299" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10297" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10317">SYSTEM</text>
-         <rect x="51" y="10343" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="10341" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10361">TABLES</text>
-         <rect x="51" y="10387" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="10385" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10405">TEMP</text>
-         <rect x="51" y="10431" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="10429" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10449">TEMPLATE</text>
-         <rect x="51" y="10475" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="10473" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10493">TEMPORARY</text>
-         <rect x="51" y="10519" width="158" height="32" rx="10"></rect>
-         <rect x="49" y="10517" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10537">TESTING_RELOCATE</text>
-         <rect x="51" y="10563" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="10561" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10581">TEXT</text>
-         <rect x="51" y="10607" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="10605" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10625">TIES</text>
-         <rect x="51" y="10651" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="10649" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10669">TRACE</text>
-         <rect x="51" y="10695" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="10693" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10713">TRANSACTION</text>
-         <rect x="51" y="10739" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="10737" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10757">TRIGGER</text>
-         <rect x="51" y="10783" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="10781" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10801">TRUNCATE</text>
-         <rect x="51" y="10827" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="10825" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10845">TRUSTED</text>
-         <rect x="51" y="10871" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="10869" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10889">TYPE</text>
-         <rect x="51" y="10915" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="10913" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10933">THROTTLING</text>
-         <rect x="51" y="10959" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="10957" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10977">UNBOUNDED</text>
-         <rect x="51" y="11003" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="11001" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11021">UNCOMMITTED</text>
-         <rect x="51" y="11047" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="11045" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11065">UNKNOWN</text>
-         <rect x="51" y="11091" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="11089" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11109">UNLOGGED</text>
-         <rect x="51" y="11135" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="11133" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11153">UNSPLIT</text>
-         <rect x="51" y="11179" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="11177" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11197">UNTIL</text>
-         <rect x="51" y="11223" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="11221" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11241">UPDATE</text>
-         <rect x="51" y="11267" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="11265" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11285">UPSERT</text>
-         <rect x="51" y="11311" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="11309" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11329">UUID</text>
-         <rect x="51" y="11355" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="11353" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11373">USE</text>
-         <rect x="51" y="11399" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11397" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11417">USERS</text>
-         <rect x="51" y="11443" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="11441" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11461">VALID</text>
-         <rect x="51" y="11487" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="11485" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11505">VALIDATE</text>
-         <rect x="51" y="11531" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11529" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11549">VALUE</text>
-         <rect x="51" y="11575" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="11573" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11593">VARYING</text>
-         <rect x="51" y="11619" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="11617" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11637">VIEW</text>
-         <rect x="51" y="11663" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="11661" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11681">WITHIN</text>
-         <rect x="51" y="11707" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="11705" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11725">WITHOUT</text>
-         <rect x="51" y="11751" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11749" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11769">WRITE</text>
+         <text class="terminal" x="59" y="10273">STORED</text>
+         <rect x="51" y="10299" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="10297" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10317">STORING</text>
+         <rect x="51" y="10343" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="10341" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10361">STRICT</text>
+         <rect x="51" y="10387" width="124" height="32" rx="10"></rect>
+         <rect x="49" y="10385" width="124" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10405">SUBSCRIPTION</text>
+         <rect x="51" y="10431" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="10429" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10449">SYNTAX</text>
+         <rect x="51" y="10475" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="10473" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10493">SYSTEM</text>
+         <rect x="51" y="10519" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="10517" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10537">TABLES</text>
+         <rect x="51" y="10563" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="10561" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10581">TEMP</text>
+         <rect x="51" y="10607" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="10605" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10625">TEMPLATE</text>
+         <rect x="51" y="10651" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="10649" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10669">TEMPORARY</text>
+         <rect x="51" y="10695" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="10693" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10713">TENANT</text>
+         <rect x="51" y="10739" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="10737" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10757">TESTING_RELOCATE</text>
+         <rect x="51" y="10783" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="10781" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10801">TEXT</text>
+         <rect x="51" y="10827" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="10825" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10845">TIES</text>
+         <rect x="51" y="10871" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="10869" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10889">TRACE</text>
+         <rect x="51" y="10915" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="10913" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10933">TRANSACTION</text>
+         <rect x="51" y="10959" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="10957" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10977">TRIGGER</text>
+         <rect x="51" y="11003" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="11001" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11021">TRUNCATE</text>
+         <rect x="51" y="11047" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="11045" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11065">TRUSTED</text>
+         <rect x="51" y="11091" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="11089" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11109">TYPE</text>
+         <rect x="51" y="11135" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="11133" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11153">THROTTLING</text>
+         <rect x="51" y="11179" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="11177" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11197">UNBOUNDED</text>
+         <rect x="51" y="11223" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="11221" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11241">UNCOMMITTED</text>
+         <rect x="51" y="11267" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="11265" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11285">UNKNOWN</text>
+         <rect x="51" y="11311" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="11309" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11329">UNLOGGED</text>
+         <rect x="51" y="11355" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="11353" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11373">UNSPLIT</text>
+         <rect x="51" y="11399" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="11397" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11417">UNTIL</text>
+         <rect x="51" y="11443" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11441" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11461">UPDATE</text>
+         <rect x="51" y="11487" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="11485" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11505">UPSERT</text>
+         <rect x="51" y="11531" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="11529" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11549">USE</text>
+         <rect x="51" y="11575" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="11573" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11593">USERS</text>
+         <rect x="51" y="11619" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="11617" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11637">VALID</text>
+         <rect x="51" y="11663" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="11661" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11681">VALIDATE</text>
+         <rect x="51" y="11707" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="11705" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11725">VALUE</text>
+         <rect x="51" y="11751" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="11749" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11769">VARYING</text>
          <rect x="51" y="11795" width="56" height="32" rx="10"></rect>
          <rect x="49" y="11793" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11813">YEAR</text>
-         <rect x="51" y="11839" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="11837" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11857">ZONE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m36 0 h10 m0 0 h198 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m134 0 h10 m0 0 h100 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m110 0 h10 m0 0 h124 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m146 0 h10 m0 0 h88 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m112 0 h10 m0 0 h122 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m122 0 h10 m0 0 h112 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m174 0 h10 m0 0 h60 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m202 0 h10 m0 0 h32 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m190 0 h10 m0 0 h44 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m128 0 h10 m0 0 h106 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m190 0 h10 m0 0 h44 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m114 0 h10 m0 0 h120 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m128 0 h10 m0 0 h106 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m114 0 h10 m0 0 h120 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m122 0 h10 m0 0 h112 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -11836 h-3"></path>
+         <text class="terminal" x="59" y="11813">VIEW</text>
+         <rect x="51" y="11839" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11837" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11857">WITHIN</text>
+         <rect x="51" y="11883" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="11881" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11901">WITHOUT</text>
+         <rect x="51" y="11927" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="11925" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11945">WRITE</text>
+         <rect x="51" y="11971" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="11969" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11989">YEAR</text>
+         <rect x="51" y="12015" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="12013" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12033">ZONE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m36 0 h10 m0 0 h198 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m134 0 h10 m0 0 h100 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m110 0 h10 m0 0 h124 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m146 0 h10 m0 0 h88 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m112 0 h10 m0 0 h122 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m208 0 h10 m0 0 h26 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m122 0 h10 m0 0 h112 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m174 0 h10 m0 0 h60 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m202 0 h10 m0 0 h32 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m190 0 h10 m0 0 h44 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m182 0 h10 m0 0 h52 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m146 0 h10 m0 0 h88 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m132 0 h10 m0 0 h102 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m128 0 h10 m0 0 h106 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m190 0 h10 m0 0 h44 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m114 0 h10 m0 0 h120 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m160 0 h10 m0 0 h74 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m122 0 h10 m0 0 h112 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -12012 h-3"></path>
          <polygon points="323 17 331 13 331 21"></polygon>
          <polygon points="323 17 315 13 315 21"></polygon>
       </svg>
@@ -6280,10 +5932,11 @@
             <li><a href="#non_reserved_word" title="non_reserved_word">non_reserved_word</a></li>
             <li><a href="#targets" title="targets">targets</a></li>
             <li><a href="#type_function_name" title="type_function_name">type_function_name</a></li>
+            <li><a href="#type_function_name_no_crdb_extra" title="type_function_name_no_crdb_extra">type_function_name_no_crdb_extra</a></li>
             <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_name_keyword" href="#col_name_keyword">col_name_keyword:</a></p>
-      <svg width="260" height="2016">
+      <svg width="260" height="2236">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -6332,100 +5985,115 @@
          <rect x="51" y="619" width="64" height="32" rx="10"></rect>
          <rect x="49" y="617" width="64" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="637">FLOAT</text>
-         <rect x="51" y="663" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">GREATEST</text>
+         <rect x="51" y="663" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">GEOGRAPHY</text>
          <rect x="51" y="707" width="94" height="32" rx="10"></rect>
          <rect x="49" y="705" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">GROUPING</text>
-         <rect x="51" y="751" width="34" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">IF</text>
-         <rect x="51" y="795" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">IFERROR</text>
-         <rect x="51" y="839" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">IFNULL</text>
-         <rect x="51" y="883" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">INT</text>
-         <rect x="51" y="927" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">INTEGER</text>
-         <rect x="51" y="971" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">INTERVAL</text>
-         <rect x="51" y="1015" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">ISERROR</text>
-         <rect x="51" y="1059" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">LEAST</text>
-         <rect x="51" y="1103" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">NULLIF</text>
-         <rect x="51" y="1147" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">NUMERIC</text>
-         <rect x="51" y="1191" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">OUT</text>
-         <rect x="51" y="1235" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">OVERLAY</text>
-         <rect x="51" y="1279" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">POSITION</text>
-         <rect x="51" y="1323" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">PRECISION</text>
-         <rect x="51" y="1367" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">REAL</text>
-         <rect x="51" y="1411" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">ROW</text>
-         <rect x="51" y="1455" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">SMALLINT</text>
-         <rect x="51" y="1499" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">SUBSTRING</text>
-         <rect x="51" y="1543" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">TIME</text>
-         <rect x="51" y="1587" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">TIMETZ</text>
-         <rect x="51" y="1631" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">TIMESTAMP</text>
-         <rect x="51" y="1675" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">TIMESTAMPTZ</text>
-         <rect x="51" y="1719" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">TREAT</text>
-         <rect x="51" y="1763" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">TRIM</text>
-         <rect x="51" y="1807" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">VALUES</text>
-         <rect x="51" y="1851" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">VARBIT</text>
-         <rect x="51" y="1895" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">VARCHAR</text>
-         <rect x="51" y="1939" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">VIRTUAL</text>
-         <rect x="51" y="1983" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">WORK</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m136 0 h10 m0 0 h26 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m56 0 h10 m0 0 h106 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m146 0 h10 m0 0 h16 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m114 0 h10 m0 0 h48 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m23 -1980 h-3"></path>
+         <text class="terminal" x="59" y="725">GEOMETRY</text>
+         <rect x="51" y="751" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">GREATEST</text>
+         <rect x="51" y="795" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">GROUPING</text>
+         <rect x="51" y="839" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">IF</text>
+         <rect x="51" y="883" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">IFERROR</text>
+         <rect x="51" y="927" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">IFNULL</text>
+         <rect x="51" y="971" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">INT</text>
+         <rect x="51" y="1015" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">INTEGER</text>
+         <rect x="51" y="1059" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">INTERVAL</text>
+         <rect x="51" y="1103" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">ISERROR</text>
+         <rect x="51" y="1147" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">LEAST</text>
+         <rect x="51" y="1191" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">NULLIF</text>
+         <rect x="51" y="1235" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">NUMERIC</text>
+         <rect x="51" y="1279" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">OUT</text>
+         <rect x="51" y="1323" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">OVERLAY</text>
+         <rect x="51" y="1367" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">POINT</text>
+         <rect x="51" y="1411" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">POLYGON</text>
+         <rect x="51" y="1455" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">POSITION</text>
+         <rect x="51" y="1499" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">PRECISION</text>
+         <rect x="51" y="1543" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">REAL</text>
+         <rect x="51" y="1587" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">ROW</text>
+         <rect x="51" y="1631" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">SMALLINT</text>
+         <rect x="51" y="1675" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">STRING</text>
+         <rect x="51" y="1719" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">SUBSTRING</text>
+         <rect x="51" y="1763" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">TIME</text>
+         <rect x="51" y="1807" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">TIMETZ</text>
+         <rect x="51" y="1851" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="1849" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1869">TIMESTAMP</text>
+         <rect x="51" y="1895" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">TIMESTAMPTZ</text>
+         <rect x="51" y="1939" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">TREAT</text>
+         <rect x="51" y="1983" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">TRIM</text>
+         <rect x="51" y="2027" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2025" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2045">VALUES</text>
+         <rect x="51" y="2071" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2069" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2089">VARBIT</text>
+         <rect x="51" y="2115" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">VARCHAR</text>
+         <rect x="51" y="2159" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">VIRTUAL</text>
+         <rect x="51" y="2203" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">WORK</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m136 0 h10 m0 0 h26 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m56 0 h10 m0 0 h106 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m146 0 h10 m0 0 h16 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m106 0 h10 m0 0 h56 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m114 0 h10 m0 0 h48 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m23 -2200 h-3"></path>
          <polygon points="251 17 259 13 259 21"></polygon>
          <polygon points="251 17 243 13 243 21"></polygon>
       </svg>
@@ -6650,7 +6318,7 @@
             <li><a href="#abort_stmt" title="abort_stmt">abort_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_stmt" href="#alter_table_stmt">alter_table_stmt:</a></p>
-      <svg width="278" height="256">
+      <svg width="306" height="300">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -6684,9 +6352,14 @@
             <rect x="49" y="221" width="180" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="241">alter_rename_table_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m148 0 h10 m0 0 h32 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m118 0 h10 m0 0 h62 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m134 0 h10 m0 0 h46 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m136 0 h10 m0 0 h44 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m164 0 h10 m0 0 h16 m-210 -10 v20 m220 0 v-20 m-220 20 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m180 0 h10 m23 -220 h-3"></path>
-         <polygon points="269 17 277 13 277 21"></polygon>
-         <polygon points="269 17 261 13 261 21"></polygon>
+         <a xlink:href="#alter_table_set_schema_stmt" xlink:title="alter_table_set_schema_stmt">
+            <rect x="51" y="267" width="208" height="32"></rect>
+            <rect x="49" y="265" width="208" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">alter_table_set_schema_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m148 0 h10 m0 0 h60 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m118 0 h10 m0 0 h90 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m134 0 h10 m0 0 h74 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m136 0 h10 m0 0 h72 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m164 0 h10 m0 0 h44 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m180 0 h10 m0 0 h28 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m208 0 h10 m23 -264 h-3"></path>
+         <polygon points="297 17 305 13 305 21"></polygon>
+         <polygon points="297 17 289 13 289 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -6736,25 +6409,30 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_view_stmt" href="#alter_view_stmt">alter_view_stmt:</a></p>
-      <svg width="236" height="36">
+      <svg width="304" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <a xlink:href="#alter_rename_view_stmt" xlink:title="alter_rename_view_stmt">
-            <rect x="31" y="3" width="178" height="32"></rect>
-            <rect x="29" y="1" width="178" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">alter_rename_view_stmt</text>
+            <rect x="51" y="3" width="178" height="32"></rect>
+            <rect x="49" y="1" width="178" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">alter_rename_view_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m178 0 h10 m3 0 h-3"></path>
-         <polygon points="227 17 235 13 235 21"></polygon>
-         <polygon points="227 17 219 13 219 21"></polygon>
+         <a xlink:href="#alter_view_set_schema_stmt" xlink:title="alter_view_set_schema_stmt">
+            <rect x="51" y="47" width="206" height="32"></rect>
+            <rect x="49" y="45" width="206" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">alter_view_set_schema_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m0 0 h28 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m206 0 h10 m23 -44 h-3"></path>
+         <polygon points="295 17 303 13 303 21"></polygon>
+         <polygon points="295 17 287 13 287 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_sequence_stmt" href="#alter_sequence_stmt">alter_sequence_stmt:</a></p>
-      <svg width="308" height="80">
+      <svg width="336" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -6768,9 +6446,14 @@
             <rect x="49" y="45" width="208" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="65">alter_sequence_options_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m210 0 h10 m-250 0 h20 m230 0 h20 m-270 0 q10 0 10 10 m250 0 q0 -10 10 -10 m-260 10 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m208 0 h10 m0 0 h2 m23 -44 h-3"></path>
-         <polygon points="299 17 307 13 307 21"></polygon>
-         <polygon points="299 17 291 13 291 21"></polygon>
+         <a xlink:href="#alter_sequence_set_schema_stmt" xlink:title="alter_sequence_set_schema_stmt">
+            <rect x="51" y="91" width="238" height="32"></rect>
+            <rect x="49" y="89" width="238" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">alter_sequence_set_schema_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m210 0 h10 m0 0 h28 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m208 0 h10 m0 0 h30 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m238 0 h10 m23 -88 h-3"></path>
+         <polygon points="327 17 335 13 335 21"></polygon>
+         <polygon points="327 17 319 13 319 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -6830,6 +6513,122 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m184 0 h10 m3 0 h-3"></path>
          <polygon points="233 17 241 13 241 21"></polygon>
          <polygon points="233 17 225 13 225 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_schema_stmt" href="#alter_schema_stmt">alter_schema_stmt:</a></p>
+      <svg width="628" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">SCHEMA</text>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="209" y="3" width="110" height="32"></rect>
+            <rect x="207" y="1" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="21">schema_name</text>
+         </a>
+         <rect x="339" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="337" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="347" y="21">RENAME</text>
+         <rect x="433" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="431" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="441" y="21">TO</text>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="491" y="3" width="110" height="32"></rect>
+            <rect x="489" y="1" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="499" y="21">schema_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m110 0 h10 m3 0 h-3"></path>
+         <polygon points="619 17 627 13 627 21"></polygon>
+         <polygon points="619 17 611 13 611 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_type_stmt" href="#alter_type_stmt">alter_type_stmt:</a></p>
+      <svg width="762" height="266">
+         
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">ALTER</text>
+         <rect x="115" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">TYPE</text>
+         <a xlink:href="#type_name" xlink:title="type_name">
+            <rect x="189" y="3" width="90" height="32"></rect>
+            <rect x="187" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="21">type_name</text>
+         </a>
+         <rect x="45" y="69" width="48" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">ADD</text>
+         <rect x="113" y="69" width="64" height="32" rx="10"></rect>
+         <rect x="111" y="67" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="87">VALUE</text>
+         <rect x="217" y="101" width="34" height="32" rx="10"></rect>
+         <rect x="215" y="99" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="119">IF</text>
+         <rect x="271" y="101" width="48" height="32" rx="10"></rect>
+         <rect x="269" y="99" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="279" y="119">NOT</text>
+         <rect x="339" y="101" width="68" height="32" rx="10"></rect>
+         <rect x="337" y="99" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="347" y="119">EXISTS</text>
+         <rect x="447" y="69" width="76" height="32" rx="10"></rect>
+         <rect x="445" y="67" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="455" y="87">SCONST</text>
+         <a xlink:href="#opt_add_val_placement" xlink:title="opt_add_val_placement">
+            <rect x="543" y="69" width="172" height="32"></rect>
+            <rect x="541" y="67" width="172" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="551" y="87">opt_add_val_placement</text>
+         </a>
+         <rect x="45" y="145" width="74" height="32" rx="10"></rect>
+         <rect x="43" y="143" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="163">RENAME</text>
+         <rect x="159" y="145" width="64" height="32" rx="10"></rect>
+         <rect x="157" y="143" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="163">VALUE</text>
+         <rect x="243" y="145" width="76" height="32" rx="10"></rect>
+         <rect x="241" y="143" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="251" y="163">SCONST</text>
+         <rect x="339" y="145" width="38" height="32" rx="10"></rect>
+         <rect x="337" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="347" y="163">TO</text>
+         <rect x="397" y="145" width="76" height="32" rx="10"></rect>
+         <rect x="395" y="143" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="405" y="163">SCONST</text>
+         <rect x="159" y="189" width="38" height="32" rx="10"></rect>
+         <rect x="157" y="187" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="207">TO</text>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="217" y="189" width="54" height="32"></rect>
+            <rect x="215" y="187" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="207">name</text>
+         </a>
+         <rect x="45" y="233" width="44" height="32" rx="10"></rect>
+         <rect x="43" y="231" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="251">SET</text>
+         <rect x="109" y="233" width="76" height="32" rx="10"></rect>
+         <rect x="107" y="231" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="117" y="251">SCHEMA</text>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="205" y="233" width="110" height="32"></rect>
+            <rect x="203" y="231" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="213" y="251">schema_name</text>
+         </a>
+         <path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-298 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m76 0 h10 m0 0 h10 m172 0 h10 m-710 0 h20 m690 0 h20 m-730 0 q10 0 10 10 m710 0 q0 -10 10 -10 m-720 10 v56 m710 0 v-56 m-710 56 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m74 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m-354 0 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v24 m354 0 v-24 m-354 24 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m0 0 h202 m20 -44 h222 m-700 -10 v20 m710 0 v-20 m-710 20 v68 m710 0 v-68 m-710 68 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m44 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h400 m23 -164 h-3"></path>
+         <polygon points="753 83 761 79 761 87"></polygon>
+         <polygon points="753 83 745 79 745 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -6911,6 +6710,940 @@
             <li><a href="#opt_as_of_clause" title="opt_as_of_clause">opt_as_of_clause</a></li>
             <li><a href="#opt_create_stats_options" title="opt_create_stats_options">opt_create_stats_options</a></li>
             <li><a href="#transaction_mode" title="transaction_mode">transaction_mode</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="backup_options_list" href="#backup_options_list">backup_options_list:</a></p>
+      <svg width="218" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#backup_options" xlink:title="backup_options">
+            <rect x="51" y="47" width="120" height="32"></rect>
+            <rect x="49" y="45" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">backup_options</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m120 0 h10 m-160 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m140 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-140 0 h10 m24 0 h10 m0 0 h96 m23 44 h-3"></path>
+         <polygon points="209 61 217 57 217 65"></polygon>
+         <polygon points="209 61 201 57 201 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_with_backup_options" title="opt_with_backup_options">opt_with_backup_options</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="a_expr" href="#a_expr">a_expr:</a></p>
+      <svg width="700" height="3786">
+         
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <a xlink:href="#c_expr" xlink:title="c_expr">
+            <rect x="53" y="3" width="62" height="32"></rect>
+            <rect x="51" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="61" y="21">c_expr</text>
+         </a>
+         <rect x="73" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="71" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="65">+</text>
+         <rect x="73" y="91" width="26" height="32" rx="10"></rect>
+         <rect x="71" y="89" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="109">-</text>
+         <rect x="73" y="135" width="30" height="32" rx="10"></rect>
+         <rect x="71" y="133" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="153">~</text>
+         <rect x="73" y="179" width="56" height="32" rx="10"></rect>
+         <rect x="71" y="177" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="197">SQRT</text>
+         <rect x="73" y="223" width="54" height="32" rx="10"></rect>
+         <rect x="71" y="221" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="241">CBRT</text>
+         <rect x="73" y="267" width="48" height="32" rx="10"></rect>
+         <rect x="71" y="265" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="285">NOT</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="169" y="47" width="64" height="32"></rect>
+            <rect x="167" y="45" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="177" y="65">a_expr</text>
+         </a>
+         <rect x="53" y="311" width="80" height="32" rx="10"></rect>
+         <rect x="51" y="309" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="61" y="329">DEFAULT</text>
+         <rect x="85" y="393" width="90" height="32" rx="10"></rect>
+         <rect x="83" y="391" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="411">TYPECAST</text>
+         <a xlink:href="#cast_target" xlink:title="cast_target">
+            <rect x="195" y="393" width="92" height="32"></rect>
+            <rect x="193" y="391" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="411">cast_target</text>
+         </a>
+         <rect x="85" y="437" width="128" height="32" rx="10"></rect>
+         <rect x="83" y="435" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="455">TYPEANNOTATE</text>
+         <a xlink:href="#typename" xlink:title="typename">
+            <rect x="233" y="437" width="82" height="32"></rect>
+            <rect x="231" y="435" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="241" y="455">typename</text>
+         </a>
+         <rect x="85" y="481" width="80" height="32" rx="10"></rect>
+         <rect x="83" y="479" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="499">COLLATE</text>
+         <a xlink:href="#collation_name" xlink:title="collation_name">
+            <rect x="185" y="481" width="114" height="32"></rect>
+            <rect x="183" y="479" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="499">collation_name</text>
+         </a>
+         <rect x="85" y="525" width="36" height="32" rx="10"></rect>
+         <rect x="83" y="523" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="543">AT</text>
+         <rect x="141" y="525" width="52" height="32" rx="10"></rect>
+         <rect x="139" y="523" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="543">TIME</text>
+         <rect x="213" y="525" width="56" height="32" rx="10"></rect>
+         <rect x="211" y="523" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="221" y="543">ZONE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="289" y="525" width="64" height="32"></rect>
+            <rect x="287" y="523" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="297" y="543">a_expr</text>
+         </a>
+         <rect x="85" y="569" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="567" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="587">+</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="569" width="64" height="32"></rect>
+            <rect x="133" y="567" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="587">a_expr</text>
+         </a>
+         <rect x="85" y="613" width="26" height="32" rx="10"></rect>
+         <rect x="83" y="611" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="631">-</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="131" y="613" width="64" height="32"></rect>
+            <rect x="129" y="611" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="631">a_expr</text>
+         </a>
+         <rect x="85" y="657" width="28" height="32" rx="10"></rect>
+         <rect x="83" y="655" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="675">*</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="133" y="657" width="64" height="32"></rect>
+            <rect x="131" y="655" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="141" y="675">a_expr</text>
+         </a>
+         <rect x="85" y="701" width="28" height="32" rx="10"></rect>
+         <rect x="83" y="699" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="719">/</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="133" y="701" width="64" height="32"></rect>
+            <rect x="131" y="699" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="141" y="719">a_expr</text>
+         </a>
+         <rect x="85" y="745" width="92" height="32" rx="10"></rect>
+         <rect x="83" y="743" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="763">FLOORDIV</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="197" y="745" width="64" height="32"></rect>
+            <rect x="195" y="743" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="763">a_expr</text>
+         </a>
+         <rect x="85" y="789" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="787" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="807">%</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="139" y="789" width="64" height="32"></rect>
+            <rect x="137" y="787" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="807">a_expr</text>
+         </a>
+         <rect x="85" y="833" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="831" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="851">^</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="833" width="64" height="32"></rect>
+            <rect x="133" y="831" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="851">a_expr</text>
+         </a>
+         <rect x="85" y="877" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="875" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="895">#</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="877" width="64" height="32"></rect>
+            <rect x="133" y="875" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="895">a_expr</text>
+         </a>
+         <rect x="85" y="921" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="919" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="939">&amp;</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="921" width="64" height="32"></rect>
+            <rect x="133" y="919" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="939">a_expr</text>
+         </a>
+         <rect x="85" y="965" width="26" height="32" rx="10"></rect>
+         <rect x="83" y="963" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="983">|</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="131" y="965" width="64" height="32"></rect>
+            <rect x="129" y="963" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="983">a_expr</text>
+         </a>
+         <rect x="85" y="1009" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="1007" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1027">&lt;</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="1009" width="64" height="32"></rect>
+            <rect x="133" y="1007" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="1027">a_expr</text>
+         </a>
+         <rect x="85" y="1053" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="1051" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1071">&gt;</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="1053" width="64" height="32"></rect>
+            <rect x="133" y="1051" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="1071">a_expr</text>
+         </a>
+         <rect x="85" y="1097" width="26" height="32" rx="10"></rect>
+         <rect x="83" y="1095" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1115">?</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="131" y="1097" width="64" height="32"></rect>
+            <rect x="129" y="1095" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="1115">a_expr</text>
+         </a>
+         <rect x="85" y="1141" width="162" height="32" rx="10"></rect>
+         <rect x="83" y="1139" width="162" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1159">JSON_SOME_EXISTS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="267" y="1141" width="64" height="32"></rect>
+            <rect x="265" y="1139" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="275" y="1159">a_expr</text>
+         </a>
+         <rect x="85" y="1185" width="148" height="32" rx="10"></rect>
+         <rect x="83" y="1183" width="148" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1203">JSON_ALL_EXISTS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="253" y="1185" width="64" height="32"></rect>
+            <rect x="251" y="1183" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="261" y="1203">a_expr</text>
+         </a>
+         <rect x="85" y="1229" width="92" height="32" rx="10"></rect>
+         <rect x="83" y="1227" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1247">CONTAINS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="197" y="1229" width="64" height="32"></rect>
+            <rect x="195" y="1227" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="1247">a_expr</text>
+         </a>
+         <rect x="85" y="1273" width="128" height="32" rx="10"></rect>
+         <rect x="83" y="1271" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1291">CONTAINED_BY</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="233" y="1273" width="64" height="32"></rect>
+            <rect x="231" y="1271" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="241" y="1291">a_expr</text>
+         </a>
+         <rect x="85" y="1317" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="1315" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1335">=</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="1317" width="64" height="32"></rect>
+            <rect x="133" y="1315" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="1335">a_expr</text>
+         </a>
+         <rect x="85" y="1361" width="76" height="32" rx="10"></rect>
+         <rect x="83" y="1359" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1379">CONCAT</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="181" y="1361" width="64" height="32"></rect>
+            <rect x="179" y="1359" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="189" y="1379">a_expr</text>
+         </a>
+         <rect x="85" y="1405" width="68" height="32" rx="10"></rect>
+         <rect x="83" y="1403" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1423">LSHIFT</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="173" y="1405" width="64" height="32"></rect>
+            <rect x="171" y="1403" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="181" y="1423">a_expr</text>
+         </a>
+         <rect x="85" y="1449" width="70" height="32" rx="10"></rect>
+         <rect x="83" y="1447" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1467">RSHIFT</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="175" y="1449" width="64" height="32"></rect>
+            <rect x="173" y="1447" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="183" y="1467">a_expr</text>
+         </a>
+         <rect x="85" y="1493" width="88" height="32" rx="10"></rect>
+         <rect x="83" y="1491" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1511">FETCHVAL</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="193" y="1493" width="64" height="32"></rect>
+            <rect x="191" y="1491" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="1511">a_expr</text>
+         </a>
+         <rect x="85" y="1537" width="96" height="32" rx="10"></rect>
+         <rect x="83" y="1535" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1555">FETCHTEXT</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="201" y="1537" width="64" height="32"></rect>
+            <rect x="199" y="1535" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="209" y="1555">a_expr</text>
+         </a>
+         <rect x="85" y="1581" width="134" height="32" rx="10"></rect>
+         <rect x="83" y="1579" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1599">FETCHVAL_PATH</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="239" y="1581" width="64" height="32"></rect>
+            <rect x="237" y="1579" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="1599">a_expr</text>
+         </a>
+         <rect x="85" y="1625" width="140" height="32" rx="10"></rect>
+         <rect x="83" y="1623" width="140" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1643">FETCHTEXT_PATH</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="245" y="1625" width="64" height="32"></rect>
+            <rect x="243" y="1623" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="253" y="1643">a_expr</text>
+         </a>
+         <rect x="85" y="1669" width="120" height="32" rx="10"></rect>
+         <rect x="83" y="1667" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1687">REMOVE_PATH</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="225" y="1669" width="64" height="32"></rect>
+            <rect x="223" y="1667" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="1687">a_expr</text>
+         </a>
+         <rect x="85" y="1713" width="262" height="32" rx="10"></rect>
+         <rect x="83" y="1711" width="262" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1731">INET_CONTAINED_BY_OR_EQUALS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="367" y="1713" width="64" height="32"></rect>
+            <rect x="365" y="1711" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="375" y="1731">a_expr</text>
+         </a>
+         <rect x="85" y="1757" width="86" height="32" rx="10"></rect>
+         <rect x="83" y="1755" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1775">AND_AND</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="191" y="1757" width="64" height="32"></rect>
+            <rect x="189" y="1755" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="199" y="1775">a_expr</text>
+         </a>
+         <rect x="85" y="1801" width="226" height="32" rx="10"></rect>
+         <rect x="83" y="1799" width="226" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1819">INET_CONTAINS_OR_EQUALS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="331" y="1801" width="64" height="32"></rect>
+            <rect x="329" y="1799" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="339" y="1819">a_expr</text>
+         </a>
+         <rect x="85" y="1845" width="118" height="32" rx="10"></rect>
+         <rect x="83" y="1843" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1863">LESS_EQUALS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="223" y="1845" width="64" height="32"></rect>
+            <rect x="221" y="1843" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="1863">a_expr</text>
+         </a>
+         <rect x="85" y="1889" width="144" height="32" rx="10"></rect>
+         <rect x="83" y="1887" width="144" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1907">GREATER_EQUALS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="249" y="1889" width="64" height="32"></rect>
+            <rect x="247" y="1887" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="257" y="1907">a_expr</text>
+         </a>
+         <rect x="85" y="1933" width="112" height="32" rx="10"></rect>
+         <rect x="83" y="1931" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1951">NOT_EQUALS</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="217" y="1933" width="64" height="32"></rect>
+            <rect x="215" y="1931" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="1951">a_expr</text>
+         </a>
+         <rect x="85" y="1977" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="1975" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1995">AND</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="153" y="1977" width="64" height="32"></rect>
+            <rect x="151" y="1975" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="161" y="1995">a_expr</text>
+         </a>
+         <rect x="85" y="2021" width="40" height="32" rx="10"></rect>
+         <rect x="83" y="2019" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2039">OR</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="145" y="2021" width="64" height="32"></rect>
+            <rect x="143" y="2019" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="153" y="2039">a_expr</text>
+         </a>
+         <rect x="85" y="2065" width="50" height="32" rx="10"></rect>
+         <rect x="83" y="2063" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2083">LIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="155" y="2065" width="64" height="32"></rect>
+            <rect x="153" y="2063" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="163" y="2083">a_expr</text>
+         </a>
+         <rect x="85" y="2109" width="50" height="32" rx="10"></rect>
+         <rect x="83" y="2107" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2127">LIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="155" y="2109" width="64" height="32"></rect>
+            <rect x="153" y="2107" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="163" y="2127">a_expr</text>
+         </a>
+         <rect x="239" y="2109" width="72" height="32" rx="10"></rect>
+         <rect x="237" y="2107" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="247" y="2127">ESCAPE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="331" y="2109" width="64" height="32"></rect>
+            <rect x="329" y="2107" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="339" y="2127">a_expr</text>
+         </a>
+         <rect x="85" y="2153" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="2151" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2171">NOT</text>
+         <rect x="153" y="2153" width="50" height="32" rx="10"></rect>
+         <rect x="151" y="2151" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="2171">LIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="223" y="2153" width="64" height="32"></rect>
+            <rect x="221" y="2151" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="2171">a_expr</text>
+         </a>
+         <rect x="85" y="2197" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="2195" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2215">NOT</text>
+         <rect x="153" y="2197" width="50" height="32" rx="10"></rect>
+         <rect x="151" y="2195" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="2215">LIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="223" y="2197" width="64" height="32"></rect>
+            <rect x="221" y="2195" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="2215">a_expr</text>
+         </a>
+         <rect x="307" y="2197" width="72" height="32" rx="10"></rect>
+         <rect x="305" y="2195" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="315" y="2215">ESCAPE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="399" y="2197" width="64" height="32"></rect>
+            <rect x="397" y="2195" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="2215">a_expr</text>
+         </a>
+         <rect x="85" y="2241" width="56" height="32" rx="10"></rect>
+         <rect x="83" y="2239" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2259">ILIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="161" y="2241" width="64" height="32"></rect>
+            <rect x="159" y="2239" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="169" y="2259">a_expr</text>
+         </a>
+         <rect x="85" y="2285" width="56" height="32" rx="10"></rect>
+         <rect x="83" y="2283" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2303">ILIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="161" y="2285" width="64" height="32"></rect>
+            <rect x="159" y="2283" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="169" y="2303">a_expr</text>
+         </a>
+         <rect x="245" y="2285" width="72" height="32" rx="10"></rect>
+         <rect x="243" y="2283" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="253" y="2303">ESCAPE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="337" y="2285" width="64" height="32"></rect>
+            <rect x="335" y="2283" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="345" y="2303">a_expr</text>
+         </a>
+         <rect x="85" y="2329" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="2327" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2347">NOT</text>
+         <rect x="153" y="2329" width="56" height="32" rx="10"></rect>
+         <rect x="151" y="2327" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="2347">ILIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="229" y="2329" width="64" height="32"></rect>
+            <rect x="227" y="2327" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="237" y="2347">a_expr</text>
+         </a>
+         <rect x="85" y="2373" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="2371" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2391">NOT</text>
+         <rect x="153" y="2373" width="56" height="32" rx="10"></rect>
+         <rect x="151" y="2371" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="2391">ILIKE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="229" y="2373" width="64" height="32"></rect>
+            <rect x="227" y="2371" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="237" y="2391">a_expr</text>
+         </a>
+         <rect x="313" y="2373" width="72" height="32" rx="10"></rect>
+         <rect x="311" y="2371" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="2391">ESCAPE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="405" y="2373" width="64" height="32"></rect>
+            <rect x="403" y="2371" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="413" y="2391">a_expr</text>
+         </a>
+         <rect x="85" y="2417" width="78" height="32" rx="10"></rect>
+         <rect x="83" y="2415" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2435">SIMILAR</text>
+         <rect x="183" y="2417" width="38" height="32" rx="10"></rect>
+         <rect x="181" y="2415" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="191" y="2435">TO</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="241" y="2417" width="64" height="32"></rect>
+            <rect x="239" y="2415" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="2435">a_expr</text>
+         </a>
+         <rect x="85" y="2461" width="78" height="32" rx="10"></rect>
+         <rect x="83" y="2459" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2479">SIMILAR</text>
+         <rect x="183" y="2461" width="38" height="32" rx="10"></rect>
+         <rect x="181" y="2459" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="191" y="2479">TO</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="241" y="2461" width="64" height="32"></rect>
+            <rect x="239" y="2459" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="2479">a_expr</text>
+         </a>
+         <rect x="325" y="2461" width="72" height="32" rx="10"></rect>
+         <rect x="323" y="2459" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="2479">ESCAPE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="417" y="2461" width="64" height="32"></rect>
+            <rect x="415" y="2459" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="425" y="2479">a_expr</text>
+         </a>
+         <rect x="85" y="2505" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="2503" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2523">NOT</text>
+         <rect x="153" y="2505" width="78" height="32" rx="10"></rect>
+         <rect x="151" y="2503" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="2523">SIMILAR</text>
+         <rect x="251" y="2505" width="38" height="32" rx="10"></rect>
+         <rect x="249" y="2503" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="2523">TO</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="309" y="2505" width="64" height="32"></rect>
+            <rect x="307" y="2503" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="317" y="2523">a_expr</text>
+         </a>
+         <rect x="85" y="2549" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="2547" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2567">NOT</text>
+         <rect x="153" y="2549" width="78" height="32" rx="10"></rect>
+         <rect x="151" y="2547" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="2567">SIMILAR</text>
+         <rect x="251" y="2549" width="38" height="32" rx="10"></rect>
+         <rect x="249" y="2547" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="2567">TO</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="309" y="2549" width="64" height="32"></rect>
+            <rect x="307" y="2547" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="317" y="2567">a_expr</text>
+         </a>
+         <rect x="393" y="2549" width="72" height="32" rx="10"></rect>
+         <rect x="391" y="2547" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="401" y="2567">ESCAPE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="485" y="2549" width="64" height="32"></rect>
+            <rect x="483" y="2547" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="493" y="2567">a_expr</text>
+         </a>
+         <rect x="85" y="2593" width="30" height="32" rx="10"></rect>
+         <rect x="83" y="2591" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2611">~</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="2593" width="64" height="32"></rect>
+            <rect x="133" y="2591" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="2611">a_expr</text>
+         </a>
+         <rect x="85" y="2637" width="132" height="32" rx="10"></rect>
+         <rect x="83" y="2635" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2655">NOT_REGMATCH</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="237" y="2637" width="64" height="32"></rect>
+            <rect x="235" y="2635" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="245" y="2655">a_expr</text>
+         </a>
+         <rect x="85" y="2681" width="100" height="32" rx="10"></rect>
+         <rect x="83" y="2679" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2699">REGIMATCH</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="205" y="2681" width="64" height="32"></rect>
+            <rect x="203" y="2679" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="213" y="2699">a_expr</text>
+         </a>
+         <rect x="85" y="2725" width="138" height="32" rx="10"></rect>
+         <rect x="83" y="2723" width="138" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2743">NOT_REGIMATCH</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="243" y="2725" width="64" height="32"></rect>
+            <rect x="241" y="2723" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="251" y="2743">a_expr</text>
+         </a>
+         <rect x="85" y="2769" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="2767" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2787">IS</text>
+         <rect x="139" y="2769" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="2767" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="2787">NAN</text>
+         <rect x="85" y="2813" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="2811" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2831">IS</text>
+         <rect x="139" y="2813" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="2811" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="2831">NOT</text>
+         <rect x="207" y="2813" width="48" height="32" rx="10"></rect>
+         <rect x="205" y="2811" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="2831">NAN</text>
+         <rect x="85" y="2857" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="2855" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2875">IS</text>
+         <rect x="139" y="2857" width="56" height="32" rx="10"></rect>
+         <rect x="137" y="2855" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="2875">NULL</text>
+         <rect x="85" y="2901" width="70" height="32" rx="10"></rect>
+         <rect x="83" y="2899" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2919">ISNULL</text>
+         <rect x="85" y="2945" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="2943" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="2963">IS</text>
+         <rect x="139" y="2945" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="2943" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="2963">NOT</text>
+         <rect x="207" y="2945" width="56" height="32" rx="10"></rect>
+         <rect x="205" y="2943" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="2963">NULL</text>
+         <rect x="85" y="2989" width="84" height="32" rx="10"></rect>
+         <rect x="83" y="2987" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3007">NOTNULL</text>
+         <rect x="85" y="3033" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3031" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3051">IS</text>
+         <rect x="139" y="3033" width="54" height="32" rx="10"></rect>
+         <rect x="137" y="3031" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3051">TRUE</text>
+         <rect x="85" y="3077" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3075" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3095">IS</text>
+         <rect x="139" y="3077" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="3075" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3095">NOT</text>
+         <rect x="207" y="3077" width="54" height="32" rx="10"></rect>
+         <rect x="205" y="3075" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="3095">TRUE</text>
+         <rect x="85" y="3121" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3119" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3139">IS</text>
+         <rect x="139" y="3121" width="62" height="32" rx="10"></rect>
+         <rect x="137" y="3119" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3139">FALSE</text>
+         <rect x="85" y="3165" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3163" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3183">IS</text>
+         <rect x="139" y="3165" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="3163" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3183">NOT</text>
+         <rect x="207" y="3165" width="62" height="32" rx="10"></rect>
+         <rect x="205" y="3163" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="3183">FALSE</text>
+         <rect x="85" y="3209" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3207" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3227">IS</text>
+         <rect x="139" y="3209" width="94" height="32" rx="10"></rect>
+         <rect x="137" y="3207" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3227">UNKNOWN</text>
+         <rect x="85" y="3253" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3251" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3271">IS</text>
+         <rect x="139" y="3253" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="3251" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3271">NOT</text>
+         <rect x="207" y="3253" width="94" height="32" rx="10"></rect>
+         <rect x="205" y="3251" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="3271">UNKNOWN</text>
+         <rect x="85" y="3297" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3295" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3315">IS</text>
+         <rect x="139" y="3297" width="86" height="32" rx="10"></rect>
+         <rect x="137" y="3295" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3315">DISTINCT</text>
+         <rect x="245" y="3297" width="58" height="32" rx="10"></rect>
+         <rect x="243" y="3295" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="253" y="3315">FROM</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="323" y="3297" width="64" height="32"></rect>
+            <rect x="321" y="3295" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="331" y="3315">a_expr</text>
+         </a>
+         <rect x="85" y="3341" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3339" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3359">IS</text>
+         <rect x="139" y="3341" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="3339" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3359">NOT</text>
+         <rect x="207" y="3341" width="86" height="32" rx="10"></rect>
+         <rect x="205" y="3339" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="3359">DISTINCT</text>
+         <rect x="313" y="3341" width="58" height="32" rx="10"></rect>
+         <rect x="311" y="3339" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="321" y="3359">FROM</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="391" y="3341" width="64" height="32"></rect>
+            <rect x="389" y="3339" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="399" y="3359">a_expr</text>
+         </a>
+         <rect x="85" y="3385" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3383" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3403">IS</text>
+         <rect x="139" y="3385" width="38" height="32" rx="10"></rect>
+         <rect x="137" y="3383" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3403">OF</text>
+         <rect x="197" y="3385" width="26" height="32" rx="10"></rect>
+         <rect x="195" y="3383" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="205" y="3403">(</text>
+         <a xlink:href="#type_list" xlink:title="type_list">
+            <rect x="243" y="3385" width="74" height="32"></rect>
+            <rect x="241" y="3383" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="251" y="3403">type_list</text>
+         </a>
+         <rect x="337" y="3385" width="26" height="32" rx="10"></rect>
+         <rect x="335" y="3383" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="345" y="3403">)</text>
+         <rect x="85" y="3429" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="3427" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3447">IS</text>
+         <rect x="139" y="3429" width="48" height="32" rx="10"></rect>
+         <rect x="137" y="3427" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="3447">NOT</text>
+         <rect x="207" y="3429" width="38" height="32" rx="10"></rect>
+         <rect x="205" y="3427" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="3447">OF</text>
+         <rect x="265" y="3429" width="26" height="32" rx="10"></rect>
+         <rect x="263" y="3427" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="273" y="3447">(</text>
+         <a xlink:href="#type_list" xlink:title="type_list">
+            <rect x="311" y="3429" width="74" height="32"></rect>
+            <rect x="309" y="3427" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="319" y="3447">type_list</text>
+         </a>
+         <rect x="405" y="3429" width="26" height="32" rx="10"></rect>
+         <rect x="403" y="3427" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="413" y="3447">)</text>
+         <rect x="85" y="3473" width="84" height="32" rx="10"></rect>
+         <rect x="83" y="3471" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3491">BETWEEN</text>
+         <a xlink:href="#opt_asymmetric" xlink:title="opt_asymmetric">
+            <rect x="189" y="3473" width="120" height="32"></rect>
+            <rect x="187" y="3471" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="197" y="3491">opt_asymmetric</text>
+         </a>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="329" y="3473" width="64" height="32"></rect>
+            <rect x="327" y="3471" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="337" y="3491">b_expr</text>
+         </a>
+         <rect x="413" y="3473" width="48" height="32" rx="10"></rect>
+         <rect x="411" y="3471" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="421" y="3491">AND</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="481" y="3473" width="64" height="32"></rect>
+            <rect x="479" y="3471" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="489" y="3491">a_expr</text>
+         </a>
+         <rect x="85" y="3517" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="3515" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3535">NOT</text>
+         <rect x="153" y="3517" width="84" height="32" rx="10"></rect>
+         <rect x="151" y="3515" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="3535">BETWEEN</text>
+         <a xlink:href="#opt_asymmetric" xlink:title="opt_asymmetric">
+            <rect x="257" y="3517" width="120" height="32"></rect>
+            <rect x="255" y="3515" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="265" y="3535">opt_asymmetric</text>
+         </a>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="397" y="3517" width="64" height="32"></rect>
+            <rect x="395" y="3515" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="405" y="3535">b_expr</text>
+         </a>
+         <rect x="481" y="3517" width="48" height="32" rx="10"></rect>
+         <rect x="479" y="3515" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="489" y="3535">AND</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="549" y="3517" width="64" height="32"></rect>
+            <rect x="547" y="3515" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="557" y="3535">a_expr</text>
+         </a>
+         <rect x="85" y="3561" width="84" height="32" rx="10"></rect>
+         <rect x="83" y="3559" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3579">BETWEEN</text>
+         <rect x="189" y="3561" width="100" height="32" rx="10"></rect>
+         <rect x="187" y="3559" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="197" y="3579">SYMMETRIC</text>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="309" y="3561" width="64" height="32"></rect>
+            <rect x="307" y="3559" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="317" y="3579">b_expr</text>
+         </a>
+         <rect x="393" y="3561" width="48" height="32" rx="10"></rect>
+         <rect x="391" y="3559" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="401" y="3579">AND</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="461" y="3561" width="64" height="32"></rect>
+            <rect x="459" y="3559" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="469" y="3579">a_expr</text>
+         </a>
+         <rect x="85" y="3605" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="3603" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3623">NOT</text>
+         <rect x="153" y="3605" width="84" height="32" rx="10"></rect>
+         <rect x="151" y="3603" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="3623">BETWEEN</text>
+         <rect x="257" y="3605" width="100" height="32" rx="10"></rect>
+         <rect x="255" y="3603" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="265" y="3623">SYMMETRIC</text>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="377" y="3605" width="64" height="32"></rect>
+            <rect x="375" y="3603" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="385" y="3623">b_expr</text>
+         </a>
+         <rect x="461" y="3605" width="48" height="32" rx="10"></rect>
+         <rect x="459" y="3603" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="469" y="3623">AND</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="529" y="3605" width="64" height="32"></rect>
+            <rect x="527" y="3603" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="537" y="3623">a_expr</text>
+         </a>
+         <rect x="85" y="3649" width="36" height="32" rx="10"></rect>
+         <rect x="83" y="3647" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3667">IN</text>
+         <a xlink:href="#in_expr" xlink:title="in_expr">
+            <rect x="141" y="3649" width="66" height="32"></rect>
+            <rect x="139" y="3647" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="3667">in_expr</text>
+         </a>
+         <rect x="85" y="3693" width="48" height="32" rx="10"></rect>
+         <rect x="83" y="3691" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="3711">NOT</text>
+         <rect x="153" y="3693" width="36" height="32" rx="10"></rect>
+         <rect x="151" y="3691" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="3711">IN</text>
+         <a xlink:href="#in_expr" xlink:title="in_expr">
+            <rect x="209" y="3693" width="66" height="32"></rect>
+            <rect x="207" y="3691" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="3711">in_expr</text>
+         </a>
+         <a xlink:href="#subquery_op" xlink:title="subquery_op">
+            <rect x="85" y="3737" width="102" height="32"></rect>
+            <rect x="83" y="3735" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="93" y="3755">subquery_op</text>
+         </a>
+         <a xlink:href="#sub_type" xlink:title="sub_type">
+            <rect x="207" y="3737" width="78" height="32"></rect>
+            <rect x="205" y="3735" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="215" y="3755">sub_type</text>
+         </a>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="305" y="3737" width="64" height="32"></rect>
+            <rect x="303" y="3735" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="313" y="3755">a_expr</text>
+         </a>
+         <path class="line" d="m19 17 h2 m20 0 h10 m62 0 h10 m0 0 h118 m-220 0 h20 m200 0 h20 m-240 0 q10 0 10 10 m220 0 q0 -10 10 -10 m-230 10 v24 m220 0 v-24 m-220 24 q0 10 10 10 m200 0 q10 0 10 -10 m-190 10 h10 m30 0 h10 m0 0 h26 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m26 0 h10 m0 0 h30 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m30 0 h10 m0 0 h26 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m54 0 h10 m0 0 h2 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m48 0 h10 m0 0 h8 m20 -220 h10 m64 0 h10 m-210 -10 v20 m220 0 v-20 m-220 20 v244 m220 0 v-244 m-220 244 q0 10 10 10 m200 0 q10 0 10 -10 m-210 10 h10 m80 0 h10 m0 0 h100 m22 -308 l2 0 m2 0 l2 0 m2 0 l2 0 m-272 390 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m90 0 h10 m0 0 h10 m92 0 h10 m0 0 h326 m-568 0 h20 m548 0 h20 m-588 0 q10 0 10 10 m568 0 q0 -10 10 -10 m-578 10 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m128 0 h10 m0 0 h10 m82 0 h10 m0 0 h298 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m80 0 h10 m0 0 h10 m114 0 h10 m0 0 h314 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m36 0 h10 m0 0 h10 m52 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h260 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m28 0 h10 m0 0 h10 m64 0 h10 m0 0 h416 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m28 0 h10 m0 0 h10 m64 0 h10 m0 0 h416 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h352 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m64 0 h10 m0 0 h410 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m162 0 h10 m0 0 h10 m64 0 h10 m0 0 h282 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m148 0 h10 m0 0 h10 m64 0 h10 m0 0 h296 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h352 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m128 0 h10 m0 0 h10 m64 0 h10 m0 0 h316 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m76 0 h10 m0 0 h10 m64 0 h10 m0 0 h368 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m68 0 h10 m0 0 h10 m64 0 h10 m0 0 h376 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m70 0 h10 m0 0 h10 m64 0 h10 m0 0 h374 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m88 0 h10 m0 0 h10 m64 0 h10 m0 0 h356 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m96 0 h10 m0 0 h10 m64 0 h10 m0 0 h348 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m134 0 h10 m0 0 h10 m64 0 h10 m0 0 h310 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m140 0 h10 m0 0 h10 m64 0 h10 m0 0 h304 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m120 0 h10 m0 0 h10 m64 0 h10 m0 0 h324 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m262 0 h10 m0 0 h10 m64 0 h10 m0 0 h182 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m86 0 h10 m0 0 h10 m64 0 h10 m0 0 h358 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m226 0 h10 m0 0 h10 m64 0 h10 m0 0 h218 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m118 0 h10 m0 0 h10 m64 0 h10 m0 0 h326 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m144 0 h10 m0 0 h10 m64 0 h10 m0 0 h300 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m112 0 h10 m0 0 h10 m64 0 h10 m0 0 h332 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h396 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m40 0 h10 m0 0 h10 m64 0 h10 m0 0 h404 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h394 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h218 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h326 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h150 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h388 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h212 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h320 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h144 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h308 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h132 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h240 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m64 0 h10 m0 0 h64 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m30 0 h10 m0 0 h10 m64 0 h10 m0 0 h414 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m132 0 h10 m0 0 h10 m64 0 h10 m0 0 h312 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m100 0 h10 m0 0 h10 m64 0 h10 m0 0 h344 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m138 0 h10 m0 0 h10 m64 0 h10 m0 0 h306 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h426 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m48 0 h10 m0 0 h358 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m56 0 h10 m0 0 h418 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m70 0 h10 m0 0 h458 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h350 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m84 0 h10 m0 0 h444 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m54 0 h10 m0 0 h420 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m54 0 h10 m0 0 h352 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m62 0 h10 m0 0 h412 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m62 0 h10 m0 0 h344 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m94 0 h10 m0 0 h380 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m94 0 h10 m0 0 h312 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m0 0 h226 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m86 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m0 0 h158 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h250 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h182 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m84 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h68 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m84 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h88 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h20 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m36 0 h10 m0 0 h10 m66 0 h10 m0 0 h406 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m48 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m66 0 h10 m0 0 h338 m-558 -10 v20 m568 0 v-20 m-568 20 v24 m568 0 v-24 m-568 24 q0 10 10 10 m548 0 q10 0 10 -10 m-558 10 h10 m102 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m64 0 h10 m0 0 h244 m-588 -3344 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m588 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-588 0 h10 m0 0 h578 m-628 32 h20 m628 0 h20 m-668 0 q10 0 10 10 m648 0 q0 -10 10 -10 m-658 10 v3358 m648 0 v-3358 m-648 3358 q0 10 10 10 m628 0 q10 0 10 -10 m-638 10 h10 m0 0 h618 m23 -3378 h-3"></path>
+         <polygon points="691 407 699 403 699 411"></polygon>
+         <polygon points="691 407 683 403 683 411"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#alter_column_default" title="alter_column_default">alter_column_default</a></li>
+            <li><a href="#alter_split_index_stmt" title="alter_split_index_stmt">alter_split_index_stmt</a></li>
+            <li><a href="#alter_split_stmt" title="alter_split_stmt">alter_split_stmt</a></li>
+            <li><a href="#array_subscript" title="array_subscript">array_subscript</a></li>
+            <li><a href="#as_of_clause" title="as_of_clause">as_of_clause</a></li>
+            <li><a href="#cancel_jobs_stmt" title="cancel_jobs_stmt">cancel_jobs_stmt</a></li>
+            <li><a href="#cancel_queries_stmt" title="cancel_queries_stmt">cancel_queries_stmt</a></li>
+            <li><a href="#cancel_sessions_stmt" title="cancel_sessions_stmt">cancel_sessions_stmt</a></li>
+            <li><a href="#case_arg" title="case_arg">case_arg</a></li>
+            <li><a href="#case_default" title="case_default">case_default</a></li>
+            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
+            <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+            <li><a href="#drop_schedule_stmt" title="drop_schedule_stmt">drop_schedule_stmt</a></li>
+            <li><a href="#expr_list" title="expr_list">expr_list</a></li>
+            <li><a href="#extract_list" title="extract_list">extract_list</a></li>
+            <li><a href="#filter_clause" title="filter_clause">filter_clause</a></li>
+            <li><a href="#for_schedules_clause" title="for_schedules_clause">for_schedules_clause</a></li>
+            <li><a href="#frame_bound" title="frame_bound">frame_bound</a></li>
+            <li><a href="#func_expr_common_subexpr" title="func_expr_common_subexpr">func_expr_common_subexpr</a></li>
+            <li><a href="#having_clause" title="having_clause">having_clause</a></li>
+            <li><a href="#index_elem" title="index_elem">index_elem</a></li>
+            <li><a href="#join_qual" title="join_qual">join_qual</a></li>
+            <li><a href="#limit_clause" title="limit_clause">limit_clause</a></li>
+            <li><a href="#offset_clause" title="offset_clause">offset_clause</a></li>
+            <li><a href="#opt_alter_column_using" title="opt_alter_column_using">opt_alter_column_using</a></li>
+            <li><a href="#opt_hash_sharded" title="opt_hash_sharded">opt_hash_sharded</a></li>
+            <li><a href="#opt_slice_bound" title="opt_slice_bound">opt_slice_bound</a></li>
+            <li><a href="#overlay_list" title="overlay_list">overlay_list</a></li>
+            <li><a href="#overlay_placing" title="overlay_placing">overlay_placing</a></li>
+            <li><a href="#pause_jobs_stmt" title="pause_jobs_stmt">pause_jobs_stmt</a></li>
+            <li><a href="#pause_schedules_stmt" title="pause_schedules_stmt">pause_schedules_stmt</a></li>
+            <li><a href="#resume_jobs_stmt" title="resume_jobs_stmt">resume_jobs_stmt</a></li>
+            <li><a href="#resume_schedules_stmt" title="resume_schedules_stmt">resume_schedules_stmt</a></li>
+            <li><a href="#show_jobs_stmt" title="show_jobs_stmt">show_jobs_stmt</a></li>
+            <li><a href="#show_schedules_stmt" title="show_schedules_stmt">show_schedules_stmt</a></li>
+            <li><a href="#single_set_clause" title="single_set_clause">single_set_clause</a></li>
+            <li><a href="#sortby" title="sortby">sortby</a></li>
+            <li><a href="#special_function" title="special_function">special_function</a></li>
+            <li><a href="#substr_for" title="substr_for">substr_for</a></li>
+            <li><a href="#substr_from" title="substr_from">substr_from</a></li>
+            <li><a href="#substr_list" title="substr_list">substr_list</a></li>
+            <li><a href="#target_elem" title="target_elem">target_elem</a></li>
+            <li><a href="#trim_list" title="trim_list">trim_list</a></li>
+            <li><a href="#tuple1_ambiguous_values" title="tuple1_ambiguous_values">tuple1_ambiguous_values</a></li>
+            <li><a href="#tuple1_unambiguous_values" title="tuple1_unambiguous_values">tuple1_unambiguous_values</a></li>
+            <li><a href="#var_value" title="var_value">var_value</a></li>
+            <li><a href="#when_clause" title="when_clause">when_clause</a></li>
+            <li><a href="#where_clause" title="where_clause">where_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="for_schedules_clause" href="#for_schedules_clause">for_schedules_clause:</a></p>
+      <svg width="378" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">FOR</text>
+         <rect x="119" y="3" width="100" height="32" rx="10"></rect>
+         <rect x="117" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="21">SCHEDULES</text>
+         <a xlink:href="#select_stmt" xlink:title="select_stmt">
+            <rect x="239" y="3" width="92" height="32"></rect>
+            <rect x="237" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="21">select_stmt</text>
+         </a>
+         <rect x="119" y="47" width="92" height="32" rx="10"></rect>
+         <rect x="117" y="45" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="65">SCHEDULE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="231" y="47" width="64" height="32"></rect>
+            <rect x="229" y="45" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="65">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m20 0 h10 m100 0 h10 m0 0 h10 m92 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v24 m252 0 v-24 m-252 24 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m92 0 h10 m0 0 h10 m64 0 h10 m0 0 h36 m23 -44 h-3"></path>
+         <polygon points="369 17 377 13 377 21"></polygon>
+         <polygon points="369 17 361 13 361 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#cancel_jobs_stmt" title="cancel_jobs_stmt">cancel_jobs_stmt</a></li>
+            <li><a href="#pause_jobs_stmt" title="pause_jobs_stmt">pause_jobs_stmt</a></li>
+            <li><a href="#resume_jobs_stmt" title="resume_jobs_stmt">resume_jobs_stmt</a></li>
+            <li><a href="#show_jobs_stmt" title="show_jobs_stmt">show_jobs_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_changefeed_stmt" href="#create_changefeed_stmt">create_changefeed_stmt:</a></p>
       <svg width="664" height="102">
@@ -7126,21 +7859,26 @@
          <rect x="1093" y="155" width="26" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="1103" y="175">)</text>
          <a xlink:href="#opt_storing" xlink:title="opt_storing">
-            <rect x="991" y="267" width="92" height="32"></rect>
-            <rect x="989" y="265" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="999" y="285">opt_storing</text>
+            <rect x="835" y="267" width="92" height="32"></rect>
+            <rect x="833" y="265" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="843" y="285">opt_storing</text>
          </a>
          <a xlink:href="#opt_interleave" xlink:title="opt_interleave">
-            <rect x="1103" y="267" width="112" height="32"></rect>
-            <rect x="1101" y="265" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="1111" y="285">opt_interleave</text>
+            <rect x="947" y="267" width="112" height="32"></rect>
+            <rect x="945" y="265" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="955" y="285">opt_interleave</text>
          </a>
          <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="1235" y="267" width="124" height="32"></rect>
-            <rect x="1233" y="265" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="1243" y="285">opt_partition_by</text>
+            <rect x="1079" y="267" width="124" height="32"></rect>
+            <rect x="1077" y="265" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1087" y="285">opt_partition_by</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m152 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m-1340 0 h20 m1320 0 h20 m-1360 0 q10 0 10 10 m1340 0 q0 -10 10 -10 m-1350 10 v68 m1340 0 v-68 m-1340 68 q0 10 10 10 m1320 0 q10 0 10 -10 m-1330 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h224 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-418 198 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
+         <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
+            <rect x="1223" y="267" width="136" height="32"></rect>
+            <rect x="1221" y="265" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1231" y="285">opt_where_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m152 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m-1340 0 h20 m1320 0 h20 m-1360 0 q10 0 10 10 m1340 0 q0 -10 10 -10 m-1350 10 v68 m1340 0 v-68 m-1340 68 q0 10 10 10 m1320 0 q10 0 10 -10 m-1330 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h224 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-574 198 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m136 0 h10 m3 0 h-3"></path>
          <polygon points="1377 281 1385 277 1385 285"></polygon>
          <polygon points="1377 281 1369 277 1369 285"></polygon>
       </svg>
@@ -7291,8 +8029,49 @@
          </p><ul>
             <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_type_stmt" href="#create_type_stmt">create_type_stmt:</a></p>
+      <svg width="696" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE</text>
+         <rect x="121" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="119" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="21">TYPE</text>
+         <a xlink:href="#type_name" xlink:title="type_name">
+            <rect x="195" y="3" width="90" height="32"></rect>
+            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="21">type_name</text>
+         </a>
+         <rect x="305" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="303" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="313" y="21">AS</text>
+         <rect x="363" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="361" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="371" y="21">ENUM</text>
+         <rect x="441" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="439" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="449" y="21">(</text>
+         <a xlink:href="#opt_enum_val_list" xlink:title="opt_enum_val_list">
+            <rect x="487" y="3" width="136" height="32"></rect>
+            <rect x="485" y="1" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="495" y="21">opt_enum_val_list</text>
+         </a>
+         <rect x="643" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="641" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="651" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="687 17 695 13 695 21"></polygon>
+         <polygon points="687 17 679 13 679 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_view_stmt" href="#create_view_stmt">create_view_stmt:</a></p>
-      <svg width="660" height="134">
+      <svg width="700" height="178">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7300,43 +8079,57 @@
          <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">CREATE</text>
          <a xlink:href="#opt_temp" xlink:title="opt_temp">
-            <rect x="121" y="3" width="80" height="32"></rect>
-            <rect x="119" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="129" y="21">opt_temp</text>
+            <rect x="141" y="3" width="80" height="32"></rect>
+            <rect x="139" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="149" y="21">opt_temp</text>
          </a>
-         <rect x="221" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="219" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="229" y="21">VIEW</text>
-         <rect x="317" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="315" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="325" y="53">IF</text>
-         <rect x="371" y="35" width="48" height="32" rx="10"></rect>
-         <rect x="369" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="379" y="53">NOT</text>
-         <rect x="439" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="437" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="447" y="53">EXISTS</text>
+         <rect x="241" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="239" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="249" y="21">VIEW</text>
+         <rect x="337" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="335" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="345" y="53">IF</text>
+         <rect x="391" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="389" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="399" y="53">NOT</text>
+         <rect x="459" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="457" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="467" y="53">EXISTS</text>
+         <rect x="141" y="79" width="40" height="32" rx="10"></rect>
+         <rect x="139" y="77" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="97">OR</text>
+         <rect x="201" y="79" width="80" height="32" rx="10"></rect>
+         <rect x="199" y="77" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="209" y="97">REPLACE</text>
+         <a xlink:href="#opt_temp" xlink:title="opt_temp">
+            <rect x="301" y="79" width="80" height="32"></rect>
+            <rect x="299" y="77" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="309" y="97">opt_temp</text>
+         </a>
+         <rect x="401" y="79" width="56" height="32" rx="10"></rect>
+         <rect x="399" y="77" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="409" y="97">VIEW</text>
          <a xlink:href="#view_name" xlink:title="view_name">
-            <rect x="547" y="3" width="92" height="32"></rect>
-            <rect x="545" y="1" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="555" y="21">view_name</text>
+            <rect x="587" y="3" width="92" height="32"></rect>
+            <rect x="585" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="595" y="21">view_name</text>
          </a>
          <a xlink:href="#opt_column_list" xlink:title="opt_column_list">
-            <rect x="345" y="101" width="118" height="32"></rect>
-            <rect x="343" y="99" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="353" y="119">opt_column_list</text>
+            <rect x="385" y="145" width="118" height="32"></rect>
+            <rect x="383" y="143" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="393" y="163">opt_column_list</text>
          </a>
-         <rect x="483" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="481" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="491" y="119">AS</text>
+         <rect x="523" y="145" width="38" height="32" rx="10"></rect>
+         <rect x="521" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="531" y="163">AS</text>
          <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="541" y="101" width="92" height="32"></rect>
-            <rect x="539" y="99" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="549" y="119">select_stmt</text>
+            <rect x="581" y="145" width="92" height="32"></rect>
+            <rect x="579" y="143" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="589" y="163">select_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
-         <polygon points="651 115 659 111 659 119"></polygon>
-         <polygon points="651 115 643 111 643 119"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m-426 -32 h20 m426 0 h20 m-466 0 q10 0 10 10 m446 0 q0 -10 10 -10 m-456 10 v56 m446 0 v-56 m-446 56 q0 10 10 10 m426 0 q10 0 10 -10 m-436 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m56 0 h10 m0 0 h90 m20 -76 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
+         <polygon points="691 159 699 155 699 163"></polygon>
+         <polygon points="691 159 683 155 683 163"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -7459,6 +8252,116 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_stats_stmt" title="create_stats_stmt">create_stats_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_description" href="#opt_description">opt_description:</a></p>
+      <svg width="256" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="51" y="23" width="158" height="32"></rect>
+            <rect x="49" y="21" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">string_or_placeholder</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m158 0 h10 m23 -32 h-3"></path>
+         <polygon points="247 5 255 1 255 9"></polygon>
+         <polygon points="247 5 239 1 239 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cron_expr" href="#cron_expr">cron_expr:</a></p>
+      <svg width="380" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="100" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">RECURRING</text>
+         <rect x="171" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="169" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="179" y="21">NEVER</text>
+         <a xlink:href="#sconst_or_placeholder" xlink:title="sconst_or_placeholder">
+            <rect x="171" y="47" width="162" height="32"></rect>
+            <rect x="169" y="45" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="179" y="65">sconst_or_placeholder</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m20 0 h10 m64 0 h10 m0 0 h98 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m23 -44 h-3"></path>
+         <polygon points="371 17 379 13 379 21"></polygon>
+         <polygon points="371 17 363 13 363 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_full_backup_clause" href="#opt_full_backup_clause">opt_full_backup_clause:</a></p>
+      <svg width="468" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">FULL</text>
+         <rect x="125" y="23" width="74" height="32" rx="10"></rect>
+         <rect x="123" y="21" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="41">BACKUP</text>
+         <a xlink:href="#sconst_or_placeholder" xlink:title="sconst_or_placeholder">
+            <rect x="239" y="23" width="162" height="32"></rect>
+            <rect x="237" y="21" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="247" y="41">sconst_or_placeholder</text>
+         </a>
+         <rect x="239" y="67" width="78" height="32" rx="10"></rect>
+         <rect x="237" y="65" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="247" y="85">ALWAYS</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h380 m-410 0 h20 m390 0 h20 m-430 0 q10 0 10 10 m410 0 q0 -10 10 -10 m-420 10 v12 m410 0 v-12 m-410 12 q0 10 10 10 m390 0 q10 0 10 -10 m-400 10 h10 m54 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m162 0 h10 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m43 -76 h-3"></path>
+         <polygon points="459 5 467 1 467 9"></polygon>
+         <polygon points="459 5 451 1 451 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_schedule_options" href="#opt_with_schedule_options">opt_with_schedule_options:</a></p>
+      <svg width="774" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <rect x="129" y="23" width="122" height="32" rx="10"></rect>
+         <rect x="127" y="21" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="41">EXPERIMENTAL</text>
+         <rect x="271" y="23" width="92" height="32" rx="10"></rect>
+         <rect x="269" y="21" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="279" y="41">SCHEDULE</text>
+         <rect x="383" y="23" width="84" height="32" rx="10"></rect>
+         <rect x="381" y="21" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="391" y="41">OPTIONS</text>
+         <a xlink:href="#kv_option_list" xlink:title="kv_option_list">
+            <rect x="507" y="23" width="108" height="32"></rect>
+            <rect x="505" y="21" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="515" y="41">kv_option_list</text>
+         </a>
+         <rect x="507" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="505" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="515" y="85">(</text>
+         <a xlink:href="#kv_option_list" xlink:title="kv_option_list">
+            <rect x="553" y="67" width="108" height="32"></rect>
+            <rect x="551" y="65" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="561" y="85">kv_option_list</text>
+         </a>
+         <rect x="681" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="679" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="689" y="85">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h686 m-716 0 h20 m696 0 h20 m-736 0 q10 0 10 10 m716 0 q0 -10 10 -10 m-726 10 v12 m716 0 v-12 m-716 12 q0 10 10 10 m696 0 q10 0 10 -10 m-706 10 h10 m58 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m84 0 h10 m20 0 h10 m108 0 h10 m0 0 h92 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"></path>
+         <polygon points="765 5 773 1 773 9"></polygon>
+         <polygon points="765 5 757 1 757 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="with_clause" href="#with_clause">with_clause:</a></p>
       <svg width="356" height="68">
@@ -7802,6 +8705,76 @@
          </p><ul>
             <li><a href="#drop_ddl_stmt" title="drop_ddl_stmt">drop_ddl_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_schema_stmt" href="#drop_schema_stmt">drop_schema_stmt:</a></p>
+      <svg width="710" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">DROP</text>
+         <rect x="109" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="107" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="117" y="21">SCHEMA</text>
+         <rect x="225" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="223" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="53">IF</text>
+         <rect x="279" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="277" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="53">EXISTS</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="387" y="3" width="136" height="32"></rect>
+            <rect x="385" y="1" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="395" y="21">schema_name_list</text>
+         </a>
+         <a xlink:href="#opt_drop_behavior" xlink:title="opt_drop_behavior">
+            <rect x="543" y="3" width="140" height="32"></rect>
+            <rect x="541" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="551" y="21">opt_drop_behavior</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m136 0 h10 m0 0 h10 m140 0 h10 m3 0 h-3"></path>
+         <polygon points="701 17 709 13 709 21"></polygon>
+         <polygon points="701 17 693 13 693 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_ddl_stmt" title="drop_ddl_stmt">drop_ddl_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_type_stmt" href="#drop_type_stmt">drop_type_stmt:</a></p>
+      <svg width="668" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">DROP</text>
+         <rect x="109" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="107" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="117" y="21">TYPE</text>
+         <rect x="203" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="201" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="211" y="53">IF</text>
+         <rect x="257" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="255" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="265" y="53">EXISTS</text>
+         <a xlink:href="#type_name_list" xlink:title="type_name_list">
+            <rect x="365" y="3" width="116" height="32"></rect>
+            <rect x="363" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="21">type_name_list</text>
+         </a>
+         <a xlink:href="#opt_drop_behavior" xlink:title="opt_drop_behavior">
+            <rect x="501" y="3" width="140" height="32"></rect>
+            <rect x="499" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="509" y="21">opt_drop_behavior</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m116 0 h10 m0 0 h10 m140 0 h10 m3 0 h-3"></path>
+         <polygon points="659 17 667 13 667 21"></polygon>
+         <polygon points="659 17 651 13 651 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_ddl_stmt" title="drop_ddl_stmt">drop_ddl_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="explain_option_name" href="#explain_option_name">explain_option_name:</a></p>
       <svg width="206" height="36">
          
@@ -7846,7 +8819,7 @@
             <li><a href="#string_or_placeholder" title="string_or_placeholder">string_or_placeholder</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_elem" href="#table_elem">table_elem:</a></p>
-      <svg width="220" height="168">
+      <svg width="436" height="212">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7870,9 +8843,22 @@
             <rect x="49" y="133" width="122" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="153">table_constraint</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m92 0 h10 m0 0 h30 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m84 0 h10 m0 0 h38 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m23 -132 h-3"></path>
-         <polygon points="211 17 219 13 219 21"></polygon>
-         <polygon points="211 17 203 13 203 21"></polygon>
+         <rect x="51" y="179" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">LIKE</text>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="121" y="179" width="94" height="32"></rect>
+            <rect x="119" y="177" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="129" y="197">table_name</text>
+         </a>
+         <a xlink:href="#like_table_option_list" xlink:title="like_table_option_list">
+            <rect x="235" y="179" width="154" height="32"></rect>
+            <rect x="233" y="177" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="197">like_table_option_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m92 0 h10 m0 0 h246 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m82 0 h10 m0 0 h256 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m84 0 h10 m0 0 h254 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m122 0 h10 m0 0 h216 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m50 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m154 0 h10 m23 -176 h-3"></path>
+         <polygon points="427 17 435 13 435 21"></polygon>
+         <polygon points="427 17 419 13 419 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -7919,349 +8905,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#on_conflict" title="on_conflict">on_conflict</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="c_expr" href="#c_expr">c_expr:</a></p>
-      <svg width="346" height="156">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#d_expr" xlink:title="d_expr">
-            <rect x="51" y="3" width="64" height="32"></rect>
-            <rect x="49" y="1" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">d_expr</text>
-         </a>
-         <a xlink:href="#array_subscripts" xlink:title="array_subscripts">
-            <rect x="155" y="35" width="124" height="32"></rect>
-            <rect x="153" y="33" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="163" y="53">array_subscripts</text>
-         </a>
-         <a xlink:href="#case_expr" xlink:title="case_expr">
-            <rect x="51" y="79" width="84" height="32"></rect>
-            <rect x="49" y="77" width="84" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="97">case_expr</text>
-         </a>
-         <rect x="51" y="123" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="121" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="141">EXISTS</text>
-         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
-            <rect x="139" y="123" width="144" height="32"></rect>
-            <rect x="137" y="121" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="147" y="141">select_with_parens</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m-268 -32 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v56 m288 0 v-56 m-288 56 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m84 0 h10 m0 0 h164 m-278 -10 v20 m288 0 v-20 m-288 20 v24 m288 0 v-24 m-288 24 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m68 0 h10 m0 0 h10 m144 0 h10 m0 0 h16 m23 -120 h-3"></path>
-         <polygon points="337 17 345 13 345 21"></polygon>
-         <polygon points="337 17 329 13 329 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
-            <li><a href="#select_fetch_first_value" title="select_fetch_first_value">select_fetch_first_value</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cast_target" href="#cast_target">cast_target:</a></p>
-      <svg width="140" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#typename" xlink:title="typename">
-            <rect x="31" y="3" width="82" height="32"></rect>
-            <rect x="29" y="1" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">typename</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m3 0 h-3"></path>
-         <polygon points="131 17 139 13 139 21"></polygon>
-         <polygon points="131 17 123 13 123 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
-            <li><a href="#func_expr_common_subexpr" title="func_expr_common_subexpr">func_expr_common_subexpr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="typename" href="#typename">typename:</a></p>
-      <svg width="384" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#simple_typename" xlink:title="simple_typename">
-            <rect x="31" y="3" width="130" height="32"></rect>
-            <rect x="29" y="1" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">simple_typename</text>
-         </a>
-         <a xlink:href="#opt_array_bounds" xlink:title="opt_array_bounds">
-            <rect x="201" y="3" width="136" height="32"></rect>
-            <rect x="199" y="1" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="209" y="21">opt_array_bounds</text>
-         </a>
-         <rect x="201" y="47" width="66" height="32" rx="10"></rect>
-         <rect x="199" y="45" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="209" y="65">ARRAY</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m130 0 h10 m20 0 h10 m136 0 h10 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m66 0 h10 m0 0 h70 m23 -44 h-3"></path>
-         <polygon points="375 17 383 13 383 21"></polygon>
-         <polygon points="375 17 367 13 367 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
-            <li><a href="#cast_target" title="cast_target">cast_target</a></li>
-            <li><a href="#column_def" title="column_def">column_def</a></li>
-            <li><a href="#func_expr_common_subexpr" title="func_expr_common_subexpr">func_expr_common_subexpr</a></li>
-            <li><a href="#type_list" title="type_list">type_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="collation_name" href="#collation_name">collation_name:</a></p>
-      <svg width="196" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="31" y="3" width="138" height="32"></rect>
-            <rect x="29" y="1" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">unrestricted_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m138 0 h10 m3 0 h-3"></path>
-         <polygon points="187 17 195 13 195 21"></polygon>
-         <polygon points="187 17 179 13 179 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#col_qualification" title="col_qualification">col_qualification</a></li>
-            <li><a href="#opt_collate" title="opt_collate">opt_collate</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_asymmetric" href="#opt_asymmetric">opt_asymmetric:</a></p>
-      <svg width="208" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="110" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="110" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">ASYMMETRIC</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m23 -32 h-3"></path>
-         <polygon points="199 5 207 1 207 9"></polygon>
-         <polygon points="199 5 191 1 191 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="b_expr" href="#b_expr">b_expr:</a></p>
-      <svg width="622" height="1234">
-         
-         <polygon points="11 17 3 13 3 21"></polygon>
-         <polygon points="19 17 11 13 11 21"></polygon>
-         <a xlink:href="#c_expr" xlink:title="c_expr">
-            <rect x="53" y="3" width="62" height="32"></rect>
-            <rect x="51" y="1" width="62" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="61" y="21">c_expr</text>
-         </a>
-         <rect x="73" y="47" width="30" height="32" rx="10"></rect>
-         <rect x="71" y="45" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="65">+</text>
-         <rect x="73" y="91" width="26" height="32" rx="10"></rect>
-         <rect x="71" y="89" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="109">-</text>
-         <rect x="73" y="135" width="30" height="32" rx="10"></rect>
-         <rect x="71" y="133" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="81" y="153">~</text>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="143" y="47" width="64" height="32"></rect>
-            <rect x="141" y="45" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="151" y="65">b_expr</text>
-         </a>
-         <rect x="85" y="217" width="90" height="32" rx="10"></rect>
-         <rect x="83" y="215" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="235">TYPECAST</text>
-         <a xlink:href="#cast_target" xlink:title="cast_target">
-            <rect x="195" y="217" width="92" height="32"></rect>
-            <rect x="193" y="215" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="235">cast_target</text>
-         </a>
-         <rect x="85" y="261" width="128" height="32" rx="10"></rect>
-         <rect x="83" y="259" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="279">TYPEANNOTATE</text>
-         <a xlink:href="#typename" xlink:title="typename">
-            <rect x="233" y="261" width="82" height="32"></rect>
-            <rect x="231" y="259" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="241" y="279">typename</text>
-         </a>
-         <rect x="105" y="305" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="303" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="323">+</text>
-         <rect x="105" y="349" width="26" height="32" rx="10"></rect>
-         <rect x="103" y="347" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="367">-</text>
-         <rect x="105" y="393" width="28" height="32" rx="10"></rect>
-         <rect x="103" y="391" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="411">*</text>
-         <rect x="105" y="437" width="28" height="32" rx="10"></rect>
-         <rect x="103" y="435" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="455">/</text>
-         <rect x="105" y="481" width="92" height="32" rx="10"></rect>
-         <rect x="103" y="479" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="499">FLOORDIV</text>
-         <rect x="105" y="525" width="34" height="32" rx="10"></rect>
-         <rect x="103" y="523" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="543">%</text>
-         <rect x="105" y="569" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="567" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="587">^</text>
-         <rect x="105" y="613" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="611" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="631">#</text>
-         <rect x="105" y="657" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="655" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="675">&amp;</text>
-         <rect x="105" y="701" width="26" height="32" rx="10"></rect>
-         <rect x="103" y="699" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="719">|</text>
-         <rect x="105" y="745" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="743" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="763">&lt;</text>
-         <rect x="105" y="789" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="787" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="807">&gt;</text>
-         <rect x="105" y="833" width="30" height="32" rx="10"></rect>
-         <rect x="103" y="831" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="851">=</text>
-         <rect x="105" y="877" width="76" height="32" rx="10"></rect>
-         <rect x="103" y="875" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="895">CONCAT</text>
-         <rect x="105" y="921" width="68" height="32" rx="10"></rect>
-         <rect x="103" y="919" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="939">LSHIFT</text>
-         <rect x="105" y="965" width="70" height="32" rx="10"></rect>
-         <rect x="103" y="963" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="983">RSHIFT</text>
-         <rect x="105" y="1009" width="118" height="32" rx="10"></rect>
-         <rect x="103" y="1007" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="1027">LESS_EQUALS</text>
-         <rect x="105" y="1053" width="144" height="32" rx="10"></rect>
-         <rect x="103" y="1051" width="144" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="1071">GREATER_EQUALS</text>
-         <rect x="105" y="1097" width="112" height="32" rx="10"></rect>
-         <rect x="103" y="1095" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="113" y="1115">NOT_EQUALS</text>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="289" y="305" width="64" height="32"></rect>
-            <rect x="287" y="303" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="297" y="323">b_expr</text>
-         </a>
-         <rect x="85" y="1141" width="34" height="32" rx="10"></rect>
-         <rect x="83" y="1139" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="93" y="1159">IS</text>
-         <rect x="159" y="1173" width="48" height="32" rx="10"></rect>
-         <rect x="157" y="1171" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="167" y="1191">NOT</text>
-         <rect x="267" y="1141" width="86" height="32" rx="10"></rect>
-         <rect x="265" y="1139" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="275" y="1159">DISTINCT</text>
-         <rect x="373" y="1141" width="58" height="32" rx="10"></rect>
-         <rect x="371" y="1139" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="381" y="1159">FROM</text>
-         <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="451" y="1141" width="64" height="32"></rect>
-            <rect x="449" y="1139" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="459" y="1159">b_expr</text>
-         </a>
-         <rect x="267" y="1185" width="38" height="32" rx="10"></rect>
-         <rect x="265" y="1183" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="275" y="1203">OF</text>
-         <rect x="325" y="1185" width="26" height="32" rx="10"></rect>
-         <rect x="323" y="1183" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="333" y="1203">(</text>
-         <a xlink:href="#type_list" xlink:title="type_list">
-            <rect x="371" y="1185" width="74" height="32"></rect>
-            <rect x="369" y="1183" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="379" y="1203">type_list</text>
-         </a>
-         <rect x="465" y="1185" width="26" height="32" rx="10"></rect>
-         <rect x="463" y="1183" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="473" y="1203">)</text>
-         <path class="line" d="m19 17 h2 m20 0 h10 m62 0 h10 m0 0 h92 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-164 10 h10 m30 0 h10 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v24 m70 0 v-24 m-70 24 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m26 0 h10 m0 0 h4 m-60 -10 v20 m70 0 v-20 m-70 20 v24 m70 0 v-24 m-70 24 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -88 h10 m64 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-246 214 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m90 0 h10 m0 0 h10 m92 0 h10 m0 0 h248 m-490 0 h20 m470 0 h20 m-510 0 q10 0 10 10 m490 0 q0 -10 10 -10 m-500 10 v24 m490 0 v-24 m-490 24 q0 10 10 10 m470 0 q10 0 10 -10 m-480 10 h10 m128 0 h10 m0 0 h10 m82 0 h10 m0 0 h220 m-480 -10 v20 m490 0 v-20 m-490 20 v24 m490 0 v-24 m-490 24 q0 10 10 10 m470 0 q10 0 10 -10 m-460 10 h10 m30 0 h10 m0 0 h114 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m92 0 h10 m0 0 h52 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m34 0 h10 m0 0 h110 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m76 0 h10 m0 0 h68 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m68 0 h10 m0 0 h76 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m70 0 h10 m0 0 h74 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m118 0 h10 m0 0 h26 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m112 0 h10 m0 0 h32 m20 -792 h10 m64 0 h10 m0 0 h182 m-480 -10 v20 m490 0 v-20 m-490 20 v816 m490 0 v-816 m-490 816 q0 10 10 10 m470 0 q10 0 10 -10 m-480 10 h10 m34 0 h10 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -32 h10 m86 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v24 m288 0 v-24 m-288 24 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h24 m-490 -968 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m510 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-510 0 h10 m0 0 h500 m-550 32 h20 m550 0 h20 m-590 0 q10 0 10 10 m570 0 q0 -10 10 -10 m-580 10 v982 m570 0 v-982 m-570 982 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m0 0 h540 m23 -1002 h-3"></path>
-         <polygon points="613 231 621 227 621 235"></polygon>
-         <polygon points="613 231 605 227 605 235"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
-            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
-            <li><a href="#position_list" title="position_list">position_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="in_expr" href="#in_expr">in_expr:</a></p>
-      <svg width="270" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
-            <rect x="51" y="3" width="144" height="32"></rect>
-            <rect x="49" y="1" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">select_with_parens</text>
-         </a>
-         <a xlink:href="#expr_tuple1_ambiguous" xlink:title="expr_tuple1_ambiguous">
-            <rect x="51" y="47" width="172" height="32"></rect>
-            <rect x="49" y="45" width="172" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">expr_tuple1_ambiguous</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m144 0 h10 m0 0 h28 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m23 -44 h-3"></path>
-         <polygon points="261 17 269 13 269 21"></polygon>
-         <polygon points="261 17 253 13 253 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-            <li><a href="#multiple_set_clause" title="multiple_set_clause">multiple_set_clause</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="subquery_op" href="#subquery_op">subquery_op:</a></p>
-      <svg width="302" height="124">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#math_op" xlink:title="math_op">
-            <rect x="51" y="3" width="76" height="32"></rect>
-            <rect x="49" y="1" width="76" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">math_op</text>
-         </a>
-         <rect x="71" y="79" width="48" height="32" rx="10"></rect>
-         <rect x="69" y="77" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="97">NOT</text>
-         <rect x="179" y="47" width="50" height="32" rx="10"></rect>
-         <rect x="177" y="45" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="187" y="65">LIKE</text>
-         <rect x="179" y="91" width="56" height="32" rx="10"></rect>
-         <rect x="177" y="89" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="187" y="109">ILIKE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m0 0 h128 m-244 0 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v24 m244 0 v-24 m-244 24 q0 10 10 10 m224 0 q10 0 10 -10 m-214 10 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -32 h10 m50 0 h10 m0 0 h6 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m43 -88 h-3"></path>
-         <polygon points="293 17 301 13 301 21"></polygon>
-         <polygon points="293 17 285 13 285 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sub_type" href="#sub_type">sub_type:</a></p>
-      <svg width="156" height="124">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ANY</text>
-         <rect x="51" y="47" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">SOME</text>
-         <rect x="51" y="91" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">ALL</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m0 0 h10 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m44 0 h10 m0 0 h14 m23 -88 h-3"></path>
-         <polygon points="147 17 155 13 155 21"></polygon>
-         <polygon points="147 17 139 13 139 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="session_var" href="#session_var">session_var:</a></p>
       <svg width="226" height="256">
@@ -8633,6 +9276,44 @@
          </p><ul>
             <li><a href="#show_grants_stmt" title="show_grants_stmt">show_grants_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_schedule_executor_type" href="#opt_schedule_executor_type">opt_schedule_executor_type:</a></p>
+      <svg width="200" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">FOR</text>
+         <rect x="99" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="97" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="107" y="21">BACKUP</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m3 0 h-3"></path>
+         <polygon points="191 17 199 13 199 21"></polygon>
+         <polygon points="191 17 183 13 183 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_schedules_stmt" title="show_schedules_stmt">show_schedules_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schedule_state" href="#schedule_state">schedule_state:</a></p>
+      <svg width="182" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">RUNNING</text>
+         <rect x="51" y="47" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">PAUSED</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m84 0 h10 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m74 0 h10 m0 0 h10 m23 -44 h-3"></path>
+         <polygon points="173 17 181 13 181 21"></polygon>
+         <polygon points="173 17 165 13 165 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_schedules_stmt" title="show_schedules_stmt">show_schedules_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_cluster" href="#opt_cluster">opt_cluster:</a></p>
       <svg width="178" height="80">
          
@@ -8768,6 +9449,9 @@
             <li><a href="#alter_rename_sequence_stmt" title="alter_rename_sequence_stmt">alter_rename_sequence_stmt</a></li>
             <li><a href="#alter_rename_table_stmt" title="alter_rename_table_stmt">alter_rename_table_stmt</a></li>
             <li><a href="#alter_rename_view_stmt" title="alter_rename_view_stmt">alter_rename_view_stmt</a></li>
+            <li><a href="#alter_sequence_set_schema_stmt" title="alter_sequence_set_schema_stmt">alter_sequence_set_schema_stmt</a></li>
+            <li><a href="#alter_table_set_schema_stmt" title="alter_table_set_schema_stmt">alter_table_set_schema_stmt</a></li>
+            <li><a href="#alter_view_set_schema_stmt" title="alter_view_set_schema_stmt">alter_view_set_schema_stmt</a></li>
             <li><a href="#relation_expr_list" title="relation_expr_list">relation_expr_list</a></li>
             <li><a href="#table_ref" title="table_ref">table_ref</a></li>
          </ul>
@@ -8968,12 +9652,45 @@
             <li><a href="#column_path_with_star" title="column_path_with_star">column_path_with_star</a></li>
             <li><a href="#complex_db_object_name" title="complex_db_object_name">complex_db_object_name</a></li>
             <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
+            <li><a href="#complex_type_name" title="complex_type_name">complex_type_name</a></li>
             <li><a href="#d_expr" title="d_expr">d_expr</a></li>
             <li><a href="#index_name" title="index_name">index_name</a></li>
             <li><a href="#partition_name" title="partition_name">partition_name</a></li>
             <li><a href="#prefixed_column_path" title="prefixed_column_path">prefixed_column_path</a></li>
             <li><a href="#target_name" title="target_name">target_name</a></li>
             <li><a href="#zone_name" title="zone_name">zone_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="typename" href="#typename">typename:</a></p>
+      <svg width="384" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#simple_typename" xlink:title="simple_typename">
+            <rect x="31" y="3" width="130" height="32"></rect>
+            <rect x="29" y="1" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">simple_typename</text>
+         </a>
+         <a xlink:href="#opt_array_bounds" xlink:title="opt_array_bounds">
+            <rect x="201" y="3" width="136" height="32"></rect>
+            <rect x="199" y="1" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="209" y="21">opt_array_bounds</text>
+         </a>
+         <rect x="201" y="47" width="66" height="32" rx="10"></rect>
+         <rect x="199" y="45" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="209" y="65">ARRAY</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m130 0 h10 m20 0 h10 m136 0 h10 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m66 0 h10 m0 0 h70 m23 -44 h-3"></path>
+         <polygon points="375 17 383 13 383 21"></polygon>
+         <polygon points="375 17 367 13 367 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
+            <li><a href="#cast_target" title="cast_target">cast_target</a></li>
+            <li><a href="#column_def" title="column_def">column_def</a></li>
+            <li><a href="#func_expr_common_subexpr" title="func_expr_common_subexpr">func_expr_common_subexpr</a></li>
+            <li><a href="#type_list" title="type_list">type_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="transaction_mode" href="#transaction_mode">transaction_mode:</a></p>
       <svg width="276" height="124">
@@ -9258,6 +9975,47 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
          <polygon points="645 115 653 111 653 119"></polygon>
          <polygon points="645 115 637 111 637 119"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_stmt" title="alter_table_stmt">alter_table_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_set_schema_stmt" href="#alter_table_set_schema_stmt">alter_table_set_schema_stmt:</a></p>
+      <svg width="662" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">TABLE</text>
+         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="53">IF</text>
+         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="277" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="377" y="3" width="104" height="32"></rect>
+            <rect x="375" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="385" y="21">relation_expr</text>
+         </a>
+         <rect x="501" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="499" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="21">SET</text>
+         <rect x="565" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="563" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="573" y="21">SCHEMA</text>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="525" y="101" width="110" height="32"></rect>
+            <rect x="523" y="99" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="533" y="119">schema_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-160 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m3 0 h-3"></path>
+         <polygon points="653 115 661 111 661 119"></polygon>
+         <polygon points="653 115 645 111 645 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -9548,6 +10306,47 @@
          </p><ul>
             <li><a href="#alter_view_stmt" title="alter_view_stmt">alter_view_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_view_set_schema_stmt" href="#alter_view_set_schema_stmt">alter_view_set_schema_stmt:</a></p>
+      <svg width="656" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">VIEW</text>
+         <rect x="209" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="207" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="217" y="53">IF</text>
+         <rect x="263" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="261" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="271" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="371" y="3" width="104" height="32"></rect>
+            <rect x="369" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="379" y="21">relation_expr</text>
+         </a>
+         <rect x="495" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="493" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="503" y="21">SET</text>
+         <rect x="559" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="557" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="567" y="21">SCHEMA</text>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="519" y="101" width="110" height="32"></rect>
+            <rect x="517" y="99" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="527" y="119">schema_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-160 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m3 0 h-3"></path>
+         <polygon points="647 115 655 111 655 119"></polygon>
+         <polygon points="647 115 639 111 639 119"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_view_stmt" title="alter_view_stmt">alter_view_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_rename_sequence_stmt" href="#alter_rename_sequence_stmt">alter_rename_sequence_stmt:</a></p>
       <svg width="684" height="134">
          
@@ -9619,6 +10418,47 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m124 0 h10 m0 0 h10 m154 0 h10 m3 0 h-3"></path>
          <polygon points="723 17 731 13 731 21"></polygon>
          <polygon points="723 17 715 13 715 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_sequence_stmt" title="alter_sequence_stmt">alter_sequence_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_sequence_set_schema_stmt" href="#alter_sequence_set_schema_stmt">alter_sequence_set_schema_stmt:</a></p>
+      <svg width="692" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">SEQUENCE</text>
+         <rect x="245" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="243" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="253" y="53">IF</text>
+         <rect x="299" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="297" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="307" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="407" y="3" width="104" height="32"></rect>
+            <rect x="405" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="415" y="21">relation_expr</text>
+         </a>
+         <rect x="531" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="529" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="539" y="21">SET</text>
+         <rect x="595" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="593" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="603" y="21">SCHEMA</text>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="555" y="101" width="110" height="32"></rect>
+            <rect x="553" y="99" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="563" y="119">schema_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-160 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m3 0 h-3"></path>
+         <polygon points="683 115 691 111 691 119"></polygon>
+         <polygon points="683 115 675 111 675 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -9776,6 +10616,72 @@
          </p><ul>
             <li><a href="#alter_partition_stmt" title="alter_partition_stmt">alter_partition_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name" href="#schema_name">schema_name:</a></p>
+      <svg width="112" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
+         <polygon points="103 17 111 13 111 21"></polygon>
+         <polygon points="103 17 95 13 95 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_schema_stmt" title="alter_schema_stmt">alter_schema_stmt</a></li>
+            <li><a href="#alter_sequence_set_schema_stmt" title="alter_sequence_set_schema_stmt">alter_sequence_set_schema_stmt</a></li>
+            <li><a href="#alter_table_set_schema_stmt" title="alter_table_set_schema_stmt">alter_table_set_schema_stmt</a></li>
+            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
+            <li><a href="#alter_view_set_schema_stmt" title="alter_view_set_schema_stmt">alter_view_set_schema_stmt</a></li>
+            <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
+            <li><a href="#schema_name_list" title="schema_name_list">schema_name_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_name" href="#type_name">type_name:</a></p>
+      <svg width="184" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#db_object_name" xlink:title="db_object_name">
+            <rect x="31" y="3" width="126" height="32"></rect>
+            <rect x="29" y="1" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">db_object_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m126 0 h10 m3 0 h-3"></path>
+         <polygon points="175 17 183 13 183 21"></polygon>
+         <polygon points="175 17 167 13 167 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
+            <li><a href="#create_type_stmt" title="create_type_stmt">create_type_stmt</a></li>
+            <li><a href="#type_name_list" title="type_name_list">type_name_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_add_val_placement" href="#opt_add_val_placement">opt_add_val_placement:</a></p>
+      <svg width="306" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="71" y="23" width="72" height="32" rx="10"></rect>
+         <rect x="69" y="21" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="41">BEFORE</text>
+         <rect x="71" y="67" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="65" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="85">AFTER</text>
+         <rect x="183" y="23" width="76" height="32" rx="10"></rect>
+         <rect x="181" y="21" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="191" y="41">SCONST</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h218 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v12 m248 0 v-12 m-248 12 q0 10 10 10 m228 0 q10 0 10 -10 m-218 10 h10 m72 0 h10 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v24 m112 0 v-24 m-112 24 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m62 0 h10 m0 0 h10 m20 -44 h10 m76 0 h10 m23 -32 h-3"></path>
+         <polygon points="297 5 305 1 305 9"></polygon>
+         <polygon points="297 5 289 1 289 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with" href="#opt_with">opt_with:</a></p>
       <svg width="156" height="56">
          
@@ -9810,6 +10716,358 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#opt_role_options" title="opt_role_options">opt_role_options</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="backup_options" href="#backup_options">backup_options:</a></p>
+      <svg width="534" height="168">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="208" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="208" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ENCRYPTION_PASSPHRASE</text>
+         <rect x="279" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="277" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="21">=</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="329" y="3" width="158" height="32"></rect>
+            <rect x="327" y="1" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="337" y="21">string_or_placeholder</text>
+         </a>
+         <rect x="51" y="47" width="160" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="160" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">REVISION_HISTORY</text>
+         <rect x="51" y="91" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">DETACHED</text>
+         <rect x="51" y="135" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">KMS</text>
+         <rect x="119" y="135" width="30" height="32" rx="10"></rect>
+         <rect x="117" y="133" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="153">=</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="169" y="135" width="212" height="32"></rect>
+            <rect x="167" y="133" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="177" y="153">string_or_placeholder_opt_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m208 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m158 0 h10 m-476 0 h20 m456 0 h20 m-496 0 q10 0 10 10 m476 0 q0 -10 10 -10 m-486 10 v24 m476 0 v-24 m-476 24 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m160 0 h10 m0 0 h276 m-466 -10 v20 m476 0 v-20 m-476 20 v24 m476 0 v-24 m-476 24 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m92 0 h10 m0 0 h344 m-466 -10 v20 m476 0 v-20 m-476 20 v24 m476 0 v-24 m-476 24 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m48 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m212 0 h10 m0 0 h106 m23 -132 h-3"></path>
+         <polygon points="525 17 533 13 533 21"></polygon>
+         <polygon points="525 17 517 13 517 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#backup_options_list" title="backup_options_list">backup_options_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="c_expr" href="#c_expr">c_expr:</a></p>
+      <svg width="346" height="156">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#d_expr" xlink:title="d_expr">
+            <rect x="51" y="3" width="64" height="32"></rect>
+            <rect x="49" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">d_expr</text>
+         </a>
+         <a xlink:href="#array_subscripts" xlink:title="array_subscripts">
+            <rect x="155" y="35" width="124" height="32"></rect>
+            <rect x="153" y="33" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="163" y="53">array_subscripts</text>
+         </a>
+         <a xlink:href="#case_expr" xlink:title="case_expr">
+            <rect x="51" y="79" width="84" height="32"></rect>
+            <rect x="49" y="77" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="97">case_expr</text>
+         </a>
+         <rect x="51" y="123" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="121" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="141">EXISTS</text>
+         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
+            <rect x="139" y="123" width="144" height="32"></rect>
+            <rect x="137" y="121" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="147" y="141">select_with_parens</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m-268 -32 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v56 m288 0 v-56 m-288 56 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m84 0 h10 m0 0 h164 m-278 -10 v20 m288 0 v-20 m-288 20 v24 m288 0 v-24 m-288 24 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m68 0 h10 m0 0 h10 m144 0 h10 m0 0 h16 m23 -120 h-3"></path>
+         <polygon points="337 17 345 13 345 21"></polygon>
+         <polygon points="337 17 329 13 329 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
+            <li><a href="#select_fetch_first_value" title="select_fetch_first_value">select_fetch_first_value</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cast_target" href="#cast_target">cast_target:</a></p>
+      <svg width="140" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#typename" xlink:title="typename">
+            <rect x="31" y="3" width="82" height="32"></rect>
+            <rect x="29" y="1" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">typename</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m3 0 h-3"></path>
+         <polygon points="131 17 139 13 139 21"></polygon>
+         <polygon points="131 17 123 13 123 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
+            <li><a href="#func_expr_common_subexpr" title="func_expr_common_subexpr">func_expr_common_subexpr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="collation_name" href="#collation_name">collation_name:</a></p>
+      <svg width="196" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="31" y="3" width="138" height="32"></rect>
+            <rect x="29" y="1" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">unrestricted_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m138 0 h10 m3 0 h-3"></path>
+         <polygon points="187 17 195 13 195 21"></polygon>
+         <polygon points="187 17 179 13 179 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#col_qualification" title="col_qualification">col_qualification</a></li>
+            <li><a href="#opt_collate" title="opt_collate">opt_collate</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_asymmetric" href="#opt_asymmetric">opt_asymmetric:</a></p>
+      <svg width="208" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">ASYMMETRIC</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m23 -32 h-3"></path>
+         <polygon points="199 5 207 1 207 9"></polygon>
+         <polygon points="199 5 191 1 191 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="b_expr" href="#b_expr">b_expr:</a></p>
+      <svg width="622" height="1234">
+         
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <a xlink:href="#c_expr" xlink:title="c_expr">
+            <rect x="53" y="3" width="62" height="32"></rect>
+            <rect x="51" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="61" y="21">c_expr</text>
+         </a>
+         <rect x="73" y="47" width="30" height="32" rx="10"></rect>
+         <rect x="71" y="45" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="65">+</text>
+         <rect x="73" y="91" width="26" height="32" rx="10"></rect>
+         <rect x="71" y="89" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="109">-</text>
+         <rect x="73" y="135" width="30" height="32" rx="10"></rect>
+         <rect x="71" y="133" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="81" y="153">~</text>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="143" y="47" width="64" height="32"></rect>
+            <rect x="141" y="45" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="151" y="65">b_expr</text>
+         </a>
+         <rect x="85" y="217" width="90" height="32" rx="10"></rect>
+         <rect x="83" y="215" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="235">TYPECAST</text>
+         <a xlink:href="#cast_target" xlink:title="cast_target">
+            <rect x="195" y="217" width="92" height="32"></rect>
+            <rect x="193" y="215" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="235">cast_target</text>
+         </a>
+         <rect x="85" y="261" width="128" height="32" rx="10"></rect>
+         <rect x="83" y="259" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="279">TYPEANNOTATE</text>
+         <a xlink:href="#typename" xlink:title="typename">
+            <rect x="233" y="261" width="82" height="32"></rect>
+            <rect x="231" y="259" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="241" y="279">typename</text>
+         </a>
+         <rect x="105" y="305" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="303" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="323">+</text>
+         <rect x="105" y="349" width="26" height="32" rx="10"></rect>
+         <rect x="103" y="347" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="367">-</text>
+         <rect x="105" y="393" width="28" height="32" rx="10"></rect>
+         <rect x="103" y="391" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="411">*</text>
+         <rect x="105" y="437" width="28" height="32" rx="10"></rect>
+         <rect x="103" y="435" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="455">/</text>
+         <rect x="105" y="481" width="92" height="32" rx="10"></rect>
+         <rect x="103" y="479" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="499">FLOORDIV</text>
+         <rect x="105" y="525" width="34" height="32" rx="10"></rect>
+         <rect x="103" y="523" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="543">%</text>
+         <rect x="105" y="569" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="567" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="587">^</text>
+         <rect x="105" y="613" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="611" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="631">#</text>
+         <rect x="105" y="657" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="655" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="675">&amp;</text>
+         <rect x="105" y="701" width="26" height="32" rx="10"></rect>
+         <rect x="103" y="699" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="719">|</text>
+         <rect x="105" y="745" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="743" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="763">&lt;</text>
+         <rect x="105" y="789" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="787" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="807">&gt;</text>
+         <rect x="105" y="833" width="30" height="32" rx="10"></rect>
+         <rect x="103" y="831" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="851">=</text>
+         <rect x="105" y="877" width="76" height="32" rx="10"></rect>
+         <rect x="103" y="875" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="895">CONCAT</text>
+         <rect x="105" y="921" width="68" height="32" rx="10"></rect>
+         <rect x="103" y="919" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="939">LSHIFT</text>
+         <rect x="105" y="965" width="70" height="32" rx="10"></rect>
+         <rect x="103" y="963" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="983">RSHIFT</text>
+         <rect x="105" y="1009" width="118" height="32" rx="10"></rect>
+         <rect x="103" y="1007" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1027">LESS_EQUALS</text>
+         <rect x="105" y="1053" width="144" height="32" rx="10"></rect>
+         <rect x="103" y="1051" width="144" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1071">GREATER_EQUALS</text>
+         <rect x="105" y="1097" width="112" height="32" rx="10"></rect>
+         <rect x="103" y="1095" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="1115">NOT_EQUALS</text>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="289" y="305" width="64" height="32"></rect>
+            <rect x="287" y="303" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="297" y="323">b_expr</text>
+         </a>
+         <rect x="85" y="1141" width="34" height="32" rx="10"></rect>
+         <rect x="83" y="1139" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="93" y="1159">IS</text>
+         <rect x="159" y="1173" width="48" height="32" rx="10"></rect>
+         <rect x="157" y="1171" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="1191">NOT</text>
+         <rect x="267" y="1141" width="86" height="32" rx="10"></rect>
+         <rect x="265" y="1139" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="275" y="1159">DISTINCT</text>
+         <rect x="373" y="1141" width="58" height="32" rx="10"></rect>
+         <rect x="371" y="1139" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="381" y="1159">FROM</text>
+         <a xlink:href="#b_expr" xlink:title="b_expr">
+            <rect x="451" y="1141" width="64" height="32"></rect>
+            <rect x="449" y="1139" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="459" y="1159">b_expr</text>
+         </a>
+         <rect x="267" y="1185" width="38" height="32" rx="10"></rect>
+         <rect x="265" y="1183" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="275" y="1203">OF</text>
+         <rect x="325" y="1185" width="26" height="32" rx="10"></rect>
+         <rect x="323" y="1183" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="1203">(</text>
+         <a xlink:href="#type_list" xlink:title="type_list">
+            <rect x="371" y="1185" width="74" height="32"></rect>
+            <rect x="369" y="1183" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="379" y="1203">type_list</text>
+         </a>
+         <rect x="465" y="1185" width="26" height="32" rx="10"></rect>
+         <rect x="463" y="1183" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="473" y="1203">)</text>
+         <path class="line" d="m19 17 h2 m20 0 h10 m62 0 h10 m0 0 h92 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v24 m194 0 v-24 m-194 24 q0 10 10 10 m174 0 q10 0 10 -10 m-164 10 h10 m30 0 h10 m-70 0 h20 m50 0 h20 m-90 0 q10 0 10 10 m70 0 q0 -10 10 -10 m-80 10 v24 m70 0 v-24 m-70 24 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m26 0 h10 m0 0 h4 m-60 -10 v20 m70 0 v-20 m-70 20 v24 m70 0 v-24 m-70 24 q0 10 10 10 m50 0 q10 0 10 -10 m-60 10 h10 m30 0 h10 m20 -88 h10 m64 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-246 214 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m90 0 h10 m0 0 h10 m92 0 h10 m0 0 h248 m-490 0 h20 m470 0 h20 m-510 0 q10 0 10 10 m490 0 q0 -10 10 -10 m-500 10 v24 m490 0 v-24 m-490 24 q0 10 10 10 m470 0 q10 0 10 -10 m-480 10 h10 m128 0 h10 m0 0 h10 m82 0 h10 m0 0 h220 m-480 -10 v20 m490 0 v-20 m-490 20 v24 m490 0 v-24 m-490 24 q0 10 10 10 m470 0 q10 0 10 -10 m-460 10 h10 m30 0 h10 m0 0 h114 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m92 0 h10 m0 0 h52 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m34 0 h10 m0 0 h110 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m76 0 h10 m0 0 h68 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m68 0 h10 m0 0 h76 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m70 0 h10 m0 0 h74 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m118 0 h10 m0 0 h26 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m112 0 h10 m0 0 h32 m20 -792 h10 m64 0 h10 m0 0 h182 m-480 -10 v20 m490 0 v-20 m-490 20 v816 m490 0 v-816 m-490 816 q0 10 10 10 m470 0 q10 0 10 -10 m-480 10 h10 m34 0 h10 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -32 h10 m86 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v24 m288 0 v-24 m-288 24 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h24 m-490 -968 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m510 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-510 0 h10 m0 0 h500 m-550 32 h20 m550 0 h20 m-590 0 q10 0 10 10 m570 0 q0 -10 10 -10 m-580 10 v982 m570 0 v-982 m-570 982 q0 10 10 10 m550 0 q10 0 10 -10 m-560 10 h10 m0 0 h540 m23 -1002 h-3"></path>
+         <polygon points="613 231 621 227 621 235"></polygon>
+         <polygon points="613 231 605 227 605 235"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#b_expr" title="b_expr">b_expr</a></li>
+            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
+            <li><a href="#position_list" title="position_list">position_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="in_expr" href="#in_expr">in_expr:</a></p>
+      <svg width="270" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
+            <rect x="51" y="3" width="144" height="32"></rect>
+            <rect x="49" y="1" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">select_with_parens</text>
+         </a>
+         <a xlink:href="#expr_tuple1_ambiguous" xlink:title="expr_tuple1_ambiguous">
+            <rect x="51" y="47" width="172" height="32"></rect>
+            <rect x="49" y="45" width="172" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">expr_tuple1_ambiguous</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m144 0 h10 m0 0 h28 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v24 m212 0 v-24 m-212 24 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m172 0 h10 m23 -44 h-3"></path>
+         <polygon points="261 17 269 13 269 21"></polygon>
+         <polygon points="261 17 253 13 253 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+            <li><a href="#multiple_set_clause" title="multiple_set_clause">multiple_set_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="subquery_op" href="#subquery_op">subquery_op:</a></p>
+      <svg width="302" height="124">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#math_op" xlink:title="math_op">
+            <rect x="51" y="3" width="76" height="32"></rect>
+            <rect x="49" y="1" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">math_op</text>
+         </a>
+         <rect x="71" y="79" width="48" height="32" rx="10"></rect>
+         <rect x="69" y="77" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="97">NOT</text>
+         <rect x="179" y="47" width="50" height="32" rx="10"></rect>
+         <rect x="177" y="45" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="187" y="65">LIKE</text>
+         <rect x="179" y="91" width="56" height="32" rx="10"></rect>
+         <rect x="177" y="89" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="187" y="109">ILIKE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m0 0 h128 m-244 0 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v24 m244 0 v-24 m-244 24 q0 10 10 10 m224 0 q10 0 10 -10 m-214 10 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -32 h10 m50 0 h10 m0 0 h6 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m43 -88 h-3"></path>
+         <polygon points="293 17 301 13 301 21"></polygon>
+         <polygon points="293 17 285 13 285 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sub_type" href="#sub_type">sub_type:</a></p>
+      <svg width="156" height="124">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ANY</text>
+         <rect x="51" y="47" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SOME</text>
+         <rect x="51" y="91" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">ALL</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m0 0 h10 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m44 0 h10 m0 0 h14 m23 -88 h-3"></path>
+         <polygon points="147 17 155 13 155 21"></polygon>
+         <polygon points="147 17 139 13 139 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#a_expr" title="a_expr">a_expr</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="changefeed_targets" href="#changefeed_targets">changefeed_targets:</a></p>
       <svg width="358" height="68">
@@ -10186,24 +11444,6 @@
             <li><a href="#list_partition" title="list_partition">list_partition</a></li>
             <li><a href="#range_partition" title="range_partition">range_partition</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name" href="#schema_name">schema_name:</a></p>
-      <svg width="112" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#name" xlink:title="name">
-            <rect x="31" y="3" width="54" height="32"></rect>
-            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="103 17 111 13 111 21"></polygon>
-         <polygon points="103 17 95 13 95 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_temp_create_table" href="#opt_temp_create_table">opt_temp_create_table:</a></p>
       <svg width="376" height="124">
          
@@ -10276,6 +11516,24 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_table_as_stmt" title="create_table_as_stmt">create_table_as_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_enum_val_list" href="#opt_enum_val_list">opt_enum_val_list:</a></p>
+      <svg width="204" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#enum_val_list" xlink:title="enum_val_list">
+            <rect x="51" y="23" width="106" height="32"></rect>
+            <rect x="49" y="21" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">enum_val_list</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m23 -32 h-3"></path>
+         <polygon points="195 5 203 1 203 9"></polygon>
+         <polygon points="195 5 187 1 187 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_type_stmt" title="create_type_stmt">create_type_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_temp" href="#opt_temp">opt_temp:</a></p>
       <svg width="202" height="100">
@@ -10354,6 +11612,26 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_sequence_stmt" title="create_sequence_stmt">create_sequence_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sconst_or_placeholder" href="#sconst_or_placeholder">sconst_or_placeholder:</a></p>
+      <svg width="216" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">SCONST</text>
+         <rect x="51" y="47" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">PLACEHOLDER</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m0 0 h42 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m23 -44 h-3"></path>
+         <polygon points="207 17 215 13 215 21"></polygon>
+         <polygon points="207 17 199 13 199 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#cron_expr" title="cron_expr">cron_expr</a></li>
+            <li><a href="#opt_full_backup_clause" title="opt_full_backup_clause">opt_full_backup_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cte_list" href="#cte_list">cte_list:</a></p>
       <svg width="246" height="80">
@@ -10437,6 +11715,7 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#single_sort_clause" title="single_sort_clause">single_sort_clause</a></li>
             <li><a href="#sort_clause" title="sort_clause">sort_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="first_or_next" href="#first_or_next">first_or_next:</a></p>
@@ -10584,6 +11863,48 @@
             <li><a href="#drop_view_stmt" title="drop_view_stmt">drop_view_stmt</a></li>
             <li><a href="#opt_locked_rels" title="opt_locked_rels">opt_locked_rels</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name_list" href="#schema_name_list">schema_name_list:</a></p>
+      <svg width="208" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="51" y="47" width="110" height="32"></rect>
+            <rect x="49" y="45" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">schema_name</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m23 44 h-3"></path>
+         <polygon points="199 61 207 57 207 65"></polygon>
+         <polygon points="199 61 191 57 191 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_name_list" href="#type_name_list">type_name_list:</a></p>
+      <svg width="188" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#type_name" xlink:title="type_name">
+            <rect x="51" y="47" width="90" height="32"></rect>
+            <rect x="49" y="45" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">type_name</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m90 0 h10 m-130 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m110 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-110 0 h10 m24 0 h10 m0 0 h66 m23 44 h-3"></path>
+         <polygon points="179 61 187 57 187 65"></polygon>
+         <polygon points="179 61 171 57 171 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_type_stmt" title="drop_type_stmt">drop_type_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="non_reserved_word" href="#non_reserved_word">non_reserved_word:</a></p>
       <svg width="284" height="168">
          
@@ -10646,7 +11967,7 @@
             <li><a href="#table_elem" title="table_elem">table_elem</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="index_def" href="#index_def">index_def:</a></p>
-      <svg width="1208" height="112">
+      <svg width="1202" height="178">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -10714,9 +12035,14 @@
          <rect x="519" y="79" width="26" height="32" rx="10"></rect>
          <rect x="517" y="77" width="26" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="527" y="97">)</text>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m62 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m-1150 0 h20 m1130 0 h20 m-1170 0 q10 0 10 10 m1150 0 q0 -10 10 -10 m-1160 10 v56 m1150 0 v-56 m-1150 56 q0 10 10 10 m1130 0 q10 0 10 -10 m-1140 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h616 m23 -76 h-3"></path>
-         <polygon points="1199 17 1207 13 1207 21"></polygon>
-         <polygon points="1199 17 1191 13 1191 21"></polygon>
+         <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
+            <rect x="1039" y="145" width="136" height="32"></rect>
+            <rect x="1037" y="143" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="1047" y="163">opt_where_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m62 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m-1150 0 h20 m1130 0 h20 m-1170 0 q10 0 10 10 m1150 0 q0 -10 10 -10 m-1160 10 v56 m1150 0 v-56 m-1150 56 q0 10 10 10 m1130 0 q10 0 10 -10 m-1140 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h616 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-186 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m136 0 h10 m3 0 h-3"></path>
+         <polygon points="1193 159 1201 155 1201 163"></polygon>
+         <polygon points="1193 159 1185 155 1185 163"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -10782,6 +12108,30 @@
             <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
             <li><a href="#table_elem" title="table_elem">table_elem</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="like_table_option_list" href="#like_table_option_list">like_table_option_list:</a></p>
+      <svg width="426" height="112">
+         
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <rect x="91" y="19" width="98" height="32" rx="10"></rect>
+         <rect x="89" y="17" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="37">INCLUDING</text>
+         <rect x="91" y="63" width="100" height="32" rx="10"></rect>
+         <rect x="89" y="61" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="99" y="81">EXCLUDING</text>
+         <a xlink:href="#like_table_option" xlink:title="like_table_option">
+            <rect x="231" y="19" width="128" height="32"></rect>
+            <rect x="229" y="17" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="239" y="37">like_table_option</text>
+         </a>
+         <path class="line" d="m17 33 h2 m60 0 h10 m98 0 h10 m0 0 h2 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -44 h10 m128 0 h10 m-328 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m308 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-308 0 h10 m0 0 h298 m-348 32 h20 m348 0 h20 m-388 0 q10 0 10 10 m368 0 q0 -10 10 -10 m-378 10 v58 m368 0 v-58 m-368 58 q0 10 10 10 m348 0 q10 0 10 -10 m-358 10 h10 m0 0 h338 m23 -78 h-3"></path>
+         <polygon points="417 33 425 29 425 37"></polygon>
+         <polygon points="417 33 409 29 409 37"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#table_elem" title="table_elem">table_elem</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="column_name" href="#column_name">column_name:</a></p>
       <svg width="112" height="36">
          
@@ -10804,319 +12154,6 @@
             <li><a href="#create_as_table_defs" title="create_as_table_defs">create_as_table_defs</a></li>
             <li><a href="#insert_column_item" title="insert_column_item">insert_column_item</a></li>
             <li><a href="#single_set_clause" title="single_set_clause">single_set_clause</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="d_expr" href="#d_expr">d_expr:</a></p>
-      <svg width="536" height="968">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="35" width="32" height="32" rx="10"></rect>
-         <rect x="69" y="33" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="53">@</text>
-         <rect x="143" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="141" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="151" y="21">ICONST</text>
-         <rect x="51" y="79" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="77" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="97">FCONST</text>
-         <a xlink:href="#const_typename" xlink:title="const_typename">
-            <rect x="71" y="155" width="124" height="32"></rect>
-            <rect x="69" y="153" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="79" y="173">const_typename</text>
-         </a>
-         <rect x="235" y="123" width="76" height="32" rx="10"></rect>
-         <rect x="233" y="121" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="243" y="141">SCONST</text>
-         <rect x="51" y="199" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="197" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="217">BCONST</text>
-         <rect x="51" y="243" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="241" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="261">BITCONST</text>
-         <a xlink:href="#interval_value" xlink:title="interval_value">
-            <rect x="51" y="287" width="108" height="32"></rect>
-            <rect x="49" y="285" width="108" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="305">interval_value</text>
-         </a>
-         <rect x="51" y="331" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="329" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="349">TRUE</text>
-         <rect x="51" y="375" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="373" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="393">FALSE</text>
-         <rect x="51" y="419" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="417" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="437">NULL</text>
-         <a xlink:href="#column_path_with_star" xlink:title="column_path_with_star">
-            <rect x="51" y="463" width="168" height="32"></rect>
-            <rect x="49" y="461" width="168" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="481">column_path_with_star</text>
-         </a>
-         <rect x="51" y="507" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="505" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="525">PLACEHOLDER</text>
-         <rect x="51" y="551" width="26" height="32" rx="10"></rect>
-         <rect x="49" y="549" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="569">(</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="97" y="551" width="64" height="32"></rect>
-            <rect x="95" y="549" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="569">a_expr</text>
-         </a>
-         <rect x="181" y="551" width="26" height="32" rx="10"></rect>
-         <rect x="179" y="549" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="189" y="569">)</text>
-         <rect x="247" y="583" width="24" height="32" rx="10"></rect>
-         <rect x="245" y="581" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="255" y="601">.</text>
-         <rect x="311" y="583" width="28" height="32" rx="10"></rect>
-         <rect x="309" y="581" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="319" y="601">*</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="311" y="627" width="138" height="32"></rect>
-            <rect x="309" y="625" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="319" y="645">unrestricted_name</text>
-         </a>
-         <rect x="311" y="671" width="32" height="32" rx="10"></rect>
-         <rect x="309" y="669" width="32" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="319" y="689">@</text>
-         <rect x="363" y="671" width="72" height="32" rx="10"></rect>
-         <rect x="361" y="669" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="371" y="689">ICONST</text>
-         <a xlink:href="#func_expr" xlink:title="func_expr">
-            <rect x="51" y="715" width="82" height="32"></rect>
-            <rect x="49" y="713" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="733">func_expr</text>
-         </a>
-         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
-            <rect x="51" y="759" width="144" height="32"></rect>
-            <rect x="49" y="757" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="777">select_with_parens</text>
-         </a>
-         <a xlink:href="#labeled_row" xlink:title="labeled_row">
-            <rect x="51" y="803" width="98" height="32"></rect>
-            <rect x="49" y="801" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="821">labeled_row</text>
-         </a>
-         <rect x="51" y="847" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="845" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="865">ARRAY</text>
-         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
-            <rect x="157" y="847" width="144" height="32"></rect>
-            <rect x="155" y="845" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="165" y="865">select_with_parens</text>
-         </a>
-         <a xlink:href="#row" xlink:title="row">
-            <rect x="157" y="891" width="44" height="32"></rect>
-            <rect x="155" y="889" width="44" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="165" y="909">row</text>
-         </a>
-         <a xlink:href="#array_expr" xlink:title="array_expr">
-            <rect x="157" y="935" width="88" height="32"></rect>
-            <rect x="155" y="933" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="165" y="953">array_expr</text>
-         </a>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h42 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v12 m72 0 v-12 m-72 12 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m32 0 h10 m20 -32 h10 m72 0 h10 m0 0 h274 m-478 0 h20 m458 0 h20 m-498 0 q10 0 10 10 m478 0 q0 -10 10 -10 m-488 10 v56 m478 0 v-56 m-478 56 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m74 0 h10 m0 0 h364 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-448 10 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m20 -32 h10 m76 0 h10 m0 0 h178 m-468 -10 v20 m478 0 v-20 m-478 20 v56 m478 0 v-56 m-478 56 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m76 0 h10 m0 0 h362 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m90 0 h10 m0 0 h348 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m108 0 h10 m0 0 h330 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m54 0 h10 m0 0 h384 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m62 0 h10 m0 0 h376 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m56 0 h10 m0 0 h382 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m168 0 h10 m0 0 h270 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m118 0 h10 m0 0 h320 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h232 m-262 0 h20 m242 0 h20 m-282 0 q10 0 10 10 m262 0 q0 -10 10 -10 m-272 10 v12 m262 0 v-12 m-262 12 q0 10 10 10 m242 0 q10 0 10 -10 m-252 10 h10 m24 0 h10 m20 0 h10 m28 0 h10 m0 0 h110 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m32 0 h10 m0 0 h10 m72 0 h10 m0 0 h14 m-428 -130 v20 m478 0 v-20 m-478 20 v144 m478 0 v-144 m-478 144 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m82 0 h10 m0 0 h356 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m144 0 h10 m0 0 h294 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m98 0 h10 m0 0 h340 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m66 0 h10 m20 0 h10 m144 0 h10 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m44 0 h10 m0 0 h100 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m88 0 h10 m0 0 h56 m20 -88 h168 m23 -844 h-3"></path>
-         <polygon points="527 17 535 13 535 21"></polygon>
-         <polygon points="527 17 519 13 519 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#c_expr" title="c_expr">c_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="array_subscripts" href="#array_subscripts">array_subscripts:</a></p>
-      <svg width="216" height="52">
-         
-         <polygon points="9 33 1 29 1 37"></polygon>
-         <polygon points="17 33 9 29 9 37"></polygon>
-         <a xlink:href="#array_subscript" xlink:title="array_subscript">
-            <rect x="51" y="19" width="118" height="32"></rect>
-            <rect x="49" y="17" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="37">array_subscript</text>
-         </a>
-         <path class="line" d="m17 33 h2 m20 0 h10 m118 0 h10 m-158 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m138 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-138 0 h10 m0 0 h128 m23 32 h-3"></path>
-         <polygon points="207 33 215 29 215 37"></polygon>
-         <polygon points="207 33 199 29 199 37"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#c_expr" title="c_expr">c_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="case_expr" href="#case_expr">case_expr:</a></p>
-      <svg width="546" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="54" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CASE</text>
-         <a xlink:href="#case_arg" xlink:title="case_arg">
-            <rect x="105" y="3" width="78" height="32"></rect>
-            <rect x="103" y="1" width="78" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="113" y="21">case_arg</text>
-         </a>
-         <a xlink:href="#when_clause_list" xlink:title="when_clause_list">
-            <rect x="203" y="3" width="128" height="32"></rect>
-            <rect x="201" y="1" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="211" y="21">when_clause_list</text>
-         </a>
-         <a xlink:href="#case_default" xlink:title="case_default">
-            <rect x="351" y="3" width="100" height="32"></rect>
-            <rect x="349" y="1" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="359" y="21">case_default</text>
-         </a>
-         <rect x="471" y="3" width="48" height="32" rx="10"></rect>
-         <rect x="469" y="1" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="479" y="21">END</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m128 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></path>
-         <polygon points="537 17 545 13 545 21"></polygon>
-         <polygon points="537 17 529 13 529 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#c_expr" title="c_expr">c_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="simple_typename" href="#simple_typename">simple_typename:</a></p>
-      <svg width="260" height="212">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#const_typename" xlink:title="const_typename">
-            <rect x="51" y="3" width="124" height="32"></rect>
-            <rect x="49" y="1" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">const_typename</text>
-         </a>
-         <a xlink:href="#bit_with_length" xlink:title="bit_with_length">
-            <rect x="51" y="47" width="118" height="32"></rect>
-            <rect x="49" y="45" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">bit_with_length</text>
-         </a>
-         <a xlink:href="#character_with_length" xlink:title="character_with_length">
-            <rect x="51" y="91" width="162" height="32"></rect>
-            <rect x="49" y="89" width="162" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="109">character_with_length</text>
-         </a>
-         <a xlink:href="#interval_type" xlink:title="interval_type">
-            <rect x="51" y="135" width="102" height="32"></rect>
-            <rect x="49" y="133" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="153">interval_type</text>
-         </a>
-         <a xlink:href="#postgres_oid" xlink:title="postgres_oid">
-            <rect x="51" y="179" width="102" height="32"></rect>
-            <rect x="49" y="177" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">postgres_oid</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m124 0 h10 m0 0 h38 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m118 0 h10 m0 0 h44 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m23 -176 h-3"></path>
-         <polygon points="251 17 259 13 259 21"></polygon>
-         <polygon points="251 17 243 13 243 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#typename" title="typename">typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_array_bounds" href="#opt_array_bounds">opt_array_bounds:</a></p>
-      <svg width="170" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="26" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">[</text>
-         <rect x="97" y="23" width="26" height="32" rx="10"></rect>
-         <rect x="95" y="21" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="105" y="41">]</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m26 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
-         <polygon points="161 5 169 1 169 9"></polygon>
-         <polygon points="161 5 153 1 153 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#typename" title="typename">typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="expr_tuple1_ambiguous" href="#expr_tuple1_ambiguous">expr_tuple1_ambiguous:</a></p>
-      <svg width="376" height="68">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">(</text>
-         <a xlink:href="#tuple1_ambiguous_values" xlink:title="tuple1_ambiguous_values">
-            <rect x="97" y="35" width="186" height="32"></rect>
-            <rect x="95" y="33" width="186" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="53">tuple1_ambiguous_values</text>
-         </a>
-         <rect x="323" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="321" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="331" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m186 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="367 17 375 13 375 21"></polygon>
-         <polygon points="367 17 359 13 359 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#in_expr" title="in_expr">in_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="math_op" href="#math_op">math_op:</a></p>
-      <svg width="242" height="696">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">+</text>
-         <rect x="51" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">-</text>
-         <rect x="51" y="91" width="28" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">*</text>
-         <rect x="51" y="135" width="28" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">/</text>
-         <rect x="51" y="179" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">FLOORDIV</text>
-         <rect x="51" y="223" width="34" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">%</text>
-         <rect x="51" y="267" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">&amp;</text>
-         <rect x="51" y="311" width="26" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">|</text>
-         <rect x="51" y="355" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">^</text>
-         <rect x="51" y="399" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">#</text>
-         <rect x="51" y="443" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">&lt;</text>
-         <rect x="51" y="487" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">&gt;</text>
-         <rect x="51" y="531" width="30" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">=</text>
-         <rect x="51" y="575" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">LESS_EQUALS</text>
-         <rect x="51" y="619" width="144" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="144" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">GREATER_EQUALS</text>
-         <rect x="51" y="663" width="112" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">NOT_EQUALS</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m30 0 h10 m0 0 h114 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m92 0 h10 m0 0 h52 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m34 0 h10 m0 0 h110 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m118 0 h10 m0 0 h26 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m112 0 h10 m0 0 h32 m23 -660 h-3"></path>
-         <polygon points="233 17 241 13 241 21"></polygon>
-         <polygon points="233 17 225 13 225 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#subquery_op" title="subquery_op">subquery_op</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="attrs" href="#attrs">attrs:</a></p>
       <svg width="280" height="52">
@@ -11619,67 +12656,21 @@
             <li><a href="#reserved_keyword" title="reserved_keyword">reserved_keyword</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_func_name_keyword" href="#type_func_name_keyword">type_func_name_keyword:</a></p>
-      <svg width="198" height="784">
+      <svg width="384" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">COLLATION</text>
-         <rect x="51" y="47" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">CROSS</text>
-         <rect x="51" y="91" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">FULL</text>
-         <rect x="51" y="135" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">INNER</text>
-         <rect x="51" y="179" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">ILIKE</text>
-         <rect x="51" y="223" width="34" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">IS</text>
-         <rect x="51" y="267" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">ISNULL</text>
-         <rect x="51" y="311" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">JOIN</text>
-         <rect x="51" y="355" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">LEFT</text>
-         <rect x="51" y="399" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">LIKE</text>
-         <rect x="51" y="443" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">NATURAL</text>
-         <rect x="51" y="487" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">NONE</text>
-         <rect x="51" y="531" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">NOTNULL</text>
-         <rect x="51" y="575" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">OUTER</text>
-         <rect x="51" y="619" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">OVERLAPS</text>
-         <rect x="51" y="663" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">RIGHT</text>
-         <rect x="51" y="707" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">SIMILAR</text>
-         <rect x="51" y="751" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">FAMILY</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m66 0 h10 m0 0 h34 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m54 0 h10 m0 0 h46 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m62 0 h10 m0 0 h38 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m56 0 h10 m0 0 h44 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m34 0 h10 m0 0 h66 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m70 0 h10 m0 0 h30 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m54 0 h10 m0 0 h46 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m52 0 h10 m0 0 h48 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m50 0 h10 m0 0 h50 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m82 0 h10 m0 0 h18 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m58 0 h10 m0 0 h42 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m84 0 h10 m0 0 h16 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m66 0 h10 m0 0 h34 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m92 0 h10 m0 0 h8 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m62 0 h10 m0 0 h38 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m78 0 h10 m0 0 h22 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m72 0 h10 m0 0 h28 m23 -748 h-3"></path>
-         <polygon points="189 17 197 13 197 21"></polygon>
-         <polygon points="189 17 181 13 181 21"></polygon>
+         <a xlink:href="#type_func_name_no_crdb_extra_keyword" xlink:title="type_func_name_no_crdb_extra_keyword">
+            <rect x="51" y="3" width="286" height="32"></rect>
+            <rect x="49" y="1" width="286" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">type_func_name_no_crdb_extra_keyword</text>
+         </a>
+         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">FAMILY</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m286 0 h10 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v24 m326 0 v-24 m-326 24 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m72 0 h10 m0 0 h214 m23 -44 h-3"></path>
+         <polygon points="375 17 383 13 383 21"></polygon>
+         <polygon points="375 17 367 13 367 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -11942,6 +12933,74 @@
          </p><ul>
             <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="simple_typename" href="#simple_typename">simple_typename:</a></p>
+      <svg width="260" height="300">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#general_type_name" xlink:title="general_type_name">
+            <rect x="51" y="3" width="146" height="32"></rect>
+            <rect x="49" y="1" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">general_type_name</text>
+         </a>
+         <rect x="51" y="47" width="32" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="32" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">@</text>
+         <rect x="103" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="101" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="111" y="65">ICONST</text>
+         <a xlink:href="#complex_type_name" xlink:title="complex_type_name">
+            <rect x="51" y="91" width="150" height="32"></rect>
+            <rect x="49" y="89" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">complex_type_name</text>
+         </a>
+         <a xlink:href="#const_typename" xlink:title="const_typename">
+            <rect x="51" y="135" width="124" height="32"></rect>
+            <rect x="49" y="133" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">const_typename</text>
+         </a>
+         <a xlink:href="#bit_with_length" xlink:title="bit_with_length">
+            <rect x="51" y="179" width="118" height="32"></rect>
+            <rect x="49" y="177" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">bit_with_length</text>
+         </a>
+         <a xlink:href="#character_with_length" xlink:title="character_with_length">
+            <rect x="51" y="223" width="162" height="32"></rect>
+            <rect x="49" y="221" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">character_with_length</text>
+         </a>
+         <a xlink:href="#interval_type" xlink:title="interval_type">
+            <rect x="51" y="267" width="102" height="32"></rect>
+            <rect x="49" y="265" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">interval_type</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m146 0 h10 m0 0 h16 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m32 0 h10 m0 0 h10 m72 0 h10 m0 0 h38 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m150 0 h10 m0 0 h12 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m124 0 h10 m0 0 h38 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m118 0 h10 m0 0 h44 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m102 0 h10 m0 0 h60 m23 -264 h-3"></path>
+         <polygon points="251 17 259 13 259 21"></polygon>
+         <polygon points="251 17 243 13 243 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#typename" title="typename">typename</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_array_bounds" href="#opt_array_bounds">opt_array_bounds:</a></p>
+      <svg width="170" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">[</text>
+         <rect x="97" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="95" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="105" y="41">]</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h82 m-112 0 h20 m92 0 h20 m-132 0 q10 0 10 10 m112 0 q0 -10 10 -10 m-122 10 v12 m112 0 v-12 m-112 12 q0 10 10 10 m92 0 q10 0 10 -10 m-102 10 h10 m26 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
+         <polygon points="161 5 169 1 169 9"></polygon>
+         <polygon points="161 5 153 1 153 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#typename" title="typename">typename</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="transaction_user_priority" href="#transaction_user_priority">transaction_user_priority:</a></p>
       <svg width="266" height="36">
          
@@ -12114,6 +13173,262 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#role_options" title="role_options">role_options</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="d_expr" href="#d_expr">d_expr:</a></p>
+      <svg width="536" height="980">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="71" y="35" width="32" height="32" rx="10"></rect>
+         <rect x="69" y="33" width="32" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="53">@</text>
+         <rect x="143" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="141" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="151" y="21">ICONST</text>
+         <rect x="51" y="79" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="77" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="97">FCONST</text>
+         <rect x="51" y="123" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="121" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="141">SCONST</text>
+         <rect x="51" y="167" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="165" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="185">BCONST</text>
+         <rect x="51" y="211" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="209" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="229">BITCONST</text>
+         <a xlink:href="#typed_literal" xlink:title="typed_literal">
+            <rect x="51" y="255" width="98" height="32"></rect>
+            <rect x="49" y="253" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="273">typed_literal</text>
+         </a>
+         <a xlink:href="#interval_value" xlink:title="interval_value">
+            <rect x="51" y="299" width="108" height="32"></rect>
+            <rect x="49" y="297" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="317">interval_value</text>
+         </a>
+         <rect x="51" y="343" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="341" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="361">TRUE</text>
+         <rect x="51" y="387" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="385" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="405">FALSE</text>
+         <rect x="51" y="431" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="429" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="449">NULL</text>
+         <a xlink:href="#column_path_with_star" xlink:title="column_path_with_star">
+            <rect x="51" y="475" width="168" height="32"></rect>
+            <rect x="49" y="473" width="168" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="493">column_path_with_star</text>
+         </a>
+         <rect x="51" y="519" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="517" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="537">PLACEHOLDER</text>
+         <rect x="51" y="563" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="561" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="581">(</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="97" y="563" width="64" height="32"></rect>
+            <rect x="95" y="561" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="581">a_expr</text>
+         </a>
+         <rect x="181" y="563" width="26" height="32" rx="10"></rect>
+         <rect x="179" y="561" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="189" y="581">)</text>
+         <rect x="247" y="595" width="24" height="32" rx="10"></rect>
+         <rect x="245" y="593" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="255" y="613">.</text>
+         <rect x="311" y="595" width="28" height="32" rx="10"></rect>
+         <rect x="309" y="593" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="319" y="613">*</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="311" y="639" width="138" height="32"></rect>
+            <rect x="309" y="637" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="319" y="657">unrestricted_name</text>
+         </a>
+         <rect x="311" y="683" width="32" height="32" rx="10"></rect>
+         <rect x="309" y="681" width="32" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="319" y="701">@</text>
+         <rect x="363" y="683" width="72" height="32" rx="10"></rect>
+         <rect x="361" y="681" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="371" y="701">ICONST</text>
+         <a xlink:href="#func_expr" xlink:title="func_expr">
+            <rect x="51" y="727" width="82" height="32"></rect>
+            <rect x="49" y="725" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="745">func_expr</text>
+         </a>
+         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
+            <rect x="51" y="771" width="144" height="32"></rect>
+            <rect x="49" y="769" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="789">select_with_parens</text>
+         </a>
+         <a xlink:href="#labeled_row" xlink:title="labeled_row">
+            <rect x="51" y="815" width="98" height="32"></rect>
+            <rect x="49" y="813" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="833">labeled_row</text>
+         </a>
+         <rect x="51" y="859" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="857" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="877">ARRAY</text>
+         <a xlink:href="#select_with_parens" xlink:title="select_with_parens">
+            <rect x="157" y="859" width="144" height="32"></rect>
+            <rect x="155" y="857" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="877">select_with_parens</text>
+         </a>
+         <a xlink:href="#row" xlink:title="row">
+            <rect x="157" y="903" width="44" height="32"></rect>
+            <rect x="155" y="901" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="921">row</text>
+         </a>
+         <a xlink:href="#array_expr" xlink:title="array_expr">
+            <rect x="157" y="947" width="88" height="32"></rect>
+            <rect x="155" y="945" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="965">array_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h42 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v12 m72 0 v-12 m-72 12 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m32 0 h10 m20 -32 h10 m72 0 h10 m0 0 h274 m-478 0 h20 m458 0 h20 m-498 0 q10 0 10 10 m478 0 q0 -10 10 -10 m-488 10 v56 m478 0 v-56 m-478 56 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m74 0 h10 m0 0 h364 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m76 0 h10 m0 0 h362 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m76 0 h10 m0 0 h362 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m90 0 h10 m0 0 h348 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m98 0 h10 m0 0 h340 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m108 0 h10 m0 0 h330 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m54 0 h10 m0 0 h384 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m62 0 h10 m0 0 h376 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m56 0 h10 m0 0 h382 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m168 0 h10 m0 0 h270 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m118 0 h10 m0 0 h320 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h232 m-262 0 h20 m242 0 h20 m-282 0 q10 0 10 10 m262 0 q0 -10 10 -10 m-272 10 v12 m262 0 v-12 m-262 12 q0 10 10 10 m242 0 q10 0 10 -10 m-252 10 h10 m24 0 h10 m20 0 h10 m28 0 h10 m0 0 h110 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m138 0 h10 m-168 -10 v20 m178 0 v-20 m-178 20 v24 m178 0 v-24 m-178 24 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m32 0 h10 m0 0 h10 m72 0 h10 m0 0 h14 m-428 -130 v20 m478 0 v-20 m-478 20 v144 m478 0 v-144 m-478 144 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m82 0 h10 m0 0 h356 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m144 0 h10 m0 0 h294 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m98 0 h10 m0 0 h340 m-468 -10 v20 m478 0 v-20 m-478 20 v24 m478 0 v-24 m-478 24 q0 10 10 10 m458 0 q10 0 10 -10 m-468 10 h10 m66 0 h10 m20 0 h10 m144 0 h10 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m44 0 h10 m0 0 h100 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m88 0 h10 m0 0 h56 m20 -88 h168 m23 -856 h-3"></path>
+         <polygon points="527 17 535 13 535 21"></polygon>
+         <polygon points="527 17 519 13 519 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#c_expr" title="c_expr">c_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="array_subscripts" href="#array_subscripts">array_subscripts:</a></p>
+      <svg width="216" height="52">
+         
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <a xlink:href="#array_subscript" xlink:title="array_subscript">
+            <rect x="51" y="19" width="118" height="32"></rect>
+            <rect x="49" y="17" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="37">array_subscript</text>
+         </a>
+         <path class="line" d="m17 33 h2 m20 0 h10 m118 0 h10 m-158 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m138 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-138 0 h10 m0 0 h128 m23 32 h-3"></path>
+         <polygon points="207 33 215 29 215 37"></polygon>
+         <polygon points="207 33 199 29 199 37"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#c_expr" title="c_expr">c_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="case_expr" href="#case_expr">case_expr:</a></p>
+      <svg width="546" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CASE</text>
+         <a xlink:href="#case_arg" xlink:title="case_arg">
+            <rect x="105" y="3" width="78" height="32"></rect>
+            <rect x="103" y="1" width="78" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="21">case_arg</text>
+         </a>
+         <a xlink:href="#when_clause_list" xlink:title="when_clause_list">
+            <rect x="203" y="3" width="128" height="32"></rect>
+            <rect x="201" y="1" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="211" y="21">when_clause_list</text>
+         </a>
+         <a xlink:href="#case_default" xlink:title="case_default">
+            <rect x="351" y="3" width="100" height="32"></rect>
+            <rect x="349" y="1" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="359" y="21">case_default</text>
+         </a>
+         <rect x="471" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="469" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="479" y="21">END</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m128 0 h10 m0 0 h10 m100 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></path>
+         <polygon points="537 17 545 13 545 21"></polygon>
+         <polygon points="537 17 529 13 529 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#c_expr" title="c_expr">c_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="expr_tuple1_ambiguous" href="#expr_tuple1_ambiguous">expr_tuple1_ambiguous:</a></p>
+      <svg width="376" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">(</text>
+         <a xlink:href="#tuple1_ambiguous_values" xlink:title="tuple1_ambiguous_values">
+            <rect x="97" y="35" width="186" height="32"></rect>
+            <rect x="95" y="33" width="186" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="53">tuple1_ambiguous_values</text>
+         </a>
+         <rect x="323" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="321" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="331" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m186 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="367 17 375 13 375 21"></polygon>
+         <polygon points="367 17 359 13 359 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#in_expr" title="in_expr">in_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="math_op" href="#math_op">math_op:</a></p>
+      <svg width="242" height="696">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">+</text>
+         <rect x="51" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">-</text>
+         <rect x="51" y="91" width="28" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">*</text>
+         <rect x="51" y="135" width="28" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">/</text>
+         <rect x="51" y="179" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">FLOORDIV</text>
+         <rect x="51" y="223" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">%</text>
+         <rect x="51" y="267" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">&amp;</text>
+         <rect x="51" y="311" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">|</text>
+         <rect x="51" y="355" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">^</text>
+         <rect x="51" y="399" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">#</text>
+         <rect x="51" y="443" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">&lt;</text>
+         <rect x="51" y="487" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">&gt;</text>
+         <rect x="51" y="531" width="30" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">=</text>
+         <rect x="51" y="575" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">LESS_EQUALS</text>
+         <rect x="51" y="619" width="144" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="144" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">GREATER_EQUALS</text>
+         <rect x="51" y="663" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">NOT_EQUALS</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m30 0 h10 m0 0 h114 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m28 0 h10 m0 0 h116 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m92 0 h10 m0 0 h52 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m34 0 h10 m0 0 h110 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h118 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m30 0 h10 m0 0 h114 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m118 0 h10 m0 0 h26 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m144 0 h10 m-174 -10 v20 m184 0 v-20 m-184 20 v24 m184 0 v-24 m-184 24 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m112 0 h10 m0 0 h32 m23 -660 h-3"></path>
+         <polygon points="233 17 241 13 241 21"></polygon>
+         <polygon points="233 17 225 13 225 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#subquery_op" title="subquery_op">subquery_op</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="single_table_pattern_list" href="#single_table_pattern_list">single_table_pattern_list:</a></p>
       <svg width="192" height="80">
@@ -12342,8 +13657,27 @@
          </p><ul>
             <li><a href="#create_as_opt_col_list" title="create_as_opt_col_list">create_as_opt_col_list</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="enum_val_list" href="#enum_val_list">enum_val_list:</a></p>
+      <svg width="174" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <rect x="51" y="47" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SCONST</text>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m23 44 h-3"></path>
+         <polygon points="165 61 173 57 173 65"></polygon>
+         <polygon points="165 61 157 57 157 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_enum_val_list" title="opt_enum_val_list">opt_enum_val_list</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="common_table_expr" href="#common_table_expr">common_table_expr:</a></p>
-      <svg width="622" height="36">
+      <svg width="622" height="134">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -12360,20 +13694,25 @@
          <rect x="321" y="3" width="38" height="32" rx="10"></rect>
          <rect x="319" y="1" width="38" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="329" y="21">AS</text>
-         <rect x="379" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="377" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="387" y="21">(</text>
-         <a xlink:href="#preparable_stmt" xlink:title="preparable_stmt">
-            <rect x="425" y="3" width="124" height="32"></rect>
-            <rect x="423" y="1" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="433" y="21">preparable_stmt</text>
+         <a xlink:href="#materialize_clause" xlink:title="materialize_clause">
+            <rect x="399" y="35" width="136" height="32"></rect>
+            <rect x="397" y="33" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="53">materialize_clause</text>
          </a>
-         <rect x="569" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="567" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="577" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="613 17 621 13 621 21"></polygon>
-         <polygon points="613 17 605 13 605 21"></polygon>
+         <rect x="575" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="573" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="583" y="21">(</text>
+         <a xlink:href="#preparable_stmt" xlink:title="preparable_stmt">
+            <rect x="425" y="101" width="124" height="32"></rect>
+            <rect x="423" y="99" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="433" y="119">preparable_stmt</text>
+         </a>
+         <rect x="569" y="101" width="26" height="32" rx="10"></rect>
+         <rect x="567" y="99" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="577" y="119">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m136 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-220 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m124 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="613 115 621 111 621 119"></polygon>
+         <polygon points="613 115 605 111 605 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -12458,6 +13797,7 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#single_sort_clause" title="single_sort_clause">single_sort_clause</a></li>
             <li><a href="#sortby_list" title="sortby_list">sortby_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="only_signed_iconst" href="#only_signed_iconst">only_signed_iconst:</a></p>
@@ -12627,6 +13967,11 @@
             <rect x="607" y="45" width="124" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="617" y="65">opt_partition_by</text>
          </a>
+         <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
+            <rect x="753" y="47" width="136" height="32"></rect>
+            <rect x="751" y="45" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="761" y="65">opt_where_clause</text>
+         </a>
          <rect x="51" y="91" width="82" height="32" rx="10"></rect>
          <rect x="49" y="89" width="82" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="109">PRIMARY</text>
@@ -12694,7 +14039,7 @@
             <rect x="895" y="133" width="132" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="905" y="153">reference_actions</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h738 m-1018 0 h20 m998 0 h20 m-1038 0 q10 0 10 10 m1018 0 q0 -10 10 -10 m-1028 10 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m0 0 h296 m-1008 -10 v20 m1018 0 v-20 m-1018 20 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h318 m-1008 -10 v20 m1018 0 v-20 m-1018 20 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m23 -132 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h738 m-1018 0 h20 m998 0 h20 m-1038 0 q10 0 10 10 m1018 0 q0 -10 10 -10 m-1028 10 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m136 0 h10 m0 0 h140 m-1008 -10 v20 m1018 0 v-20 m-1018 20 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h318 m-1008 -10 v20 m1018 0 v-20 m-1018 20 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m23 -132 h-3"></path>
          <polygon points="1067 17 1075 13 1075 21"></polygon>
          <polygon points="1067 17 1059 13 1059 21"></polygon>
       </svg>
@@ -12702,547 +14047,33 @@
          </p><ul>
             <li><a href="#table_constraint" title="table_constraint">table_constraint</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="const_typename" href="#const_typename">const_typename:</a></p>
-      <svg width="280" height="960">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="like_table_option" href="#like_table_option">like_table_option:</a></p>
+      <svg width="216" height="212">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#numeric" xlink:title="numeric">
-            <rect x="51" y="3" width="68" height="32"></rect>
-            <rect x="49" y="1" width="68" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">numeric</text>
-         </a>
-         <a xlink:href="#bit_without_length" xlink:title="bit_without_length">
-            <rect x="51" y="47" width="140" height="32"></rect>
-            <rect x="49" y="45" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">bit_without_length</text>
-         </a>
-         <a xlink:href="#character_without_length" xlink:title="character_without_length">
-            <rect x="51" y="91" width="182" height="32"></rect>
-            <rect x="49" y="89" width="182" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="109">character_without_length</text>
-         </a>
-         <a xlink:href="#const_datetime" xlink:title="const_datetime">
-            <rect x="51" y="135" width="118" height="32"></rect>
-            <rect x="49" y="133" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="153">const_datetime</text>
-         </a>
-         <a xlink:href="#const_json" xlink:title="const_json">
-            <rect x="51" y="179" width="88" height="32"></rect>
-            <rect x="49" y="177" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">const_json</text>
-         </a>
-         <rect x="51" y="223" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">BLOB</text>
-         <rect x="51" y="267" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">BYTES</text>
-         <rect x="51" y="311" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">BYTEA</text>
-         <rect x="51" y="355" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">TEXT</text>
-         <rect x="51" y="399" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">NAME</text>
-         <rect x="51" y="443" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">SERIAL</text>
-         <rect x="51" y="487" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">SERIAL2</text>
-         <rect x="51" y="531" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">SMALLSERIAL</text>
-         <rect x="51" y="575" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">SERIAL4</text>
-         <rect x="51" y="619" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">SERIAL8</text>
-         <rect x="51" y="663" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">BIGSERIAL</text>
-         <rect x="51" y="707" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">UUID</text>
-         <rect x="51" y="751" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">INET</text>
-         <rect x="51" y="795" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">OID</text>
-         <rect x="51" y="839" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">OIDVECTOR</text>
-         <rect x="51" y="883" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">INT2VECTOR</text>
-         <rect x="51" y="927" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">identifier</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m68 0 h10 m0 0 h114 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m140 0 h10 m0 0 h42 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m182 0 h10 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m118 0 h10 m0 0 h64 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m88 0 h10 m0 0 h94 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m56 0 h10 m0 0 h126 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m64 0 h10 m0 0 h118 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m64 0 h10 m0 0 h118 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m52 0 h10 m0 0 h130 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m58 0 h10 m0 0 h124 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m68 0 h10 m0 0 h114 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m78 0 h10 m0 0 h104 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m114 0 h10 m0 0 h68 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m78 0 h10 m0 0 h104 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m78 0 h10 m0 0 h104 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m94 0 h10 m0 0 h88 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m56 0 h10 m0 0 h126 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m52 0 h10 m0 0 h130 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m46 0 h10 m0 0 h136 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m100 0 h10 m0 0 h82 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m106 0 h10 m0 0 h76 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m80 0 h10 m0 0 h102 m23 -924 h-3"></path>
-         <polygon points="271 17 279 13 279 21"></polygon>
-         <polygon points="271 17 263 13 263 21"></polygon>
+         <rect x="51" y="3" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">CONSTRAINTS</text>
+         <rect x="51" y="47" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">DEFAULTS</text>
+         <rect x="51" y="91" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">GENERATED</text>
+         <rect x="51" y="135" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">INDEXES</text>
+         <rect x="51" y="179" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">ALL</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m118 0 h10 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m90 0 h10 m0 0 h28 m-148 -10 v20 m158 0 v-20 m-158 20 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m100 0 h10 m0 0 h18 m-148 -10 v20 m158 0 v-20 m-158 20 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m80 0 h10 m0 0 h38 m-148 -10 v20 m158 0 v-20 m-158 20 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m44 0 h10 m0 0 h74 m23 -176 h-3"></path>
+         <polygon points="207 17 215 13 215 21"></polygon>
+         <polygon points="207 17 199 13 199 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_value" href="#interval_value">interval_value:</a></p>
-      <svg width="464" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="86" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">INTERVAL</text>
-         <rect x="157" y="3" width="76" height="32" rx="10"></rect>
-         <rect x="155" y="1" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="165" y="21">SCONST</text>
-         <a xlink:href="#opt_interval_qualifier" xlink:title="opt_interval_qualifier">
-            <rect x="253" y="3" width="154" height="32"></rect>
-            <rect x="251" y="1" width="154" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="261" y="21">opt_interval_qualifier</text>
-         </a>
-         <rect x="157" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="155" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="165" y="65">(</text>
-         <rect x="203" y="47" width="72" height="32" rx="10"></rect>
-         <rect x="201" y="45" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="211" y="65">ICONST</text>
-         <rect x="295" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="293" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="303" y="65">)</text>
-         <rect x="341" y="47" width="76" height="32" rx="10"></rect>
-         <rect x="339" y="45" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="349" y="65">SCONST</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m76 0 h10 m0 0 h10 m154 0 h10 m0 0 h10 m-300 0 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v24 m300 0 v-24 m-300 24 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m76 0 h10 m23 -44 h-3"></path>
-         <polygon points="455 17 463 13 463 21"></polygon>
-         <polygon points="455 17 447 13 447 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="column_path_with_star" href="#column_path_with_star">column_path_with_star:</a></p>
-      <svg width="878" height="144">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#column_path" xlink:title="column_path">
-            <rect x="51" y="3" width="100" height="32"></rect>
-            <rect x="49" y="1" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">column_path</text>
-         </a>
-         <a xlink:href="#db_object_name_component" xlink:title="db_object_name_component">
-            <rect x="51" y="47" width="204" height="32"></rect>
-            <rect x="49" y="45" width="204" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">db_object_name_component</text>
-         </a>
-         <rect x="275" y="47" width="24" height="32" rx="10"></rect>
-         <rect x="273" y="45" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="283" y="65">.</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="339" y="79" width="138" height="32"></rect>
-            <rect x="337" y="77" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="347" y="97">unrestricted_name</text>
-         </a>
-         <rect x="497" y="79" width="24" height="32" rx="10"></rect>
-         <rect x="495" y="77" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="505" y="97">.</text>
-         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
-            <rect x="561" y="111" width="138" height="32"></rect>
-            <rect x="559" y="109" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="569" y="129">unrestricted_name</text>
-         </a>
-         <rect x="719" y="111" width="24" height="32" rx="10"></rect>
-         <rect x="717" y="109" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="727" y="129">.</text>
-         <rect x="803" y="47" width="28" height="32" rx="10"></rect>
-         <rect x="801" y="45" width="28" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="811" y="65">*</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m100 0 h10 m0 0 h680 m-820 0 h20 m800 0 h20 m-840 0 q10 0 10 10 m820 0 q0 -10 10 -10 m-830 10 v24 m820 0 v-24 m-820 24 q0 10 10 10 m800 0 q10 0 10 -10 m-810 10 h10 m204 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h434 m-464 0 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v12 m464 0 v-12 m-464 12 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m138 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m138 0 h10 m0 0 h10 m24 0 h10 m40 -64 h10 m28 0 h10 m23 -44 h-3"></path>
-         <polygon points="869 17 877 13 877 21"></polygon>
-         <polygon points="869 17 861 13 861 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="func_expr" href="#func_expr">func_expr:</a></p>
-      <svg width="452" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#func_application" xlink:title="func_application">
-            <rect x="51" y="3" width="122" height="32"></rect>
-            <rect x="49" y="1" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">func_application</text>
-         </a>
-         <a xlink:href="#filter_clause" xlink:title="filter_clause">
-            <rect x="193" y="3" width="96" height="32"></rect>
-            <rect x="191" y="1" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="201" y="21">filter_clause</text>
-         </a>
-         <a xlink:href="#over_clause" xlink:title="over_clause">
-            <rect x="309" y="3" width="96" height="32"></rect>
-            <rect x="307" y="1" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="317" y="21">over_clause</text>
-         </a>
-         <a xlink:href="#func_expr_common_subexpr" xlink:title="func_expr_common_subexpr">
-            <rect x="51" y="47" width="200" height="32"></rect>
-            <rect x="49" y="45" width="200" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">func_expr_common_subexpr</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m122 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m96 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v24 m394 0 v-24 m-394 24 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m200 0 h10 m0 0 h154 m23 -44 h-3"></path>
-         <polygon points="443 17 451 13 451 21"></polygon>
-         <polygon points="443 17 435 13 435 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="labeled_row" href="#labeled_row">labeled_row:</a></p>
-      <svg width="392" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#row" xlink:title="row">
-            <rect x="51" y="3" width="44" height="32"></rect>
-            <rect x="49" y="1" width="44" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">row</text>
-         </a>
-         <rect x="51" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">(</text>
-         <a xlink:href="#row" xlink:title="row">
-            <rect x="97" y="47" width="44" height="32"></rect>
-            <rect x="95" y="45" width="44" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="65">row</text>
-         </a>
-         <rect x="161" y="47" width="38" height="32" rx="10"></rect>
-         <rect x="159" y="45" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="169" y="65">AS</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="219" y="47" width="80" height="32"></rect>
-            <rect x="217" y="45" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="227" y="65">name_list</text>
-         </a>
-         <rect x="319" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="317" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="327" y="65">)</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h250 m-334 0 h20 m314 0 h20 m-354 0 q10 0 10 10 m334 0 q0 -10 10 -10 m-344 10 v24 m334 0 v-24 m-334 24 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m26 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m23 -44 h-3"></path>
-         <polygon points="383 17 391 13 391 21"></polygon>
-         <polygon points="383 17 375 13 375 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="row" href="#row">row:</a></p>
-      <svg width="366" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ROW</text>
-         <rect x="125" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="123" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="133" y="21">(</text>
-         <a xlink:href="#opt_expr_list" xlink:title="opt_expr_list">
-            <rect x="171" y="3" width="102" height="32"></rect>
-            <rect x="169" y="1" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="179" y="21">opt_expr_list</text>
-         </a>
-         <rect x="293" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="291" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="301" y="21">)</text>
-         <a xlink:href="#expr_tuple_unambiguous" xlink:title="expr_tuple_unambiguous">
-            <rect x="51" y="47" width="180" height="32"></rect>
-            <rect x="49" y="45" width="180" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">expr_tuple_unambiguous</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m26 0 h10 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v24 m308 0 v-24 m-308 24 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m180 0 h10 m0 0 h88 m23 -44 h-3"></path>
-         <polygon points="357 17 365 13 365 21"></polygon>
-         <polygon points="357 17 349 13 349 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-            <li><a href="#labeled_row" title="labeled_row">labeled_row</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="array_expr" href="#array_expr">array_expr:</a></p>
-      <svg width="304" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">[</text>
-         <a xlink:href="#opt_expr_list" xlink:title="opt_expr_list">
-            <rect x="97" y="3" width="102" height="32"></rect>
-            <rect x="95" y="1" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="21">opt_expr_list</text>
-         </a>
-         <a xlink:href="#array_expr_list" xlink:title="array_expr_list">
-            <rect x="97" y="47" width="114" height="32"></rect>
-            <rect x="95" y="45" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="65">array_expr_list</text>
-         </a>
-         <rect x="251" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="249" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="259" y="21">]</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m102 0 h10 m0 0 h12 m-154 0 h20 m134 0 h20 m-174 0 q10 0 10 10 m154 0 q0 -10 10 -10 m-164 10 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m114 0 h10 m20 -44 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="295 17 303 13 303 21"></polygon>
-         <polygon points="295 17 287 13 287 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#array_expr_list" title="array_expr_list">array_expr_list</a></li>
-            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="array_subscript" href="#array_subscript">array_subscript:</a></p>
-      <svg width="502" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">[</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="97" y="3" width="64" height="32"></rect>
-            <rect x="95" y="1" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="21">a_expr</text>
-         </a>
-         <a xlink:href="#opt_slice_bound" xlink:title="opt_slice_bound">
-            <rect x="97" y="47" width="124" height="32"></rect>
-            <rect x="95" y="45" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="65">opt_slice_bound</text>
-         </a>
-         <rect x="241" y="47" width="24" height="32" rx="10"></rect>
-         <rect x="239" y="45" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="249" y="65">:</text>
-         <a xlink:href="#opt_slice_bound" xlink:title="opt_slice_bound">
-            <rect x="285" y="47" width="124" height="32"></rect>
-            <rect x="283" y="45" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="293" y="65">opt_slice_bound</text>
-         </a>
-         <rect x="449" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="447" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="457" y="21">]</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m0 0 h248 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v24 m352 0 v-24 m-352 24 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m124 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m124 0 h10 m20 -44 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="493 17 501 13 501 21"></polygon>
-         <polygon points="493 17 485 13 485 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#array_subscripts" title="array_subscripts">array_subscripts</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="case_arg" href="#case_arg">case_arg:</a></p>
-      <svg width="162" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="51" y="23" width="64" height="32"></rect>
-            <rect x="49" y="21" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="41">a_expr</text>
-         </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m23 -32 h-3"></path>
-         <polygon points="153 5 161 1 161 9"></polygon>
-         <polygon points="153 5 145 1 145 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#case_expr" title="case_expr">case_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="when_clause_list" href="#when_clause_list">when_clause_list:</a></p>
-      <svg width="200" height="52">
-         
-         <polygon points="9 33 1 29 1 37"></polygon>
-         <polygon points="17 33 9 29 9 37"></polygon>
-         <a xlink:href="#when_clause" xlink:title="when_clause">
-            <rect x="51" y="19" width="102" height="32"></rect>
-            <rect x="49" y="17" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="37">when_clause</text>
-         </a>
-         <path class="line" d="m17 33 h2 m20 0 h10 m102 0 h10 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m122 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-122 0 h10 m0 0 h112 m23 32 h-3"></path>
-         <polygon points="191 33 199 29 199 37"></polygon>
-         <polygon points="191 33 183 29 183 37"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#case_expr" title="case_expr">case_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="case_default" href="#case_default">case_default:</a></p>
-      <svg width="234" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">ELSE</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="123" y="23" width="64" height="32"></rect>
-            <rect x="121" y="21" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="131" y="41">a_expr</text>
-         </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m52 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
-         <polygon points="225 5 233 1 233 9"></polygon>
-         <polygon points="225 5 217 1 217 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#case_expr" title="case_expr">case_expr</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="bit_with_length" href="#bit_with_length">bit_with_length:</a></p>
-      <svg width="438" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="42" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="42" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">BIT</text>
-         <a xlink:href="#opt_varying" xlink:title="opt_varying">
-            <rect x="113" y="3" width="94" height="32"></rect>
-            <rect x="111" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="121" y="21">opt_varying</text>
-         </a>
-         <rect x="51" y="47" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">VARBIT</text>
-         <rect x="247" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="245" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="255" y="21">(</text>
-         <rect x="293" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="291" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="301" y="21">ICONST</text>
-         <rect x="385" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="383" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="393" y="21">)</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m42 0 h10 m0 0 h10 m94 0 h10 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v24 m196 0 v-24 m-196 24 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m70 0 h10 m0 0 h86 m20 -44 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="429 17 437 13 437 21"></polygon>
-         <polygon points="429 17 421 13 421 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="character_with_length" href="#character_with_length">character_with_length:</a></p>
-      <svg width="360" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#character_base" xlink:title="character_base">
-            <rect x="31" y="3" width="118" height="32"></rect>
-            <rect x="29" y="1" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">character_base</text>
-         </a>
-         <rect x="169" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="167" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="177" y="21">(</text>
-         <rect x="215" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="213" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="21">ICONST</text>
-         <rect x="307" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="305" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="315" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m118 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="351 17 359 13 359 21"></polygon>
-         <polygon points="351 17 343 13 343 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_type" href="#interval_type">interval_type:</a></p>
-      <svg width="368" height="112">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="86" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">INTERVAL</text>
-         <a xlink:href="#interval_qualifier" xlink:title="interval_qualifier">
-            <rect x="157" y="35" width="124" height="32"></rect>
-            <rect x="155" y="33" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="165" y="53">interval_qualifier</text>
-         </a>
-         <rect x="157" y="79" width="26" height="32" rx="10"></rect>
-         <rect x="155" y="77" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="165" y="97">(</text>
-         <rect x="203" y="79" width="72" height="32" rx="10"></rect>
-         <rect x="201" y="77" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="211" y="97">ICONST</text>
-         <rect x="295" y="79" width="26" height="32" rx="10"></rect>
-         <rect x="293" y="77" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="303" y="97">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m124 0 h10 m0 0 h40 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m23 -76 h-3"></path>
-         <polygon points="359 17 367 13 367 21"></polygon>
-         <polygon points="359 17 351 13 351 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="postgres_oid" href="#postgres_oid">postgres_oid:</a></p>
-      <svg width="228" height="212">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">REGPROC</text>
-         <rect x="51" y="47" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">REGPROCEDURE</text>
-         <rect x="51" y="91" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">REGCLASS</text>
-         <rect x="51" y="135" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">REGTYPE</text>
-         <rect x="51" y="179" width="128" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">REGNAMESPACE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m84 0 h10 m0 0 h46 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m90 0 h10 m0 0 h40 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m82 0 h10 m0 0 h48 m-160 -10 v20 m170 0 v-20 m-170 20 v24 m170 0 v-24 m-170 24 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m128 0 h10 m0 0 h2 m23 -176 h-3"></path>
-         <polygon points="219 17 227 13 227 21"></polygon>
-         <polygon points="219 17 211 13 211 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="tuple1_ambiguous_values" href="#tuple1_ambiguous_values">tuple1_ambiguous_values:</a></p>
-      <svg width="340" height="100">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="31" y="3" width="64" height="32"></rect>
-            <rect x="29" y="1" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">a_expr</text>
-         </a>
-         <rect x="135" y="35" width="24" height="32" rx="10"></rect>
-         <rect x="133" y="33" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="53">,</text>
-         <a xlink:href="#expr_list" xlink:title="expr_list">
-            <rect x="199" y="67" width="74" height="32"></rect>
-            <rect x="197" y="65" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="207" y="85">expr_list</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m24 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m43 -64 h-3"></path>
-         <polygon points="331 17 339 13 339 21"></polygon>
-         <polygon points="331 17 323 13 323 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#expr_tuple1_ambiguous" title="expr_tuple1_ambiguous">expr_tuple1_ambiguous</a></li>
+            <li><a href="#like_table_option_list" title="like_table_option_list">like_table_option_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="scrub_option" href="#scrub_option">scrub_option:</a></p>
       <svg width="478" height="124">
@@ -13715,6 +14546,253 @@
          </p><ul>
             <li><a href="#table_ref" title="table_ref">table_ref</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_func_name_no_crdb_extra_keyword" href="#type_func_name_no_crdb_extra_keyword">type_func_name_no_crdb_extra_keyword:</a></p>
+      <svg width="198" height="740">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">COLLATION</text>
+         <rect x="51" y="47" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">CROSS</text>
+         <rect x="51" y="91" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">FULL</text>
+         <rect x="51" y="135" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">INNER</text>
+         <rect x="51" y="179" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">ILIKE</text>
+         <rect x="51" y="223" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">IS</text>
+         <rect x="51" y="267" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">ISNULL</text>
+         <rect x="51" y="311" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">JOIN</text>
+         <rect x="51" y="355" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">LEFT</text>
+         <rect x="51" y="399" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">LIKE</text>
+         <rect x="51" y="443" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">NATURAL</text>
+         <rect x="51" y="487" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">NONE</text>
+         <rect x="51" y="531" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">NOTNULL</text>
+         <rect x="51" y="575" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">OUTER</text>
+         <rect x="51" y="619" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">OVERLAPS</text>
+         <rect x="51" y="663" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">RIGHT</text>
+         <rect x="51" y="707" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">SIMILAR</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m66 0 h10 m0 0 h34 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m54 0 h10 m0 0 h46 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m62 0 h10 m0 0 h38 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m56 0 h10 m0 0 h44 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m34 0 h10 m0 0 h66 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m70 0 h10 m0 0 h30 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m54 0 h10 m0 0 h46 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m52 0 h10 m0 0 h48 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m50 0 h10 m0 0 h50 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m82 0 h10 m0 0 h18 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m58 0 h10 m0 0 h42 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m84 0 h10 m0 0 h16 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m66 0 h10 m0 0 h34 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m92 0 h10 m0 0 h8 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m62 0 h10 m0 0 h38 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m78 0 h10 m0 0 h22 m23 -704 h-3"></path>
+         <polygon points="189 17 197 13 197 21"></polygon>
+         <polygon points="189 17 181 13 181 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#type_func_name_keyword" title="type_func_name_keyword">type_func_name_keyword</a></li>
+            <li><a href="#type_function_name_no_crdb_extra" title="type_function_name_no_crdb_extra">type_function_name_no_crdb_extra</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="general_type_name" href="#general_type_name">general_type_name:</a></p>
+      <svg width="306" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#type_function_name_no_crdb_extra" xlink:title="type_function_name_no_crdb_extra">
+            <rect x="31" y="3" width="248" height="32"></rect>
+            <rect x="29" y="1" width="248" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">type_function_name_no_crdb_extra</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m248 0 h10 m3 0 h-3"></path>
+         <polygon points="297 17 305 13 305 21"></polygon>
+         <polygon points="297 17 289 13 289 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#complex_type_name" title="complex_type_name">complex_type_name</a></li>
+            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="complex_type_name" href="#complex_type_name">complex_type_name:</a></p>
+      <svg width="648" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#general_type_name" xlink:title="general_type_name">
+            <rect x="31" y="3" width="146" height="32"></rect>
+            <rect x="29" y="1" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">general_type_name</text>
+         </a>
+         <rect x="197" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="195" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="205" y="21">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="241" y="3" width="138" height="32"></rect>
+            <rect x="239" y="1" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="21">unrestricted_name</text>
+         </a>
+         <rect x="419" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="417" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="427" y="53">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="463" y="35" width="138" height="32"></rect>
+            <rect x="461" y="33" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="471" y="53">unrestricted_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m146 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m138 0 h10 m20 0 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m24 0 h10 m0 0 h10 m138 0 h10 m23 -32 h-3"></path>
+         <polygon points="639 17 647 13 647 21"></polygon>
+         <polygon points="639 17 631 13 631 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="const_typename" href="#const_typename">const_typename:</a></p>
+      <svg width="280" height="212">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#numeric" xlink:title="numeric">
+            <rect x="51" y="3" width="68" height="32"></rect>
+            <rect x="49" y="1" width="68" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">numeric</text>
+         </a>
+         <a xlink:href="#bit_without_length" xlink:title="bit_without_length">
+            <rect x="51" y="47" width="140" height="32"></rect>
+            <rect x="49" y="45" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">bit_without_length</text>
+         </a>
+         <a xlink:href="#character_without_length" xlink:title="character_without_length">
+            <rect x="51" y="91" width="182" height="32"></rect>
+            <rect x="49" y="89" width="182" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">character_without_length</text>
+         </a>
+         <a xlink:href="#const_datetime" xlink:title="const_datetime">
+            <rect x="51" y="135" width="118" height="32"></rect>
+            <rect x="49" y="133" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">const_datetime</text>
+         </a>
+         <a xlink:href="#const_geo" xlink:title="const_geo">
+            <rect x="51" y="179" width="86" height="32"></rect>
+            <rect x="49" y="177" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">const_geo</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m68 0 h10 m0 0 h114 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m140 0 h10 m0 0 h42 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m182 0 h10 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m118 0 h10 m0 0 h64 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m86 0 h10 m0 0 h96 m23 -176 h-3"></path>
+         <polygon points="271 17 279 13 279 21"></polygon>
+         <polygon points="271 17 263 13 263 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
+            <li><a href="#typed_literal" title="typed_literal">typed_literal</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="bit_with_length" href="#bit_with_length">bit_with_length:</a></p>
+      <svg width="438" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="42" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="42" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">BIT</text>
+         <a xlink:href="#opt_varying" xlink:title="opt_varying">
+            <rect x="113" y="3" width="94" height="32"></rect>
+            <rect x="111" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="121" y="21">opt_varying</text>
+         </a>
+         <rect x="51" y="47" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">VARBIT</text>
+         <rect x="247" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="245" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="255" y="21">(</text>
+         <rect x="293" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="291" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="301" y="21">ICONST</text>
+         <rect x="385" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="383" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="393" y="21">)</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m42 0 h10 m0 0 h10 m94 0 h10 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v24 m196 0 v-24 m-196 24 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m70 0 h10 m0 0 h86 m20 -44 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="429 17 437 13 437 21"></polygon>
+         <polygon points="429 17 421 13 421 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="character_with_length" href="#character_with_length">character_with_length:</a></p>
+      <svg width="360" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#character_base" xlink:title="character_base">
+            <rect x="31" y="3" width="118" height="32"></rect>
+            <rect x="29" y="1" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">character_base</text>
+         </a>
+         <rect x="169" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="167" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="177" y="21">(</text>
+         <rect x="215" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="213" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="21">ICONST</text>
+         <rect x="307" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="305" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="315" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m118 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="351 17 359 13 359 21"></polygon>
+         <polygon points="351 17 343 13 343 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_type" href="#interval_type">interval_type:</a></p>
+      <svg width="368" height="112">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="86" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">INTERVAL</text>
+         <a xlink:href="#interval_qualifier" xlink:title="interval_qualifier">
+            <rect x="157" y="35" width="124" height="32"></rect>
+            <rect x="155" y="33" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="165" y="53">interval_qualifier</text>
+         </a>
+         <rect x="157" y="79" width="26" height="32" rx="10"></rect>
+         <rect x="155" y="77" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="165" y="97">(</text>
+         <rect x="203" y="79" width="72" height="32" rx="10"></rect>
+         <rect x="201" y="77" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="211" y="97">ICONST</text>
+         <rect x="295" y="79" width="26" height="32" rx="10"></rect>
+         <rect x="293" y="77" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="303" y="97">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m124 0 h10 m0 0 h40 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m23 -76 h-3"></path>
+         <polygon points="359 17 367 13 367 21"></polygon>
+         <polygon points="359 17 351 13 351 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#simple_typename" title="simple_typename">simple_typename</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="user_priority" href="#user_priority">user_priority:</a></p>
       <svg width="176" height="124">
          
@@ -14158,6 +15236,371 @@
          </p><ul>
             <li><a href="#role_option" title="role_option">role_option</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="typed_literal" href="#typed_literal">typed_literal:</a></p>
+      <svg width="382" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#func_name_no_crdb_extra" xlink:title="func_name_no_crdb_extra">
+            <rect x="51" y="3" width="188" height="32"></rect>
+            <rect x="49" y="1" width="188" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">func_name_no_crdb_extra</text>
+         </a>
+         <a xlink:href="#const_typename" xlink:title="const_typename">
+            <rect x="51" y="47" width="124" height="32"></rect>
+            <rect x="49" y="45" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">const_typename</text>
+         </a>
+         <rect x="279" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="277" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="287" y="21">SCONST</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m188 0 h10 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v24 m228 0 v-24 m-228 24 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m124 0 h10 m0 0 h64 m20 -44 h10 m76 0 h10 m3 0 h-3"></path>
+         <polygon points="373 17 381 13 381 21"></polygon>
+         <polygon points="373 17 365 13 365 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_value" href="#interval_value">interval_value:</a></p>
+      <svg width="464" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="86" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">INTERVAL</text>
+         <rect x="157" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="155" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="165" y="21">SCONST</text>
+         <a xlink:href="#opt_interval_qualifier" xlink:title="opt_interval_qualifier">
+            <rect x="253" y="3" width="154" height="32"></rect>
+            <rect x="251" y="1" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="261" y="21">opt_interval_qualifier</text>
+         </a>
+         <rect x="157" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="155" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="165" y="65">(</text>
+         <rect x="203" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="201" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="211" y="65">ICONST</text>
+         <rect x="295" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="293" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="303" y="65">)</text>
+         <rect x="341" y="47" width="76" height="32" rx="10"></rect>
+         <rect x="339" y="45" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="349" y="65">SCONST</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m86 0 h10 m20 0 h10 m76 0 h10 m0 0 h10 m154 0 h10 m0 0 h10 m-300 0 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v24 m300 0 v-24 m-300 24 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m76 0 h10 m23 -44 h-3"></path>
+         <polygon points="455 17 463 13 463 21"></polygon>
+         <polygon points="455 17 447 13 447 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="column_path_with_star" href="#column_path_with_star">column_path_with_star:</a></p>
+      <svg width="878" height="144">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#column_path" xlink:title="column_path">
+            <rect x="51" y="3" width="100" height="32"></rect>
+            <rect x="49" y="1" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">column_path</text>
+         </a>
+         <a xlink:href="#db_object_name_component" xlink:title="db_object_name_component">
+            <rect x="51" y="47" width="204" height="32"></rect>
+            <rect x="49" y="45" width="204" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">db_object_name_component</text>
+         </a>
+         <rect x="275" y="47" width="24" height="32" rx="10"></rect>
+         <rect x="273" y="45" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="65">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="339" y="79" width="138" height="32"></rect>
+            <rect x="337" y="77" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="347" y="97">unrestricted_name</text>
+         </a>
+         <rect x="497" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="495" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="505" y="97">.</text>
+         <a xlink:href="#unrestricted_name" xlink:title="unrestricted_name">
+            <rect x="561" y="111" width="138" height="32"></rect>
+            <rect x="559" y="109" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="569" y="129">unrestricted_name</text>
+         </a>
+         <rect x="719" y="111" width="24" height="32" rx="10"></rect>
+         <rect x="717" y="109" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="727" y="129">.</text>
+         <rect x="803" y="47" width="28" height="32" rx="10"></rect>
+         <rect x="801" y="45" width="28" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="811" y="65">*</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m100 0 h10 m0 0 h680 m-820 0 h20 m800 0 h20 m-840 0 q10 0 10 10 m820 0 q0 -10 10 -10 m-830 10 v24 m820 0 v-24 m-820 24 q0 10 10 10 m800 0 q10 0 10 -10 m-810 10 h10 m204 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h434 m-464 0 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v12 m464 0 v-12 m-464 12 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m138 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m138 0 h10 m0 0 h10 m24 0 h10 m40 -64 h10 m28 0 h10 m23 -44 h-3"></path>
+         <polygon points="869 17 877 13 877 21"></polygon>
+         <polygon points="869 17 861 13 861 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="func_expr" href="#func_expr">func_expr:</a></p>
+      <svg width="622" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#func_application" xlink:title="func_application">
+            <rect x="51" y="3" width="122" height="32"></rect>
+            <rect x="49" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">func_application</text>
+         </a>
+         <a xlink:href="#within_group_clause" xlink:title="within_group_clause">
+            <rect x="193" y="3" width="150" height="32"></rect>
+            <rect x="191" y="1" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="21">within_group_clause</text>
+         </a>
+         <a xlink:href="#filter_clause" xlink:title="filter_clause">
+            <rect x="363" y="3" width="96" height="32"></rect>
+            <rect x="361" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="371" y="21">filter_clause</text>
+         </a>
+         <a xlink:href="#over_clause" xlink:title="over_clause">
+            <rect x="479" y="3" width="96" height="32"></rect>
+            <rect x="477" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="487" y="21">over_clause</text>
+         </a>
+         <a xlink:href="#func_expr_common_subexpr" xlink:title="func_expr_common_subexpr">
+            <rect x="51" y="47" width="200" height="32"></rect>
+            <rect x="49" y="45" width="200" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">func_expr_common_subexpr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m122 0 h10 m0 0 h10 m150 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m96 0 h10 m-564 0 h20 m544 0 h20 m-584 0 q10 0 10 10 m564 0 q0 -10 10 -10 m-574 10 v24 m564 0 v-24 m-564 24 q0 10 10 10 m544 0 q10 0 10 -10 m-554 10 h10 m200 0 h10 m0 0 h324 m23 -44 h-3"></path>
+         <polygon points="613 17 621 13 621 21"></polygon>
+         <polygon points="613 17 605 13 605 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="labeled_row" href="#labeled_row">labeled_row:</a></p>
+      <svg width="392" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#row" xlink:title="row">
+            <rect x="51" y="3" width="44" height="32"></rect>
+            <rect x="49" y="1" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">row</text>
+         </a>
+         <rect x="51" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">(</text>
+         <a xlink:href="#row" xlink:title="row">
+            <rect x="97" y="47" width="44" height="32"></rect>
+            <rect x="95" y="45" width="44" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="65">row</text>
+         </a>
+         <rect x="161" y="47" width="38" height="32" rx="10"></rect>
+         <rect x="159" y="45" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="169" y="65">AS</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="219" y="47" width="80" height="32"></rect>
+            <rect x="217" y="45" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="227" y="65">name_list</text>
+         </a>
+         <rect x="319" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="317" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="327" y="65">)</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h250 m-334 0 h20 m314 0 h20 m-354 0 q10 0 10 10 m334 0 q0 -10 10 -10 m-344 10 v24 m334 0 v-24 m-334 24 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m26 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m23 -44 h-3"></path>
+         <polygon points="383 17 391 13 391 21"></polygon>
+         <polygon points="383 17 375 13 375 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="row" href="#row">row:</a></p>
+      <svg width="366" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ROW</text>
+         <rect x="125" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="123" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="21">(</text>
+         <a xlink:href="#opt_expr_list" xlink:title="opt_expr_list">
+            <rect x="171" y="3" width="102" height="32"></rect>
+            <rect x="169" y="1" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="179" y="21">opt_expr_list</text>
+         </a>
+         <rect x="293" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="291" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="301" y="21">)</text>
+         <a xlink:href="#expr_tuple_unambiguous" xlink:title="expr_tuple_unambiguous">
+            <rect x="51" y="47" width="180" height="32"></rect>
+            <rect x="49" y="45" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">expr_tuple_unambiguous</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m26 0 h10 m-308 0 h20 m288 0 h20 m-328 0 q10 0 10 10 m308 0 q0 -10 10 -10 m-318 10 v24 m308 0 v-24 m-308 24 q0 10 10 10 m288 0 q10 0 10 -10 m-298 10 h10 m180 0 h10 m0 0 h88 m23 -44 h-3"></path>
+         <polygon points="357 17 365 13 365 21"></polygon>
+         <polygon points="357 17 349 13 349 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+            <li><a href="#labeled_row" title="labeled_row">labeled_row</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="array_expr" href="#array_expr">array_expr:</a></p>
+      <svg width="304" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">[</text>
+         <a xlink:href="#opt_expr_list" xlink:title="opt_expr_list">
+            <rect x="97" y="3" width="102" height="32"></rect>
+            <rect x="95" y="1" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="21">opt_expr_list</text>
+         </a>
+         <a xlink:href="#array_expr_list" xlink:title="array_expr_list">
+            <rect x="97" y="47" width="114" height="32"></rect>
+            <rect x="95" y="45" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="65">array_expr_list</text>
+         </a>
+         <rect x="251" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="249" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="21">]</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m102 0 h10 m0 0 h12 m-154 0 h20 m134 0 h20 m-174 0 q10 0 10 10 m154 0 q0 -10 10 -10 m-164 10 v24 m154 0 v-24 m-154 24 q0 10 10 10 m134 0 q10 0 10 -10 m-144 10 h10 m114 0 h10 m20 -44 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="295 17 303 13 303 21"></polygon>
+         <polygon points="295 17 287 13 287 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#array_expr_list" title="array_expr_list">array_expr_list</a></li>
+            <li><a href="#d_expr" title="d_expr">d_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="array_subscript" href="#array_subscript">array_subscript:</a></p>
+      <svg width="502" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">[</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="97" y="3" width="64" height="32"></rect>
+            <rect x="95" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="21">a_expr</text>
+         </a>
+         <a xlink:href="#opt_slice_bound" xlink:title="opt_slice_bound">
+            <rect x="97" y="47" width="124" height="32"></rect>
+            <rect x="95" y="45" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="105" y="65">opt_slice_bound</text>
+         </a>
+         <rect x="241" y="47" width="24" height="32" rx="10"></rect>
+         <rect x="239" y="45" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="249" y="65">:</text>
+         <a xlink:href="#opt_slice_bound" xlink:title="opt_slice_bound">
+            <rect x="285" y="47" width="124" height="32"></rect>
+            <rect x="283" y="45" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="293" y="65">opt_slice_bound</text>
+         </a>
+         <rect x="449" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="447" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="457" y="21">]</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m20 0 h10 m64 0 h10 m0 0 h248 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v24 m352 0 v-24 m-352 24 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m124 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m124 0 h10 m20 -44 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="493 17 501 13 501 21"></polygon>
+         <polygon points="493 17 485 13 485 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#array_subscripts" title="array_subscripts">array_subscripts</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="case_arg" href="#case_arg">case_arg:</a></p>
+      <svg width="162" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="51" y="23" width="64" height="32"></rect>
+            <rect x="49" y="21" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">a_expr</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m23 -32 h-3"></path>
+         <polygon points="153 5 161 1 161 9"></polygon>
+         <polygon points="153 5 145 1 145 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#case_expr" title="case_expr">case_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="when_clause_list" href="#when_clause_list">when_clause_list:</a></p>
+      <svg width="200" height="52">
+         
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <a xlink:href="#when_clause" xlink:title="when_clause">
+            <rect x="51" y="19" width="102" height="32"></rect>
+            <rect x="49" y="17" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="37">when_clause</text>
+         </a>
+         <path class="line" d="m17 33 h2 m20 0 h10 m102 0 h10 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m122 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-122 0 h10 m0 0 h112 m23 32 h-3"></path>
+         <polygon points="191 33 199 29 199 37"></polygon>
+         <polygon points="191 33 183 29 183 37"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#case_expr" title="case_expr">case_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="case_default" href="#case_default">case_default:</a></p>
+      <svg width="234" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">ELSE</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="123" y="23" width="64" height="32"></rect>
+            <rect x="121" y="21" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="131" y="41">a_expr</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m52 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+         <polygon points="225 5 233 1 233 9"></polygon>
+         <polygon points="225 5 217 1 217 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#case_expr" title="case_expr">case_expr</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="tuple1_ambiguous_values" href="#tuple1_ambiguous_values">tuple1_ambiguous_values:</a></p>
+      <svg width="340" height="100">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="31" y="3" width="64" height="32"></rect>
+            <rect x="29" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">a_expr</text>
+         </a>
+         <rect x="135" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="133" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="53">,</text>
+         <a xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="199" y="67" width="74" height="32"></rect>
+            <rect x="197" y="65" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="207" y="85">expr_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m24 0 h10 m20 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m43 -64 h-3"></path>
+         <polygon points="331 17 339 13 339 21"></polygon>
+         <polygon points="331 17 323 13 323 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#expr_tuple1_ambiguous" title="expr_tuple1_ambiguous">expr_tuple1_ambiguous</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_asc_desc" href="#opt_asc_desc">opt_asc_desc:</a></p>
       <svg width="154" height="100">
          
@@ -14278,6 +15721,25 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_as_table_defs" title="create_as_table_defs">create_as_table_defs</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="materialize_clause" href="#materialize_clause">materialize_clause:</a></p>
+      <svg width="286" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">NOT</text>
+         <rect x="139" y="3" width="120" height="32" rx="10"></rect>
+         <rect x="137" y="1" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="21">MATERIALIZED</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m120 0 h10 m3 0 h-3"></path>
+         <polygon points="277 17 285 13 285 21"></polygon>
+         <polygon points="277 17 269 13 269 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#common_table_expr" title="common_table_expr">common_table_expr</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="index_flags_param" href="#index_flags_param">index_flags_param:</a></p>
       <svg width="380" height="80">
@@ -14433,8 +15895,262 @@
             <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
             <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="window_definition_list" href="#window_definition_list">window_definition_list:</a></p>
+      <svg width="232" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#window_definition" xlink:title="window_definition">
+            <rect x="51" y="47" width="134" height="32"></rect>
+            <rect x="49" y="45" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">window_definition</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m134 0 h10 m-174 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m154 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-154 0 h10 m24 0 h10 m0 0 h110 m23 44 h-3"></path>
+         <polygon points="223 61 231 57 231 65"></polygon>
+         <polygon points="223 61 215 57 215 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#window_clause" title="window_clause">window_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="for_locking_strength" href="#for_locking_strength">for_locking_strength:</a></p>
+      <svg width="406" height="144">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">FOR</text>
+         <rect x="139" y="35" width="40" height="32" rx="10"></rect>
+         <rect x="137" y="33" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="53">NO</text>
+         <rect x="199" y="35" width="46" height="32" rx="10"></rect>
+         <rect x="197" y="33" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="207" y="53">KEY</text>
+         <rect x="285" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="283" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="293" y="21">UPDATE</text>
+         <rect x="139" y="111" width="46" height="32" rx="10"></rect>
+         <rect x="137" y="109" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="129">KEY</text>
+         <rect x="225" y="79" width="64" height="32" rx="10"></rect>
+         <rect x="223" y="77" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="97">SHARE</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m40 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m40 0 h10 m0 0 h10 m46 0 h10 m20 -32 h10 m74 0 h10 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v56 m280 0 v-56 m-280 56 q0 10 10 10 m260 0 q10 0 10 -10 m-250 10 h10 m0 0 h56 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v12 m86 0 v-12 m-86 12 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m46 0 h10 m20 -32 h10 m64 0 h10 m0 0 h70 m23 -76 h-3"></path>
+         <polygon points="397 17 405 13 405 21"></polygon>
+         <polygon points="397 17 389 13 389 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_locked_rels" href="#opt_locked_rels">opt_locked_rels:</a></p>
+      <svg width="236" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">OF</text>
+         <a xlink:href="#table_name_list" xlink:title="table_name_list">
+            <rect x="89" y="3" width="120" height="32"></rect>
+            <rect x="87" y="1" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="97" y="21">table_name_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m120 0 h10 m3 0 h-3"></path>
+         <polygon points="227 17 235 13 235 21"></polygon>
+         <polygon points="227 17 219 13 219 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_nowait_or_skip" href="#opt_nowait_or_skip">opt_nowait_or_skip:</a></p>
+      <svg width="244" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">SKIP</text>
+         <rect x="123" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="121" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="131" y="21">LOCKED</text>
+         <rect x="51" y="47" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">NOWAIT</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m52 0 h10 m0 0 h10 m74 0 h10 m-186 0 h20 m166 0 h20 m-206 0 q10 0 10 10 m186 0 q0 -10 10 -10 m-196 10 v24 m186 0 v-24 m-186 24 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m78 0 h10 m0 0 h68 m23 -44 h-3"></path>
+         <polygon points="235 17 243 13 243 21"></polygon>
+         <polygon points="235 17 227 13 227 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_join_hint" href="#opt_join_hint">opt_join_hint:</a></p>
+      <svg width="176" height="144">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">HASH</text>
+         <rect x="51" y="67" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="65" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="85">MERGE</text>
+         <rect x="51" y="111" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="109" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="129">LOOKUP</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m58 0 h10 m0 0 h20 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m66 0 h10 m0 0 h12 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -120 h-3"></path>
+         <polygon points="167 5 175 1 175 9"></polygon>
+         <polygon points="167 5 159 1 159 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#joined_table" title="joined_table">joined_table</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="join_type" href="#join_type">join_type:</a></p>
+      <svg width="304" height="168">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="71" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">FULL</text>
+         <rect x="71" y="47" width="52" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">LEFT</text>
+         <rect x="71" y="91" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="89" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="109">RIGHT</text>
+         <a xlink:href="#join_outer" xlink:title="join_outer">
+            <rect x="173" y="3" width="84" height="32"></rect>
+            <rect x="171" y="1" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="181" y="21">join_outer</text>
+         </a>
+         <rect x="51" y="135" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">INNER</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m54 0 h10 m0 0 h8 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m52 0 h10 m0 0 h10 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -88 h10 m84 0 h10 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v112 m246 0 v-112 m-246 112 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m62 0 h10 m0 0 h144 m23 -132 h-3"></path>
+         <polygon points="295 17 303 13 303 21"></polygon>
+         <polygon points="295 17 287 13 287 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#joined_table" title="joined_table">joined_table</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="join_qual" href="#join_qual">join_qual:</a></p>
+      <svg width="354" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">USING</text>
+         <rect x="135" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="133" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="21">(</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="181" y="3" width="80" height="32"></rect>
+            <rect x="179" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="189" y="21">name_list</text>
+         </a>
+         <rect x="281" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="279" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="289" y="21">)</text>
+         <rect x="51" y="47" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">ON</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="111" y="47" width="64" height="32"></rect>
+            <rect x="109" y="45" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="119" y="65">a_expr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m-296 0 h20 m276 0 h20 m-316 0 q10 0 10 10 m296 0 q0 -10 10 -10 m-306 10 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m40 0 h10 m0 0 h10 m64 0 h10 m0 0 h132 m23 -44 h-3"></path>
+         <polygon points="345 17 353 13 353 21"></polygon>
+         <polygon points="345 17 337 13 337 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#joined_table" title="joined_table">joined_table</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="func_expr_windowless" href="#func_expr_windowless">func_expr_windowless:</a></p>
+      <svg width="298" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#func_application" xlink:title="func_application">
+            <rect x="51" y="3" width="122" height="32"></rect>
+            <rect x="49" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">func_application</text>
+         </a>
+         <a xlink:href="#func_expr_common_subexpr" xlink:title="func_expr_common_subexpr">
+            <rect x="51" y="47" width="200" height="32"></rect>
+            <rect x="49" y="45" width="200" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">func_expr_common_subexpr</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m122 0 h10 m0 0 h78 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m200 0 h10 m23 -44 h-3"></path>
+         <polygon points="289 17 297 13 297 21"></polygon>
+         <polygon points="289 17 281 13 281 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#func_table" title="func_table">func_table</a></li>
+            <li><a href="#rowsfrom_item" title="rowsfrom_item">rowsfrom_item</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="rowsfrom_list" href="#rowsfrom_list">rowsfrom_list:</a></p>
+      <svg width="212" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#rowsfrom_item" xlink:title="rowsfrom_item">
+            <rect x="51" y="47" width="114" height="32"></rect>
+            <rect x="49" y="45" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">rowsfrom_item</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m23 44 h-3"></path>
+         <polygon points="203 61 211 57 211 65"></polygon>
+         <polygon points="203 61 195 57 195 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#func_table" title="func_table">func_table</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_function_name_no_crdb_extra" href="#type_function_name_no_crdb_extra">type_function_name_no_crdb_extra:</a></p>
+      <svg width="384" height="124">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">identifier</text>
+         <a xlink:href="#unreserved_keyword" xlink:title="unreserved_keyword">
+            <rect x="51" y="47" width="154" height="32"></rect>
+            <rect x="49" y="45" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">unreserved_keyword</text>
+         </a>
+         <a xlink:href="#type_func_name_no_crdb_extra_keyword" xlink:title="type_func_name_no_crdb_extra_keyword">
+            <rect x="51" y="91" width="286" height="32"></rect>
+            <rect x="49" y="89" width="286" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">type_func_name_no_crdb_extra_keyword</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m80 0 h10 m0 0 h206 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v24 m326 0 v-24 m-326 24 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m154 0 h10 m0 0 h132 m-316 -10 v20 m326 0 v-20 m-326 20 v24 m326 0 v-24 m-326 24 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m286 0 h10 m23 -88 h-3"></path>
+         <polygon points="375 17 383 13 383 21"></polygon>
+         <polygon points="375 17 367 13 367 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#func_name_no_crdb_extra" title="func_name_no_crdb_extra">func_name_no_crdb_extra</a></li>
+            <li><a href="#general_type_name" title="general_type_name">general_type_name</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="numeric" href="#numeric">numeric:</a></p>
-      <svg width="402" height="784">
+      <svg width="402" height="476">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -14444,68 +16160,47 @@
          <rect x="51" y="47" width="78" height="32" rx="10"></rect>
          <rect x="49" y="45" width="78" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="65">INTEGER</text>
-         <rect x="51" y="91" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">INT2</text>
-         <rect x="51" y="135" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">SMALLINT</text>
-         <rect x="51" y="179" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">INT4</text>
-         <rect x="51" y="223" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">INT8</text>
-         <rect x="51" y="267" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">INT64</text>
-         <rect x="51" y="311" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">BIGINT</text>
-         <rect x="51" y="355" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">REAL</text>
-         <rect x="51" y="399" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">FLOAT4</text>
-         <rect x="51" y="443" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">FLOAT8</text>
-         <rect x="51" y="487" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">FLOAT</text>
+         <rect x="51" y="91" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">SMALLINT</text>
+         <rect x="51" y="135" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">BIGINT</text>
+         <rect x="51" y="179" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">REAL</text>
+         <rect x="51" y="223" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">FLOAT</text>
          <a xlink:href="#opt_float" xlink:title="opt_float">
-            <rect x="135" y="487" width="76" height="32"></rect>
-            <rect x="133" y="485" width="76" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="505">opt_float</text>
+            <rect x="135" y="223" width="76" height="32"></rect>
+            <rect x="133" y="221" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="241">opt_float</text>
          </a>
-         <rect x="51" y="531" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">DOUBLE</text>
-         <rect x="147" y="531" width="96" height="32" rx="10"></rect>
-         <rect x="145" y="529" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="155" y="549">PRECISION</text>
-         <rect x="71" y="575" width="80" height="32" rx="10"></rect>
-         <rect x="69" y="573" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="593">DECIMAL</text>
-         <rect x="71" y="619" width="46" height="32" rx="10"></rect>
-         <rect x="69" y="617" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="637">DEC</text>
-         <rect x="71" y="663" width="82" height="32" rx="10"></rect>
-         <rect x="69" y="661" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="681">NUMERIC</text>
+         <rect x="51" y="267" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">DOUBLE</text>
+         <rect x="147" y="267" width="96" height="32" rx="10"></rect>
+         <rect x="145" y="265" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="285">PRECISION</text>
+         <rect x="71" y="311" width="80" height="32" rx="10"></rect>
+         <rect x="69" y="309" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="329">DECIMAL</text>
+         <rect x="71" y="355" width="46" height="32" rx="10"></rect>
+         <rect x="69" y="353" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="373">DEC</text>
+         <rect x="71" y="399" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="397" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="417">NUMERIC</text>
          <a xlink:href="#opt_numeric_modifiers" xlink:title="opt_numeric_modifiers">
-            <rect x="193" y="575" width="162" height="32"></rect>
-            <rect x="191" y="573" width="162" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="201" y="593">opt_numeric_modifiers</text>
+            <rect x="193" y="311" width="162" height="32"></rect>
+            <rect x="191" y="309" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="329">opt_numeric_modifiers</text>
          </a>
-         <rect x="51" y="707" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">BOOLEAN</text>
-         <rect x="51" y="751" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">BOOL</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h260 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m78 0 h10 m0 0 h226 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m52 0 h10 m0 0 h252 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m88 0 h10 m0 0 h216 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m52 0 h10 m0 0 h252 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m52 0 h10 m0 0 h252 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m62 0 h10 m0 0 h242 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m68 0 h10 m0 0 h236 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m54 0 h10 m0 0 h250 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m72 0 h10 m0 0 h232 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m72 0 h10 m0 0 h232 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h144 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h112 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-314 10 h10 m80 0 h10 m0 0 h2 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m46 0 h10 m0 0 h36 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -88 h10 m162 0 h10 m-334 -10 v20 m344 0 v-20 m-344 20 v112 m344 0 v-112 m-344 112 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m86 0 h10 m0 0 h218 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m58 0 h10 m0 0 h246 m23 -748 h-3"></path>
+         <rect x="51" y="443" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">BOOLEAN</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h260 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m78 0 h10 m0 0 h226 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m88 0 h10 m0 0 h216 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m68 0 h10 m0 0 h236 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m54 0 h10 m0 0 h250 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h144 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h112 m-334 -10 v20 m344 0 v-20 m-344 20 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-314 10 h10 m80 0 h10 m0 0 h2 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m46 0 h10 m0 0 h36 m-112 -10 v20 m122 0 v-20 m-122 20 v24 m122 0 v-24 m-122 24 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m20 -88 h10 m162 0 h10 m-334 -10 v20 m344 0 v-20 m-344 20 v112 m344 0 v-112 m-344 112 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m86 0 h10 m0 0 h218 m23 -440 h-3"></path>
          <polygon points="393 17 401 13 401 21"></polygon>
          <polygon points="393 17 385 13 385 21"></polygon>
       </svg>
@@ -14604,24 +16299,349 @@
          </p><ul>
             <li><a href="#const_typename" title="const_typename">const_typename</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="const_json" href="#const_json">const_json:</a></p>
-      <svg width="164" height="80">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="const_geo" href="#const_geo">const_geo:</a></p>
+      <svg width="692" height="100">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">GEOGRAPHY</text>
+         <rect x="51" y="47" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">GEOMETRY</text>
+         <rect x="217" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="215" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="53">(</text>
+         <a xlink:href="#geo_shape_type" xlink:title="geo_shape_type">
+            <rect x="263" y="35" width="126" height="32"></rect>
+            <rect x="261" y="33" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="271" y="53">geo_shape_type</text>
+         </a>
+         <rect x="429" y="67" width="24" height="32" rx="10"></rect>
+         <rect x="427" y="65" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="437" y="85">,</text>
+         <a xlink:href="#signed_iconst" xlink:title="signed_iconst">
+            <rect x="473" y="67" width="106" height="32"></rect>
+            <rect x="471" y="65" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="481" y="85">signed_iconst</text>
+         </a>
+         <rect x="619" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="617" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="627" y="53">)</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m106 0 h10 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m94 0 h10 m0 0 h12 m40 -44 h10 m0 0 h438 m-468 0 h20 m448 0 h20 m-488 0 q10 0 10 10 m468 0 q0 -10 10 -10 m-478 10 v12 m468 0 v-12 m-468 12 q0 10 10 10 m448 0 q10 0 10 -10 m-458 10 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m24 0 h10 m0 0 h10 m106 0 h10 m20 -32 h10 m26 0 h10 m23 -32 h-3"></path>
+         <polygon points="683 17 691 13 691 21"></polygon>
+         <polygon points="683 17 675 13 675 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#const_typename" title="const_typename">const_typename</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_varying" href="#opt_varying">opt_varying:</a></p>
+      <svg width="180" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">VARYING</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m23 -32 h-3"></path>
+         <polygon points="171 5 179 1 179 9"></polygon>
+         <polygon points="171 5 163 1 163 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#bit_with_length" title="bit_with_length">bit_with_length</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="character_base" href="#character_base">character_base:</a></p>
+      <svg width="338" height="156">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#char_aliases" xlink:title="char_aliases">
+            <rect x="51" y="3" width="98" height="32"></rect>
+            <rect x="49" y="1" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">char_aliases</text>
+         </a>
+         <rect x="189" y="35" width="82" height="32" rx="10"></rect>
+         <rect x="187" y="33" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="197" y="53">VARYING</text>
+         <rect x="51" y="79" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="77" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="97">VARCHAR</text>
+         <rect x="51" y="123" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="121" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="141">STRING</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m98 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m-260 -32 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v56 m280 0 v-56 m-280 56 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m84 0 h10 m0 0 h156 m-270 -10 v20 m280 0 v-20 m-280 20 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m72 0 h10 m0 0 h168 m23 -120 h-3"></path>
+         <polygon points="329 17 337 13 337 21"></polygon>
+         <polygon points="329 17 321 13 321 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#character_with_length" title="character_with_length">character_with_length</a></li>
+            <li><a href="#character_without_length" title="character_without_length">character_without_length</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_qualifier" href="#interval_qualifier">interval_qualifier:</a></p>
+      <svg width="436" height="516">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="51" y="3" width="56" height="32" rx="10"></rect>
          <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">JSON</text>
-         <rect x="51" y="47" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">JSONB</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h10 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m23 -44 h-3"></path>
+         <text class="terminal" x="59" y="21">YEAR</text>
+         <rect x="147" y="35" width="38" height="32" rx="10"></rect>
+         <rect x="145" y="33" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="53">TO</text>
+         <rect x="205" y="35" width="70" height="32" rx="10"></rect>
+         <rect x="203" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="213" y="53">MONTH</text>
+         <rect x="51" y="79" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="77" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="97">MONTH</text>
+         <rect x="51" y="123" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="121" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="141">DAY</text>
+         <rect x="139" y="155" width="38" height="32" rx="10"></rect>
+         <rect x="137" y="153" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="173">TO</text>
+         <rect x="217" y="155" width="60" height="32" rx="10"></rect>
+         <rect x="215" y="153" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="173">HOUR</text>
+         <rect x="217" y="199" width="72" height="32" rx="10"></rect>
+         <rect x="215" y="197" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="225" y="217">MINUTE</text>
+         <a xlink:href="#interval_second" xlink:title="interval_second">
+            <rect x="217" y="243" width="120" height="32"></rect>
+            <rect x="215" y="241" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="261">interval_second</text>
+         </a>
+         <rect x="51" y="287" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="285" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="305">HOUR</text>
+         <rect x="151" y="319" width="38" height="32" rx="10"></rect>
+         <rect x="149" y="317" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="159" y="337">TO</text>
+         <rect x="229" y="319" width="72" height="32" rx="10"></rect>
+         <rect x="227" y="317" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="237" y="337">MINUTE</text>
+         <a xlink:href="#interval_second" xlink:title="interval_second">
+            <rect x="229" y="363" width="120" height="32"></rect>
+            <rect x="227" y="361" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="237" y="381">interval_second</text>
+         </a>
+         <rect x="51" y="407" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="405" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="425">MINUTE</text>
+         <rect x="163" y="439" width="38" height="32" rx="10"></rect>
+         <rect x="161" y="437" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="171" y="457">TO</text>
+         <a xlink:href="#interval_second" xlink:title="interval_second">
+            <rect x="221" y="439" width="120" height="32"></rect>
+            <rect x="219" y="437" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="229" y="457">interval_second</text>
+         </a>
+         <a xlink:href="#interval_second" xlink:title="interval_second">
+            <rect x="51" y="483" width="120" height="32"></rect>
+            <rect x="49" y="481" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="501">interval_second</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m20 0 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m38 0 h10 m0 0 h10 m70 0 h10 m20 -32 h94 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v56 m378 0 v-56 m-378 56 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m70 0 h10 m0 0 h268 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m48 0 h10 m20 0 h10 m0 0 h228 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v12 m258 0 v-12 m-258 12 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m38 0 h10 m20 0 h10 m60 0 h10 m0 0 h60 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m72 0 h10 m0 0 h48 m-150 -10 v20 m160 0 v-20 m-160 20 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m40 -120 h12 m-368 -10 v20 m378 0 v-20 m-378 20 v144 m378 0 v-144 m-378 144 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m60 0 h10 m20 0 h10 m0 0 h228 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v12 m258 0 v-12 m-258 12 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m38 0 h10 m20 0 h10 m72 0 h10 m0 0 h48 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m-328 -86 v20 m378 0 v-20 m-378 20 v100 m378 0 v-100 m-378 100 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m72 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m38 0 h10 m0 0 h10 m120 0 h10 m20 -32 h28 m-368 -10 v20 m378 0 v-20 m-378 20 v56 m378 0 v-56 m-378 56 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m120 0 h10 m0 0 h218 m23 -480 h-3"></path>
+         <polygon points="427 17 435 13 435 21"></polygon>
+         <polygon points="427 17 419 13 419 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#interval_type" title="interval_type">interval_type</a></li>
+            <li><a href="#opt_interval_qualifier" title="opt_interval_qualifier">opt_interval_qualifier</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_column" href="#opt_column">opt_column:</a></p>
+      <svg width="176" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">COLUMN</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -32 h-3"></path>
+         <polygon points="167 5 175 1 175 9"></polygon>
+         <polygon points="167 5 159 1 159 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_column_default" href="#alter_column_default">alter_column_default:</a></p>
+      <svg width="326" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">SET</text>
+         <rect x="115" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">DEFAULT</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="215" y="3" width="64" height="32"></rect>
+            <rect x="213" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="223" y="21">a_expr</text>
+         </a>
+         <rect x="51" y="47" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">DROP</text>
+         <rect x="129" y="47" width="80" height="32" rx="10"></rect>
+         <rect x="127" y="45" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="65">DEFAULT</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m64 0 h10 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v24 m268 0 v-24 m-268 24 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m58 0 h10 m0 0 h10 m80 0 h10 m0 0 h70 m23 -44 h-3"></path>
+         <polygon points="317 17 325 13 325 21"></polygon>
+         <polygon points="317 17 309 13 309 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_set_data" href="#opt_set_data">opt_set_data:</a></p>
+      <svg width="218" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">SET</text>
+         <rect x="115" y="23" width="56" height="32" rx="10"></rect>
+         <rect x="113" y="21" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="41">DATA</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m44 0 h10 m0 0 h10 m56 0 h10 m23 -32 h-3"></path>
+         <polygon points="209 5 217 1 217 9"></polygon>
+         <polygon points="209 5 201 1 201 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_collate" href="#opt_collate">opt_collate:</a></p>
+      <svg width="312" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">COLLATE</text>
+         <a xlink:href="#collation_name" xlink:title="collation_name">
+            <rect x="151" y="23" width="114" height="32"></rect>
+            <rect x="149" y="21" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="159" y="41">collation_name</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m80 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"></path>
+         <polygon points="303 5 311 1 311 9"></polygon>
+         <polygon points="303 5 295 1 295 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_alter_column_using" href="#opt_alter_column_using">opt_alter_column_using:</a></p>
+      <svg width="246" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">USING</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="135" y="23" width="64" height="32"></rect>
+            <rect x="133" y="21" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="143" y="41">a_expr</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
+         <polygon points="237 5 245 1 245 9"></polygon>
+         <polygon points="237 5 229 1 229 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_validate_behavior" href="#opt_validate_behavior">opt_validate_behavior:</a></p>
+      <svg width="228" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">NOT</text>
+         <rect x="119" y="23" width="62" height="32" rx="10"></rect>
+         <rect x="117" y="21" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="41">VALID</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m48 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
+         <polygon points="219 5 227 1 227 9"></polygon>
+         <polygon points="219 5 211 1 211 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="audit_mode" href="#audit_mode">audit_mode:</a></p>
+      <svg width="238" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">READ</text>
+         <rect x="127" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="125" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="135" y="21">WRITE</text>
+         <rect x="51" y="47" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">OFF</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m46 0 h10 m0 0 h94 m23 -44 h-3"></path>
+         <polygon points="229 17 237 13 237 21"></polygon>
+         <polygon points="229 17 221 13 221 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="signed_iconst64" href="#signed_iconst64">signed_iconst64:</a></p>
+      <svg width="164" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#signed_iconst" xlink:title="signed_iconst">
+            <rect x="31" y="3" width="106" height="32"></rect>
+            <rect x="29" y="1" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">signed_iconst</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m106 0 h10 m3 0 h-3"></path>
          <polygon points="155 17 163 13 163 21"></polygon>
          <polygon points="155 17 147 13 147 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#const_typename" title="const_typename">const_typename</a></li>
+            <li><a href="#sequence_option_elem" title="sequence_option_elem">sequence_option_elem</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="func_name_no_crdb_extra" href="#func_name_no_crdb_extra">func_name_no_crdb_extra:</a></p>
+      <svg width="346" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#type_function_name_no_crdb_extra" xlink:title="type_function_name_no_crdb_extra">
+            <rect x="51" y="3" width="248" height="32"></rect>
+            <rect x="49" y="1" width="248" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">type_function_name_no_crdb_extra</text>
+         </a>
+         <a xlink:href="#prefixed_column_path" xlink:title="prefixed_column_path">
+            <rect x="51" y="47" width="160" height="32"></rect>
+            <rect x="49" y="45" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">prefixed_column_path</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m248 0 h10 m-288 0 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v24 m288 0 v-24 m-288 24 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m160 0 h10 m0 0 h88 m23 -44 h-3"></path>
+         <polygon points="337 17 345 13 345 21"></polygon>
+         <polygon points="337 17 329 13 329 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#typed_literal" title="typed_literal">typed_literal</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_interval_qualifier" href="#opt_interval_qualifier">opt_interval_qualifier:</a></p>
       <svg width="222" height="56">
@@ -14689,6 +16709,36 @@
          </p><ul>
             <li><a href="#func_expr" title="func_expr">func_expr</a></li>
             <li><a href="#func_expr_windowless" title="func_expr_windowless">func_expr_windowless</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="within_group_clause" href="#within_group_clause">within_group_clause:</a></p>
+      <svg width="510" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITHIN</text>
+         <rect x="145" y="23" width="68" height="32" rx="10"></rect>
+         <rect x="143" y="21" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="41">GROUP</text>
+         <rect x="233" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="231" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="241" y="41">(</text>
+         <a xlink:href="#single_sort_clause" xlink:title="single_sort_clause">
+            <rect x="279" y="23" width="138" height="32"></rect>
+            <rect x="277" y="21" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="287" y="41">single_sort_clause</text>
+         </a>
+         <rect x="437" y="23" width="26" height="32" rx="10"></rect>
+         <rect x="435" y="21" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="445" y="41">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h422 m-452 0 h20 m432 0 h20 m-472 0 q10 0 10 10 m452 0 q0 -10 10 -10 m-462 10 v12 m452 0 v-12 m-452 12 q0 10 10 10 m432 0 q10 0 10 -10 m-442 10 h10 m74 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m138 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
+         <polygon points="501 5 509 1 509 9"></polygon>
+         <polygon points="501 5 493 1 493 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#func_expr" title="func_expr">func_expr</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="filter_clause" href="#filter_clause">filter_clause:</a></p>
       <svg width="428" height="56">
@@ -15035,516 +17085,6 @@
          </p><ul>
             <li><a href="#when_clause_list" title="when_clause_list">when_clause_list</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_varying" href="#opt_varying">opt_varying:</a></p>
-      <svg width="180" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">VARYING</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m23 -32 h-3"></path>
-         <polygon points="171 5 179 1 179 9"></polygon>
-         <polygon points="171 5 163 1 163 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#bit_with_length" title="bit_with_length">bit_with_length</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="character_base" href="#character_base">character_base:</a></p>
-      <svg width="338" height="156">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#char_aliases" xlink:title="char_aliases">
-            <rect x="51" y="3" width="98" height="32"></rect>
-            <rect x="49" y="1" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">char_aliases</text>
-         </a>
-         <rect x="189" y="35" width="82" height="32" rx="10"></rect>
-         <rect x="187" y="33" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="197" y="53">VARYING</text>
-         <rect x="51" y="79" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="77" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="97">VARCHAR</text>
-         <rect x="51" y="123" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="121" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="141">STRING</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m98 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m82 0 h10 m-260 -32 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v56 m280 0 v-56 m-280 56 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m84 0 h10 m0 0 h156 m-270 -10 v20 m280 0 v-20 m-280 20 v24 m280 0 v-24 m-280 24 q0 10 10 10 m260 0 q10 0 10 -10 m-270 10 h10 m72 0 h10 m0 0 h168 m23 -120 h-3"></path>
-         <polygon points="329 17 337 13 337 21"></polygon>
-         <polygon points="329 17 321 13 321 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#character_with_length" title="character_with_length">character_with_length</a></li>
-            <li><a href="#character_without_length" title="character_without_length">character_without_length</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_qualifier" href="#interval_qualifier">interval_qualifier:</a></p>
-      <svg width="436" height="516">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">YEAR</text>
-         <rect x="147" y="35" width="38" height="32" rx="10"></rect>
-         <rect x="145" y="33" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="155" y="53">TO</text>
-         <rect x="205" y="35" width="70" height="32" rx="10"></rect>
-         <rect x="203" y="33" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="213" y="53">MONTH</text>
-         <rect x="51" y="79" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="77" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="97">MONTH</text>
-         <rect x="51" y="123" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="121" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="141">DAY</text>
-         <rect x="139" y="155" width="38" height="32" rx="10"></rect>
-         <rect x="137" y="153" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="173">TO</text>
-         <rect x="217" y="155" width="60" height="32" rx="10"></rect>
-         <rect x="215" y="153" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="225" y="173">HOUR</text>
-         <rect x="217" y="199" width="72" height="32" rx="10"></rect>
-         <rect x="215" y="197" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="225" y="217">MINUTE</text>
-         <a xlink:href="#interval_second" xlink:title="interval_second">
-            <rect x="217" y="243" width="120" height="32"></rect>
-            <rect x="215" y="241" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="225" y="261">interval_second</text>
-         </a>
-         <rect x="51" y="287" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="285" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="305">HOUR</text>
-         <rect x="151" y="319" width="38" height="32" rx="10"></rect>
-         <rect x="149" y="317" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="159" y="337">TO</text>
-         <rect x="229" y="319" width="72" height="32" rx="10"></rect>
-         <rect x="227" y="317" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="237" y="337">MINUTE</text>
-         <a xlink:href="#interval_second" xlink:title="interval_second">
-            <rect x="229" y="363" width="120" height="32"></rect>
-            <rect x="227" y="361" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="237" y="381">interval_second</text>
-         </a>
-         <rect x="51" y="407" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="405" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="425">MINUTE</text>
-         <rect x="163" y="439" width="38" height="32" rx="10"></rect>
-         <rect x="161" y="437" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="171" y="457">TO</text>
-         <a xlink:href="#interval_second" xlink:title="interval_second">
-            <rect x="221" y="439" width="120" height="32"></rect>
-            <rect x="219" y="437" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="229" y="457">interval_second</text>
-         </a>
-         <a xlink:href="#interval_second" xlink:title="interval_second">
-            <rect x="51" y="483" width="120" height="32"></rect>
-            <rect x="49" y="481" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="501">interval_second</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m20 0 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m38 0 h10 m0 0 h10 m70 0 h10 m20 -32 h94 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v56 m378 0 v-56 m-378 56 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m70 0 h10 m0 0 h268 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m48 0 h10 m20 0 h10 m0 0 h228 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v12 m258 0 v-12 m-258 12 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m38 0 h10 m20 0 h10 m60 0 h10 m0 0 h60 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m72 0 h10 m0 0 h48 m-150 -10 v20 m160 0 v-20 m-160 20 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m40 -120 h12 m-368 -10 v20 m378 0 v-20 m-378 20 v144 m378 0 v-144 m-378 144 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m60 0 h10 m20 0 h10 m0 0 h228 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v12 m258 0 v-12 m-258 12 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m38 0 h10 m20 0 h10 m72 0 h10 m0 0 h48 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m-328 -86 v20 m378 0 v-20 m-378 20 v100 m378 0 v-100 m-378 100 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m72 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m38 0 h10 m0 0 h10 m120 0 h10 m20 -32 h28 m-368 -10 v20 m378 0 v-20 m-378 20 v56 m378 0 v-56 m-378 56 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m120 0 h10 m0 0 h218 m23 -480 h-3"></path>
-         <polygon points="427 17 435 13 435 21"></polygon>
-         <polygon points="427 17 419 13 419 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#interval_type" title="interval_type">interval_type</a></li>
-            <li><a href="#opt_interval_qualifier" title="opt_interval_qualifier">opt_interval_qualifier</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="window_definition_list" href="#window_definition_list">window_definition_list:</a></p>
-      <svg width="232" height="80">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#window_definition" xlink:title="window_definition">
-            <rect x="51" y="47" width="134" height="32"></rect>
-            <rect x="49" y="45" width="134" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">window_definition</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m134 0 h10 m-174 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m154 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-154 0 h10 m24 0 h10 m0 0 h110 m23 44 h-3"></path>
-         <polygon points="223 61 231 57 231 65"></polygon>
-         <polygon points="223 61 215 57 215 65"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#window_clause" title="window_clause">window_clause</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="for_locking_strength" href="#for_locking_strength">for_locking_strength:</a></p>
-      <svg width="406" height="144">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="48" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">FOR</text>
-         <rect x="139" y="35" width="40" height="32" rx="10"></rect>
-         <rect x="137" y="33" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="53">NO</text>
-         <rect x="199" y="35" width="46" height="32" rx="10"></rect>
-         <rect x="197" y="33" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="207" y="53">KEY</text>
-         <rect x="285" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="283" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="293" y="21">UPDATE</text>
-         <rect x="139" y="111" width="46" height="32" rx="10"></rect>
-         <rect x="137" y="109" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="129">KEY</text>
-         <rect x="225" y="79" width="64" height="32" rx="10"></rect>
-         <rect x="223" y="77" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="233" y="97">SHARE</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m48 0 h10 m40 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m40 0 h10 m0 0 h10 m46 0 h10 m20 -32 h10 m74 0 h10 m-280 0 h20 m260 0 h20 m-300 0 q10 0 10 10 m280 0 q0 -10 10 -10 m-290 10 v56 m280 0 v-56 m-280 56 q0 10 10 10 m260 0 q10 0 10 -10 m-250 10 h10 m0 0 h56 m-86 0 h20 m66 0 h20 m-106 0 q10 0 10 10 m86 0 q0 -10 10 -10 m-96 10 v12 m86 0 v-12 m-86 12 q0 10 10 10 m66 0 q10 0 10 -10 m-76 10 h10 m46 0 h10 m20 -32 h10 m64 0 h10 m0 0 h70 m23 -76 h-3"></path>
-         <polygon points="397 17 405 13 405 21"></polygon>
-         <polygon points="397 17 389 13 389 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_locked_rels" href="#opt_locked_rels">opt_locked_rels:</a></p>
-      <svg width="236" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">OF</text>
-         <a xlink:href="#table_name_list" xlink:title="table_name_list">
-            <rect x="89" y="3" width="120" height="32"></rect>
-            <rect x="87" y="1" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="97" y="21">table_name_list</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m120 0 h10 m3 0 h-3"></path>
-         <polygon points="227 17 235 13 235 21"></polygon>
-         <polygon points="227 17 219 13 219 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_nowait_or_skip" href="#opt_nowait_or_skip">opt_nowait_or_skip:</a></p>
-      <svg width="244" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">SKIP</text>
-         <rect x="123" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="121" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="131" y="21">LOCKED</text>
-         <rect x="51" y="47" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">NOWAIT</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m52 0 h10 m0 0 h10 m74 0 h10 m-186 0 h20 m166 0 h20 m-206 0 q10 0 10 10 m186 0 q0 -10 10 -10 m-196 10 v24 m186 0 v-24 m-186 24 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m78 0 h10 m0 0 h68 m23 -44 h-3"></path>
-         <polygon points="235 17 243 13 243 21"></polygon>
-         <polygon points="235 17 227 13 227 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_join_hint" href="#opt_join_hint">opt_join_hint:</a></p>
-      <svg width="176" height="144">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">HASH</text>
-         <rect x="51" y="67" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="65" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="85">MERGE</text>
-         <rect x="51" y="111" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="109" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="129">LOOKUP</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m58 0 h10 m0 0 h20 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m66 0 h10 m0 0 h12 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -120 h-3"></path>
-         <polygon points="167 5 175 1 175 9"></polygon>
-         <polygon points="167 5 159 1 159 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#joined_table" title="joined_table">joined_table</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="join_type" href="#join_type">join_type:</a></p>
-      <svg width="304" height="168">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="3" width="54" height="32" rx="10"></rect>
-         <rect x="69" y="1" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="21">FULL</text>
-         <rect x="71" y="47" width="52" height="32" rx="10"></rect>
-         <rect x="69" y="45" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="65">LEFT</text>
-         <rect x="71" y="91" width="62" height="32" rx="10"></rect>
-         <rect x="69" y="89" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="109">RIGHT</text>
-         <a xlink:href="#join_outer" xlink:title="join_outer">
-            <rect x="173" y="3" width="84" height="32"></rect>
-            <rect x="171" y="1" width="84" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="181" y="21">join_outer</text>
-         </a>
-         <rect x="51" y="135" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">INNER</text>
-         <path class="line" d="m17 17 h2 m40 0 h10 m54 0 h10 m0 0 h8 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m52 0 h10 m0 0 h10 m-92 -10 v20 m102 0 v-20 m-102 20 v24 m102 0 v-24 m-102 24 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -88 h10 m84 0 h10 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v112 m246 0 v-112 m-246 112 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m62 0 h10 m0 0 h144 m23 -132 h-3"></path>
-         <polygon points="295 17 303 13 303 21"></polygon>
-         <polygon points="295 17 287 13 287 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#joined_table" title="joined_table">joined_table</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="join_qual" href="#join_qual">join_qual:</a></p>
-      <svg width="354" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">USING</text>
-         <rect x="135" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="133" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="21">(</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="181" y="3" width="80" height="32"></rect>
-            <rect x="179" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="189" y="21">name_list</text>
-         </a>
-         <rect x="281" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="279" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="289" y="21">)</text>
-         <rect x="51" y="47" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">ON</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="111" y="47" width="64" height="32"></rect>
-            <rect x="109" y="45" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="119" y="65">a_expr</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m-296 0 h20 m276 0 h20 m-316 0 q10 0 10 10 m296 0 q0 -10 10 -10 m-306 10 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m40 0 h10 m0 0 h10 m64 0 h10 m0 0 h132 m23 -44 h-3"></path>
-         <polygon points="345 17 353 13 353 21"></polygon>
-         <polygon points="345 17 337 13 337 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#joined_table" title="joined_table">joined_table</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="func_expr_windowless" href="#func_expr_windowless">func_expr_windowless:</a></p>
-      <svg width="298" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#func_application" xlink:title="func_application">
-            <rect x="51" y="3" width="122" height="32"></rect>
-            <rect x="49" y="1" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">func_application</text>
-         </a>
-         <a xlink:href="#func_expr_common_subexpr" xlink:title="func_expr_common_subexpr">
-            <rect x="51" y="47" width="200" height="32"></rect>
-            <rect x="49" y="45" width="200" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">func_expr_common_subexpr</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m122 0 h10 m0 0 h78 m-240 0 h20 m220 0 h20 m-260 0 q10 0 10 10 m240 0 q0 -10 10 -10 m-250 10 v24 m240 0 v-24 m-240 24 q0 10 10 10 m220 0 q10 0 10 -10 m-230 10 h10 m200 0 h10 m23 -44 h-3"></path>
-         <polygon points="289 17 297 13 297 21"></polygon>
-         <polygon points="289 17 281 13 281 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#func_table" title="func_table">func_table</a></li>
-            <li><a href="#rowsfrom_item" title="rowsfrom_item">rowsfrom_item</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="rowsfrom_list" href="#rowsfrom_list">rowsfrom_list:</a></p>
-      <svg width="212" height="80">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#rowsfrom_item" xlink:title="rowsfrom_item">
-            <rect x="51" y="47" width="114" height="32"></rect>
-            <rect x="49" y="45" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">rowsfrom_item</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m114 0 h10 m-154 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m134 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-134 0 h10 m24 0 h10 m0 0 h90 m23 44 h-3"></path>
-         <polygon points="203 61 211 57 211 65"></polygon>
-         <polygon points="203 61 195 57 195 65"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#func_table" title="func_table">func_table</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_column" href="#opt_column">opt_column:</a></p>
-      <svg width="176" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">COLUMN</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -32 h-3"></path>
-         <polygon points="167 5 175 1 175 9"></polygon>
-         <polygon points="167 5 159 1 159 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_column_default" href="#alter_column_default">alter_column_default:</a></p>
-      <svg width="326" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">SET</text>
-         <rect x="115" y="3" width="80" height="32" rx="10"></rect>
-         <rect x="113" y="1" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="123" y="21">DEFAULT</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="215" y="3" width="64" height="32"></rect>
-            <rect x="213" y="1" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="223" y="21">a_expr</text>
-         </a>
-         <rect x="51" y="47" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">DROP</text>
-         <rect x="129" y="47" width="80" height="32" rx="10"></rect>
-         <rect x="127" y="45" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="137" y="65">DEFAULT</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m64 0 h10 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v24 m268 0 v-24 m-268 24 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m58 0 h10 m0 0 h10 m80 0 h10 m0 0 h70 m23 -44 h-3"></path>
-         <polygon points="317 17 325 13 325 21"></polygon>
-         <polygon points="317 17 309 13 309 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_set_data" href="#opt_set_data">opt_set_data:</a></p>
-      <svg width="218" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">SET</text>
-         <rect x="115" y="23" width="56" height="32" rx="10"></rect>
-         <rect x="113" y="21" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="123" y="41">DATA</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m44 0 h10 m0 0 h10 m56 0 h10 m23 -32 h-3"></path>
-         <polygon points="209 5 217 1 217 9"></polygon>
-         <polygon points="209 5 201 1 201 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_collate" href="#opt_collate">opt_collate:</a></p>
-      <svg width="312" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">COLLATE</text>
-         <a xlink:href="#collation_name" xlink:title="collation_name">
-            <rect x="151" y="23" width="114" height="32"></rect>
-            <rect x="149" y="21" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="159" y="41">collation_name</text>
-         </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m80 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"></path>
-         <polygon points="303 5 311 1 311 9"></polygon>
-         <polygon points="303 5 295 1 295 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_alter_column_using" href="#opt_alter_column_using">opt_alter_column_using:</a></p>
-      <svg width="246" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">USING</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="135" y="23" width="64" height="32"></rect>
-            <rect x="133" y="21" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="143" y="41">a_expr</text>
-         </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h158 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v12 m188 0 v-12 m-188 12 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m64 0 h10 m0 0 h10 m64 0 h10 m23 -32 h-3"></path>
-         <polygon points="237 5 245 1 245 9"></polygon>
-         <polygon points="237 5 229 1 229 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_validate_behavior" href="#opt_validate_behavior">opt_validate_behavior:</a></p>
-      <svg width="228" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">NOT</text>
-         <rect x="119" y="23" width="62" height="32" rx="10"></rect>
-         <rect x="117" y="21" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="127" y="41">VALID</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m48 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
-         <polygon points="219 5 227 1 227 9"></polygon>
-         <polygon points="219 5 211 1 211 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="audit_mode" href="#audit_mode">audit_mode:</a></p>
-      <svg width="238" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">READ</text>
-         <rect x="127" y="3" width="64" height="32" rx="10"></rect>
-         <rect x="125" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="135" y="21">WRITE</text>
-         <rect x="51" y="47" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">OFF</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h10 m64 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m46 0 h10 m0 0 h94 m23 -44 h-3"></path>
-         <polygon points="229 17 237 13 237 21"></polygon>
-         <polygon points="229 17 221 13 221 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="signed_iconst64" href="#signed_iconst64">signed_iconst64:</a></p>
-      <svg width="164" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#signed_iconst" xlink:title="signed_iconst">
-            <rect x="31" y="3" width="106" height="32"></rect>
-            <rect x="29" y="1" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">signed_iconst</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m106 0 h10 m3 0 h-3"></path>
-         <polygon points="155 17 163 13 163 21"></polygon>
-         <polygon points="155 17 147 13 147 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#sequence_option_elem" title="sequence_option_elem">sequence_option_elem</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="list_partition" href="#list_partition">list_partition:</a></p>
       <svg width="608" height="36">
          
@@ -15780,24 +17320,26 @@
             <rect x="553" y="285" width="132" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="563" y="305">reference_actions</text>
          </a>
-         <rect x="51" y="331" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="329" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="349">AS</text>
-         <rect x="109" y="331" width="26" height="32" rx="10"></rect>
-         <rect x="107" y="329" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="117" y="349">(</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="155" y="331" width="64" height="32"></rect>
-            <rect x="153" y="329" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="163" y="349">a_expr</text>
+         <a xlink:href="#generated_as" xlink:title="generated_as">
+            <rect x="51" y="331" width="108" height="32"></rect>
+            <rect x="49" y="329" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="349">generated_as</text>
          </a>
-         <rect x="239" y="331" width="26" height="32" rx="10"></rect>
-         <rect x="237" y="329" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="247" y="349">)</text>
-         <rect x="285" y="331" width="74" height="32" rx="10"></rect>
-         <rect x="283" y="329" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="293" y="349">STORED</text>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m56 0 h10 m0 0 h548 m-752 0 h20 m732 0 h20 m-772 0 q10 0 10 10 m752 0 q0 -10 10 -10 m-762 10 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m74 0 h10 m0 0 h638 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m20 0 h10 m0 0 h514 m-544 0 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v12 m544 0 v-12 m-544 12 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m64 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m64 0 h10 m-722 -42 v20 m752 0 v-20 m-752 20 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h472 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m80 0 h10 m0 0 h10 m64 0 h10 m0 0 h548 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m0 0 h76 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h404 m23 -328 h-3"></path>
+         <rect x="179" y="331" width="26" height="32" rx="10"></rect>
+         <rect x="177" y="329" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="187" y="349">(</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="225" y="331" width="64" height="32"></rect>
+            <rect x="223" y="329" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="349">a_expr</text>
+         </a>
+         <rect x="309" y="331" width="26" height="32" rx="10"></rect>
+         <rect x="307" y="329" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="317" y="349">)</text>
+         <rect x="355" y="331" width="74" height="32" rx="10"></rect>
+         <rect x="353" y="329" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="363" y="349">STORED</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m56 0 h10 m0 0 h548 m-752 0 h20 m732 0 h20 m-772 0 q10 0 10 10 m752 0 q0 -10 10 -10 m-762 10 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m74 0 h10 m0 0 h638 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m20 0 h10 m0 0 h514 m-544 0 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v12 m544 0 v-12 m-544 12 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m64 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m64 0 h10 m-722 -42 v20 m752 0 v-20 m-752 20 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h472 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m80 0 h10 m0 0 h10 m64 0 h10 m0 0 h548 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m0 0 h76 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h334 m23 -328 h-3"></path>
          <polygon points="801 17 809 13 809 21"></polygon>
          <polygon points="801 17 793 13 793 21"></polygon>
       </svg>
@@ -15871,6 +17413,66 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#reference_actions" title="reference_actions">reference_actions</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="window_definition" href="#window_definition">window_definition:</a></p>
+      <svg width="402" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#window_name" xlink:title="window_name">
+            <rect x="31" y="3" width="112" height="32"></rect>
+            <rect x="29" y="1" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">window_name</text>
+         </a>
+         <rect x="163" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="161" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="171" y="21">AS</text>
+         <a xlink:href="#window_specification" xlink:title="window_specification">
+            <rect x="221" y="3" width="154" height="32"></rect>
+            <rect x="219" y="1" width="154" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="229" y="21">window_specification</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m112 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m154 0 h10 m3 0 h-3"></path>
+         <polygon points="393 17 401 13 401 21"></polygon>
+         <polygon points="393 17 385 13 385 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#window_definition_list" title="window_definition_list">window_definition_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="join_outer" href="#join_outer">join_outer:</a></p>
+      <svg width="164" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">OUTER</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m23 -32 h-3"></path>
+         <polygon points="155 5 163 1 163 9"></polygon>
+         <polygon points="155 5 147 1 147 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#join_type" title="join_type">join_type</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="rowsfrom_item" href="#rowsfrom_item">rowsfrom_item:</a></p>
+      <svg width="222" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#func_expr_windowless" xlink:title="func_expr_windowless">
+            <rect x="31" y="3" width="164" height="32"></rect>
+            <rect x="29" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">func_expr_windowless</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m164 0 h10 m3 0 h-3"></path>
+         <polygon points="213 17 221 13 221 21"></polygon>
+         <polygon points="213 17 205 13 205 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#rowsfrom_list" title="rowsfrom_list">rowsfrom_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_float" href="#opt_float">opt_float:</a></p>
       <svg width="262" height="56">
@@ -15947,6 +17549,109 @@
          </p><ul>
             <li><a href="#const_datetime" title="const_datetime">const_datetime</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="geo_shape_type" href="#geo_shape_type">geo_shape_type:</a></p>
+      <svg width="280" height="344">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">POINT</text>
+         <rect x="51" y="47" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">LINESTRING</text>
+         <rect x="51" y="91" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">POLYGON</text>
+         <rect x="51" y="135" width="182" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="182" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">GEOMETRYCOLLECTION</text>
+         <rect x="51" y="179" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">MULTIPOLYGON</text>
+         <rect x="51" y="223" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">MULTILINESTRING</text>
+         <rect x="51" y="267" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">MULTIPOINT</text>
+         <rect x="51" y="311" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">GEOMETRY</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h118 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m104 0 h10 m0 0 h78 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m88 0 h10 m0 0 h94 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m182 0 h10 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m132 0 h10 m0 0 h50 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m146 0 h10 m0 0 h36 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m106 0 h10 m0 0 h76 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m94 0 h10 m0 0 h88 m23 -308 h-3"></path>
+         <polygon points="271 17 279 13 279 21"></polygon>
+         <polygon points="271 17 263 13 263 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#const_geo" title="const_geo">const_geo</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="signed_iconst" href="#signed_iconst">signed_iconst:</a></p>
+      <svg width="238" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ICONST</text>
+         <a xlink:href="#only_signed_iconst" xlink:title="only_signed_iconst">
+            <rect x="51" y="47" width="140" height="32"></rect>
+            <rect x="49" y="45" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">only_signed_iconst</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m72 0 h10 m0 0 h68 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m140 0 h10 m23 -44 h-3"></path>
+         <polygon points="229 17 237 13 237 21"></polygon>
+         <polygon points="229 17 221 13 221 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#const_geo" title="const_geo">const_geo</a></li>
+            <li><a href="#signed_iconst64" title="signed_iconst64">signed_iconst64</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="char_aliases" href="#char_aliases">char_aliases:</a></p>
+      <svg width="198" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">CHAR</text>
+         <rect x="51" y="47" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">CHARACTER</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h44 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m23 -44 h-3"></path>
+         <polygon points="189 17 197 13 197 21"></polygon>
+         <polygon points="189 17 181 13 181 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#character_base" title="character_base">character_base</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_second" href="#interval_second">interval_second:</a></p>
+      <svg width="358" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SECOND</text>
+         <rect x="147" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="145" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="53">(</text>
+         <rect x="193" y="35" width="72" height="32" rx="10"></rect>
+         <rect x="191" y="33" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="201" y="53">ICONST</text>
+         <rect x="285" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="283" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="293" y="53">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
+         <polygon points="349 17 357 13 357 21"></polygon>
+         <polygon points="349 17 341 13 341 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#interval_qualifier" title="interval_qualifier">interval_qualifier</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="func_name" href="#func_name">func_name:</a></p>
       <svg width="258" height="80">
          
@@ -15969,6 +17674,38 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#func_application" title="func_application">func_application</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="single_sort_clause" href="#single_sort_clause">single_sort_clause:</a></p>
+      <svg width="452" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ORDER</text>
+         <rect x="117" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="115" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="125" y="21">BY</text>
+         <a xlink:href="#sortby" xlink:title="sortby">
+            <rect x="175" y="3" width="60" height="32"></rect>
+            <rect x="173" y="1" width="60" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="183" y="21">sortby</text>
+         </a>
+         <rect x="275" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="273" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="283" y="53">,</text>
+         <a xlink:href="#sortby_list" xlink:title="sortby_list">
+            <rect x="319" y="35" width="86" height="32"></rect>
+            <rect x="317" y="33" width="86" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="327" y="53">sortby_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m60 0 h10 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m24 0 h10 m0 0 h10 m86 0 h10 m23 -32 h-3"></path>
+         <polygon points="443 17 451 13 451 21"></polygon>
+         <polygon points="443 17 435 13 435 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#within_group_clause" title="within_group_clause">within_group_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="window_specification" href="#window_specification">window_specification:</a></p>
       <svg width="760" height="102">
@@ -16184,131 +17921,6 @@
          </p><ul>
             <li><a href="#expr_tuple_unambiguous" title="expr_tuple_unambiguous">expr_tuple_unambiguous</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="char_aliases" href="#char_aliases">char_aliases:</a></p>
-      <svg width="198" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">CHAR</text>
-         <rect x="51" y="47" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">CHARACTER</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h44 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m23 -44 h-3"></path>
-         <polygon points="189 17 197 13 197 21"></polygon>
-         <polygon points="189 17 181 13 181 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#character_base" title="character_base">character_base</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="interval_second" href="#interval_second">interval_second:</a></p>
-      <svg width="358" height="68">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="76" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">SECOND</text>
-         <rect x="147" y="35" width="26" height="32" rx="10"></rect>
-         <rect x="145" y="33" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="155" y="53">(</text>
-         <rect x="193" y="35" width="72" height="32" rx="10"></rect>
-         <rect x="191" y="33" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="201" y="53">ICONST</text>
-         <rect x="285" y="35" width="26" height="32" rx="10"></rect>
-         <rect x="283" y="33" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="293" y="53">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m26 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
-         <polygon points="349 17 357 13 357 21"></polygon>
-         <polygon points="349 17 341 13 341 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#interval_qualifier" title="interval_qualifier">interval_qualifier</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="window_definition" href="#window_definition">window_definition:</a></p>
-      <svg width="402" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#window_name" xlink:title="window_name">
-            <rect x="31" y="3" width="112" height="32"></rect>
-            <rect x="29" y="1" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">window_name</text>
-         </a>
-         <rect x="163" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="161" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="171" y="21">AS</text>
-         <a xlink:href="#window_specification" xlink:title="window_specification">
-            <rect x="221" y="3" width="154" height="32"></rect>
-            <rect x="219" y="1" width="154" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="229" y="21">window_specification</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m112 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m154 0 h10 m3 0 h-3"></path>
-         <polygon points="393 17 401 13 401 21"></polygon>
-         <polygon points="393 17 385 13 385 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#window_definition_list" title="window_definition_list">window_definition_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="join_outer" href="#join_outer">join_outer:</a></p>
-      <svg width="164" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">OUTER</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m23 -32 h-3"></path>
-         <polygon points="155 5 163 1 163 9"></polygon>
-         <polygon points="155 5 147 1 147 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#join_type" title="join_type">join_type</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="rowsfrom_item" href="#rowsfrom_item">rowsfrom_item:</a></p>
-      <svg width="222" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#func_expr_windowless" xlink:title="func_expr_windowless">
-            <rect x="31" y="3" width="164" height="32"></rect>
-            <rect x="29" y="1" width="164" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">func_expr_windowless</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m164 0 h10 m3 0 h-3"></path>
-         <polygon points="213 17 221 13 221 21"></polygon>
-         <polygon points="213 17 205 13 205 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#rowsfrom_list" title="rowsfrom_list">rowsfrom_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="signed_iconst" href="#signed_iconst">signed_iconst:</a></p>
-      <svg width="238" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">ICONST</text>
-         <a xlink:href="#only_signed_iconst" xlink:title="only_signed_iconst">
-            <rect x="51" y="47" width="140" height="32"></rect>
-            <rect x="49" y="45" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">only_signed_iconst</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m72 0 h10 m0 0 h68 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m140 0 h10 m23 -44 h-3"></path>
-         <polygon points="229 17 237 13 237 21"></polygon>
-         <polygon points="229 17 221 13 221 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#signed_iconst64" title="signed_iconst64">signed_iconst64</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_as_col_qualification_elem" href="#create_as_col_qualification_elem">create_as_col_qualification_elem:</a></p>
       <svg width="206" height="36">
          
@@ -16368,6 +17980,28 @@
          <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h156 m-186 0 h20 m166 0 h20 m-206 0 q10 0 10 10 m186 0 q0 -10 10 -10 m-196 10 v12 m186 0 v-12 m-186 12 q0 10 10 10 m166 0 q10 0 10 -10 m-176 10 h10 m26 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
          <polygon points="235 5 243 1 243 9"></polygon>
          <polygon points="235 5 227 1 227 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="generated_as" href="#generated_as">generated_as:</a></p>
+      <svg width="422" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="168" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="168" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">GENERATED_ALWAYS</text>
+         <rect x="239" y="35" width="78" height="32" rx="10"></rect>
+         <rect x="237" y="33" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="247" y="53">ALWAYS</text>
+         <rect x="357" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="355" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="365" y="21">AS</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m168 0 h10 m0 0 h10 m78 0 h10 m20 -32 h10 m38 0 h10 m3 0 h-3"></path>
+         <polygon points="413 17 421 13 421 21"></polygon>
+         <polygon points="413 17 405 13 405 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>


### PR DESCRIPTION
Updated stmt_block. This update is required for new diagrams to not break the build with broken links (e.g., #7964).