### PR TITLE
Large deletes guidance and TTL workarounds

### DIFF
--- a/v19.2/delete-data.md
+++ b/v19.2/delete-data.md
@@ -106,6 +106,10 @@ You can delete multiple rows from a table in several ways:
 
 - Using [`TRUNCATE`](truncate.html) instead of [`DELETE`](delete.html) to delete all of the rows from a table, as recommended in our [performance best practices](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
 
+{{site.data.alerts.callout_success}}
+We recommend [deleting large amounts of data in batches](delete.html#batch-deletes).
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_info}}
 Before deleting large amounts of data, see [Performance considerations](#performance-considerations).
 {{site.data.alerts.end}}
@@ -117,7 +121,7 @@ Because of the way CockroachDB works under the hood, deleting data from the data
 The practical implications of the above are:
 
 - Deleting data will not immediately decrease disk usage.
-- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly, for reasons [explained in this FAQ entry](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly. For details, see [Preserving `DELETE` performance over time](delete.html#preserving-delete-performance-over-time).
 - To delete all of the rows in a table, [it's faster to use `TRUNCATE` instead of `DELETE`](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
 
 For more information about how the storage layer of CockroachDB works, see the [storage layer reference documentation](architecture/storage-layer.html).
@@ -128,11 +132,9 @@ Reference information related to this task:
 
 - [`DELETE`](delete.html)
 - [Disk space usage after deletes](delete.html#disk-space-usage-after-deletes)
-- [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time)
 - [`TRUNCATE`](truncate.html)
 - [`DROP TABLE`](drop-table.html)
 - [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
-- [Delete Multiple Rows](delete.html#delete-specific-rows)
 
 Other common tasks:
 

--- a/v19.2/delete.md
+++ b/v19.2/delete.md
@@ -10,6 +10,12 @@ The `DELETE` [statement](sql-statements.html) deletes rows from a table.
 
 {{site.data.alerts.callout_info}}To delete columns, see <a href="drop-column.html"><code>DROP COLUMN</code></a>.{{site.data.alerts.end}}
 
+## Performance best practices
+
+- To delete all rows in a table, use [`TRUNCATE`](truncate.html) instead of `DELETE`. Unless your table is small (less than 1000 rows), `TRUNCATE` will be more performant.
+
+- To delete a large number of rows, we recommend iteratively deleting batches of rows until all of the unwanted rows are deleted. For more information, see [batch deletes](#batch-deletes).
+
 ## Required privileges
 
 The user must have the `DELETE` and `SELECT` [privileges](authorization.html#assign-privileges) on the table.
@@ -33,7 +39,7 @@ table td:first-child {
  `common_table_expr` | See [Common Table Expressions](common-table-expressions.html).
  `table_name` | The name of the table that contains the rows you want to update.
  `AS table_alias_name` | An alias for the table name. When an alias is provided, it completely hides the actual table name.
-`WHERE a_expr`| `a_expr` must be an expression that returns Boolean values using columns (e.g., `<column> = <value>`). Delete rows that return   `TRUE`.<br><br/>__Without a `WHERE` clause in your statement, `DELETE` removes all rows from the table.__
+`WHERE a_expr`| `a_expr` must be an expression that returns Boolean values using columns (e.g., `<column> = <value>`). Delete rows that return `TRUE`.<br><br/>__Without a `WHERE` clause in your statement, `DELETE` removes all rows from the table. To delete all rows in a table, we recommend using [`TRUNCATE`](truncate.html) instead of `DELETE`.__
  `sort_clause` | An `ORDER BY` clause. <br /><br />See [Ordering of rows in DML statements](query-order.html#ordering-rows-in-dml-statements) for more details.
  `limit_clause` | A `LIMIT` clause. See [Limiting Query Results](limit-offset.html) for more details.
  `RETURNING target_list` | Return values based on rows deleted, where `target_list` can be specific column names from the table, `*` for all columns, or computations using [scalar expressions](scalar-expressions.html). <br><br>To return nothing in the response, not even the number of rows updated, use `RETURNING NOTHING`.
@@ -54,7 +60,7 @@ due to the fact that CockroachDB retains [the ability to query tables
 historically](https://www.cockroachlabs.com/blog/time-travel-queries-select-witty_subtitle-the_future/).
 
 If disk usage is a concern, the solution is to
-[reduce the time-to-live](configure-replication-zones.html) (TTL) for
+[reduce the garbage collection time-to-live](configure-replication-zones.html) (TTL) for
 the zone by setting `gc.ttlseconds` to a lower value, which will cause
 garbage collection to clean up deleted objects (rows, tables) more
 frequently.
@@ -65,7 +71,7 @@ Queries that scan across tables that have lots of deleted rows will
 have to scan over deletions that have not yet been garbage
 collected. Certain database usage patterns that frequently scan over
 and delete lots of rows will want to reduce the
-[time-to-live](configure-replication-zones.html) values to clean up
+[garbage collection time-to-live](configure-replication-zones.html) values to clean up
 deleted rows more frequently.
 
 ## Sorting the output of deletes
@@ -75,12 +81,6 @@ deleted rows more frequently.
 For more information about ordering query results in general, see
 [Ordering Query Results](query-order.html) and [Ordering of rows in
 DML statements](query-order.html#ordering-rows-in-dml-statements).
-
-## Delete performance on large data sets
-
-If you are deleting a large amount of data using iterative `DELETE ... LIMIT` statements, you are likely to see a drop in performance for each subsequent `DELETE` statement.
-
-For an explanation of why this happens, and for instructions showing how to iteratively delete rows in constant time, see [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
 
 ## Force index selection for deletes
 
@@ -108,52 +108,154 @@ To view how the index hint modifies the query plan that CockroachDB follows for 
 
 For examples, see [Delete with index hints](#delete-with-index-hints).
 
+## Batch deletes
+
+To delete a large number of rows (i.e., tens of thousands of rows or more), we recommend iteratively deleting subsets of the rows that you want to delete, until all of the unwanted rows have been deleted. You can write a script to do this, or you can write a loop into your application.
+
+In the sections below, we provide guidance on batch deleting with the `DELETE` query filter [on an indexed column](#batch-delete-on-an-indexed-column) and [on a non-indexed column](#batch-delete-on-a-non-indexed-column). Filtering on an indexed column is both simpler to implement and more efficient, but adding an index to a table can slow down insertions to the table and may cause bottlenecks. Queries that filter on a non-indexed column must perform at least one full-table scan, a process that takes time proportional to the size of the entire table.
+
+### Batch delete on an indexed column
+
+For high-performance batch deletes, we recommending filtering the `DELETE` query on an [indexed column](indexes.html).
+
+{{site.data.alerts.callout_info}}
+Having an indexed filtering column can make delete operations faster, but it might lead to bottlenecks in execution, especially if the filtering column is a [timestamp](timestamp.html).
+{{site.data.alerts.end}}
+
+Each iteration of a batch-delete loop should execute a transaction containing a single `DELETE` query. When writing this `DELETE` query:
+
+- Use a `WHERE` clause to filter on a column that identifies the unwanted rows. If the filtering column is not the primary key, the column should have [a secondary index](indexes.html). Note that if the filtering column is not already indexed, it is not beneficial to add an index just to speed up batch deletes. Instead, consider [batch deleting on non-indexed columns](#batch-delete-on-a-non-indexed-column).
+- To ensure that rows are efficiently scanned in the `DELETE` query, add an [`ORDER BY`](query-order.html) clause on the filtering column.
+- Use a [`LIMIT`](limit-offset.html) clause to limit the number of rows to the desired batch size. To determine the optimal batch size, try out different batch sizes (1,000 rows, 10,000 rows, 100,000 rows, etc.) and monitor the change in performance.
+- Add a `RETURNING` clause to the end of the query that returns the filtering column values of the deleted rows. Then, using the values of the deleted rows, update the filter to match only the subset of remaining rows to delete. This narrows each query's scan to the fewest rows possible, and [preserves the performance of the deletes over time](#preserving-delete-performance-over-time). This pattern assumes that no new rows are generated that match on the `DELETE` filter during the time that it takes to perform the delete.
+
+For example, suppose that you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `new_order` table where `no_w_id` is less than `5`, in batches of 5,000 rows. To do this, you can write a script that loops over batches of 5,000 rows, following the `DELETE` query guidance provided above. Note that in this case, `no_w_id` is the first column in the primary index, and, as a result, you do not need to create a secondary index on the column.
+
+In Python, the script would look similar to the following:
+
+{% include copy-clipboard.html %}
+~~~ python
+#!/usr/bin/env python3
+
+import psycopg2
+import psycopg2.sql
+import os
+
+conn = psycopg2.connect(os.environ.get('DB_URI'))
+filter = 4
+lastrow = None
+
+while True:
+  with conn:
+    with conn.cursor() as cur:
+        if lastrow:
+            filter = lastrow[0]
+        query = psycopg2.sql.SQL("DELETE FROM new_order WHERE no_w_id <= %s ORDER BY no_w_id DESC LIMIT 5000 RETURNING no_w_id")
+        cur.execute(query, (filter,))
+        print(cur.statusmessage)
+        if cur.rowcount == 0:
+            break
+        lastrow = cur.fetchone()
+
+conn.close()
+~~~
+
+This script iteratively deletes rows in batches of 5,000, until all of the rows where `no_w_id <= 4` are deleted. Note that at each iteration, the filter is updated to match a narrower subset of rows.
+
+### Batch delete on a non-indexed column
+
+If you cannot index the column that identifies the unwanted rows, we recommend defining the batch loop to execute separate read and write operations at each iteration:
+
+1. Execute a [`SELECT` query](selection-queries.html) that returns the primary key values for the rows that you want to delete. When writing the `SELECT` query:
+    - Use a `WHERE` clause that filters on the column identifying the rows.
+    - Add an [`AS OF SYSTEM TIME` clause](as-of-system-time.html) to the end of the selection subquery, or run the selection query in a separate, read-only transaction with [`SET TRANSACTION AS OF SYSTEM TIME`](as-of-system-time.html#using-as-of-system-time-in-transactions). This helps to reduce [transaction contention](transactions.html#transaction-contention).
+    - Use a [`LIMIT`](limit-offset.html) clause to limit the number of rows queried to a subset of the rows that you want to delete. To determine the optimal `SELECT` batch size, try out different sizes (10,000 rows, 100,000 rows, 1,000,000 rows, etc.), and monitor the change in performance. Note that this `SELECT` batch size can be much larger than the batch size of rows that are deleted in the subsequent `DELETE` query.
+    - To ensure that rows are efficiently scanned in the subsequent `DELETE` query, include an [`ORDER BY`](query-order.html) clause on the primary key.
+
+2. Write a nested `DELETE` loop over the primary key values returned by the `SELECT` query, in batches smaller than the initial `SELECT` batch size. To determine the optimal `DELETE` batch size, try out different sizes (1,000 rows, 10,000 rows, 100,000 rows, etc.), and monitor the change in performance. Where possible, we recommend executing each `DELETE` in a separate transaction.
+
+For example, suppose that you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `history` table that are older than a month. You can create a script that loops over the data and deletes unwanted rows in batches, following the query guidance provided above.
+
+In Python, the script would look similar to the following:
+
+{% include copy-clipboard.html %}
+~~~ python
+#!/usr/bin/env python3
+
+import psycopg2
+import os
+import time
+
+conn = psycopg2.connect(os.environ.get('DB_URI'))
+
+while True:
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION AS OF SYSTEM TIME '-5s'")
+            cur.execute("SELECT h_w_id, rowid FROM history WHERE h_date < current_date() - INTERVAL '1 MONTH' ORDER BY h_w_id, rowid LIMIT 20000")
+            pkvals = list(cur)
+    if not pkvals:
+        return
+    while pkvals:
+        batch = pkvals[:5000]
+        pkvals = pkvals[5000:]
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM history WHERE (h_w_id, rowid) = ANY %s", (batch,))
+                print(cur.statusmessage)
+    del batch
+    del pkvals
+    time.sleep(5)
+
+conn.close()
+~~~
+
+At each iteration, the selection query returns the primary key values of up to 20,000 rows of matching historical data from 5 seconds in the past, in a read-only transaction. Then, a nested loop iterates over the returned primary key values in smaller batches of 5,000 rows. At each iteration of the nested `DELETE` loop, a batch of rows is deleted. After the nested `DELETE` loop deletes all of the rows from the initial selection query, a time delay ensures that the next selection query reads historical data from the table after the last iteration's `DELETE` final delete.
+
+### Batch-delete "expired" data
+
+CockroachDB does not support Time to Live (TTL) on table rows. To delete "expired" rows, we recommend automating a batch delete process using a job scheduler like `cron`.
+
+For example, suppose that every morning you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `history` table that are older than a month. To do this, you could use the example Python script that [batch deletes on the non-indexed `h_date` column](#batch-delete-on-a-non-indexed-column).
+
+To run the script with a daily `cron` job:
+
+1. Make the file executable:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ chmod +x cleanup.py
+    ~~~
+
+2. Create a new `cron` job:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ crontab -e
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ txt
+    30 10 * * * DB_URI='cockroachdb://user@host:26257/bank' cleanup.py >> ~/cron.log 2>&1
+    ~~~
+
+Saving the `cron` file will install a new job that runs the `cleanup.py` file every morning at 10:30 A.M., writing the results to the `cron.log` file.
+
+### Preserving `DELETE` performance over time
+
+CockroachDB relies on [multi-version concurrency control (MVCC)](architecture/storage-layer.html#mvcc) to process concurrent requests while guaranteeing [strong consistency](frequently-asked-questions.html#how-is-cockroachdb-strongly-consistent). As such, when you delete a row, it is not immediately removed from disk. The MVCC values for the row will remain until the garbage collection period defined by the [`gc.ttlseconds`](configure-replication-zones.html#gc-ttlseconds) variable in the applicable [zone configuration](show-zone-configurations.html) has passed. By default, this period is 25 hours.
+
+This means that with the default settings, each iteration of your `DELETE` statement must scan over all of the rows previously marked for deletion within the last 25 hours. If you try to delete 10,000 rows 10 times within the same 25 hour period, the 10th command will have to scan over the 90,000 rows previously marked for deletion.
+
+To preserve performance over iterative `DELETE` queries, we recommend taking one of the following approaches:
+
+- At each iteration, update the `WHERE` clause to filter only the rows that have not yet been marked for deletion. For an example, see [Batch-delete on an indexed filter](#batch-delete-on-an-indexed-column) above.
+- At each iteration, first use a `SELECT` statement to return primary key values on rows that are not yet deleted. Rows marked for deletion will not be returned. Then, use a nested `DELETE` loop over a smaller batch size, filtering on the primary key values. For an example, see [Batch delete on a non-indexed column](#batch-delete-on-a-non-indexed-column) above.
+- To iteratively delete rows in constant time, using a simple `DELETE` loop, you can [alter your zone configuration](configure-replication-zones.html#overview) and change `gc.ttlseconds` to a low value like 5 minutes (i.e., `300`), and then run your `DELETE` statement once per GC interval.
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}
 
-### Delete all rows
-
-You can delete all rows from a table by not including a `WHERE` clause in your `DELETE` statement.
-
-{{site.data.alerts.callout_info}}
-If the [`sql_safe_updates`](cockroach-sql.html#allow-potentially-unsafe-sql-statements) session variable is set to `true`, the client will prevent the update. `sql_safe_updates` is set to `true` by default.
-{{site.data.alerts.end}}
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DELETE FROM vehicle_location_histories;
-~~~
-
-~~~
-pq: rejected: DELETE without WHERE clause (sql_safe_updates = true)
-~~~
-
-You can use a [`SET`](set-vars.html) statement to set session variables.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET sql_safe_updates = false;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DELETE FROM vehicle_location_histories;
-~~~
-
-~~~
-DELETE 1000
-~~~
-
-{{site.data.alerts.callout_success}}
-Unless your table is small (less than 1000 rows), using [`TRUNCATE`][truncate] to delete the contents of a table will be more performant than using `DELETE`.
-{{site.data.alerts.end}}
-
-### Delete specific rows
-
-When deleting specific rows from a table, the most important decision you make is which columns to use in your `WHERE` clause. When making that choice, consider the potential impact of using columns with the [Primary Key](primary-key.html)/[Unique](unique.html) constraints (both of which enforce uniqueness) versus those that are not unique.
-
-#### Delete rows using Primary Key/unique columns
+### Delete rows using Primary Key/unique columns
 
 Using columns with the [Primary Key](primary-key.html) or [Unique](unique.html) constraints to delete rows ensures your statement is unambiguous&mdash;no two rows contain the same column value, so it's less likely to delete data unintentionally.
 
@@ -167,7 +269,7 @@ In this example, `code` is our primary key and we want to delete the row where t
 DELETE 1
 ~~~
 
-#### Delete rows using non-unique columns
+### Delete rows using non-unique columns
 
 Deleting rows using non-unique columns removes _every_ row that returns `TRUE` for the `WHERE` clause's `a_expr`. This can easily result in deleting data you didn't intend to.
 
@@ -206,7 +308,6 @@ To retrieve specific columns, name them in the `RETURNING` clause.
   study_piece_war        | {"type": "percent_discount", "value": "10%"}
   tv_this_list           | {"type": "percent_discount", "value": "10%"}
 (5 rows)
-
 ~~~
 
 #### Change column labels
@@ -317,36 +418,10 @@ If you provide an index hint (i.e. force the index selection) to use the primary
 - [`INSERT`](insert.html)
 - [`UPDATE`](update.html)
 - [`UPSERT`](upsert.html)
-- [`TRUNCATE`][truncate]
+- [`TRUNCATE`](truncate.html)
 - [`ALTER TABLE`](alter-table.html)
 - [`DROP TABLE`](drop-table.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
 - [Limiting Query Results](limit-offset.html)
 
-<!-- Reference Links -->
-
-[truncate]: truncate.html
-
-<!--
-
-SQL for example table:
-
-CREATE TABLE account_details (
-       account_id INT PRIMARY KEY,
-       balance FLOAT,
-       account_type VARCHAR
-);
-
-INSERT INTO account_details (account_id, balance, account_type) VALUES (1, 32000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (2, 30000, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (3, 30000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (4, 22000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (5, 43696.95, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (6, 23500, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (7, 79493.51, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (8, 40761.66, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (9, 2111.67, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (10, 59173.15, 'Savings');
-
--->

--- a/v19.2/learn-cockroachdb-sql.md
+++ b/v19.2/learn-cockroachdb-sql.md
@@ -329,7 +329,9 @@ To delete rows from a table, use [`DELETE FROM`](delete.html) followed by the ta
 DELETE 669
 ~~~
 
-Just as with the `UPDATE` statement, if a table has a primary key, you can use that in the `WHERE` clause to reliably delete specific rows; otherwise, each row matching the `WHERE` clause is deleted. When there's no `WHERE` clause, all rows in the table are deleted.
+Just as with the `UPDATE` statement, if a table has a primary key, you can use that in the `WHERE` clause to reliably delete specific rows; otherwise, each row matching the `WHERE` clause is deleted. When there's no `WHERE` clause, all rows in the table are deleted. We do not recommend using `WHERE` to delete all of the rows in a table. Instead, use [`TRUNCATE`](truncate.html).
+
+To delete a large number of rows, we recommend iteratively deleting batches of rows until all of the unwanted rows are deleted. For an example, see [Batch deletes](delete.html#batch-deletes).
 
 ## Remove a table
 

--- a/v19.2/performance-best-practices-overview.md
+++ b/v19.2/performance-best-practices-overview.md
@@ -20,12 +20,12 @@ For more information, see:
 
 - [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table)
 - [Upsert Multiple Rows](upsert.html#upsert-multiple-rows)
-- [Delete Multiple Rows](delete.html#delete-specific-rows)
+- [Delete Multiple Rows](delete.html#examples)
 - [How to improve IoT application performance with multi-row DML](https://www.cockroachlabs.com/blog/multi-row-dml/)
 
 ### Use `TRUNCATE` instead of `DELETE` to delete all rows in a table
 
-The [`TRUNCATE`](truncate.html) statement removes all rows from a table by dropping the table and recreating a new table with the same name. This performs better than using `DELETE`, which performs multiple transactions to delete all rows. For smaller tables (with less than 1000 rows), however, using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
+The [`TRUNCATE`](truncate.html) statement removes all rows from a table by dropping the table and recreating a new table with the same name. This performs better than using `DELETE`, which performs multiple transactions to delete all rows
 
 ## Bulk insert best practices
 
@@ -41,9 +41,15 @@ To bulk-insert data into an existing table, batch multiple rows in one multi-row
 
 To bulk-insert data into a brand new table, the [`IMPORT`](import.html) statement performs better than `INSERT`.
 
-## Bulk deletion best practices
+## Bulk delete best practices
 
-To get the best performance when deleting large amounts of data, follow the instructions in [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+### Batch deletes
+
+To delete a large number of rows, we recommend iteratively deleting batches of rows until all of the unwanted rows are deleted. For an example, see [Batch deletes](delete.html#batch-deletes).
+
+### Batch-delete "expired" data
+
+CockroachDB does not support Time to Live (TTL) on table rows. To delete "expired" rows, we recommend automating a batch delete process with a job scheduler like `cron`. For an example, see [Batch-delete "expired" data](delete.html#batch-delete-expired-data).
 
 ## Assign column families
 

--- a/v19.2/sql-faqs.md
+++ b/v19.2/sql-faqs.md
@@ -14,6 +14,12 @@ toc_not_nested: true
     {{site.data.alerts.end}}
 - To bulk-insert data into a new table, the [`IMPORT`](import.html) statement performs better than `INSERT`. `IMPORT` can also be used to [migrate data from other databases](migration-overview.html) like MySQL, Oracle, and Postgres.  
 
+## How do I bulk delete data from CockroachDB?
+
+- To delete all of the contents of a table, but not the table itself, use a [`TRUNCATE`](truncate.html) statement.
+
+- To delete a large number of rows from a table, we recommend iteratively deleting batches of rows with [`DELETE`](delete.html) statements until all of the unwanted rows are deleted. For an example, see [Batch deletes](delete.html#batch-deletes).
+
 ## How do I auto-generate unique row IDs in CockroachDB?
 
 {% include {{ page.version.version }}/faq/auto-generate-unique-ids.html %}
@@ -139,18 +145,6 @@ require('long').fromString(idString).add(1).toString(); // GOOD: returns '235191
 ## Can I use CockroachDB as a key-value store?
 
 {% include {{ page.version.version }}/faq/simulate-key-value-store.html %}
-
-## Why are my deletes getting slower over time?
-
-> I need to delete a large amount of data. I'm iteratively deleting a certain number of rows using a [`DELETE`](delete.html) statement with a [`LIMIT`](limit-offset.html) clause, but it's getting slower over time. Why?
-
-CockroachDB relies on [multi-version concurrency control (MVCC)](architecture/storage-layer.html#mvcc) to process concurrent requests while guaranteeing [strong consistency](frequently-asked-questions.html#how-is-cockroachdb-strongly-consistent). As such, when you delete a row, it is not immediately removed from disk. The MVCC values for the row will remain until the garbage collection period defined by the [`gc.ttlseconds`](configure-replication-zones.html#gc-ttlseconds) variable in the applicable [zone configuration](show-zone-configurations.html) has passed.  By default, this period is 25 hours.
-
-This means that with the default settings, each iteration of your `DELETE` statement must scan over all of the rows previously marked for deletion within the last 25 hours. This means that if you try to delete 10,000 rows 10 times within the same 25 hour period, the 10th command will have to scan over the 90,000 rows previously marked for deletion.
-
-If you need to iteratively delete rows in constant time, you can [alter your zone configuration](configure-replication-zones.html#overview) and change `gc.ttlseconds` to a low value like 5 minutes (i.e., `300`), and run your `DELETE` statement once per GC interval. We strongly recommend returning `gc.ttlseconds` to the default value after your large deletion is completed.
-
-For instructions showing how to delete specific rows, see [Delete specific rows](delete.html#delete-specific-rows).
 
 ## See also
 

--- a/v19.2/truncate.md
+++ b/v19.2/truncate.md
@@ -6,10 +6,6 @@ toc: true
 
 The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. At a high level, it works by dropping the table and recreating a new table with the same name.
 
-{{site.data.alerts.callout_info}}
-For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
-{{site.data.alerts.end}}
-
 {% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Synopsis

--- a/v20.1/delete-data.md
+++ b/v20.1/delete-data.md
@@ -117,7 +117,7 @@ Because of the way CockroachDB works under the hood, deleting data from the data
 The practical implications of the above are:
 
 - Deleting data will not immediately decrease disk usage.
-- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly, for reasons [explained in this FAQ entry](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly. For details, see [Preserving `DELETE` performance over time](delete.html#preserving-delete-performance-over-time).
 - To delete all of the rows in a table, [it's faster to use `TRUNCATE` instead of `DELETE`](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
 
 For more information about how the storage layer of CockroachDB works, see the [storage layer reference documentation](architecture/storage-layer.html).
@@ -128,11 +128,9 @@ Reference information related to this task:
 
 - [`DELETE`](delete.html)
 - [Disk space usage after deletes](delete.html#disk-space-usage-after-deletes)
-- [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time)
 - [`TRUNCATE`](truncate.html)
 - [`DROP TABLE`](drop-table.html)
 - [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
-- [Delete Multiple Rows](delete.html#delete-specific-rows)
 
 Other common tasks:
 

--- a/v20.1/delete.md
+++ b/v20.1/delete.md
@@ -33,7 +33,7 @@ table td:first-child {
  `common_table_expr` | See [Common Table Expressions](common-table-expressions.html).
  `table_name` | The name of the table that contains the rows you want to update.
  `AS table_alias_name` | An alias for the table name. When an alias is provided, it completely hides the actual table name.
-`WHERE a_expr`| `a_expr` must be an expression that returns Boolean values using columns (e.g., `<column> = <value>`). Delete rows that return   `TRUE`.<br><br/>__Without a `WHERE` clause in your statement, `DELETE` removes all rows from the table.__
+`WHERE a_expr`| `a_expr` must be an expression that returns Boolean values using columns (e.g., `<column> = <value>`). Delete rows that return   `TRUE`.<br><br/>__Without a `WHERE` clause in your statement, `DELETE` removes all rows from the table. To delete all rows in a table, we recommend using [`TRUNCATE`](truncate.html) instead of `DELETE`.__
  `sort_clause` | An `ORDER BY` clause. <br /><br />See [Ordering of rows in DML statements](query-order.html#ordering-rows-in-dml-statements) for more details.
  `limit_clause` | A `LIMIT` clause. See [Limiting Query Results](limit-offset.html) for more details.
  `RETURNING target_list` | Return values based on rows deleted, where `target_list` can be specific column names from the table, `*` for all columns, or computations using [scalar expressions](scalar-expressions.html). <br><br>To return nothing in the response, not even the number of rows updated, use `RETURNING NOTHING`.
@@ -76,12 +76,6 @@ For more information about ordering query results in general, see
 [Ordering Query Results](query-order.html) and [Ordering of rows in
 DML statements](query-order.html#ordering-rows-in-dml-statements).
 
-## Delete performance on large data sets
-
-If you are deleting a large amount of data using iterative `DELETE ... LIMIT` statements, you are likely to see a drop in performance for each subsequent `DELETE` statement.
-
-For an explanation of why this happens, and for instructions showing how to iteratively delete rows in constant time, see [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
-
 ## Force index selection for deletes
 
 By using the explicit index annotation (also known as "index hinting"), you can override [CockroachDB's index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/) and use a specific [index](indexes.html) for deleting rows of a named table.
@@ -108,52 +102,154 @@ To view how the index hint modifies the query plan that CockroachDB follows for 
 
 For examples, see [Delete with index hints](#delete-with-index-hints).
 
+## Batch deletes
+
+To delete a large number of rows (i.e., tens of thousands of rows or more), we recommend iteratively deleting subsets of the rows that you want to delete, until all of the unwanted rows have been deleted. You can write a script to do this, or you can write a loop into your application.
+
+In the sections below, we provide guidance on batch deleting with the `DELETE` query filter [on an indexed column](#batch-delete-on-an-indexed-column) and [on a non-indexed column](#batch-delete-on-a-non-indexed-column). Filtering on an indexed column is both simpler to implement and more efficient, but adding an index to a table can slow down insertions to the table and may cause bottlenecks. Queries that filter on a non-indexed column must perform at least one full-table scan, a process that takes time proportional to the size of the entire table.
+
+### Batch delete on an indexed column
+
+For high-performance batch deletes, we recommending filtering the `DELETE` query on an [indexed column](indexes.html).
+
+{{site.data.alerts.callout_info}}
+Having an indexed filtering column can make delete operations faster, but it might lead to bottlenecks in execution, especially if the filtering column is a [timestamp](timestamp.html). To reduce bottlenecks, we recommend using a [hash-sharded index](indexes.html#hash-sharded-indexes).
+{{site.data.alerts.end}}
+
+Each iteration of a batch-delete loop should execute a transaction containing a single `DELETE` query. When writing this `DELETE` query:
+
+- Use a `WHERE` clause to filter on a column that identifies the unwanted rows. If the filtering column is not the primary key, the column should have [a secondary index](indexes.html). Note that if the filtering column is not already indexed, it is not beneficial to add an index just to speed up batch deletes. Instead, consider [batch deleting on non-indexed columns](#batch-delete-on-a-non-indexed-column).
+- To ensure that rows are efficiently scanned in the `DELETE` query, add an [`ORDER BY`](query-order.html) clause on the filtering column.
+- Use a [`LIMIT`](limit-offset.html) clause to limit the number of rows to the desired batch size. To determine the optimal batch size, try out different batch sizes (1,000 rows, 10,000 rows, 100,000 rows, etc.) and monitor the change in performance.
+- Add a `RETURNING` clause to the end of the query that returns the filtering column values of the deleted rows. Then, using the values of the deleted rows, update the filter to match only the subset of remaining rows to delete. This narrows each query's scan to the fewest rows possible, and [preserves the performance of the deletes over time](#preserving-delete-performance-over-time). This pattern assumes that no new rows are generated that match on the `DELETE` filter during the time that it takes to perform the delete.
+
+For example, suppose that you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `new_order` table where `no_w_id` is less than `5`, in batches of 5,000 rows. To do this, you can write a script that loops over batches of 5,000 rows, following the `DELETE` query guidance provided above. Note that in this case, `no_w_id` is the first column in the primary index, and, as a result, you do not need to create a secondary index on the column.
+
+In Python, the script would look similar to the following:
+
+{% include copy-clipboard.html %}
+~~~ python
+#!/usr/bin/env python3
+
+import psycopg2
+import psycopg2.sql
+import os
+
+conn = psycopg2.connect(os.environ.get('DB_URI'))
+filter = 4
+lastrow = None
+
+while True:
+  with conn:
+    with conn.cursor() as cur:
+        if lastrow:
+            filter = lastrow[0]
+        query = psycopg2.sql.SQL("DELETE FROM new_order WHERE no_w_id <= %s ORDER BY no_w_id DESC LIMIT 5000 RETURNING no_w_id")
+        cur.execute(query, (filter,))
+        print(cur.statusmessage)
+        if cur.rowcount == 0:
+            break
+        lastrow = cur.fetchone()
+
+conn.close()
+~~~
+
+This script iteratively deletes rows in batches of 5,000, until all of the rows where `no_w_id <= 4` are deleted. Note that at each iteration, the filter is updated to match a narrower subset of rows.
+
+### Batch delete on a non-indexed column
+
+If you cannot index the column that identifies the unwanted rows, we recommend defining the batch loop to execute separate read and write operations at each iteration:
+
+1. Execute a [`SELECT` query](selection-queries.html) that returns the primary key values for the rows that you want to delete. When writing the `SELECT` query:
+    - Use a `WHERE` clause that filters on the column identifying the rows.
+    - Add an [`AS OF SYSTEM TIME` clause](as-of-system-time.html) to the end of the selection subquery, or run the selection query in a separate, read-only transaction with [`SET TRANSACTION AS OF SYSTEM TIME`](as-of-system-time.html#using-as-of-system-time-in-transactions). This helps to reduce [transaction contention](transactions.html#transaction-contention).
+    - Use a [`LIMIT`](limit-offset.html) clause to limit the number of rows queried to a subset of the rows that you want to delete. To determine the optimal `SELECT` batch size, try out different sizes (10,000 rows, 100,000 rows, 1,000,000 rows, etc.), and monitor the change in performance. Note that this `SELECT` batch size can be much larger than the batch size of rows that are deleted in the subsequent `DELETE` query.
+    - To ensure that rows are efficiently scanned in the subsequent `DELETE` query, include an [`ORDER BY`](query-order.html) clause on the primary key.
+
+2. Write a nested `DELETE` loop over the primary key values returned by the `SELECT` query, in batches smaller than the initial `SELECT` batch size. To determine the optimal `DELETE` batch size, try out different sizes (1,000 rows, 10,000 rows, 100,000 rows, etc.), and monitor the change in performance. Where possible, we recommend executing each `DELETE` in a separate transaction.
+
+For example, suppose that you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `history` table that are older than a month. You can create a script that loops over the data and deletes unwanted rows in batches, following the query guidance provided above.
+
+In Python, the script would look similar to the following:
+
+{% include copy-clipboard.html %}
+~~~ python
+#!/usr/bin/env python3
+
+import psycopg2
+import os
+import time
+
+conn = psycopg2.connect(os.environ.get('DB_URI'))
+
+while True:
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION AS OF SYSTEM TIME '-5s'")
+            cur.execute("SELECT h_w_id, rowid FROM history WHERE h_date < current_date() - INTERVAL '1 MONTH' ORDER BY h_w_id, rowid LIMIT 20000")
+            pkvals = list(cur)
+    if not pkvals:
+        return
+    while pkvals:
+        batch = pkvals[:5000]
+        pkvals = pkvals[5000:]
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM history WHERE (h_w_id, rowid) = ANY %s", (batch,))
+                print(cur.statusmessage)
+    del batch
+    del pkvals
+    time.sleep(5)
+
+conn.close()
+~~~
+
+At each iteration, the selection query returns the primary key values of up to 20,000 rows of matching historical data from 5 seconds in the past, in a read-only transaction. Then, a nested loop iterates over the returned primary key values in smaller batches of 5,000 rows. At each iteration of the nested `DELETE` loop, a batch of rows is deleted. After the nested `DELETE` loop deletes all of the rows from the initial selection query, a time delay ensures that the next selection query reads historical data from the table after the last iteration's `DELETE` final delete.
+
+### Batch-delete "expired" data
+
+CockroachDB does not support Time to Live (TTL) on table rows. To delete "expired" rows, we recommend automating a batch delete process using a job scheduler like `cron`.
+
+For example, suppose that every morning you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `history` table that are older than a month. To do this, you could use the example Python script that [batch deletes on the non-indexed `h_date` column](#batch-delete-on-a-non-indexed-column).
+
+To run the script with a daily `cron` job:
+
+1. Make the file executable:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ chmod +x cleanup.py
+    ~~~
+
+2. Create a new `cron` job:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ crontab -e
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ txt
+    30 10 * * * DB_URI='cockroachdb://user@host:26257/bank' cleanup.py >> ~/cron.log 2>&1
+    ~~~
+
+Saving the `cron` file will install a new job that runs the `cleanup.py` file every morning at 10:30 A.M., writing the results to the `cron.log` file.
+
+### Preserving `DELETE` performance over time
+
+CockroachDB relies on [multi-version concurrency control (MVCC)](architecture/storage-layer.html#mvcc) to process concurrent requests while guaranteeing [strong consistency](frequently-asked-questions.html#how-is-cockroachdb-strongly-consistent). As such, when you delete a row, it is not immediately removed from disk. The MVCC values for the row will remain until the garbage collection period defined by the [`gc.ttlseconds`](configure-replication-zones.html#gc-ttlseconds) variable in the applicable [zone configuration](show-zone-configurations.html) has passed. By default, this period is 25 hours.
+
+This means that with the default settings, each iteration of your `DELETE` statement must scan over all of the rows previously marked for deletion within the last 25 hours. If you try to delete 10,000 rows 10 times within the same 25 hour period, the 10th command will have to scan over the 90,000 rows previously marked for deletion.
+
+To preserve performance over iterative `DELETE` queries, we recommend taking one of the following approaches:
+
+- At each iteration, update the `WHERE` clause to filter only the rows that have not yet been marked for deletion. For an example, see [Batch-delete on an indexed filter](#batch-delete-on-an-indexed-column) above.
+- At each iteration, first use a `SELECT` statement to return primary key values on rows that are not yet deleted. Rows marked for deletion will not be returned. Then, use a nested `DELETE` loop over a smaller batch size, filtering on the primary key values. For an example, see [Batch delete on a non-indexed column](#batch-delete-on-a-non-indexed-column) above.
+- To iteratively delete rows in constant time, using a simple `DELETE` loop, you can [alter your zone configuration](configure-replication-zones.html#overview) and change `gc.ttlseconds` to a low value like 5 minutes (i.e., `300`), and then run your `DELETE` statement once per GC interval.
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}
 
-### Delete all rows
-
-You can delete all rows from a table by not including a `WHERE` clause in your `DELETE` statement.
-
-{{site.data.alerts.callout_info}}
-If the [`sql_safe_updates`](cockroach-sql.html#allow-potentially-unsafe-sql-statements) session variable is set to `true`, the client will prevent the update. `sql_safe_updates` is set to `true` by default.
-{{site.data.alerts.end}}
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DELETE FROM vehicle_location_histories;
-~~~
-
-~~~
-pq: rejected: DELETE without WHERE clause (sql_safe_updates = true)
-~~~
-
-You can use a [`SET`](set-vars.html) statement to set session variables.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET sql_safe_updates = false;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DELETE FROM vehicle_location_histories;
-~~~
-
-~~~
-DELETE 1000
-~~~
-
-{{site.data.alerts.callout_success}}
-Unless your table is small (less than 1000 rows), using [`TRUNCATE`][truncate] to delete the contents of a table will be more performant than using `DELETE`.
-{{site.data.alerts.end}}
-
-### Delete specific rows
-
-When deleting specific rows from a table, the most important decision you make is which columns to use in your `WHERE` clause. When making that choice, consider the potential impact of using columns with the [Primary Key](primary-key.html)/[Unique](unique.html) constraints (both of which enforce uniqueness) versus those that are not unique.
-
-#### Delete rows using Primary Key/unique columns
+### Delete rows using Primary Key/unique columns
 
 Using columns with the [Primary Key](primary-key.html) or [Unique](unique.html) constraints to delete rows ensures your statement is unambiguous&mdash;no two rows contain the same column value, so it's less likely to delete data unintentionally.
 
@@ -167,7 +263,7 @@ In this example, `code` is our primary key and we want to delete the row where t
 DELETE 1
 ~~~
 
-#### Delete rows using non-unique columns
+### Delete rows using non-unique columns
 
 Deleting rows using non-unique columns removes _every_ row that returns `TRUE` for the `WHERE` clause's `a_expr`. This can easily result in deleting data you didn't intend to.
 
@@ -372,36 +468,9 @@ If you provide an index hint (i.e. force the index selection) to use the primary
 - [`INSERT`](insert.html)
 - [`UPDATE`](update.html)
 - [`UPSERT`](upsert.html)
-- [`TRUNCATE`][truncate]
+- [`TRUNCATE`](truncate.html)
 - [`ALTER TABLE`](alter-table.html)
 - [`DROP TABLE`](drop-table.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
 - [Limiting Query Results](limit-offset.html)
-
-<!-- Reference Links -->
-
-[truncate]: truncate.html
-
-<!--
-
-SQL for example table:
-
-CREATE TABLE account_details (
-       account_id INT PRIMARY KEY,
-       balance FLOAT,
-       account_type VARCHAR
-);
-
-INSERT INTO account_details (account_id, balance, account_type) VALUES (1, 32000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (2, 30000, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (3, 30000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (4, 22000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (5, 43696.95, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (6, 23500, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (7, 79493.51, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (8, 40761.66, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (9, 2111.67, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (10, 59173.15, 'Savings');
-
--->

--- a/v20.1/performance-best-practices-overview.md
+++ b/v20.1/performance-best-practices-overview.md
@@ -25,12 +25,12 @@ For more information, see:
 
 - [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table)
 - [Upsert Multiple Rows](upsert.html#upsert-multiple-rows)
-- [Delete Multiple Rows](delete.html#delete-specific-rows)
+- [Delete Multiple Rows](delete.html)
 - [How to improve IoT application performance with multi-row DML](https://www.cockroachlabs.com/blog/multi-row-dml/)
 
 ### Use `TRUNCATE` instead of `DELETE` to delete all rows in a table
 
-The [`TRUNCATE`](truncate.html) statement removes all rows from a table by dropping the table and recreating a new table with the same name. This performs better than using `DELETE`, which performs multiple transactions to delete all rows. For smaller tables (with less than 1000 rows), however, using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
+The [`TRUNCATE`](truncate.html) statement removes all rows from a table by dropping the table and recreating a new table with the same name. This performs better than using `DELETE`, which performs multiple transactions to delete all rows.
 
 ## Bulk insert best practices
 
@@ -46,9 +46,15 @@ You can also use the [`IMPORT INTO`](import-into.html) statement to bulk-insert 
 
 To bulk-insert data into a brand new table, the [`IMPORT`](import.html) statement performs better than `INSERT`.
 
-## Bulk deletion best practices
+## Bulk delete best practices
 
-To get the best performance when deleting large amounts of data, follow the instructions in [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+### Batch deletes
+
+To delete a large number of rows, we recommend iteratively deleting batches of rows until all of the unwanted rows are deleted. For an example, see [Batch deletes](delete.html#batch-deletes).
+
+### Batch-delete "expired" data
+
+CockroachDB does not support Time to Live (TTL) on table rows. To delete "expired" rows, we recommend automating a batch delete process with a job scheduler like `cron`. For an example, see [Batch-delete "expired" data](delete.html#batch-delete-expired-data).
 
 ## Assign column families
 

--- a/v20.1/sql-faqs.md
+++ b/v20.1/sql-faqs.md
@@ -140,18 +140,6 @@ require('long').fromString(idString).add(1).toString(); // GOOD: returns '235191
 
 {% include {{ page.version.version }}/faq/simulate-key-value-store.html %}
 
-## Why are my deletes getting slower over time?
-
-> I need to delete a large amount of data. I'm iteratively deleting a certain number of rows using a [`DELETE`](delete.html) statement with a [`LIMIT`](limit-offset.html) clause, but it's getting slower over time. Why?
-
-CockroachDB relies on [multi-version concurrency control (MVCC)](architecture/storage-layer.html#mvcc) to process concurrent requests while guaranteeing [strong consistency](frequently-asked-questions.html#how-is-cockroachdb-strongly-consistent). As such, when you delete a row, it is not immediately removed from disk. The MVCC values for the row will remain until the garbage collection period defined by the [`gc.ttlseconds`](configure-replication-zones.html#gc-ttlseconds) variable in the applicable [zone configuration](show-zone-configurations.html) has passed.  By default, this period is 25 hours.
-
-This means that with the default settings, each iteration of your `DELETE` statement must scan over all of the rows previously marked for deletion within the last 25 hours. This means that if you try to delete 10,000 rows 10 times within the same 25 hour period, the 10th command will have to scan over the 90,000 rows previously marked for deletion.
-
-If you need to iteratively delete rows in constant time, you can [alter your zone configuration](configure-replication-zones.html#overview) and change `gc.ttlseconds` to a low value like 5 minutes (i.e., `300`), and run your `DELETE` statement once per GC interval. We strongly recommend returning `gc.ttlseconds` to the default value after your large deletion is completed.
-
-For instructions showing how to delete specific rows, see [Delete specific rows](delete.html#delete-specific-rows).
-
 ## See also
 
 - [Product FAQs](frequently-asked-questions.html)

--- a/v20.1/truncate.md
+++ b/v20.1/truncate.md
@@ -6,10 +6,6 @@ toc: true
 
 The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. At a high level, it works by dropping the table and recreating a new table with the same name.
 
-{{site.data.alerts.callout_info}}
-For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
-{{site.data.alerts.end}}
-
 {% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Synopsis

--- a/v20.2/delete-data.md
+++ b/v20.2/delete-data.md
@@ -117,7 +117,7 @@ Because of the way CockroachDB works under the hood, deleting data from the data
 The practical implications of the above are:
 
 - Deleting data will not immediately decrease disk usage.
-- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly, for reasons [explained in this FAQ entry](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+- If you issue multiple [`DELETE`](delete.html) statements in sequence that each delete large amounts of data, each subsequent `DELETE` statement will run more slowly. For details, see [Preserving `DELETE` performance over time](delete.html#preserving-delete-performance-over-time).
 - To delete all of the rows in a table, [it's faster to use `TRUNCATE` instead of `DELETE`](performance-best-practices-overview.html#use-truncate-instead-of-delete-to-delete-all-rows-in-a-table).
 
 For more information about how the storage layer of CockroachDB works, see the [storage layer reference documentation](architecture/storage-layer.html).
@@ -128,11 +128,9 @@ Reference information related to this task:
 
 - [`DELETE`](delete.html)
 - [Disk space usage after deletes](delete.html#disk-space-usage-after-deletes)
-- [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time)
 - [`TRUNCATE`](truncate.html)
 - [`DROP TABLE`](drop-table.html)
 - [Understanding and Avoiding Transaction Contention](performance-best-practices-overview.html#understanding-and-avoiding-transaction-contention)
-- [Delete Multiple Rows](delete.html#delete-specific-rows)
 
 Other common tasks:
 

--- a/v20.2/delete.md
+++ b/v20.2/delete.md
@@ -33,7 +33,7 @@ table td:first-child {
  `common_table_expr` | See [Common Table Expressions](common-table-expressions.html).
  `table_name` | The name of the table that contains the rows you want to update.
  `AS table_alias_name` | An alias for the table name. When an alias is provided, it completely hides the actual table name.
-`WHERE a_expr`| `a_expr` must be an expression that returns Boolean values using columns (e.g., `<column> = <value>`). Delete rows that return   `TRUE`.<br><br/>__Without a `WHERE` clause in your statement, `DELETE` removes all rows from the table.__
+`WHERE a_expr`| `a_expr` must be an expression that returns Boolean values using columns (e.g., `<column> = <value>`). Delete rows that return   `TRUE`.<br><br/>__Without a `WHERE` clause in your statement, `DELETE` removes all rows from the table. To delete all rows in a table, we recommend using [`TRUNCATE`](truncate.html) instead of `DELETE`.__
  `sort_clause` | An `ORDER BY` clause. <br /><br />See [Ordering of rows in DML statements](query-order.html#ordering-rows-in-dml-statements) for more details.
  `limit_clause` | A `LIMIT` clause. See [Limiting Query Results](limit-offset.html) for more details.
  `RETURNING target_list` | Return values based on rows deleted, where `target_list` can be specific column names from the table, `*` for all columns, or computations using [scalar expressions](scalar-expressions.html). <br><br>To return nothing in the response, not even the number of rows updated, use `RETURNING NOTHING`.
@@ -76,12 +76,6 @@ For more information about ordering query results in general, see
 [Ordering Query Results](query-order.html) and [Ordering of rows in
 DML statements](query-order.html#ordering-rows-in-dml-statements).
 
-## Delete performance on large data sets
-
-If you are deleting a large amount of data using iterative `DELETE ... LIMIT` statements, you are likely to see a drop in performance for each subsequent `DELETE` statement.
-
-For an explanation of why this happens, and for instructions showing how to iteratively delete rows in constant time, see [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
-
 ## Force index selection for deletes
 
 By using the explicit index annotation (also known as "index hinting"), you can override [CockroachDB's index selection](https://www.cockroachlabs.com/blog/index-selection-cockroachdb-2/) and use a specific [index](indexes.html) for deleting rows of a named table.
@@ -108,52 +102,160 @@ To view how the index hint modifies the query plan that CockroachDB follows for 
 
 For examples, see [Delete with index hints](#delete-with-index-hints).
 
+## Batch deletes
+
+To delete a large number of rows (i.e., tens of thousands of rows or more), we recommend iteratively deleting subsets of the rows that you want to delete, until all of the unwanted rows have been deleted. You can write a script to do this, or you can write a loop into your application.
+
+In the sections below, we provide guidance on batch deleting with the `DELETE` query filter [on an indexed column](#batch-delete-on-an-indexed-column) and [on a non-indexed column](#batch-delete-on-a-non-indexed-column). Filtering on an indexed column is both simpler to implement and more efficient, but adding an index to a table can slow down insertions to the table and may cause bottlenecks. Queries that filter on a non-indexed column must perform at least one full-table scan, a process that takes time proportional to the size of the entire table.
+
+### Batch delete on an indexed column
+
+For high-performance batch deletes, we recommending filtering the `DELETE` query on an [indexed column](indexes.html).
+
+{{site.data.alerts.callout_info}}
+Having an indexed filtering column can make delete operations faster, but it might lead to bottlenecks in execution, especially if the filtering column is a [timestamp](timestamp.html). To reduce bottlenecks, we recommend using a [hash-sharded index](indexes.html#hash-sharded-indexes).
+{{site.data.alerts.end}}
+
+Each iteration of a batch-delete loop should execute a transaction containing a single `DELETE` query. When writing this `DELETE` query:
+
+- Use a `WHERE` clause to filter on a column that identifies the unwanted rows. If the filtering column is not the primary key, the column should have [a secondary index](indexes.html). Note that if the filtering column is not already indexed, it is not beneficial to add an index just to speed up batch deletes. Instead, consider [batch deleting on non-indexed columns](#batch-delete-on-a-non-indexed-column).
+- To ensure that rows are efficiently scanned in the `DELETE` query, add an [`ORDER BY`](query-order.html) clause on the filtering column.
+- Use a [`LIMIT`](limit-offset.html) clause to limit the number of rows to the desired batch size. To determine the optimal batch size, try out different batch sizes (1,000 rows, 10,000 rows, 100,000 rows, etc.) and monitor the change in performance.
+- Add a `RETURNING` clause to the end of the query that returns the filtering column values of the deleted rows. Then, using the values of the deleted rows, update the filter to match only the subset of remaining rows to delete. This narrows each query's scan to the fewest rows possible, and [preserves the performance of the deletes over time](#preserving-delete-performance-over-time). This pattern assumes that no new rows are generated that match on the `DELETE` filter during the time that it takes to perform the delete.
+
+For example, suppose that you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `new_order` table where `no_w_id` is less than `5`, in batches of 5,000 rows. To do this, you can write a script that loops over batches of 5,000 rows, following the `DELETE` query guidance provided above. Note that in this case, `no_w_id` is the first column in the primary index, and, as a result, you do not need to create a secondary index on the column.
+
+In Python, the script would look similar to the following:
+
+{% include copy-clipboard.html %}
+~~~ python
+#!/usr/bin/env python3
+
+import psycopg2
+import psycopg2.sql
+import os
+
+conn = psycopg2.connect(os.environ.get('DB_URI'))
+filter = 4
+lastrow = None
+
+while True:
+  with conn:
+    with conn.cursor() as cur:
+        if lastrow:
+            filter = lastrow[0]
+        query = psycopg2.sql.SQL("DELETE FROM new_order WHERE no_w_id <= %s ORDER BY no_w_id DESC LIMIT 5000 RETURNING no_w_id")
+        cur.execute(query, (filter,))
+        print(cur.statusmessage)
+        if cur.rowcount == 0:
+            break
+        lastrow = cur.fetchone()
+
+conn.close()
+~~~
+
+This script iteratively deletes rows in batches of 5,000, until all of the rows where `no_w_id <= 4` are deleted. Note that at each iteration, the filter is updated to match a narrower subset of rows.
+
+### Batch delete on a non-indexed column
+
+If you cannot index the column that identifies the unwanted rows, we recommend defining the batch loop to execute separate read and write operations at each iteration:
+
+1. Execute a [`SELECT` query](selection-queries.html) that returns the primary key values for the rows that you want to delete. When writing the `SELECT` query:
+    - Use a `WHERE` clause that filters on the column identifying the rows.
+    - Add an [`AS OF SYSTEM TIME` clause](as-of-system-time.html) to the end of the selection subquery, or run the selection query in a separate, read-only transaction with [`SET TRANSACTION AS OF SYSTEM TIME`](as-of-system-time.html#using-as-of-system-time-in-transactions). This helps to reduce [transaction contention](transactions.html#transaction-contention).
+    - Use a [`LIMIT`](limit-offset.html) clause to limit the number of rows queried to a subset of the rows that you want to delete. To determine the optimal `SELECT` batch size, try out different sizes (10,000 rows, 100,000 rows, 1,000,000 rows, etc.), and monitor the change in performance. Note that this `SELECT` batch size can be much larger than the batch size of rows that are deleted in the subsequent `DELETE` query.
+    - To ensure that rows are efficiently scanned in the subsequent `DELETE` query, include an [`ORDER BY`](query-order.html) clause on the primary key.
+
+2. Write a nested `DELETE` loop over the primary key values returned by the `SELECT` query, in batches smaller than the initial `SELECT` batch size. To determine the optimal `DELETE` batch size, try out different sizes (1,000 rows, 10,000 rows, 100,000 rows, etc.), and monitor the change in performance. Where possible, we recommend executing each `DELETE` in a separate transaction.
+
+For example, suppose that you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `history` table that are older than a month. You can create a script that loops over the data and deletes unwanted rows in batches, following the query guidance provided above.
+
+In Python, the script would look similar to the following:
+
+{% include copy-clipboard.html %}
+~~~ python
+#!/usr/bin/env python3
+
+import psycopg2
+import os
+import time
+
+conn = psycopg2.connect(os.environ.get('DB_URI'))
+
+while True:
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute("SET TRANSACTION AS OF SYSTEM TIME '-5s'")
+            cur.execute("SELECT h_w_id, rowid FROM history WHERE h_date < current_date() - INTERVAL '1 MONTH' ORDER BY h_w_id, rowid LIMIT 20000")
+            pkvals = list(cur)
+    if not pkvals:
+        return
+    while pkvals:
+        batch = pkvals[:5000]
+        pkvals = pkvals[5000:]
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM history WHERE (h_w_id, rowid) = ANY %s", (batch,))
+                print(cur.statusmessage)
+    del batch
+    del pkvals
+    time.sleep(5)
+
+conn.close()
+~~~
+
+At each iteration, the selection query returns the primary key values of up to 20,000 rows of matching historical data from 5 seconds in the past, in a read-only transaction. Then, a nested loop iterates over the returned primary key values in smaller batches of 5,000 rows. At each iteration of the nested `DELETE` loop, a batch of rows is deleted. After the nested `DELETE` loop deletes all of the rows from the initial selection query, a time delay ensures that the next selection query reads historical data from the table after the last iteration's `DELETE` final delete.
+
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v20.2:</span> CockroachDB records the timestamp of each row created in the database with the `crdb_internal_mvcc_timestamp` metadata column. In the absence of an explicit timestamp column in your table, you can use `crdb_internal_mvcc_timestamp` to filter expired data.
+
+Note that `crdb_internal_mvcc_timestamp` cannot be indexed. As a result, we recommend following the non-indexed column pattern shown above if you plan to use `crdb_internal_mvcc_timestamp` as a filter for large deletes.
+{{site.data.alerts.end}}
+
+### Batch-delete "expired" data
+
+CockroachDB does not support Time to Live (TTL) on table rows. To delete "expired" rows, we recommend automating a batch delete process using a job scheduler like `cron`.
+
+For example, suppose that every morning you want to delete all rows in the [`tpcc`](cockroach-workload.html#tpcc-workload) `history` table that are older than a month. To do this, you could use the example Python script that [batch deletes on the non-indexed `h_date` column](#batch-delete-on-a-non-indexed-column).
+
+To run the script with a daily `cron` job:
+
+1. Make the file executable:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ chmod +x cleanup.py
+    ~~~
+
+2. Create a new `cron` job:
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ crontab -e
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ txt
+    30 10 * * * DB_URI='cockroachdb://user@host:26257/bank' cleanup.py >> ~/cron.log 2>&1
+    ~~~
+
+Saving the `cron` file will install a new job that runs the `cleanup.py` file every morning at 10:30 A.M., writing the results to the `cron.log` file.
+
+### Preserving `DELETE` performance over time
+
+CockroachDB relies on [multi-version concurrency control (MVCC)](architecture/storage-layer.html#mvcc) to process concurrent requests while guaranteeing [strong consistency](frequently-asked-questions.html#how-is-cockroachdb-strongly-consistent). As such, when you delete a row, it is not immediately removed from disk. The MVCC values for the row will remain until the garbage collection period defined by the [`gc.ttlseconds`](configure-replication-zones.html#gc-ttlseconds) variable in the applicable [zone configuration](show-zone-configurations.html) has passed. By default, this period is 25 hours.
+
+This means that with the default settings, each iteration of your `DELETE` statement must scan over all of the rows previously marked for deletion within the last 25 hours. If you try to delete 10,000 rows 10 times within the same 25 hour period, the 10th command will have to scan over the 90,000 rows previously marked for deletion.
+
+To preserve performance over iterative `DELETE` queries, we recommend taking one of the following approaches:
+
+- At each iteration, update the `WHERE` clause to filter only the rows that have not yet been marked for deletion. For an example, see [Batch-delete on an indexed filter](#batch-delete-on-an-indexed-column) above.
+- At each iteration, first use a `SELECT` statement to return primary key values on rows that are not yet deleted. Rows marked for deletion will not be returned. Then, use a nested `DELETE` loop over a smaller batch size, filtering on the primary key values. For an example, see [Batch delete on a non-indexed column](#batch-delete-on-a-non-indexed-column) above.
+- To iteratively delete rows in constant time, using a simple `DELETE` loop, you can [alter your zone configuration](configure-replication-zones.html#overview) and change `gc.ttlseconds` to a low value like 5 minutes (i.e., `300`), and then run your `DELETE` statement once per GC interval.
+
 ## Examples
 
 {% include {{page.version.version}}/sql/movr-statements.md %}
 
-### Delete all rows
-
-You can delete all rows from a table by not including a `WHERE` clause in your `DELETE` statement.
-
-{{site.data.alerts.callout_info}}
-If the [`sql_safe_updates`](cockroach-sql.html#allow-potentially-unsafe-sql-statements) session variable is set to `true`, the client will prevent the update. `sql_safe_updates` is set to `true` by default.
-{{site.data.alerts.end}}
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DELETE FROM vehicle_location_histories;
-~~~
-
-~~~
-pq: rejected: DELETE without WHERE clause (sql_safe_updates = true)
-~~~
-
-You can use a [`SET`](set-vars.html) statement to set session variables.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SET sql_safe_updates = false;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DELETE FROM vehicle_location_histories;
-~~~
-
-~~~
-DELETE 1000
-~~~
-
-{{site.data.alerts.callout_success}}
-Unless your table is small (less than 1000 rows), using [`TRUNCATE`][truncate] to delete the contents of a table will be more performant than using `DELETE`.
-{{site.data.alerts.end}}
-
-### Delete specific rows
-
-When deleting specific rows from a table, the most important decision you make is which columns to use in your `WHERE` clause. When making that choice, consider the potential impact of using columns with the [Primary Key](primary-key.html)/[Unique](unique.html) constraints (both of which enforce uniqueness) versus those that are not unique.
-
-#### Delete rows using Primary Key/unique columns
+### Delete rows using Primary Key/unique columns
 
 Using columns with the [Primary Key](primary-key.html) or [Unique](unique.html) constraints to delete rows ensures your statement is unambiguous&mdash;no two rows contain the same column value, so it's less likely to delete data unintentionally.
 
@@ -167,7 +269,7 @@ In this example, `code` is our primary key and we want to delete the row where t
 DELETE 1
 ~~~
 
-#### Delete rows using non-unique columns
+### Delete rows using non-unique columns
 
 Deleting rows using non-unique columns removes _every_ row that returns `TRUE` for the `WHERE` clause's `a_expr`. This can easily result in deleting data you didn't intend to.
 
@@ -368,36 +470,9 @@ If you provide an index hint (i.e. force the index selection) to use the primary
 - [`INSERT`](insert.html)
 - [`UPDATE`](update.html)
 - [`UPSERT`](upsert.html)
-- [`TRUNCATE`][truncate]
+- [`TRUNCATE`](truncate.html)
 - [`ALTER TABLE`](alter-table.html)
 - [`DROP TABLE`](drop-table.html)
 - [`DROP DATABASE`](drop-database.html)
 - [Other SQL Statements](sql-statements.html)
 - [Limiting Query Results](limit-offset.html)
-
-<!-- Reference Links -->
-
-[truncate]: truncate.html
-
-<!--
-
-SQL for example table:
-
-CREATE TABLE account_details (
-       account_id INT PRIMARY KEY,
-       balance FLOAT,
-       account_type VARCHAR
-);
-
-INSERT INTO account_details (account_id, balance, account_type) VALUES (1, 32000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (2, 30000, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (3, 30000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (4, 22000, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (5, 43696.95, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (6, 23500, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (7, 79493.51, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (8, 40761.66, 'Savings');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (9, 2111.67, 'Checking');
-INSERT INTO account_details (account_id, balance, account_type) VALUES (10, 59173.15, 'Savings');
-
--->

--- a/v20.2/performance-best-practices-overview.md
+++ b/v20.2/performance-best-practices-overview.md
@@ -25,12 +25,12 @@ For more information, see:
 
 - [Insert Multiple Rows](insert.html#insert-multiple-rows-into-an-existing-table)
 - [Upsert Multiple Rows](upsert.html#upsert-multiple-rows)
-- [Delete Multiple Rows](delete.html#delete-specific-rows)
+- [Delete Multiple Rows](delete.html)
 - [How to improve IoT application performance with multi-row DML](https://www.cockroachlabs.com/blog/multi-row-dml/)
 
 ### Use `TRUNCATE` instead of `DELETE` to delete all rows in a table
 
-The [`TRUNCATE`](truncate.html) statement removes all rows from a table by dropping the table and recreating a new table with the same name. This performs better than using `DELETE`, which performs multiple transactions to delete all rows. For smaller tables (with less than 1000 rows), however, using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
+The [`TRUNCATE`](truncate.html) statement removes all rows from a table by dropping the table and recreating a new table with the same name. This performs better than using `DELETE`, which performs multiple transactions to delete all rows.
 
 ## Bulk insert best practices
 
@@ -46,9 +46,15 @@ You can also use the [`IMPORT INTO`](import-into.html) statement to bulk-insert 
 
 To bulk-insert data into a brand new table, the [`IMPORT`](import.html) statement performs better than `INSERT`.
 
-## Bulk deletion best practices
+## Bulk delete best practices
 
-To get the best performance when deleting large amounts of data, follow the instructions in [Why are my deletes getting slower over time?](sql-faqs.html#why-are-my-deletes-getting-slower-over-time).
+### Batch deletes
+
+To delete a large number of rows, we recommend iteratively deleting batches of rows until all of the unwanted rows are deleted. For an example, see [Batch deletes](delete.html#batch-deletes).
+
+### Batch-delete "expired" data
+
+CockroachDB does not support Time to Live (TTL) on table rows. To delete "expired" rows, we recommend automating a batch delete process with a job scheduler like `cron`. For an example, see [Batch-delete "expired" data](delete.html#batch-delete-expired-data).
 
 ## Assign column families
 

--- a/v20.2/sql-faqs.md
+++ b/v20.2/sql-faqs.md
@@ -140,17 +140,6 @@ require('long').fromString(idString).add(1).toString(); // GOOD: returns '235191
 
 {% include {{ page.version.version }}/faq/simulate-key-value-store.html %}
 
-## Why are my deletes getting slower over time?
-
-> I need to delete a large amount of data. I'm iteratively deleting a certain number of rows using a [`DELETE`](delete.html) statement with a [`LIMIT`](limit-offset.html) clause, but it's getting slower over time. Why?
-
-CockroachDB relies on [multi-version concurrency control (MVCC)](architecture/storage-layer.html#mvcc) to process concurrent requests while guaranteeing [strong consistency](frequently-asked-questions.html#how-is-cockroachdb-strongly-consistent). As such, when you delete a row, it is not immediately removed from disk. The MVCC values for the row will remain until the garbage collection period defined by the [`gc.ttlseconds`](configure-replication-zones.html#gc-ttlseconds) variable in the applicable [zone configuration](show-zone-configurations.html) has passed.  By default, this period is 25 hours.
-
-This means that with the default settings, each iteration of your `DELETE` statement must scan over all of the rows previously marked for deletion within the last 25 hours. This means that if you try to delete 10,000 rows 10 times within the same 25 hour period, the 10th command will have to scan over the 90,000 rows previously marked for deletion.
-
-If you need to iteratively delete rows in constant time, you can [alter your zone configuration](configure-replication-zones.html#overview) and change `gc.ttlseconds` to a low value like 5 minutes (i.e., `300`), and run your `DELETE` statement once per GC interval. We strongly recommend returning `gc.ttlseconds` to the default value after your large deletion is completed.
-
-For instructions showing how to delete specific rows, see [Delete specific rows](delete.html#delete-specific-rows).
 
 ## See also
 

--- a/v20.2/truncate.md
+++ b/v20.2/truncate.md
@@ -6,10 +6,6 @@ toc: true
 
 The `TRUNCATE` [statement](sql-statements.html) removes all rows from a table. At a high level, it works by dropping the table and recreating a new table with the same name.
 
-{{site.data.alerts.callout_info}}
-For smaller tables (with less than 1000 rows), using a [`DELETE` statement without a `WHERE` clause](delete.html#delete-all-rows) will be more performant than using `TRUNCATE`.
-{{site.data.alerts.end}}
-
 {% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Synopsis


### PR DESCRIPTION
Fixes #5592.
Fixes #4818. 
Fixes #5647. 
Fixes #8137.

Adding examples in other languages will likely be part of the larger [Dev Guide v2 initiative](https://github.com/cockroachdb/docs/issues/6667).