### PR TITLE
Simplest, most manual breadcrumbs

### DIFF
--- a/_data/breadcrumbs.yml
+++ b/_data/breadcrumbs.yml
@@ -1,0 +1,11 @@
+- title: GUIDES
+  breadcrumb: guides
+
+- title: Get Started
+  breadcrumb: get-started
+
+- title: Develop
+  breadcrumb: develop
+
+- title: Start a Local Cluster
+  breadcrumb: start-a-local-cluster

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,12 +3,34 @@ layout: default
 ---
 
 <div class="cf-5329-area-16739"></div>
-<div class="post-header">
 
+<div class="breadcrumb-header">
+<ol class="breadcrumb">
+  {% assign nested = false %}
+  {% for crumb in site.data.breadcrumbs %}
+    {% for pagecrumb in page.breadcrumbs %}
+      {% if pagecrumb == crumb.breadcrumb %}
+        {% assign nested = true %}
+        <li class="breadcrumb-item">
+          {{ crumb.title }}
+        </li>
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+  {% if nested == true %}
+    <li class="breadcrumb-item active">
+      {{ page.title }}
+    </li>
+  {% endif %}
+</ol>
+</div>
+
+<div class="post-header">
   <h1 class="post-title-main">{% if page.homepage == true %} {{site.homepage_title}} {% else %}{{ page.title }}{% endif %}</h1>
   {% unless page.contribute == false %}
       {% include contribute-options.html %}
   {% endunless %}
+
 </div>
 
 <div class="post-content">

--- a/v20.1/install-cockroachdb-linux.html
+++ b/v20.1/install-cockroachdb-linux.html
@@ -1,5 +1,6 @@
 ---
 title: Install CockroachDB on Linux
+breadcrumbs: [guides, get-started]
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 tags: download, binary, homebrew
 toc: true

--- a/v20.1/install-cockroachdb-mac.html
+++ b/v20.1/install-cockroachdb-mac.html
@@ -1,5 +1,6 @@
 ---
 title: Install CockroachDB on Mac
+breadcrumbs: [guides, get-started]
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 tags: download, binary, homebrew
 toc: true

--- a/v20.1/install-cockroachdb-windows.html
+++ b/v20.1/install-cockroachdb-windows.html
@@ -1,5 +1,6 @@
 ---
 title: Install CockroachDB on Windows
+breadcrumbs: [guides, get-started]
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 tags: download, binary, homebrew
 toc: true

--- a/v20.1/install-cockroachdb.html
+++ b/v20.1/install-cockroachdb.html
@@ -1,5 +1,6 @@
 ---
 title: Install CockroachDB
+breadcrumbs: [guides, get-started]
 summary: Install CockroachDB on Mac, Linux, or Windows. Sign up for product release notes.
 toc: false
 feedback: false

--- a/v20.1/learn-cockroachdb-sql.md
+++ b/v20.1/learn-cockroachdb-sql.md
@@ -1,5 +1,6 @@
 ---
 title: Learn CockroachDB SQL
+breadcrumbs: [guides, get-started]
 summary: Learn some of the most essential CockroachDB SQL statements on a local cluster.
 toc: true
 build_for: [cockroachdb, cockroachcloud]

--- a/v20.1/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v20.1/orchestrate-a-local-cluster-with-kubernetes.md
@@ -1,5 +1,6 @@
 ---
 title: Orchestrate a Local Cluster with Kubernetes
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: Orchestrate the deployment and management of a local cluster using Kubernetes.
 toc: true
 secure: true

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -1,5 +1,6 @@
 ---
 title: Orchestrate CockroachDB in a Single Kubernetes Cluster (Insecure)
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: How to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster with Kubernetes.
 toc: true
 toc_not_nested: true

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -1,5 +1,6 @@
 ---
 title: Start a Local Cluster (Secure)
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: Run a secure multi-node CockroachDB cluster locally, using TLS certificates to encrypt network communication.
 toc: true
 asciicast: true

--- a/v20.1/start-a-local-cluster-in-docker-linux.md
+++ b/v20.1/start-a-local-cluster-in-docker-linux.md
@@ -1,5 +1,6 @@
 ---
 title: Start a Cluster in Docker (Insecure)
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: Run an insecure multi-node CockroachDB cluster across multiple Docker containers on a single host.
 toc: true
 asciicast: true

--- a/v20.1/start-a-local-cluster-in-docker-mac.md
+++ b/v20.1/start-a-local-cluster-in-docker-mac.md
@@ -1,5 +1,6 @@
 ---
 title: Start a Cluster in Docker (Insecure)
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: Run an insecure multi-node CockroachDB cluster across multiple Docker containers on a single host.
 toc: true
 asciicast: true

--- a/v20.1/start-a-local-cluster-in-docker-windows.md
+++ b/v20.1/start-a-local-cluster-in-docker-windows.md
@@ -1,5 +1,6 @@
 ---
 title: Start a Cluster in Docker (Insecure)
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: Run an insecure multi-node CockroachDB cluster across multiple Docker containers on a single host.
 toc: true
 asciicast: true

--- a/v20.1/start-a-local-cluster.md
+++ b/v20.1/start-a-local-cluster.md
@@ -1,5 +1,6 @@
 ---
 title: Start a Local Cluster (Insecure)
+breadcrumbs: [guides, get-started, start-a-local-cluster]
 summary: Run an insecure multi-node CockroachDB cluster locally with each node listening on a different port.
 toc: true
 toc_not_nested: true


### PR DESCRIPTION
This works by going into every page we want to list on the sidenav and manually specifying their parents, in top-down hierarchical order.

If you want to see this in preview, I enabled breadcrumbs only for v20.1 pages under "GUIDES > Get Started". (Ignore styling ugliness for now of course.) The nice thing about this solution is it supports arbitrary/infinite sidenav hierarchies.

The other really nice thing is this solution will support breadcrumbs in Algolia, i.e. we should be able to get breadcrumbs in search results as well.