### PR TITLE
Removed TLS guidance for v20.1 and v19.2

### DIFF
--- a/_includes/v19.2/app/java-tls-note.md
+++ b/_includes/v19.2/app/java-tls-note.md
@@ -1,3 +1,0 @@
-{{site.data.alerts.callout_danger}}
-CockroachDB versions v20.1 and lower require TLS 1.2. By default, Java 8 uses TLS 1.2, but applications running on Java 9+ must be configured to run TLS 1.2. For example, when starting your app, use: `$ java -Djdk.tls.client.protocols=TLSv1.2 appName`
-{{site.data.alerts.end}}

--- a/_includes/v20.1/app/java-tls-note.md
+++ b/_includes/v20.1/app/java-tls-note.md
@@ -1,3 +1,0 @@
-{{site.data.alerts.callout_danger}}
-CockroachDB versions v20.1 and lower require TLS 1.2. By default, Java 8 uses TLS 1.2, but applications running on Java 9+ must be configured to run TLS 1.2. For example, when starting your app, use: `$ java -Djdk.tls.client.protocols=TLSv1.2 appName`
-{{site.data.alerts.end}}

--- a/v19.2/install-client-drivers.md
+++ b/v19.2/install-client-drivers.md
@@ -131,8 +131,6 @@ For instructions on using peewee with CockroachDB, see the [CockroachDatabase pe
 
 {% include {{page.version.version}}/app/java-version-note.md %}
 
-{% include {{page.version.version}}/app/java-tls-note.md %}
-
 ## Drivers
 
 ### JDBC

--- a/v20.1/install-client-drivers.md
+++ b/v20.1/install-client-drivers.md
@@ -132,8 +132,6 @@ For instructions on using peewee with CockroachDB, see the [CockroachDatabase pe
 
 {% include {{page.version.version}}/app/java-version-note.md %}
 
-{% include {{page.version.version}}/app/java-tls-note.md %}
-
 ### JDBC
 
 **Support level:** Full


### PR DESCRIPTION
https://github.com/cockroachdb/docs/issues/7820#issuecomment-675037589