### PR TITLE
Update info about enabling rangefeeds

### DIFF
--- a/v19.1/change-data-capture.md
+++ b/v19.1/change-data-capture.md
@@ -123,7 +123,7 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 
 <span class="version-tag">New in v19.1:</span> Previously created changefeeds collect changes by periodically sending a request for any recent changes. Newly created changefeeds now behave differently: they connect a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
 
-To enable rangefeeds, set the `kv.rangefeed.enabled` [cluster setting](cluster-settings.html) to `true`. Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being using in a changefeed.
+To enable rangefeeds, set the `kv.rangefeed.enabled` [cluster setting](cluster-settings.html) to `true`. Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being used in a changefeed.
 
 If you are experiencing an issue, you can revert back to the previous behavior by setting `changefeed.push.enabled` to `false`. Note that this setting will be removed in a future release; if you have to use the fallback, please [file a Github issue](file-an-issue.html).
 

--- a/v19.2/change-data-capture.md
+++ b/v19.2/change-data-capture.md
@@ -17,7 +17,7 @@ The main feature of CDC is the changefeed, which targets an allowlist of tables,
 
 ## Enable rangefeeds
 
-Changefeeds they connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
+Changefeeds connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
 
 **Rangefeeds must be enabled for a changefeed to work.** To [enable the cluster setting](set-cluster-setting.html):
 
@@ -26,7 +26,7 @@ Changefeeds they connect to a long-lived request (i.e., a rangefeed), which push
 > SET CLUSTER SETTING kv.rangefeed.enabled = true;
 ~~~
 
-Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being using in a changefeed.
+Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being used in a changefeed.
 
 The `kv.closed_timestamp.target_duration` [cluster setting](cluster-settings.html) can be used with changefeeds. Resolved timestamps will always be behind by at least this setting's duration; however, decreasing the duration leads to more transaction restarts in your cluster, which can affect performance.
 

--- a/v20.1/change-data-capture.md
+++ b/v20.1/change-data-capture.md
@@ -17,7 +17,7 @@ The main feature of CDC is the changefeed, which targets an allowlist of tables,
 
 ## Enable rangefeeds
 
-Changefeeds they connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
+Changefeeds connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
 
 **Rangefeeds must be enabled for a changefeed to work.** To [enable the cluster setting](set-cluster-setting.html):
 
@@ -26,7 +26,7 @@ Changefeeds they connect to a long-lived request (i.e., a rangefeed), which push
 > SET CLUSTER SETTING kv.rangefeed.enabled = true;
 ~~~
 
-Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being using in a changefeed.
+Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being used in a changefeed.
 
 The `kv.closed_timestamp.target_duration` [cluster setting](cluster-settings.html) can be used with changefeeds. Resolved timestamps will always be behind by at least this setting's duration; however, decreasing the duration leads to more transaction restarts in your cluster, which can affect performance.
 

--- a/v20.1/stream-changefeed-to-snowflake-aws.md
+++ b/v20.1/stream-changefeed-to-snowflake-aws.md
@@ -44,7 +44,7 @@ If you have not done so already, [create a cluster](cockroachcloud-create-your-c
     If you haven't connected to your CockroachCloud cluster before, see [Connect to your CockroachCloud Cluster](cockroachcloud-connect-to-your-cluster.html) for information on how to initially connect.
     {{site.data.alerts.end}}
 
-2. Enable [rangefeeds](change-data-capture.html#enable-rangefeeds-to-reduce-latency):
+2. Enable [rangefeeds](change-data-capture.html#enable-rangefeeds):
 
     {% include copy-clipboard.html %}
     ~~~ sql

--- a/v20.2/change-data-capture.md
+++ b/v20.2/change-data-capture.md
@@ -17,7 +17,7 @@ The main feature of CDC is the changefeed, which targets an allowlist of tables,
 
 ## Enable rangefeeds
 
-Changefeeds they connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
+Changefeeds connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
 
 **Rangefeeds must be enabled for a changefeed to work.** To [enable the cluster setting](set-cluster-setting.html):
 
@@ -26,7 +26,7 @@ Changefeeds they connect to a long-lived request (i.e., a rangefeed), which push
 > SET CLUSTER SETTING kv.rangefeed.enabled = true;
 ~~~
 
-Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being using in a changefeed.
+Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being used in a changefeed.
 
 The `kv.closed_timestamp.target_duration` [cluster setting](cluster-settings.html) can be used with changefeeds. Resolved timestamps will always be behind by at least this setting's duration; however, decreasing the duration leads to more transaction restarts in your cluster, which can affect performance.
 

--- a/v20.2/change-data-capture.md
+++ b/v20.2/change-data-capture.md
@@ -134,19 +134,22 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 [3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
 ~~~
 
-## Enable rangefeeds to reduce latency
+## Create a changefeed (Core)
 
-Previously created changefeeds collect changes by periodically sending a request for any recent changes. Newly created changefeeds now behave differently: they connect to a long-lived request (i.e., a rangefeed), which pushes changes as they happen. This reduces the latency of row changes, as well as reduces transaction restarts on tables being watched by a changefeed for some workloads.
+A core changefeed streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
 
-To enable rangefeeds, set the `kv.rangefeed.enabled` [cluster setting](cluster-settings.html) to `true`. Any created changefeed will error until this setting is enabled. Note that enabling rangefeeds currently has a small performance cost (about a 5-10% increase in latencies), whether or not the rangefeed is being using in a changefeed.
+To create a core changefeed:
 
-If you are experiencing an issue, you can revert back to the previous behavior by setting `changefeed.push.enabled` to `false`. Note that this setting will be removed in a future release; if you have to use the fallback, please [file a Github issue](file-an-issue.html).
+{% include copy-clipboard.html %}
+~~~ sql
+> EXPERIMENTAL CHANGEFEED FOR name;
+~~~
 
-{{site.data.alerts.callout_info}}
-To enable rangefeeds for an existing changefeed, you must also restart the changefeed. For an enterprise changefeed, [pause](#pause) and [resume](#resume) the changefeed. For a core changefeed, cut the connection (**CTRL+C**) and reconnect using the `cursor` option.
-{{site.data.alerts.end}}
+For more information, see [`CHANGEFEED FOR`](changefeed-for.html).
 
-The `kv.closed_timestamp.target_duration` [cluster setting](cluster-settings.html) can be used with push changefeeds. Resolved timestamps will always be behind by at least this setting's duration; however, decreasing the duration leads to more transaction restarts in your cluster, which can affect performance.
+## Configure a changefeed (Enterprise)
+
+An enterprise changefeed streams row-level changes in a configurable format to a configurable sink (i.e., Kafka or a cloud storage sink). You can [create](#create), [pause](#pause), [resume](#resume), [cancel](#cancel), [monitor](#monitor-a-changefeed), and [debug](#debug-a-changefeed) an enterprise changefeed.
 
 ### Create
 


### PR DESCRIPTION
Updated Enable Rangefeeds section:
- Removed outdated info about changefeeds that collect changes by 
periodically sending a request for any recent changes. Rangefeeds have 
been the only type of changefeed available since at least v19.2 
- Moved the Enable Rangefeeds section to be higher on the page since 
it's required for changefeeds to work

Closes #8003