### PR TITLE
Update logic in retry pseudocode to match real code

### DIFF
--- a/_includes/v19.2/misc/client-side-intervention-example.md
+++ b/_includes/v19.2/misc/client-side-intervention-example.md
@@ -13,6 +13,7 @@ while true:
     try:
         # add logic here to run all your statements
         conn.exec('COMMIT')
+        break
     catch error:
         if error.code != "40001":
             throw error

--- a/_includes/v20.1/misc/client-side-intervention-example.md
+++ b/_includes/v20.1/misc/client-side-intervention-example.md
@@ -13,6 +13,7 @@ while true:
     try:
         # add logic here to run all your statements
         conn.exec('COMMIT')
+        break
     catch error:
         if error.code != "40001":
             throw error

--- a/_includes/v20.2/misc/client-side-intervention-example.md
+++ b/_includes/v20.2/misc/client-side-intervention-example.md
@@ -13,6 +13,7 @@ while true:
     try:
         # add logic here to run all your statements
         conn.exec('COMMIT')
+        break
     catch error:
         if error.code != "40001":
             throw error


### PR DESCRIPTION
Fixes #8211.

Summary of changes:

- Added a `break` statement to the pseudocode based on reader feedback
  that the `while` loop in question would never exit.  Turned out they
  were right; after reviewing our actual Python code, we had a `break`
  tucked in there after the db `COMMIT`.