### PR TITLE
Updating stmt_block diagram for v20.2-alpha.3

### DIFF
--- a/_includes/v20.2/sql/diagrams/create_table.html
+++ b/_includes/v20.2/sql/diagrams/create_table.html
@@ -1,71 +1,58 @@
-<div><svg width="756" height="326">
+<div><svg width="719" height="437">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
-<rect x="31" y="3" width="70" height="32" rx="10"></rect>
-<rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="39" y="21">CREATE</text>
-<a xlink:href="sql-grammar.html#opt_temp_create_table" xlink:title="opt_temp_create_table">
-<rect x="121" y="3" width="168" height="32"></rect>
-<rect x="119" y="1" width="168" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="129" y="21">opt_temp_create_table</text>
-</a>
-<rect x="309" y="3" width="62" height="32" rx="10"></rect>
-<rect x="307" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="317" y="21">TABLE</text>
-<rect x="411" y="35" width="34" height="32" rx="10"></rect>
-<rect x="409" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="419" y="53">IF</text>
-<rect x="465" y="35" width="48" height="32" rx="10"></rect>
-<rect x="463" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="473" y="53">NOT</text>
-<rect x="533" y="35" width="68" height="32" rx="10"></rect>
-<rect x="531" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="541" y="53">EXISTS</text>
-<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="641" y="3" width="94" height="32"></rect>
-<rect x="639" y="1" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="649" y="21">table_name</text>
-</a>
-<rect x="119" y="145" width="26" height="32" rx="10"></rect>
-<rect x="117" y="143" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="127" y="163">(</text>
-<a xlink:href="sql-grammar.html#column_def" xlink:title="column_def">
-<rect x="225" y="145" width="92" height="32"></rect>
-<rect x="223" y="143" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="233" y="163">column_def</text>
-</a>
-<a xlink:href="sql-grammar.html#index_def" xlink:title="index_def">
-<rect x="225" y="189" width="82" height="32"></rect>
-<rect x="223" y="187" width="82" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="233" y="207">index_def</text>
-</a>
-<a xlink:href="sql-grammar.html#family_def" xlink:title="family_def">
-<rect x="225" y="233" width="84" height="32"></rect>
-<rect x="223" y="231" width="84" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="233" y="251">family_def</text>
-</a>
-<a xlink:href="sql-grammar.html#table_constraint" xlink:title="table_constraint">
-<rect x="225" y="277" width="122" height="32"></rect>
-<rect x="223" y="275" width="122" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="233" y="295">table_constraint</text>
-</a>
-<rect x="205" y="101" width="24" height="32" rx="10"></rect>
-<rect x="203" y="99" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="213" y="119">,</text>
-<rect x="427" y="145" width="26" height="32" rx="10"></rect>
-<rect x="425" y="143" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="435" y="163">)</text>
-<a xlink:href="sql-grammar.html#opt_interleave" xlink:title="opt_interleave">
-<rect x="473" y="145" width="112" height="32"></rect>
-<rect x="471" y="143" width="112" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="481" y="163">opt_interleave</text>
-</a>
-<a xlink:href="sql-grammar.html#opt_partition_by" xlink:title="opt_partition_by">
-<rect x="605" y="145" width="124" height="32"></rect>
-<rect x="603" y="143" width="124" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="613" y="163">opt_partition_by</text>
-</a>
-<path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m168 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-660 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m60 0 h10 m92 0 h10 m0 0 h30 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m82 0 h10 m0 0 h40 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m84 0 h10 m0 0 h38 m-152 -10 v20 m162 0 v-20 m-162 20 v24 m162 0 v-24 m-162 24 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-182 -132 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m182 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-182 0 h10 m24 0 h10 m0 0 h138 m-222 44 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v146 m242 0 v-146 m-242 146 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m0 0 h212 m20 -166 h10 m26 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
-<polygon points="747 159 755 155 755 163"></polygon>
-<polygon points="747 159 739 155 739 163"></polygon>
-</svg></div>
+<rect x="31" y="3" width="72" height="32" rx="10"></rect>
+<rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">CREATE</text><a xlink:href="sql-grammar.html#opt_persistence_temp_table" xlink:title="opt_persistence_temp_table">
+<rect x="123" y="3" width="204" height="32"></rect>
+<rect x="121" y="1" width="204" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="131" y="21">opt_persistence_temp_table</text></a><rect x="347" y="3" width="62" height="32" rx="10"></rect>
+<rect x="345" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="21">TABLE</text>
+<rect x="449" y="35" width="34" height="32" rx="10"></rect>
+<rect x="447" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="457" y="53">IF</text>
+<rect x="503" y="35" width="48" height="32" rx="10"></rect>
+<rect x="501" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="511" y="53">NOT</text>
+<rect x="571" y="35" width="70" height="32" rx="10"></rect>
+<rect x="569" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="579" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="25" y="145" width="96" height="32"></rect>
+<rect x="23" y="143" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="33" y="163">table_name</text></a><rect x="141" y="145" width="26" height="32" rx="10"></rect>
+<rect x="139" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="149" y="163">(</text><a xlink:href="sql-grammar.html#column_def" xlink:title="column_def">
+<rect x="247" y="145" width="92" height="32"></rect>
+<rect x="245" y="143" width="92" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="255" y="163">column_def</text></a><a xlink:href="sql-grammar.html#index_def" xlink:title="index_def">
+<rect x="247" y="189" width="82" height="32"></rect>
+<rect x="245" y="187" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="255" y="207">index_def</text></a><a xlink:href="sql-grammar.html#family_def" xlink:title="family_def">
+<rect x="247" y="233" width="86" height="32"></rect>
+<rect x="245" y="231" width="86" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="255" y="251">family_def</text></a><a xlink:href="sql-grammar.html#table_constraint" xlink:title="table_constraint">
+<rect x="247" y="277" width="124" height="32"></rect>
+<rect x="245" y="275" width="124" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="255" y="295">table_constraint</text></a><rect x="247" y="321" width="52" height="32" rx="10"></rect>
+<rect x="245" y="319" width="52" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="255" y="339">LIKE</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="319" y="321" width="96" height="32"></rect>
+<rect x="317" y="319" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="327" y="339">table_name</text></a><a xlink:href="sql-grammar.html#like_table_option_list" xlink:title="like_table_option_list">
+<rect x="435" y="321" width="156" height="32"></rect>
+<rect x="433" y="319" width="156" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="443" y="339">like_table_option_list</text></a><rect x="227" y="101" width="24" height="32" rx="10"></rect>
+<rect x="225" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="235" y="119">,</text>
+<rect x="671" y="145" width="26" height="32" rx="10"></rect>
+<rect x="669" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="679" y="163">)</text><a xlink:href="sql-grammar.html#opt_interleave" xlink:title="opt_interleave">
+<rect x="433" y="403" width="112" height="32"></rect>
+<rect x="431" y="401" width="112" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="441" y="421">opt_interleave</text></a><a xlink:href="sql-grammar.html#opt_partition_by" xlink:title="opt_partition_by">
+<rect x="565" y="403" width="126" height="32"></rect>
+<rect x="563" y="401" width="126" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="573" y="421">opt_partition_by</text></a><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m204 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-680 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m0 0 h10 m26 0 h10 m60 0 h10 m92 0 h10 m0 0 h252 m-384 0 h20 m364 0 h20 m-404 0 q10 0 10 10 m384 0 q0 -10 10 -10 m-394 10 v24 m384 0 v-24 m-384 24 q0 10 10 10 m364 0 q10 0 10 -10 m-374 10 h10 m82 0 h10 m0 0 h262 m-374 -10 v20 m384 0 v-20 m-384 20 v24 m384 0 v-24 m-384 24 q0 10 10 10 m364 0 q10 0 10 -10 m-374 10 h10 m86 0 h10 m0 0 h258 m-374 -10 v20 m384 0 v-20 m-384 20 v24 m384 0 v-24 m-384 24 q0 10 10 10 m364 0 q10 0 10 -10 m-374 10 h10 m124 0 h10 m0 0 h220 m-374 -10 v20 m384 0 v-20 m-384 20 v24 m384 0 v-24 m-384 24 q0 10 10 10 m364 0 q10 0 10 -10 m-374 10 h10 m52 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m156 0 h10 m-404 -176 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m404 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-404 0 h10 m24 0 h10 m0 0 h360 m-444 44 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v190 m464 0 v-190 m-464 190 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m0 0 h434 m20 -210 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-308 258 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m112 0 h10 m0 0 h10 m126 0 h10 m3 0 h-3"></path>
+<polygon points="709 417 717 413 717 421"></polygon>
+<polygon points="709 417 701 413 701 421"></polygon></svg></div>

--- a/_includes/v20.2/sql/diagrams/create_table_as.html
+++ b/_includes/v20.2/sql/diagrams/create_table_as.html
@@ -1,79 +1,55 @@
-<div><svg width="950" height="336">
+<div><svg width="959" height="403">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
-<rect x="31" y="3" width="70" height="32" rx="10"></rect>
-<rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="39" y="21">CREATE</text>
-<a xlink:href="sql-grammar.html#opt_temp_create_table" xlink:title="opt_temp_create_table">
-<rect x="121" y="3" width="168" height="32"></rect>
-<rect x="119" y="1" width="168" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="129" y="21">opt_temp_create_table</text>
-</a>
-<rect x="309" y="3" width="62" height="32" rx="10"></rect>
-<rect x="307" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="317" y="21">TABLE</text>
-<rect x="411" y="35" width="34" height="32" rx="10"></rect>
-<rect x="409" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="419" y="53">IF</text>
-<rect x="465" y="35" width="48" height="32" rx="10"></rect>
-<rect x="463" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="473" y="53">NOT</text>
-<rect x="533" y="35" width="68" height="32" rx="10"></rect>
-<rect x="531" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="541" y="53">EXISTS</text>
-<a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
-<rect x="641" y="3" width="94" height="32"></rect>
-<rect x="639" y="1" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="649" y="21">table_name</text>
-</a>
-<rect x="45" y="117" width="26" height="32" rx="10"></rect>
-<rect x="43" y="115" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="53" y="135">(</text>
-<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="91" y="117" width="106" height="32"></rect>
-<rect x="89" y="115" width="106" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="99" y="135">column_name</text>
-</a>
-<a xlink:href="sql-grammar.html#create_as_col_qual_list" xlink:title="create_as_col_qual_list">
-<rect x="217" y="117" width="168" height="32"></rect>
-<rect x="215" y="115" width="168" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="225" y="135">create_as_col_qual_list</text>
-</a>
-<rect x="445" y="117" width="24" height="32" rx="10"></rect>
-<rect x="443" y="115" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="453" y="135">,</text>
-<a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
-<rect x="509" y="117" width="106" height="32"></rect>
-<rect x="507" y="115" width="106" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="517" y="135">column_name</text>
-</a>
-<a xlink:href="sql-grammar.html#create_as_col_qual_list" xlink:title="create_as_col_qual_list">
-<rect x="635" y="117" width="168" height="32"></rect>
-<rect x="633" y="115" width="168" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="643" y="135">create_as_col_qual_list</text>
-</a>
-<a xlink:href="sql-grammar.html#family_def" xlink:title="family_def">
-<rect x="509" y="161" width="84" height="32"></rect>
-<rect x="507" y="159" width="84" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="517" y="179">family_def</text>
-</a>
-<a xlink:href="sql-grammar.html#create_as_constraint_def" xlink:title="create_as_constraint_def">
-<rect x="509" y="205" width="182" height="32"></rect>
-<rect x="507" y="203" width="182" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="517" y="223">create_as_constraint_def</text>
-</a>
-<rect x="883" y="117" width="26" height="32" rx="10"></rect>
-<rect x="881" y="115" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="891" y="135">)</text>
-<rect x="773" y="303" width="38" height="32" rx="10"></rect>
-<rect x="771" y="301" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="781" y="321">AS</text>
-<a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="831" y="303" width="92" height="32"></rect>
-<rect x="829" y="301" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="839" y="321">select_stmt</text>
-</a>
-<path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m168 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-754 114 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m168 0 h10 m40 0 h10 m24 0 h10 m20 0 h10 m106 0 h10 m0 0 h10 m168 0 h10 m-334 0 h20 m314 0 h20 m-354 0 q10 0 10 10 m334 0 q0 -10 10 -10 m-344 10 v24 m334 0 v-24 m-334 24 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m84 0 h10 m0 0 h210 m-324 -10 v20 m334 0 v-20 m-334 20 v24 m334 0 v-24 m-334 24 q0 10 10 10 m314 0 q10 0 10 -10 m-324 10 h10 m182 0 h10 m0 0 h112 m-398 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m398 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-398 0 h10 m0 0 h388 m-438 32 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v102 m458 0 v-102 m-458 102 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m0 0 h428 m20 -122 h10 m26 0 h10 m-904 0 h20 m884 0 h20 m-924 0 q10 0 10 10 m904 0 q0 -10 10 -10 m-914 10 v118 m904 0 v-118 m-904 118 q0 10 10 10 m884 0 q10 0 10 -10 m-894 10 h10 m0 0 h874 m22 -138 l2 0 m2 0 l2 0 m2 0 l2 0 m-200 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
-<polygon points="941 317 949 313 949 321"></polygon>
-<polygon points="941 317 933 313 933 321"></polygon>
-</svg></div>
+<rect x="31" y="3" width="72" height="32" rx="10"></rect>
+<rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">CREATE</text><a xlink:href="sql-grammar.html#opt_persistence_temp_table" xlink:title="opt_persistence_temp_table">
+<rect x="123" y="3" width="204" height="32"></rect>
+<rect x="121" y="1" width="204" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="131" y="21">opt_persistence_temp_table</text></a><rect x="347" y="3" width="62" height="32" rx="10"></rect>
+<rect x="345" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="355" y="21">TABLE</text>
+<rect x="449" y="35" width="34" height="32" rx="10"></rect>
+<rect x="447" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="457" y="53">IF</text>
+<rect x="503" y="35" width="48" height="32" rx="10"></rect>
+<rect x="501" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="511" y="53">NOT</text>
+<rect x="571" y="35" width="70" height="32" rx="10"></rect>
+<rect x="569" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="579" y="53">EXISTS</text><a xlink:href="sql-grammar.html#table_name" xlink:title="table_name">
+<rect x="433" y="101" width="96" height="32"></rect>
+<rect x="431" y="99" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="441" y="119">table_name</text></a><rect x="45" y="183" width="26" height="32" rx="10"></rect>
+<rect x="43" y="181" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="53" y="201">(</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="91" y="183" width="108" height="32"></rect>
+<rect x="89" y="181" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="99" y="201">column_name</text></a><a xlink:href="sql-grammar.html#create_as_col_qual_list" xlink:title="create_as_col_qual_list">
+<rect x="219" y="183" width="170" height="32"></rect>
+<rect x="217" y="181" width="170" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="227" y="201">create_as_col_qual_list</text></a><rect x="449" y="183" width="24" height="32" rx="10"></rect>
+<rect x="447" y="181" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="457" y="201">,</text><a xlink:href="sql-grammar.html#column_name" xlink:title="column_name">
+<rect x="513" y="183" width="108" height="32"></rect>
+<rect x="511" y="181" width="108" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="521" y="201">column_name</text></a><a xlink:href="sql-grammar.html#create_as_col_qual_list" xlink:title="create_as_col_qual_list">
+<rect x="641" y="183" width="170" height="32"></rect>
+<rect x="639" y="181" width="170" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="649" y="201">create_as_col_qual_list</text></a><a xlink:href="sql-grammar.html#family_def" xlink:title="family_def">
+<rect x="513" y="227" width="86" height="32"></rect>
+<rect x="511" y="225" width="86" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="521" y="245">family_def</text></a><a xlink:href="sql-grammar.html#create_as_constraint_def" xlink:title="create_as_constraint_def">
+<rect x="513" y="271" width="182" height="32"></rect>
+<rect x="511" y="269" width="182" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="521" y="289">create_as_constraint_def</text></a><rect x="891" y="183" width="26" height="32" rx="10"></rect>
+<rect x="889" y="181" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="899" y="201">)</text>
+<rect x="779" y="369" width="38" height="32" rx="10"></rect>
+<rect x="777" y="367" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="787" y="387">AS</text><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="837" y="369" width="94" height="32"></rect>
+<rect x="835" y="367" width="94" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="845" y="387">select_stmt</text></a><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m204 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-272 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m96 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-548 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m170 0 h10 m40 0 h10 m24 0 h10 m20 0 h10 m108 0 h10 m0 0 h10 m170 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v24 m338 0 v-24 m-338 24 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m86 0 h10 m0 0 h212 m-328 -10 v20 m338 0 v-20 m-338 20 v24 m338 0 v-24 m-338 24 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m182 0 h10 m0 0 h116 m-402 -88 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m402 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-402 0 h10 m0 0 h392 m-442 32 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v102 m462 0 v-102 m-462 102 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m0 0 h432 m20 -122 h10 m26 0 h10 m-912 0 h20 m892 0 h20 m-932 0 q10 0 10 10 m912 0 q0 -10 10 -10 m-922 10 v118 m912 0 v-118 m-912 118 q0 10 10 10 m892 0 q10 0 10 -10 m-902 10 h10 m0 0 h882 m22 -138 l2 0 m2 0 l2 0 m2 0 l2 0 m-202 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m38 0 h10 m0 0 h10 m94 0 h10 m3 0 h-3"></path>
+<polygon points="949 383 957 379 957 387"></polygon>
+<polygon points="949 383 941 379 941 387"></polygon></svg></div>

--- a/_includes/v20.2/sql/diagrams/opt_persistence_temp_table.html
+++ b/_includes/v20.2/sql/diagrams/opt_persistence_temp_table.html
@@ -1,0 +1,22 @@
+<div><svg width="376" height="176">
+<polygon points="9 5 1 1 1 9"></polygon>
+<polygon points="17 5 9 1 9 9"></polygon>
+<rect x="71" y="55" width="64" height="32" rx="10"></rect>
+<rect x="69" y="53" width="64" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="79" y="73">LOCAL</text>
+<rect x="71" y="99" width="74" height="32" rx="10"></rect>
+<rect x="69" y="97" width="74" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="79" y="117">GLOBAL</text>
+<rect x="205" y="23" width="104" height="32" rx="10"></rect>
+<rect x="203" y="21" width="104" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="213" y="41">TEMPORARY</text>
+<rect x="205" y="67" width="56" height="32" rx="10"></rect>
+<rect x="203" y="65" width="56" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="213" y="85">TEMP</text>
+<rect x="51" y="143" width="96" height="32" rx="10"></rect>
+<rect x="49" y="141" width="96" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="59" y="161">UNLOGGED</text>
+<path class="line" d="m17 5 h2 m20 0 h10 m0 0 h288 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v12 m318 0 v-12 m-318 12 q0 10 10 10 m298 0 q10 0 10 -10 m-288 10 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m64 0 h10 m0 0 h10 m-104 -10 v20 m114 0 v-20 m-114 20 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -76 h10 m104 0 h10 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m56 0 h10 m0 0 h48 m-288 -54 v20 m318 0 v-20 m-318 20 v100 m318 0 v-100 m-318 100 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m96 0 h10 m0 0 h182 m23 -152 h-3"></path>
+<polygon points="367 5 375 1 375 9"></polygon>
+<polygon points="367 5 359 1 359 9"></polygon>
+</svg></div>

--- a/_includes/v20.2/sql/diagrams/stmt_block.html
+++ b/_includes/v20.2/sql/diagrams/stmt_block.html
@@ -16,7 +16,7 @@
          <polygon points="97 17 89 13 89 21"></polygon>
       </svg>
       <p>no references</p><br/><p style="font-size: 14px; font-weight:bold"><a name="stmt" href="#stmt">stmt:</a></p>
-      <svg width="274" height="716">
+      <svg width="274" height="760">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
@@ -83,22 +83,27 @@
             <rect x="49" y="549" width="102" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="569">release_stmt</text>
          </a>
+         <a xlink:href="#refresh_stmt" xlink:title="refresh_stmt">
+            <rect x="51" y="595" width="100" height="32"></rect>
+            <rect x="49" y="593" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="613">refresh_stmt</text>
+         </a>
          <a xlink:href="#nonpreparable_set_stmt" xlink:title="nonpreparable_set_stmt">
-            <rect x="51" y="595" width="176" height="32"></rect>
-            <rect x="49" y="593" width="176" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="613">nonpreparable_set_stmt</text>
+            <rect x="51" y="639" width="176" height="32"></rect>
+            <rect x="49" y="637" width="176" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="657">nonpreparable_set_stmt</text>
          </a>
          <a xlink:href="#transaction_stmt" xlink:title="transaction_stmt">
-            <rect x="51" y="639" width="126" height="32"></rect>
-            <rect x="49" y="637" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="657">transaction_stmt</text>
+            <rect x="51" y="683" width="126" height="32"></rect>
+            <rect x="49" y="681" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="701">transaction_stmt</text>
          </a>
          <a xlink:href="#close_cursor_stmt" xlink:title="close_cursor_stmt">
-            <rect x="51" y="683" width="134" height="32"></rect>
-            <rect x="49" y="681" width="134" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="701">close_cursor_stmt</text>
+            <rect x="51" y="727" width="134" height="32"></rect>
+            <rect x="49" y="725" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="745">close_cursor_stmt</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m124 0 h10 m0 0 h52 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m104 0 h10 m0 0 h72 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m112 0 h10 m0 0 h64 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m90 0 h10 m0 0 h86 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m98 0 h10 m0 0 h78 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m118 0 h10 m0 0 h58 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m102 0 h10 m0 0 h74 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m176 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m126 0 h10 m0 0 h50 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m134 0 h10 m0 0 h42 m23 -692 h-3"></path>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m124 0 h10 m0 0 h52 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m104 0 h10 m0 0 h72 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m112 0 h10 m0 0 h64 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m90 0 h10 m0 0 h86 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m98 0 h10 m0 0 h78 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m118 0 h10 m0 0 h58 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m102 0 h10 m0 0 h74 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m176 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m126 0 h10 m0 0 h50 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m134 0 h10 m0 0 h42 m23 -736 h-3"></path>
          <polygon points="265 5 273 1 273 9"></polygon>
          <polygon points="265 5 257 1 257 9"></polygon>
       </svg>
@@ -252,7 +257,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="copy_from_stmt" href="#copy_from_stmt">copy_from_stmt:</a></p>
-      <svg width="678" height="36">
+      <svg width="716" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -275,14 +280,14 @@
          <rect x="439" y="3" width="62" height="32" rx="10"></rect>
          <rect x="437" y="1" width="62" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="447" y="21">STDIN</text>
-         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
-            <rect x="521" y="3" width="130" height="32"></rect>
-            <rect x="519" y="1" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="529" y="21">opt_with_options</text>
+         <a xlink:href="#opt_with_copy_options" xlink:title="opt_with_copy_options">
+            <rect x="521" y="3" width="168" height="32"></rect>
+            <rect x="519" y="1" width="168" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="529" y="21">opt_with_copy_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m130 0 h10 m3 0 h-3"></path>
-         <polygon points="669 17 677 13 677 21"></polygon>
-         <polygon points="669 17 661 13 661 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m168 0 h10 m3 0 h-3"></path>
+         <polygon points="707 17 715 13 715 21"></polygon>
+         <polygon points="707 17 699 13 699 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -420,59 +425,75 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="grant_stmt" href="#grant_stmt">grant_stmt:</a></p>
-      <svg width="738" height="112">
+      <svg width="682" height="266">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="66" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">GRANT</text>
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">GRANT</text>
          <a xlink:href="#privileges" xlink:title="privileges">
-            <rect x="137" y="3" width="80" height="32"></rect>
-            <rect x="135" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="145" y="21">privileges</text>
+            <rect x="45" y="69" width="80" height="32"></rect>
+            <rect x="43" y="67" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="87">privileges</text>
          </a>
-         <rect x="237" y="3" width="40" height="32" rx="10"></rect>
-         <rect x="235" y="1" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="245" y="21">ON</text>
+         <rect x="145" y="69" width="40" height="32" rx="10"></rect>
+         <rect x="143" y="67" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="87">ON</text>
          <a xlink:href="#targets" xlink:title="targets">
-            <rect x="297" y="3" width="66" height="32"></rect>
-            <rect x="295" y="1" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="305" y="21">targets</text>
+            <rect x="225" y="69" width="66" height="32"></rect>
+            <rect x="223" y="67" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="87">targets</text>
          </a>
-         <rect x="383" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="381" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="391" y="21">TO</text>
+         <rect x="225" y="113" width="54" height="32" rx="10"></rect>
+         <rect x="223" y="111" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="131">TYPE</text>
+         <a xlink:href="#target_types" xlink:title="target_types">
+            <rect x="299" y="113" width="102" height="32"></rect>
+            <rect x="297" y="111" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="131">target_types</text>
+         </a>
+         <rect x="225" y="157" width="76" height="32" rx="10"></rect>
+         <rect x="223" y="155" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="175">SCHEMA</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="321" y="157" width="136" height="32"></rect>
+            <rect x="319" y="155" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="329" y="175">schema_name_list</text>
+         </a>
+         <rect x="497" y="69" width="38" height="32" rx="10"></rect>
+         <rect x="495" y="67" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="505" y="87">TO</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="441" y="3" width="80" height="32"></rect>
-            <rect x="439" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="449" y="21">name_list</text>
+            <rect x="555" y="69" width="80" height="32"></rect>
+            <rect x="553" y="67" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="563" y="87">name_list</text>
          </a>
          <a xlink:href="#privilege_list" xlink:title="privilege_list">
-            <rect x="137" y="47" width="98" height="32"></rect>
-            <rect x="135" y="45" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="145" y="65">privilege_list</text>
+            <rect x="45" y="201" width="98" height="32"></rect>
+            <rect x="43" y="199" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="219">privilege_list</text>
          </a>
-         <rect x="255" y="47" width="38" height="32" rx="10"></rect>
-         <rect x="253" y="45" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="263" y="65">TO</text>
+         <rect x="163" y="201" width="38" height="32" rx="10"></rect>
+         <rect x="161" y="199" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="171" y="219">TO</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="313" y="47" width="80" height="32"></rect>
-            <rect x="311" y="45" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="321" y="65">name_list</text>
+            <rect x="221" y="201" width="80" height="32"></rect>
+            <rect x="219" y="199" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="229" y="219">name_list</text>
          </a>
-         <rect x="433" y="79" width="58" height="32" rx="10"></rect>
-         <rect x="431" y="77" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="441" y="97">WITH</text>
-         <rect x="511" y="79" width="66" height="32" rx="10"></rect>
-         <rect x="509" y="77" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="97">ADMIN</text>
-         <rect x="597" y="79" width="74" height="32" rx="10"></rect>
-         <rect x="595" y="77" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="605" y="97">OPTION</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h170 m-594 0 h20 m574 0 h20 m-614 0 q10 0 10 10 m594 0 q0 -10 10 -10 m-604 10 v24 m594 0 v-24 m-594 24 q0 10 10 10 m574 0 q10 0 10 -10 m-584 10 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m74 0 h10 m43 -76 h-3"></path>
-         <polygon points="729 17 737 13 737 21"></polygon>
-         <polygon points="729 17 721 13 721 21"></polygon>
+         <rect x="341" y="233" width="58" height="32" rx="10"></rect>
+         <rect x="339" y="231" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="349" y="251">WITH</text>
+         <rect x="419" y="233" width="66" height="32" rx="10"></rect>
+         <rect x="417" y="231" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="427" y="251">ADMIN</text>
+         <rect x="505" y="233" width="74" height="32" rx="10"></rect>
+         <rect x="503" y="231" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="513" y="251">OPTION</text>
+         <path class="line" d="m19 17 h2 m0 0 h10 m66 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-118 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m66 0 h10 m0 0 h166 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m54 0 h10 m0 0 h10 m102 0 h10 m0 0 h56 m-262 -10 v20 m272 0 v-20 m-272 20 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m76 0 h10 m0 0 h10 m136 0 h10 m20 -88 h10 m38 0 h10 m0 0 h10 m80 0 h10 m-630 0 h20 m610 0 h20 m-650 0 q10 0 10 10 m630 0 q0 -10 10 -10 m-640 10 v112 m630 0 v-112 m-630 112 q0 10 10 10 m610 0 q10 0 10 -10 m-620 10 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m74 0 h10 m20 -32 h36 m23 -132 h-3"></path>
+         <polygon points="673 83 681 79 681 87"></polygon>
+         <polygon points="673 83 665 79 665 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -513,7 +534,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="revoke_stmt" href="#revoke_stmt">revoke_stmt:</a></p>
-      <svg width="650" height="178">
+      <svg width="696" height="266">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -529,35 +550,51 @@
          <rect x="243" y="1" width="40" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="253" y="21">ON</text>
          <a xlink:href="#targets" xlink:title="targets">
-            <rect x="305" y="3" width="66" height="32"></rect>
-            <rect x="303" y="1" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="313" y="21">targets</text>
+            <rect x="325" y="3" width="66" height="32"></rect>
+            <rect x="323" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="333" y="21">targets</text>
          </a>
-         <rect x="165" y="79" width="66" height="32" rx="10"></rect>
-         <rect x="163" y="77" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="173" y="97">ADMIN</text>
-         <rect x="251" y="79" width="74" height="32" rx="10"></rect>
-         <rect x="249" y="77" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="259" y="97">OPTION</text>
-         <rect x="345" y="79" width="48" height="32" rx="10"></rect>
-         <rect x="343" y="77" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="353" y="97">FOR</text>
+         <rect x="325" y="47" width="54" height="32" rx="10"></rect>
+         <rect x="323" y="45" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="65">TYPE</text>
+         <a xlink:href="#target_types" xlink:title="target_types">
+            <rect x="399" y="47" width="102" height="32"></rect>
+            <rect x="397" y="45" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="407" y="65">target_types</text>
+         </a>
+         <rect x="325" y="91" width="76" height="32" rx="10"></rect>
+         <rect x="323" y="89" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="333" y="109">SCHEMA</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="421" y="91" width="136" height="32"></rect>
+            <rect x="419" y="89" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="429" y="109">schema_name_list</text>
+         </a>
+         <rect x="165" y="167" width="66" height="32" rx="10"></rect>
+         <rect x="163" y="165" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="173" y="185">ADMIN</text>
+         <rect x="251" y="167" width="74" height="32" rx="10"></rect>
+         <rect x="249" y="165" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="185">OPTION</text>
+         <rect x="345" y="167" width="48" height="32" rx="10"></rect>
+         <rect x="343" y="165" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="353" y="185">FOR</text>
          <a xlink:href="#privilege_list" xlink:title="privilege_list">
-            <rect x="433" y="47" width="98" height="32"></rect>
-            <rect x="431" y="45" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="441" y="65">privilege_list</text>
+            <rect x="433" y="135" width="98" height="32"></rect>
+            <rect x="431" y="133" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="441" y="153">privilege_list</text>
          </a>
-         <rect x="571" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="569" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="579" y="21">FROM</text>
+         <rect x="617" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="615" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="625" y="21">FROM</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="543" y="145" width="80" height="32"></rect>
-            <rect x="541" y="143" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="551" y="163">name_list</text>
+            <rect x="589" y="233" width="80" height="32"></rect>
+            <rect x="587" y="231" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="597" y="251">name_list</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m66 0 h10 m0 0 h160 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v24 m426 0 v-24 m-426 24 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m66 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m48 0 h10 m20 -32 h10 m98 0 h10 m20 -44 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-130 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m3 0 h-3"></path>
-         <polygon points="641 159 649 155 649 163"></polygon>
-         <polygon points="641 159 633 155 633 163"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m66 0 h10 m0 0 h166 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m54 0 h10 m0 0 h10 m102 0 h10 m0 0 h56 m-262 -10 v20 m272 0 v-20 m-272 20 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m76 0 h10 m0 0 h10 m136 0 h10 m-452 -88 h20 m452 0 h20 m-492 0 q10 0 10 10 m472 0 q0 -10 10 -10 m-482 10 v112 m472 0 v-112 m-472 112 q0 10 10 10 m452 0 q10 0 10 -10 m-442 10 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m66 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m48 0 h10 m20 -32 h10 m98 0 h10 m0 0 h46 m20 -132 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-130 230 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="687 247 695 243 695 251"></polygon>
+         <polygon points="687 247 679 243 679 251"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -600,6 +637,43 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m78 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
          <polygon points="271 17 279 13 279 21"></polygon>
          <polygon points="271 17 263 13 263 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#stmt" title="stmt">stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="refresh_stmt" href="#refresh_stmt">refresh_stmt:</a></p>
+      <svg width="748" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">REFRESH</text>
+         <rect x="131" y="3" width="120" height="32" rx="10"></rect>
+         <rect x="129" y="1" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="139" y="21">MATERIALIZED</text>
+         <rect x="271" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="269" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="279" y="21">VIEW</text>
+         <a xlink:href="#opt_concurrently" xlink:title="opt_concurrently">
+            <rect x="347" y="3" width="126" height="32"></rect>
+            <rect x="345" y="1" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="355" y="21">opt_concurrently</text>
+         </a>
+         <a xlink:href="#view_name" xlink:title="view_name">
+            <rect x="493" y="3" width="92" height="32"></rect>
+            <rect x="491" y="1" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="501" y="21">view_name</text>
+         </a>
+         <a xlink:href="#opt_clear_data" xlink:title="opt_clear_data">
+            <rect x="605" y="3" width="116" height="32"></rect>
+            <rect x="603" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="613" y="21">opt_clear_data</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m80 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m116 0 h10 m3 0 h-3"></path>
+         <polygon points="739 17 747 13 747 21"></polygon>
+         <polygon points="739 17 731 13 731 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -699,7 +773,7 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="backup_stmt" href="#backup_stmt">backup_stmt:</a></p>
-      <svg width="710" height="244">
+      <svg width="842" height="288">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -714,48 +788,53 @@
          <rect x="45" y="69" width="54" height="32" rx="10"></rect>
          <rect x="43" y="67" width="54" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="53" y="87">INTO</text>
-         <rect x="139" y="101" width="70" height="32" rx="10"></rect>
-         <rect x="137" y="99" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="119">LATEST</text>
-         <rect x="229" y="101" width="36" height="32" rx="10"></rect>
-         <rect x="227" y="99" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="237" y="119">IN</text>
+         <a xlink:href="#sconst_or_placeholder" xlink:title="sconst_or_placeholder">
+            <rect x="159" y="101" width="162" height="32"></rect>
+            <rect x="157" y="99" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="119">sconst_or_placeholder</text>
+         </a>
+         <rect x="159" y="145" width="70" height="32" rx="10"></rect>
+         <rect x="157" y="143" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="163">LATEST</text>
+         <rect x="361" y="101" width="36" height="32" rx="10"></rect>
+         <rect x="359" y="99" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="369" y="119">IN</text>
          <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
-            <rect x="305" y="69" width="212" height="32"></rect>
-            <rect x="303" y="67" width="212" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="313" y="87">string_or_placeholder_opt_list</text>
+            <rect x="437" y="69" width="212" height="32"></rect>
+            <rect x="435" y="67" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="445" y="87">string_or_placeholder_opt_list</text>
          </a>
          <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
-            <rect x="537" y="69" width="132" height="32"></rect>
-            <rect x="535" y="67" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="545" y="87">opt_as_of_clause</text>
+            <rect x="669" y="69" width="132" height="32"></rect>
+            <rect x="667" y="67" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="677" y="87">opt_as_of_clause</text>
          </a>
-         <rect x="45" y="145" width="38" height="32" rx="10"></rect>
-         <rect x="43" y="143" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="163">TO</text>
+         <rect x="45" y="189" width="38" height="32" rx="10"></rect>
+         <rect x="43" y="187" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="207">TO</text>
          <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
-            <rect x="103" y="145" width="212" height="32"></rect>
-            <rect x="101" y="143" width="212" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="111" y="163">string_or_placeholder_opt_list</text>
+            <rect x="103" y="189" width="212" height="32"></rect>
+            <rect x="101" y="187" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="111" y="207">string_or_placeholder_opt_list</text>
          </a>
          <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
-            <rect x="335" y="145" width="132" height="32"></rect>
-            <rect x="333" y="143" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="343" y="163">opt_as_of_clause</text>
+            <rect x="335" y="189" width="132" height="32"></rect>
+            <rect x="333" y="187" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="343" y="207">opt_as_of_clause</text>
          </a>
          <a xlink:href="#opt_incremental" xlink:title="opt_incremental">
-            <rect x="487" y="145" width="122" height="32"></rect>
-            <rect x="485" y="143" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="495" y="163">opt_incremental</text>
+            <rect x="487" y="189" width="122" height="32"></rect>
+            <rect x="485" y="187" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="495" y="207">opt_incremental</text>
          </a>
          <a xlink:href="#opt_with_backup_options" xlink:title="opt_with_backup_options">
-            <rect x="499" y="211" width="184" height="32"></rect>
-            <rect x="497" y="209" width="184" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="507" y="229">opt_with_backup_options</text>
+            <rect x="631" y="255" width="184" height="32"></rect>
+            <rect x="629" y="253" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="639" y="273">opt_with_backup_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m54 0 h10 m20 0 h10 m0 0 h136 m-166 0 h20 m146 0 h20 m-186 0 q10 0 10 10 m166 0 q0 -10 10 -10 m-176 10 v12 m166 0 v-12 m-166 12 q0 10 10 10 m146 0 q10 0 10 -10 m-156 10 h10 m70 0 h10 m0 0 h10 m36 0 h10 m20 -32 h10 m212 0 h10 m0 0 h10 m132 0 h10 m-664 0 h20 m644 0 h20 m-684 0 q10 0 10 10 m664 0 q0 -10 10 -10 m-674 10 v56 m664 0 v-56 m-664 56 q0 10 10 10 m644 0 q10 0 10 -10 m-654 10 h10 m38 0 h10 m0 0 h10 m212 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m122 0 h10 m0 0 h60 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-234 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m184 0 h10 m3 0 h-3"></path>
-         <polygon points="701 225 709 221 709 229"></polygon>
-         <polygon points="701 225 693 221 693 229"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m54 0 h10 m20 0 h10 m0 0 h268 m-298 0 h20 m278 0 h20 m-318 0 q10 0 10 10 m298 0 q0 -10 10 -10 m-308 10 v12 m298 0 v-12 m-298 12 q0 10 10 10 m278 0 q10 0 10 -10 m-268 10 h10 m162 0 h10 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m20 -44 h10 m36 0 h10 m20 -32 h10 m212 0 h10 m0 0 h10 m132 0 h10 m-796 0 h20 m776 0 h20 m-816 0 q10 0 10 10 m796 0 q0 -10 10 -10 m-806 10 v100 m796 0 v-100 m-796 100 q0 10 10 10 m776 0 q10 0 10 -10 m-786 10 h10 m38 0 h10 m0 0 h10 m212 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m122 0 h10 m0 0 h192 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-234 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m184 0 h10 m3 0 h-3"></path>
+         <polygon points="833 269 841 265 841 273"></polygon>
+         <polygon points="833 269 825 265 825 273"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1162,32 +1241,32 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="restore_stmt" href="#restore_stmt">restore_stmt:</a></p>
-      <svg width="612" height="178">
+      <svg width="666" height="178">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="82" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">RESTORE</text>
-         <rect x="153" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="151" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="21">FROM</text>
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="82" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">RESTORE</text>
+         <rect x="155" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="153" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="163" y="21">FROM</text>
          <a xlink:href="#targets" xlink:title="targets">
-            <rect x="153" y="47" width="66" height="32"></rect>
-            <rect x="151" y="45" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="161" y="65">targets</text>
+            <rect x="155" y="47" width="66" height="32"></rect>
+            <rect x="153" y="45" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="163" y="65">targets</text>
          </a>
-         <rect x="239" y="47" width="58" height="32" rx="10"></rect>
-         <rect x="237" y="45" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="247" y="65">FROM</text>
+         <rect x="241" y="47" width="58" height="32" rx="10"></rect>
+         <rect x="239" y="45" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="249" y="65">FROM</text>
          <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="337" y="79" width="158" height="32"></rect>
-            <rect x="335" y="77" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="345" y="97">string_or_placeholder</text>
+            <rect x="339" y="79" width="158" height="32"></rect>
+            <rect x="337" y="77" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="347" y="97">string_or_placeholder</text>
          </a>
-         <rect x="515" y="79" width="36" height="32" rx="10"></rect>
-         <rect x="513" y="77" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="523" y="97">IN</text>
+         <rect x="517" y="79" width="36" height="32" rx="10"></rect>
+         <rect x="515" y="77" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="525" y="97">IN</text>
          <a xlink:href="#list_of_string_or_placeholder_opt_list" xlink:title="list_of_string_or_placeholder_opt_list">
             <rect x="25" y="145" width="258" height="32"></rect>
             <rect x="23" y="143" width="258" height="32" class="nonterminal"></rect>
@@ -1198,14 +1277,14 @@
             <rect x="301" y="143" width="132" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="311" y="163">opt_as_of_clause</text>
          </a>
-         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
-            <rect x="455" y="145" width="130" height="32"></rect>
-            <rect x="453" y="143" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="463" y="163">opt_with_options</text>
+         <a xlink:href="#opt_with_restore_options" xlink:title="opt_with_restore_options">
+            <rect x="455" y="145" width="184" height="32"></rect>
+            <rect x="453" y="143" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="463" y="163">opt_with_restore_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h360 m-458 0 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m66 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-610 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m258 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m130 0 h10 m3 0 h-3"></path>
-         <polygon points="603 159 611 155 611 163"></polygon>
-         <polygon points="603 159 595 155 595 163"></polygon>
+         <path class="line" d="m19 17 h2 m0 0 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h360 m-458 0 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m66 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-612 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m258 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m184 0 h10 m3 0 h-3"></path>
+         <polygon points="657 159 665 155 665 163"></polygon>
+         <polygon points="657 159 649 155 649 163"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1370,7 +1449,7 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stmt" href="#show_stmt">show_stmt:</a></p>
-      <svg width="290" height="1136">
+      <svg width="290" height="1224">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1409,102 +1488,112 @@
             <rect x="49" y="265" width="140" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="285">show_enums_stmt</text>
          </a>
+         <a xlink:href="#show_types_stmt" xlink:title="show_types_stmt">
+            <rect x="51" y="311" width="132" height="32"></rect>
+            <rect x="49" y="309" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">show_types_stmt</text>
+         </a>
          <a xlink:href="#show_grants_stmt" xlink:title="show_grants_stmt">
-            <rect x="51" y="311" width="138" height="32"></rect>
-            <rect x="49" y="309" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="329">show_grants_stmt</text>
+            <rect x="51" y="355" width="138" height="32"></rect>
+            <rect x="49" y="353" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">show_grants_stmt</text>
          </a>
          <a xlink:href="#show_indexes_stmt" xlink:title="show_indexes_stmt">
-            <rect x="51" y="355" width="146" height="32"></rect>
-            <rect x="49" y="353" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="373">show_indexes_stmt</text>
+            <rect x="51" y="399" width="146" height="32"></rect>
+            <rect x="49" y="397" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="417">show_indexes_stmt</text>
          </a>
          <a xlink:href="#show_partitions_stmt" xlink:title="show_partitions_stmt">
-            <rect x="51" y="399" width="158" height="32"></rect>
-            <rect x="49" y="397" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="417">show_partitions_stmt</text>
+            <rect x="51" y="443" width="158" height="32"></rect>
+            <rect x="49" y="441" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="461">show_partitions_stmt</text>
          </a>
          <a xlink:href="#show_jobs_stmt" xlink:title="show_jobs_stmt">
-            <rect x="51" y="443" width="124" height="32"></rect>
-            <rect x="49" y="441" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="461">show_jobs_stmt</text>
+            <rect x="51" y="487" width="124" height="32"></rect>
+            <rect x="49" y="485" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="505">show_jobs_stmt</text>
          </a>
          <a xlink:href="#show_schedules_stmt" xlink:title="show_schedules_stmt">
-            <rect x="51" y="487" width="160" height="32"></rect>
-            <rect x="49" y="485" width="160" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="505">show_schedules_stmt</text>
+            <rect x="51" y="531" width="160" height="32"></rect>
+            <rect x="49" y="529" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="549">show_schedules_stmt</text>
          </a>
          <a xlink:href="#show_queries_stmt" xlink:title="show_queries_stmt">
-            <rect x="51" y="531" width="144" height="32"></rect>
-            <rect x="49" y="529" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="549">show_queries_stmt</text>
+            <rect x="51" y="575" width="144" height="32"></rect>
+            <rect x="49" y="573" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="593">show_queries_stmt</text>
          </a>
          <a xlink:href="#show_ranges_stmt" xlink:title="show_ranges_stmt">
-            <rect x="51" y="575" width="142" height="32"></rect>
-            <rect x="49" y="573" width="142" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="593">show_ranges_stmt</text>
+            <rect x="51" y="619" width="142" height="32"></rect>
+            <rect x="49" y="617" width="142" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="637">show_ranges_stmt</text>
          </a>
          <a xlink:href="#show_range_for_row_stmt" xlink:title="show_range_for_row_stmt">
-            <rect x="51" y="619" width="192" height="32"></rect>
-            <rect x="49" y="617" width="192" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="637">show_range_for_row_stmt</text>
+            <rect x="51" y="663" width="192" height="32"></rect>
+            <rect x="49" y="661" width="192" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="681">show_range_for_row_stmt</text>
          </a>
          <a xlink:href="#show_roles_stmt" xlink:title="show_roles_stmt">
-            <rect x="51" y="663" width="128" height="32"></rect>
-            <rect x="49" y="661" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="681">show_roles_stmt</text>
+            <rect x="51" y="707" width="128" height="32"></rect>
+            <rect x="49" y="705" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="725">show_roles_stmt</text>
          </a>
          <a xlink:href="#show_savepoint_stmt" xlink:title="show_savepoint_stmt">
-            <rect x="51" y="707" width="160" height="32"></rect>
-            <rect x="49" y="705" width="160" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="725">show_savepoint_stmt</text>
+            <rect x="51" y="751" width="160" height="32"></rect>
+            <rect x="49" y="749" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="769">show_savepoint_stmt</text>
          </a>
          <a xlink:href="#show_schemas_stmt" xlink:title="show_schemas_stmt">
-            <rect x="51" y="751" width="152" height="32"></rect>
-            <rect x="49" y="749" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="769">show_schemas_stmt</text>
+            <rect x="51" y="795" width="152" height="32"></rect>
+            <rect x="49" y="793" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="813">show_schemas_stmt</text>
          </a>
          <a xlink:href="#show_sequences_stmt" xlink:title="show_sequences_stmt">
-            <rect x="51" y="795" width="166" height="32"></rect>
-            <rect x="49" y="793" width="166" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="813">show_sequences_stmt</text>
+            <rect x="51" y="839" width="166" height="32"></rect>
+            <rect x="49" y="837" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="857">show_sequences_stmt</text>
          </a>
          <a xlink:href="#show_session_stmt" xlink:title="show_session_stmt">
-            <rect x="51" y="839" width="146" height="32"></rect>
-            <rect x="49" y="837" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="857">show_session_stmt</text>
+            <rect x="51" y="883" width="146" height="32"></rect>
+            <rect x="49" y="881" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="901">show_session_stmt</text>
          </a>
          <a xlink:href="#show_sessions_stmt" xlink:title="show_sessions_stmt">
-            <rect x="51" y="883" width="152" height="32"></rect>
-            <rect x="49" y="881" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="901">show_sessions_stmt</text>
+            <rect x="51" y="927" width="152" height="32"></rect>
+            <rect x="49" y="925" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="945">show_sessions_stmt</text>
          </a>
          <a xlink:href="#show_stats_stmt" xlink:title="show_stats_stmt">
-            <rect x="51" y="927" width="130" height="32"></rect>
-            <rect x="49" y="925" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="945">show_stats_stmt</text>
+            <rect x="51" y="971" width="130" height="32"></rect>
+            <rect x="49" y="969" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="989">show_stats_stmt</text>
          </a>
          <a xlink:href="#show_tables_stmt" xlink:title="show_tables_stmt">
-            <rect x="51" y="971" width="136" height="32"></rect>
-            <rect x="49" y="969" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="989">show_tables_stmt</text>
+            <rect x="51" y="1015" width="136" height="32"></rect>
+            <rect x="49" y="1013" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1033">show_tables_stmt</text>
          </a>
          <a xlink:href="#show_trace_stmt" xlink:title="show_trace_stmt">
-            <rect x="51" y="1015" width="130" height="32"></rect>
-            <rect x="49" y="1013" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1033">show_trace_stmt</text>
+            <rect x="51" y="1059" width="130" height="32"></rect>
+            <rect x="49" y="1057" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1077">show_trace_stmt</text>
+         </a>
+         <a xlink:href="#show_transactions_stmt" xlink:title="show_transactions_stmt">
+            <rect x="51" y="1103" width="176" height="32"></rect>
+            <rect x="49" y="1101" width="176" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1121">show_transactions_stmt</text>
          </a>
          <a xlink:href="#show_users_stmt" xlink:title="show_users_stmt">
-            <rect x="51" y="1059" width="132" height="32"></rect>
-            <rect x="49" y="1057" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1077">show_users_stmt</text>
+            <rect x="51" y="1147" width="132" height="32"></rect>
+            <rect x="49" y="1145" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1165">show_users_stmt</text>
          </a>
          <a xlink:href="#show_zone_stmt" xlink:title="show_zone_stmt">
-            <rect x="51" y="1103" width="128" height="32"></rect>
-            <rect x="49" y="1101" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1121">show_zone_stmt</text>
+            <rect x="51" y="1191" width="128" height="32"></rect>
+            <rect x="49" y="1189" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1209">show_zone_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h50 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m148 0 h10 m0 0 h44 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m168 0 h10 m0 0 h24 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m154 0 h10 m0 0 h38 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m164 0 h10 m0 0 h28 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m140 0 h10 m0 0 h52 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m158 0 h10 m0 0 h34 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m124 0 h10 m0 0 h68 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m144 0 h10 m0 0 h48 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m142 0 h10 m0 0 h50 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m192 0 h10 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m166 0 h10 m0 0 h26 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m136 0 h10 m0 0 h56 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m23 -1100 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h50 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m148 0 h10 m0 0 h44 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m168 0 h10 m0 0 h24 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m154 0 h10 m0 0 h38 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m164 0 h10 m0 0 h28 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m140 0 h10 m0 0 h52 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m158 0 h10 m0 0 h34 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m124 0 h10 m0 0 h68 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m144 0 h10 m0 0 h48 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m142 0 h10 m0 0 h50 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m192 0 h10 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m166 0 h10 m0 0 h26 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m136 0 h10 m0 0 h56 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m176 0 h10 m0 0 h16 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m23 -1188 h-3"></path>
          <polygon points="281 17 289 13 289 21"></polygon>
          <polygon points="281 17 273 13 273 21"></polygon>
       </svg>
@@ -1743,45 +1832,28 @@
             <li><a href="#copy_from_stmt" title="copy_from_stmt">copy_from_stmt</a></li>
             <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_options" href="#opt_with_options">opt_with_options:</a></p>
-      <svg width="520" height="100">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_copy_options" href="#opt_with_copy_options">opt_with_copy_options:</a></p>
+      <svg width="324" height="56">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">WITH</text>
-         <a xlink:href="#kv_option_list" xlink:title="kv_option_list">
-            <rect x="149" y="23" width="108" height="32"></rect>
-            <rect x="147" y="21" width="108" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="157" y="41">kv_option_list</text>
+         <a xlink:href="#opt_with" xlink:title="opt_with">
+            <rect x="51" y="23" width="76" height="32"></rect>
+            <rect x="49" y="21" width="76" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">opt_with</text>
          </a>
-         <rect x="149" y="67" width="84" height="32" rx="10"></rect>
-         <rect x="147" y="65" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="157" y="85">OPTIONS</text>
-         <rect x="253" y="67" width="26" height="32" rx="10"></rect>
-         <rect x="251" y="65" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="261" y="85">(</text>
-         <a xlink:href="#kv_option_list" xlink:title="kv_option_list">
-            <rect x="299" y="67" width="108" height="32"></rect>
-            <rect x="297" y="65" width="108" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="307" y="85">kv_option_list</text>
+         <a xlink:href="#copy_options_list" xlink:title="copy_options_list">
+            <rect x="147" y="23" width="130" height="32"></rect>
+            <rect x="145" y="21" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="41">copy_options_list</text>
          </a>
-         <rect x="427" y="67" width="26" height="32" rx="10"></rect>
-         <rect x="425" y="65" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="435" y="85">)</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"></path>
-         <polygon points="511 5 519 1 519 9"></polygon>
-         <polygon points="511 5 503 1 503 9"></polygon>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h236 m-266 0 h20 m246 0 h20 m-286 0 q10 0 10 10 m266 0 q0 -10 10 -10 m-276 10 v12 m266 0 v-12 m-266 12 q0 10 10 10 m246 0 q10 0 10 -10 m-256 10 h10 m76 0 h10 m0 0 h10 m130 0 h10 m23 -32 h-3"></path>
+         <polygon points="315 5 323 1 323 9"></polygon>
+         <polygon points="315 5 307 1 307 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#copy_from_stmt" title="copy_from_stmt">copy_from_stmt</a></li>
-            <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
-            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
-            <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
-            <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
-            <li><a href="#show_backup_stmt" title="show_backup_stmt">show_backup_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="database_name" href="#database_name">database_name:</a></p>
       <svg width="112" height="36">
@@ -1799,6 +1871,8 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#alter_database_owner" title="alter_database_owner">alter_database_owner</a></li>
+            <li><a href="#alter_database_to_schema_stmt" title="alter_database_to_schema_stmt">alter_database_to_schema_stmt</a></li>
             <li><a href="#alter_rename_database_stmt" title="alter_rename_database_stmt">alter_rename_database_stmt</a></li>
             <li><a href="#alter_zone_database_stmt" title="alter_zone_database_stmt">alter_zone_database_stmt</a></li>
             <li><a href="#comment_stmt" title="comment_stmt">comment_stmt</a></li>
@@ -2107,8 +2181,8 @@
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
             <li><a href="#join_qual" title="join_qual">join_qual</a></li>
             <li><a href="#labeled_row" title="labeled_row">labeled_row</a></li>
+            <li><a href="#on_conflict" title="on_conflict">on_conflict</a></li>
             <li><a href="#opt_column_list" title="opt_column_list">opt_column_list</a></li>
-            <li><a href="#opt_conf_expr" title="opt_conf_expr">opt_conf_expr</a></li>
             <li><a href="#opt_interleave" title="opt_interleave">opt_interleave</a></li>
             <li><a href="#opt_stats_columns" title="opt_stats_columns">opt_stats_columns</a></li>
             <li><a href="#opt_storing" title="opt_storing">opt_storing</a></li>
@@ -2139,6 +2213,48 @@
          </p><ul>
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
             <li><a href="#privileges" title="privileges">privileges</a></li>
+            <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="target_types" href="#target_types">target_types:</a></p>
+      <svg width="174" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#type_name_list" xlink:title="type_name_list">
+            <rect x="31" y="3" width="116" height="32"></rect>
+            <rect x="29" y="1" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">type_name_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m116 0 h10 m3 0 h-3"></path>
+         <polygon points="165 17 173 13 173 21"></polygon>
+         <polygon points="165 17 157 13 157 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
+            <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name_list" href="#schema_name_list">schema_name_list:</a></p>
+      <svg width="208" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#schema_name" xlink:title="schema_name">
+            <rect x="51" y="47" width="110" height="32"></rect>
+            <rect x="49" y="45" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">schema_name</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m23 44 h-3"></path>
+         <polygon points="199 61 207 57 207 65"></polygon>
+         <polygon points="199 61 191 57 191 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
+            <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="prep_type_clause" href="#prep_type_clause">prep_type_clause:</a></p>
@@ -2186,6 +2302,66 @@
          </p><ul>
             <li><a href="#release_stmt" title="release_stmt">release_stmt</a></li>
             <li><a href="#rollback_stmt" title="rollback_stmt">rollback_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_concurrently" href="#opt_concurrently">opt_concurrently:</a></p>
+      <svg width="228" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">CONCURRENTLY</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m23 -32 h-3"></path>
+         <polygon points="219 5 227 1 227 9"></polygon>
+         <polygon points="219 5 211 1 211 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_index_stmt" title="create_index_stmt">create_index_stmt</a></li>
+            <li><a href="#drop_index_stmt" title="drop_index_stmt">drop_index_stmt</a></li>
+            <li><a href="#refresh_stmt" title="refresh_stmt">refresh_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="view_name" href="#view_name">view_name:</a></p>
+      <svg width="152" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="31" y="3" width="94" height="32"></rect>
+            <rect x="29" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">table_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m3 0 h-3"></path>
+         <polygon points="143 17 151 13 151 21"></polygon>
+         <polygon points="143 17 135 13 135 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_rename_view_stmt" title="alter_rename_view_stmt">alter_rename_view_stmt</a></li>
+            <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
+            <li><a href="#refresh_stmt" title="refresh_stmt">refresh_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_clear_data" href="#opt_clear_data">opt_clear_data:</a></p>
+      <svg width="332" height="88">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <rect x="149" y="55" width="40" height="32" rx="10"></rect>
+         <rect x="147" y="53" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="73">NO</text>
+         <rect x="229" y="23" width="56" height="32" rx="10"></rect>
+         <rect x="227" y="21" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="237" y="41">DATA</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h244 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v12 m274 0 v-12 m-274 12 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m20 0 h10 m0 0 h50 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v12 m80 0 v-12 m-80 12 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m40 0 h10 m20 -32 h10 m56 0 h10 m23 -32 h-3"></path>
+         <polygon points="323 5 331 1 331 9"></polygon>
+         <polygon points="323 5 315 1 315 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#refresh_stmt" title="refresh_stmt">refresh_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="set_transaction_stmt" href="#set_transaction_stmt">set_transaction_stmt:</a></p>
       <svg width="562" height="68">
@@ -2434,6 +2610,27 @@
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sconst_or_placeholder" href="#sconst_or_placeholder">sconst_or_placeholder:</a></p>
+      <svg width="216" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">SCONST</text>
+         <rect x="51" y="47" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">PLACEHOLDER</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m0 0 h42 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m23 -44 h-3"></path>
+         <polygon points="207 17 215 13 215 21"></polygon>
+         <polygon points="207 17 199 13 199 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
+            <li><a href="#cron_expr" title="cron_expr">cron_expr</a></li>
+            <li><a href="#opt_full_backup_clause" title="opt_full_backup_clause">opt_full_backup_clause</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="string_or_placeholder_opt_list" href="#string_or_placeholder_opt_list">string_or_placeholder_opt_list:</a></p>
       <svg width="374" height="80">
          
@@ -2465,6 +2662,7 @@
             <li><a href="#backup_stmt" title="backup_stmt">backup_stmt</a></li>
             <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
             <li><a href="#list_of_string_or_placeholder_opt_list" title="list_of_string_or_placeholder_opt_list">list_of_string_or_placeholder_opt_list</a></li>
+            <li><a href="#restore_options" title="restore_options">restore_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_as_of_clause" href="#opt_as_of_clause">opt_as_of_clause:</a></p>
       <svg width="200" height="56">
@@ -2814,7 +3012,7 @@
             <li><a href="#create_stmt" title="create_stmt">create_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_schedule_for_backup_stmt" href="#create_schedule_for_backup_stmt">create_schedule_for_backup_stmt:</a></p>
-      <svg width="760" height="168">
+      <svg width="702" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -2840,37 +3038,37 @@
             <rect x="531" y="1" width="148" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="541" y="21">opt_backup_targets</text>
          </a>
-         <rect x="701" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="699" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="709" y="21">TO</text>
+         <rect x="57" y="69" width="54" height="32" rx="10"></rect>
+         <rect x="55" y="67" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="65" y="87">INTO</text>
          <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
-            <rect x="29" y="69" width="212" height="32"></rect>
-            <rect x="27" y="67" width="212" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="37" y="87">string_or_placeholder_opt_list</text>
+            <rect x="131" y="69" width="212" height="32"></rect>
+            <rect x="129" y="67" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="87">string_or_placeholder_opt_list</text>
          </a>
          <a xlink:href="#opt_with_backup_options" xlink:title="opt_with_backup_options">
-            <rect x="261" y="69" width="184" height="32"></rect>
-            <rect x="259" y="67" width="184" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="269" y="87">opt_with_backup_options</text>
+            <rect x="363" y="69" width="184" height="32"></rect>
+            <rect x="361" y="67" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="371" y="87">opt_with_backup_options</text>
          </a>
          <a xlink:href="#cron_expr" xlink:title="cron_expr">
-            <rect x="465" y="69" width="82" height="32"></rect>
-            <rect x="463" y="67" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="473" y="87">cron_expr</text>
+            <rect x="567" y="69" width="82" height="32"></rect>
+            <rect x="565" y="67" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="575" y="87">cron_expr</text>
          </a>
          <a xlink:href="#opt_full_backup_clause" xlink:title="opt_full_backup_clause">
-            <rect x="567" y="69" width="168" height="32"></rect>
-            <rect x="565" y="67" width="168" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="575" y="87">opt_full_backup_clause</text>
+            <rect x="293" y="135" width="168" height="32"></rect>
+            <rect x="291" y="133" width="168" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="301" y="153">opt_full_backup_clause</text>
          </a>
          <a xlink:href="#opt_with_schedule_options" xlink:title="opt_with_schedule_options">
-            <rect x="539" y="135" width="194" height="32"></rect>
-            <rect x="537" y="133" width="194" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="547" y="153">opt_with_schedule_options</text>
+            <rect x="481" y="135" width="194" height="32"></rect>
+            <rect x="479" y="133" width="194" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="489" y="153">opt_with_schedule_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-754 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m212 0 h10 m0 0 h10 m184 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-240 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m194 0 h10 m3 0 h-3"></path>
-         <polygon points="751 149 759 145 759 153"></polygon>
-         <polygon points="751 149 743 145 743 153"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-668 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m54 0 h10 m0 0 h10 m212 0 h10 m0 0 h10 m184 0 h10 m0 0 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-400 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m0 0 h10 m194 0 h10 m3 0 h-3"></path>
+         <polygon points="693 149 701 145 701 153"></polygon>
+         <polygon points="693 149 685 145 685 153"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -3189,6 +3387,7 @@
          </p><ul>
             <li><a href="#alter_role_stmt" title="alter_role_stmt">alter_role_stmt</a></li>
             <li><a href="#backup_options" title="backup_options">backup_options</a></li>
+            <li><a href="#copy_options" title="copy_options">copy_options</a></li>
             <li><a href="#create_role_stmt" title="create_role_stmt">create_role_stmt</a></li>
             <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
             <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
@@ -3196,11 +3395,50 @@
             <li><a href="#opt_changefeed_sink" title="opt_changefeed_sink">opt_changefeed_sink</a></li>
             <li><a href="#opt_description" title="opt_description">opt_description</a></li>
             <li><a href="#password_clause" title="password_clause">password_clause</a></li>
+            <li><a href="#restore_options" title="restore_options">restore_options</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
             <li><a href="#show_backup_stmt" title="show_backup_stmt">show_backup_stmt</a></li>
             <li><a href="#string_or_placeholder_list" title="string_or_placeholder_list">string_or_placeholder_list</a></li>
             <li><a href="#string_or_placeholder_opt_list" title="string_or_placeholder_opt_list">string_or_placeholder_opt_list</a></li>
             <li><a href="#valid_until_clause" title="valid_until_clause">valid_until_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_options" href="#opt_with_options">opt_with_options:</a></p>
+      <svg width="520" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <a xlink:href="#kv_option_list" xlink:title="kv_option_list">
+            <rect x="149" y="23" width="108" height="32"></rect>
+            <rect x="147" y="21" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="41">kv_option_list</text>
+         </a>
+         <rect x="149" y="67" width="84" height="32" rx="10"></rect>
+         <rect x="147" y="65" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="85">OPTIONS</text>
+         <rect x="253" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="251" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="85">(</text>
+         <a xlink:href="#kv_option_list" xlink:title="kv_option_list">
+            <rect x="299" y="67" width="108" height="32"></rect>
+            <rect x="297" y="65" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="85">kv_option_list</text>
+         </a>
+         <rect x="427" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="425" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="435" y="85">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h432 m-462 0 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v12 m462 0 v-12 m-462 12 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m58 0 h10 m20 0 h10 m108 0 h10 m0 0 h196 m-344 0 h20 m324 0 h20 m-364 0 q10 0 10 10 m344 0 q0 -10 10 -10 m-354 10 v24 m344 0 v-24 m-344 24 q0 10 10 10 m324 0 q10 0 10 -10 m-334 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"></path>
+         <polygon points="511 5 519 1 519 9"></polygon>
+         <polygon points="511 5 503 1 503 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
+            <li><a href="#export_stmt" title="export_stmt">export_stmt</a></li>
+            <li><a href="#import_stmt" title="import_stmt">import_stmt</a></li>
+            <li><a href="#show_backup_stmt" title="show_backup_stmt">show_backup_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="string_or_placeholder_list" href="#string_or_placeholder_list">string_or_placeholder_list:</a></p>
       <svg width="256" height="80">
@@ -3335,7 +3573,7 @@
             <li><a href="#upsert_stmt" title="upsert_stmt">upsert_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="on_conflict" href="#on_conflict">on_conflict:</a></p>
-      <svg width="520" height="146">
+      <svg width="968" height="190">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
@@ -3345,36 +3583,53 @@
          <rect x="93" y="3" width="88" height="32" rx="10"></rect>
          <rect x="91" y="1" width="88" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="101" y="21">CONFLICT</text>
-         <a xlink:href="#opt_conf_expr" xlink:title="opt_conf_expr">
-            <rect x="201" y="3" width="110" height="32"></rect>
-            <rect x="199" y="1" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="209" y="21">opt_conf_expr</text>
+         <rect x="45" y="69" width="40" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">DO</text>
+         <rect x="105" y="69" width="84" height="32" rx="10"></rect>
+         <rect x="103" y="67" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="113" y="87">NOTHING</text>
+         <rect x="45" y="113" width="26" height="32" rx="10"></rect>
+         <rect x="43" y="111" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="131">(</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="91" y="113" width="80" height="32"></rect>
+            <rect x="89" y="111" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="99" y="131">name_list</text>
          </a>
-         <rect x="331" y="3" width="40" height="32" rx="10"></rect>
-         <rect x="329" y="1" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="339" y="21">DO</text>
-         <rect x="45" y="69" width="74" height="32" rx="10"></rect>
-         <rect x="43" y="67" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="87">UPDATE</text>
-         <rect x="139" y="69" width="44" height="32" rx="10"></rect>
-         <rect x="137" y="67" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="147" y="87">SET</text>
+         <rect x="191" y="113" width="26" height="32" rx="10"></rect>
+         <rect x="189" y="111" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="199" y="131">)</text>
+         <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
+            <rect x="237" y="113" width="136" height="32"></rect>
+            <rect x="235" y="111" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="245" y="131">opt_where_clause</text>
+         </a>
+         <rect x="393" y="113" width="40" height="32" rx="10"></rect>
+         <rect x="391" y="111" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="401" y="131">DO</text>
+         <rect x="473" y="113" width="84" height="32" rx="10"></rect>
+         <rect x="471" y="111" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="481" y="131">NOTHING</text>
+         <rect x="473" y="157" width="74" height="32" rx="10"></rect>
+         <rect x="471" y="155" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="481" y="175">UPDATE</text>
+         <rect x="567" y="157" width="44" height="32" rx="10"></rect>
+         <rect x="565" y="155" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="575" y="175">SET</text>
          <a xlink:href="#set_clause_list" xlink:title="set_clause_list">
-            <rect x="203" y="69" width="114" height="32"></rect>
-            <rect x="201" y="67" width="114" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="211" y="87">set_clause_list</text>
+            <rect x="631" y="157" width="114" height="32"></rect>
+            <rect x="629" y="155" width="114" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="639" y="175">set_clause_list</text>
          </a>
          <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
-            <rect x="337" y="69" width="136" height="32"></rect>
-            <rect x="335" y="67" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="345" y="87">opt_where_clause</text>
+            <rect x="765" y="157" width="136" height="32"></rect>
+            <rect x="763" y="155" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="773" y="175">opt_where_clause</text>
          </a>
-         <rect x="45" y="113" width="84" height="32" rx="10"></rect>
-         <rect x="43" y="111" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="131">NOTHING</text>
-         <path class="line" d="m19 17 h2 m0 0 h10 m40 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-390 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m74 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m114 0 h10 m0 0 h10 m136 0 h10 m-468 0 h20 m448 0 h20 m-488 0 q10 0 10 10 m468 0 q0 -10 10 -10 m-478 10 v24 m468 0 v-24 m-468 24 q0 10 10 10 m448 0 q10 0 10 -10 m-458 10 h10 m84 0 h10 m0 0 h344 m23 -44 h-3"></path>
-         <polygon points="511 83 519 79 519 87"></polygon>
-         <polygon points="511 83 503 79 503 87"></polygon>
+         <path class="line" d="m19 17 h2 m0 0 h10 m40 0 h10 m0 0 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-200 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m40 0 h10 m0 0 h10 m84 0 h10 m0 0 h732 m-916 0 h20 m896 0 h20 m-936 0 q10 0 10 10 m916 0 q0 -10 10 -10 m-926 10 v24 m916 0 v-24 m-916 24 q0 10 10 10 m896 0 q10 0 10 -10 m-906 10 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m84 0 h10 m0 0 h344 m-468 0 h20 m448 0 h20 m-488 0 q10 0 10 10 m468 0 q0 -10 10 -10 m-478 10 v24 m468 0 v-24 m-468 24 q0 10 10 10 m448 0 q10 0 10 -10 m-458 10 h10 m74 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m114 0 h10 m0 0 h10 m136 0 h10 m43 -88 h-3"></path>
+         <polygon points="959 83 967 79 967 87"></polygon>
+         <polygon points="959 83 951 79 951 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -3516,6 +3771,41 @@
          <path class="line" d="m17 61 h2 m20 0 h10 m212 0 h10 m-252 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m232 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-232 0 h10 m24 0 h10 m0 0 h188 m23 44 h-3"></path>
          <polygon points="301 61 309 57 309 65"></polygon>
          <polygon points="301 61 293 57 293 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_restore_options" href="#opt_with_restore_options">opt_with_restore_options:</a></p>
+      <svg width="558" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <a xlink:href="#restore_options_list" xlink:title="restore_options_list">
+            <rect x="149" y="23" width="146" height="32"></rect>
+            <rect x="147" y="21" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="41">restore_options_list</text>
+         </a>
+         <rect x="149" y="67" width="84" height="32" rx="10"></rect>
+         <rect x="147" y="65" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="85">OPTIONS</text>
+         <rect x="253" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="251" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="85">(</text>
+         <a xlink:href="#restore_options_list" xlink:title="restore_options_list">
+            <rect x="299" y="67" width="146" height="32"></rect>
+            <rect x="297" y="65" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="85">restore_options_list</text>
+         </a>
+         <rect x="465" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="463" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="473" y="85">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h470 m-500 0 h20 m480 0 h20 m-520 0 q10 0 10 10 m500 0 q0 -10 10 -10 m-510 10 v12 m500 0 v-12 m-500 12 q0 10 10 10 m480 0 q10 0 10 -10 m-490 10 h10 m58 0 h10 m20 0 h10 m146 0 h10 m0 0 h196 m-382 0 h20 m362 0 h20 m-402 0 q10 0 10 10 m382 0 q0 -10 10 -10 m-392 10 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m146 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"></path>
+         <polygon points="549 5 557 1 557 9"></polygon>
+         <polygon points="549 5 541 1 541 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -3890,32 +4180,51 @@
             <li><a href="#preparable_set_stmt" title="preparable_set_stmt">preparable_set_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_backup_stmt" href="#show_backup_stmt">show_backup_stmt:</a></p>
-      <svg width="688" height="68">
+      <svg width="768" height="222">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">SHOW</text>
-         <rect x="115" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="113" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="123" y="21">BACKUP</text>
-         <rect x="229" y="35" width="84" height="32" rx="10"></rect>
-         <rect x="227" y="33" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="237" y="53">SCHEMAS</text>
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">SHOW</text>
+         <rect x="45" y="69" width="84" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">BACKUPS</text>
+         <rect x="149" y="69" width="36" height="32" rx="10"></rect>
+         <rect x="147" y="67" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="87">IN</text>
          <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="353" y="3" width="158" height="32"></rect>
-            <rect x="351" y="1" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="361" y="21">string_or_placeholder</text>
+            <rect x="205" y="69" width="158" height="32"></rect>
+            <rect x="203" y="67" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="213" y="87">string_or_placeholder</text>
+         </a>
+         <rect x="45" y="113" width="74" height="32" rx="10"></rect>
+         <rect x="43" y="111" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="131">BACKUP</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="159" y="145" width="158" height="32"></rect>
+            <rect x="157" y="143" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="167" y="163">string_or_placeholder</text>
+         </a>
+         <rect x="337" y="145" width="36" height="32" rx="10"></rect>
+         <rect x="335" y="143" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="345" y="163">IN</text>
+         <rect x="159" y="189" width="84" height="32" rx="10"></rect>
+         <rect x="157" y="187" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="207">SCHEMAS</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="413" y="113" width="158" height="32"></rect>
+            <rect x="411" y="111" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="421" y="131">string_or_placeholder</text>
          </a>
          <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
-            <rect x="531" y="3" width="130" height="32"></rect>
-            <rect x="529" y="1" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="539" y="21">opt_with_options</text>
+            <rect x="591" y="113" width="130" height="32"></rect>
+            <rect x="589" y="111" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="599" y="131">opt_with_options</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m20 -32 h10 m158 0 h10 m0 0 h10 m130 0 h10 m3 0 h-3"></path>
-         <polygon points="679 17 687 13 687 21"></polygon>
-         <polygon points="679 17 671 13 671 21"></polygon>
+         <path class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m84 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m158 0 h10 m0 0 h358 m-716 0 h20 m696 0 h20 m-736 0 q10 0 10 10 m716 0 q0 -10 10 -10 m-726 10 v24 m716 0 v-24 m-716 24 q0 10 10 10 m696 0 q10 0 10 -10 m-706 10 h10 m74 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m-244 -10 v20 m254 0 v-20 m-254 20 v24 m254 0 v-24 m-254 24 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m84 0 h10 m0 0 h130 m20 -76 h10 m158 0 h10 m0 0 h10 m130 0 h10 m23 -44 h-3"></path>
+         <polygon points="759 83 767 79 767 87"></polygon>
+         <polygon points="759 83 751 79 751 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4090,6 +4399,25 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m68 0 h10 m3 0 h-3"></path>
          <polygon points="201 17 209 13 209 21"></polygon>
          <polygon points="201 17 193 13 193 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_types_stmt" href="#show_types_stmt">show_types_stmt:</a></p>
+      <svg width="206" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="115" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">TYPES</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m64 0 h10 m3 0 h-3"></path>
+         <polygon points="197 17 205 13 205 21"></polygon>
+         <polygon points="197 17 189 13 189 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4696,6 +5024,33 @@
          </p><ul>
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_transactions_stmt" href="#show_transactions_stmt">show_transactions_stmt:</a></p>
+      <svg width="482" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="135" y="35" width="44" height="32" rx="10"></rect>
+         <rect x="133" y="33" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="53">ALL</text>
+         <a xlink:href="#opt_cluster" xlink:title="opt_cluster">
+            <rect x="219" y="3" width="90" height="32"></rect>
+            <rect x="217" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="227" y="21">opt_cluster</text>
+         </a>
+         <rect x="329" y="3" width="126" height="32" rx="10"></rect>
+         <rect x="327" y="1" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="21">TRANSACTIONS</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m90 0 h10 m0 0 h10 m126 0 h10 m3 0 h-3"></path>
+         <polygon points="473 17 481 13 481 21"></polygon>
+         <polygon points="473 17 465 13 465 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_users_stmt" href="#show_users_stmt">show_users_stmt:</a></p>
       <svg width="206" height="36">
          
@@ -4949,27 +5304,41 @@
             <li><a href="#table_name" title="table_name">table_name</a></li>
             <li><a href="#type_name" title="type_name">type_name</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="kv_option_list" href="#kv_option_list">kv_option_list:</a></p>
-      <svg width="180" height="80">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with" href="#opt_with">opt_with:</a></p>
+      <svg width="156" height="56">
          
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#kv_option" xlink:title="kv_option">
-            <rect x="51" y="47" width="82" height="32"></rect>
-            <rect x="49" y="45" width="82" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">kv_option</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m23 44 h-3"></path>
-         <polygon points="171 61 179 57 179 65"></polygon>
-         <polygon points="171 61 163 57 163 65"></polygon>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m23 -32 h-3"></path>
+         <polygon points="147 5 155 1 155 9"></polygon>
+         <polygon points="147 5 139 1 139 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#opt_with_options" title="opt_with_options">opt_with_options</a></li>
-            <li><a href="#opt_with_schedule_options" title="opt_with_schedule_options">opt_with_schedule_options</a></li>
+            <li><a href="#create_database_stmt" title="create_database_stmt">create_database_stmt</a></li>
+            <li><a href="#opt_role_options" title="opt_role_options">opt_role_options</a></li>
+            <li><a href="#opt_with_copy_options" title="opt_with_copy_options">opt_with_copy_options</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="copy_options_list" href="#copy_options_list">copy_options_list:</a></p>
+      <svg width="202" height="52">
+         
+         <polygon points="9 33 1 29 1 37"></polygon>
+         <polygon points="17 33 9 29 9 37"></polygon>
+         <a xlink:href="#copy_options" xlink:title="copy_options">
+            <rect x="51" y="19" width="104" height="32"></rect>
+            <rect x="49" y="17" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="37">copy_options</text>
+         </a>
+         <path class="line" d="m17 33 h2 m20 0 h10 m104 0 h10 m-144 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m124 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-124 0 h10 m0 0 h114 m23 32 h-3"></path>
+         <polygon points="193 33 201 29 201 37"></polygon>
+         <polygon points="193 33 185 29 185 37"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_with_copy_options" title="opt_with_copy_options">opt_with_copy_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="prefixed_column_path" href="#prefixed_column_path">prefixed_column_path:</a></p>
       <svg width="516" height="154">
@@ -5096,7 +5465,7 @@
             <li><a href="#values_clause" title="values_clause">values_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
-      <svg width="332" height="12048">
+      <svg width="372" height="13104">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -5139,792 +5508,864 @@
          <rect x="51" y="531" width="74" height="32" rx="10"></rect>
          <rect x="49" y="529" width="74" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="549">BACKUP</text>
-         <rect x="51" y="575" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">BEFORE</text>
-         <rect x="51" y="619" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">BEGIN</text>
-         <rect x="51" y="663" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">BUCKET_COUNT</text>
-         <rect x="51" y="707" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">BUNDLE</text>
-         <rect x="51" y="751" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">BY</text>
-         <rect x="51" y="795" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">CACHE</text>
-         <rect x="51" y="839" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">CANCEL</text>
-         <rect x="51" y="883" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">CASCADE</text>
-         <rect x="51" y="927" width="110" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="110" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">CHANGEFEED</text>
-         <rect x="51" y="971" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">CLOSE</text>
-         <rect x="51" y="1015" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">CLUSTER</text>
-         <rect x="51" y="1059" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">COLUMNS</text>
-         <rect x="51" y="1103" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">COMMENT</text>
-         <rect x="51" y="1147" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">COMMENTS</text>
-         <rect x="51" y="1191" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">COMMIT</text>
-         <rect x="51" y="1235" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">COMMITTED</text>
-         <rect x="51" y="1279" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">COMPACT</text>
-         <rect x="51" y="1323" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">COMPLETE</text>
-         <rect x="51" y="1367" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">CONFLICT</text>
-         <rect x="51" y="1411" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">CONFIGURATION</text>
-         <rect x="51" y="1455" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">CONFIGURATIONS</text>
-         <rect x="51" y="1499" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">CONFIGURE</text>
-         <rect x="51" y="1543" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">CONSTRAINTS</text>
-         <rect x="51" y="1587" width="112" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">CONVERSION</text>
-         <rect x="51" y="1631" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">COPY</text>
-         <rect x="51" y="1675" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">COVERING</text>
-         <rect x="51" y="1719" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">CREATEROLE</text>
-         <rect x="51" y="1763" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">CUBE</text>
-         <rect x="51" y="1807" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">CURRENT</text>
-         <rect x="51" y="1851" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">CYCLE</text>
-         <rect x="51" y="1895" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">DATA</text>
-         <rect x="51" y="1939" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">DATABASE</text>
-         <rect x="51" y="1983" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">DATABASES</text>
-         <rect x="51" y="2027" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">DAY</text>
-         <rect x="51" y="2071" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">DEALLOCATE</text>
-         <rect x="51" y="2115" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">DECLARE</text>
-         <rect x="51" y="2159" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">DELETE</text>
-         <rect x="51" y="2203" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">DEFAULTS</text>
-         <rect x="51" y="2247" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">DEFERRED</text>
-         <rect x="51" y="2291" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">DETACHED</text>
-         <rect x="51" y="2335" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">DISCARD</text>
-         <rect x="51" y="2379" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">DOMAIN</text>
-         <rect x="51" y="2423" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">DOUBLE</text>
-         <rect x="51" y="2467" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">DROP</text>
-         <rect x="51" y="2511" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">ENCODING</text>
-         <rect x="51" y="2555" width="208" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="208" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">ENCRYPTION_PASSPHRASE</text>
-         <rect x="51" y="2599" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">ENUM</text>
-         <rect x="51" y="2643" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">ENUMS</text>
-         <rect x="51" y="2687" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">ESCAPE</text>
+         <rect x="51" y="575" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">BACKUPS</text>
+         <rect x="51" y="619" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">BEFORE</text>
+         <rect x="51" y="663" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">BEGIN</text>
+         <rect x="51" y="707" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">BINARY</text>
+         <rect x="51" y="751" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">BUCKET_COUNT</text>
+         <rect x="51" y="795" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">BUNDLE</text>
+         <rect x="51" y="839" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">BY</text>
+         <rect x="51" y="883" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">CACHE</text>
+         <rect x="51" y="927" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">CANCEL</text>
+         <rect x="51" y="971" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">CANCELQUERY</text>
+         <rect x="51" y="1015" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">CASCADE</text>
+         <rect x="51" y="1059" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">CHANGEFEED</text>
+         <rect x="51" y="1103" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">CLOSE</text>
+         <rect x="51" y="1147" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">CLUSTER</text>
+         <rect x="51" y="1191" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">COLUMNS</text>
+         <rect x="51" y="1235" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">COMMENT</text>
+         <rect x="51" y="1279" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">COMMENTS</text>
+         <rect x="51" y="1323" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">COMMIT</text>
+         <rect x="51" y="1367" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">COMMITTED</text>
+         <rect x="51" y="1411" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">COMPACT</text>
+         <rect x="51" y="1455" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">COMPLETE</text>
+         <rect x="51" y="1499" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">CONFLICT</text>
+         <rect x="51" y="1543" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">CONFIGURATION</text>
+         <rect x="51" y="1587" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">CONFIGURATIONS</text>
+         <rect x="51" y="1631" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">CONFIGURE</text>
+         <rect x="51" y="1675" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">CONSTRAINTS</text>
+         <rect x="51" y="1719" width="176" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="176" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">CONTROLCHANGEFEED</text>
+         <rect x="51" y="1763" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">CONTROLJOB</text>
+         <rect x="51" y="1807" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">CONVERSION</text>
+         <rect x="51" y="1851" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="1849" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1869">CONVERT</text>
+         <rect x="51" y="1895" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">COPY</text>
+         <rect x="51" y="1939" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">COVERING</text>
+         <rect x="51" y="1983" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">CREATEDB</text>
+         <rect x="51" y="2027" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="2025" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2045">CREATELOGIN</text>
+         <rect x="51" y="2071" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="2069" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2089">CREATEROLE</text>
+         <rect x="51" y="2115" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">CUBE</text>
+         <rect x="51" y="2159" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">CURRENT</text>
+         <rect x="51" y="2203" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">CYCLE</text>
+         <rect x="51" y="2247" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="2245" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2265">DATA</text>
+         <rect x="51" y="2291" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2289" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2309">DATABASE</text>
+         <rect x="51" y="2335" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="2333" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2353">DATABASES</text>
+         <rect x="51" y="2379" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="2377" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2397">DAY</text>
+         <rect x="51" y="2423" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="2421" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2441">DEALLOCATE</text>
+         <rect x="51" y="2467" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="2465" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2485">DECLARE</text>
+         <rect x="51" y="2511" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2509" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2529">DELETE</text>
+         <rect x="51" y="2555" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2553" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2573">DEFAULTS</text>
+         <rect x="51" y="2599" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2597" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2617">DEFERRED</text>
+         <rect x="51" y="2643" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="2641" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2661">DESTINATION</text>
+         <rect x="51" y="2687" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="2685" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2705">DETACHED</text>
          <rect x="51" y="2731" width="82" height="32" rx="10"></rect>
          <rect x="49" y="2729" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">EXCLUDE</text>
-         <rect x="51" y="2775" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">EXCLUDING</text>
-         <rect x="51" y="2819" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">EXECUTE</text>
-         <rect x="51" y="2863" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">EXECUTION</text>
-         <rect x="51" y="2907" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">EXPERIMENTAL</text>
-         <rect x="51" y="2951" width="174" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="174" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">EXPERIMENTAL_AUDIT</text>
-         <rect x="51" y="2995" width="234" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="234" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">EXPERIMENTAL_FINGERPRINTS</text>
-         <rect x="51" y="3039" width="202" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="202" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">EXPERIMENTAL_RELOCATE</text>
-         <rect x="51" y="3083" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">EXPERIMENTAL_REPLICA</text>
-         <rect x="51" y="3127" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">EXPIRATION</text>
-         <rect x="51" y="3171" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">EXPLAIN</text>
-         <rect x="51" y="3215" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">EXPORT</text>
+         <text class="terminal" x="59" y="2749">DISCARD</text>
+         <rect x="51" y="2775" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">DOMAIN</text>
+         <rect x="51" y="2819" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">DOUBLE</text>
+         <rect x="51" y="2863" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">DROP</text>
+         <rect x="51" y="2907" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">ENCODING</text>
+         <rect x="51" y="2951" width="208" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="208" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">ENCRYPTION_PASSPHRASE</text>
+         <rect x="51" y="2995" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">ENUM</text>
+         <rect x="51" y="3039" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">ENUMS</text>
+         <rect x="51" y="3083" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">ESCAPE</text>
+         <rect x="51" y="3127" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">EXCLUDE</text>
+         <rect x="51" y="3171" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">EXCLUDING</text>
+         <rect x="51" y="3215" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">EXECUTE</text>
          <rect x="51" y="3259" width="98" height="32" rx="10"></rect>
          <rect x="49" y="3257" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">EXTENSION</text>
-         <rect x="51" y="3303" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">FILES</text>
-         <rect x="51" y="3347" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">FILTER</text>
-         <rect x="51" y="3391" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">FIRST</text>
-         <rect x="51" y="3435" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">FOLLOWING</text>
-         <rect x="51" y="3479" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">FORCE_INDEX</text>
-         <rect x="51" y="3523" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">FUNCTION</text>
-         <rect x="51" y="3567" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">GENERATED</text>
-         <rect x="51" y="3611" width="182" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="182" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">GEOMETRYCOLLECTION</text>
-         <rect x="51" y="3655" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">GLOBAL</text>
-         <rect x="51" y="3699" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3697" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">GRANTS</text>
-         <rect x="51" y="3743" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="3741" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3761">GROUPS</text>
-         <rect x="51" y="3787" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="3785" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3805">HASH</text>
-         <rect x="51" y="3831" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="3829" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3849">HIGH</text>
-         <rect x="51" y="3875" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="3873" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3893">HISTOGRAM</text>
-         <rect x="51" y="3919" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3917" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3937">HOUR</text>
-         <rect x="51" y="3963" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="3961" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3981">IDENTITY</text>
-         <rect x="51" y="4007" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="4005" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4025">IMMEDIATE</text>
+         <text class="terminal" x="59" y="3277">EXECUTION</text>
+         <rect x="51" y="3303" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">EXPERIMENTAL</text>
+         <rect x="51" y="3347" width="174" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="174" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">EXPERIMENTAL_AUDIT</text>
+         <rect x="51" y="3391" width="234" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="234" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">EXPERIMENTAL_FINGERPRINTS</text>
+         <rect x="51" y="3435" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">EXPERIMENTAL_RELOCATE</text>
+         <rect x="51" y="3479" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">EXPERIMENTAL_REPLICA</text>
+         <rect x="51" y="3523" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">EXPIRATION</text>
+         <rect x="51" y="3567" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">EXPLAIN</text>
+         <rect x="51" y="3611" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3609" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3629">EXPORT</text>
+         <rect x="51" y="3655" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="3653" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3673">EXTENSION</text>
+         <rect x="51" y="3699" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3697" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3717">FILES</text>
+         <rect x="51" y="3743" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="3741" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3761">FILTER</text>
+         <rect x="51" y="3787" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="3785" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3805">FIRST</text>
+         <rect x="51" y="3831" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="3829" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3849">FOLLOWING</text>
+         <rect x="51" y="3875" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="3873" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3893">FORCE_INDEX</text>
+         <rect x="51" y="3919" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="3917" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3937">FUNCTION</text>
+         <rect x="51" y="3963" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="3961" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3981">GENERATED</text>
+         <rect x="51" y="4007" width="182" height="32" rx="10"></rect>
+         <rect x="49" y="4005" width="182" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4025">GEOMETRYCOLLECTION</text>
          <rect x="51" y="4051" width="74" height="32" rx="10"></rect>
          <rect x="49" y="4049" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4069">IMPORT</text>
-         <rect x="51" y="4095" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4093" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4113">INCLUDE</text>
-         <rect x="51" y="4139" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4137" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4157">INCLUDING</text>
-         <rect x="51" y="4183" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4181" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4201">INCREMENT</text>
-         <rect x="51" y="4227" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="4225" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4245">INCREMENTAL</text>
-         <rect x="51" y="4271" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4269" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4289">INDEXES</text>
-         <rect x="51" y="4315" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="4313" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4333">INJECT</text>
-         <rect x="51" y="4359" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="4357" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4377">INSERT</text>
-         <rect x="51" y="4403" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="4401" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4421">INTERLEAVE</text>
-         <rect x="51" y="4447" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="4445" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4465">INVERTED</text>
-         <rect x="51" y="4491" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4489" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4509">ISOLATION</text>
-         <rect x="51" y="4535" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="4533" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4553">JOB</text>
-         <rect x="51" y="4579" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4577" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4597">JOBS</text>
-         <rect x="51" y="4623" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4621" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4641">JSON</text>
-         <rect x="51" y="4667" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="4665" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4685">KEY</text>
-         <rect x="51" y="4711" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4709" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4729">KEYS</text>
-         <rect x="51" y="4755" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="4753" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4773">KMS</text>
-         <rect x="51" y="4799" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="4797" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4817">KV</text>
-         <rect x="51" y="4843" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="4841" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4861">LANGUAGE</text>
-         <rect x="51" y="4887" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="4885" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4905">LAST</text>
-         <rect x="51" y="4931" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="4929" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4949">LATEST</text>
-         <rect x="51" y="4975" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="4973" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4993">LC_COLLATE</text>
-         <rect x="51" y="5019" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="5017" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5037">LC_CTYPE</text>
-         <rect x="51" y="5063" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="5061" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5081">LEASE</text>
-         <rect x="51" y="5107" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="5105" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5125">LESS</text>
-         <rect x="51" y="5151" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="5149" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5169">LEVEL</text>
-         <rect x="51" y="5195" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="5193" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5213">LINESTRING</text>
-         <rect x="51" y="5239" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="5237" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5257">LIST</text>
-         <rect x="51" y="5283" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="5281" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5301">LOCAL</text>
-         <rect x="51" y="5327" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="5325" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5345">LOCKED</text>
-         <rect x="51" y="5371" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="5369" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5389">LOGIN</text>
-         <rect x="51" y="5415" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="5413" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5433">LOOKUP</text>
-         <rect x="51" y="5459" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="5457" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5477">LOW</text>
-         <rect x="51" y="5503" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5501" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5521">MATCH</text>
-         <rect x="51" y="5547" width="120" height="32" rx="10"></rect>
-         <rect x="49" y="5545" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5565">MATERIALIZED</text>
-         <rect x="51" y="5591" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="5589" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5609">MAXVALUE</text>
-         <rect x="51" y="5635" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="5633" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5653">MERGE</text>
-         <rect x="51" y="5679" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="5677" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5697">MINUTE</text>
-         <rect x="51" y="5723" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="5721" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5741">MINVALUE</text>
-         <rect x="51" y="5767" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="5765" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5785">MULTILINESTRING</text>
-         <rect x="51" y="5811" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="5809" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5829">MULTIPOINT</text>
-         <rect x="51" y="5855" width="132" height="32" rx="10"></rect>
-         <rect x="49" y="5853" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5873">MULTIPOLYGON</text>
-         <rect x="51" y="5899" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="5897" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5917">MONTH</text>
+         <text class="terminal" x="59" y="4069">GLOBAL</text>
+         <rect x="51" y="4095" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4093" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4113">GRANTS</text>
+         <rect x="51" y="4139" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="4137" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4157">GROUPS</text>
+         <rect x="51" y="4183" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="4181" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4201">HASH</text>
+         <rect x="51" y="4227" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="4225" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4245">HIGH</text>
+         <rect x="51" y="4271" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="4269" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4289">HISTOGRAM</text>
+         <rect x="51" y="4315" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="4313" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4333">HOUR</text>
+         <rect x="51" y="4359" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="4357" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4377">IDENTITY</text>
+         <rect x="51" y="4403" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="4401" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4421">IMMEDIATE</text>
+         <rect x="51" y="4447" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4445" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4465">IMPORT</text>
+         <rect x="51" y="4491" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="4489" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4509">INCLUDE</text>
+         <rect x="51" y="4535" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="4533" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4553">INCLUDING</text>
+         <rect x="51" y="4579" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="4577" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4597">INCREMENT</text>
+         <rect x="51" y="4623" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="4621" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4641">INCREMENTAL</text>
+         <rect x="51" y="4667" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="4665" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4685">INDEXES</text>
+         <rect x="51" y="4711" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="4709" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4729">INJECT</text>
+         <rect x="51" y="4755" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="4753" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4773">INSERT</text>
+         <rect x="51" y="4799" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="4797" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4817">INTERLEAVE</text>
+         <rect x="51" y="4843" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="4841" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4861">INTO_DB</text>
+         <rect x="51" y="4887" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="4885" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4905">INVERTED</text>
+         <rect x="51" y="4931" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="4929" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4949">ISOLATION</text>
+         <rect x="51" y="4975" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="4973" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4993">JOB</text>
+         <rect x="51" y="5019" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5017" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5037">JOBS</text>
+         <rect x="51" y="5063" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5061" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5081">JSON</text>
+         <rect x="51" y="5107" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="5105" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5125">KEY</text>
+         <rect x="51" y="5151" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5149" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5169">KEYS</text>
+         <rect x="51" y="5195" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="5193" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5213">KMS</text>
+         <rect x="51" y="5239" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="5237" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5257">KV</text>
+         <rect x="51" y="5283" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="5281" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5301">LANGUAGE</text>
+         <rect x="51" y="5327" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="5325" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5345">LAST</text>
+         <rect x="51" y="5371" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="5369" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5389">LATEST</text>
+         <rect x="51" y="5415" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="5413" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5433">LC_COLLATE</text>
+         <rect x="51" y="5459" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="5457" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5477">LC_CTYPE</text>
+         <rect x="51" y="5503" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="5501" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5521">LEASE</text>
+         <rect x="51" y="5547" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="5545" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5565">LESS</text>
+         <rect x="51" y="5591" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="5589" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5609">LEVEL</text>
+         <rect x="51" y="5635" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="5633" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5653">LINESTRING</text>
+         <rect x="51" y="5679" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="5677" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5697">LIST</text>
+         <rect x="51" y="5723" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5721" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5741">LOCAL</text>
+         <rect x="51" y="5767" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="5765" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5785">LOCKED</text>
+         <rect x="51" y="5811" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="5809" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5829">LOGIN</text>
+         <rect x="51" y="5855" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="5853" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5873">LOOKUP</text>
+         <rect x="51" y="5899" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="5897" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5917">LOW</text>
          <rect x="51" y="5943" width="66" height="32" rx="10"></rect>
          <rect x="49" y="5941" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5961">NAMES</text>
-         <rect x="51" y="5987" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="5985" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6005">NAN</text>
-         <rect x="51" y="6031" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6029" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6049">NEVER</text>
-         <rect x="51" y="6075" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="6073" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6093">NEXT</text>
-         <rect x="51" y="6119" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="6117" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6137">NO</text>
-         <rect x="51" y="6163" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="6161" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6181">NORMAL</text>
-         <rect x="51" y="6207" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="6205" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6225">NO_INDEX_JOIN</text>
-         <rect x="51" y="6251" width="128" height="32" rx="10"></rect>
-         <rect x="49" y="6249" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6269">NOCREATEROLE</text>
-         <rect x="51" y="6295" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="6293" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6313">NOLOGIN</text>
-         <rect x="51" y="6339" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="6337" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6357">NOWAIT</text>
-         <rect x="51" y="6383" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6381" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6401">NULLS</text>
-         <rect x="51" y="6427" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="6425" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6445">IGNORE_FOREIGN_KEYS</text>
-         <rect x="51" y="6471" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="6469" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6489">OF</text>
-         <rect x="51" y="6515" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="6513" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6533">OFF</text>
-         <rect x="51" y="6559" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6557" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6577">OIDS</text>
-         <rect x="51" y="6603" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="6601" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6621">OPERATOR</text>
-         <rect x="51" y="6647" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="6645" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6665">OPT</text>
-         <rect x="51" y="6691" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6689" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6709">OPTION</text>
-         <rect x="51" y="6735" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="6733" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6753">OPTIONS</text>
-         <rect x="51" y="6779" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="6777" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6797">ORDINALITY</text>
-         <rect x="51" y="6823" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6821" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6841">OTHERS</text>
-         <rect x="51" y="6867" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="6865" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6885">OVER</text>
-         <rect x="51" y="6911" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="6909" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6929">OWNED</text>
-         <rect x="51" y="6955" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="6953" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6973">OWNER</text>
-         <rect x="51" y="6999" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="6997" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7017">PARENT</text>
+         <text class="terminal" x="59" y="5961">MATCH</text>
+         <rect x="51" y="5987" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="5985" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6005">MATERIALIZED</text>
+         <rect x="51" y="6031" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="6029" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6049">MAXVALUE</text>
+         <rect x="51" y="6075" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="6073" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6093">MERGE</text>
+         <rect x="51" y="6119" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6117" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6137">MINUTE</text>
+         <rect x="51" y="6163" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="6161" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6181">MINVALUE</text>
+         <rect x="51" y="6207" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="6205" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6225">MULTILINESTRING</text>
+         <rect x="51" y="6251" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="6249" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6269">MULTIPOINT</text>
+         <rect x="51" y="6295" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="6293" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6313">MULTIPOLYGON</text>
+         <rect x="51" y="6339" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="6337" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6357">MONTH</text>
+         <rect x="51" y="6383" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="6381" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6401">NAMES</text>
+         <rect x="51" y="6427" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="6425" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6445">NAN</text>
+         <rect x="51" y="6471" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="6469" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6489">NEVER</text>
+         <rect x="51" y="6515" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="6513" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6533">NEXT</text>
+         <rect x="51" y="6559" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="6557" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6577">NO</text>
+         <rect x="51" y="6603" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6601" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6621">NORMAL</text>
+         <rect x="51" y="6647" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="6645" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6665">NO_INDEX_JOIN</text>
+         <rect x="51" y="6691" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="6689" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6709">NOCREATEDB</text>
+         <rect x="51" y="6735" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="6733" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6753">NOCREATELOGIN</text>
+         <rect x="51" y="6779" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="6777" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6797">NOCANCELQUERY</text>
+         <rect x="51" y="6823" width="128" height="32" rx="10"></rect>
+         <rect x="49" y="6821" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6841">NOCREATEROLE</text>
+         <rect x="51" y="6867" width="196" height="32" rx="10"></rect>
+         <rect x="49" y="6865" width="196" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6885">NOCONTROLCHANGEFEED</text>
+         <rect x="51" y="6911" width="134" height="32" rx="10"></rect>
+         <rect x="49" y="6909" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6929">NOCONTROLJOB</text>
+         <rect x="51" y="6955" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="6953" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6973">NOLOGIN</text>
+         <rect x="51" y="6999" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="6997" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7017">NOVIEWACTIVITY</text>
          <rect x="51" y="7043" width="78" height="32" rx="10"></rect>
          <rect x="49" y="7041" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7061">PARTIAL</text>
-         <rect x="51" y="7087" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="7085" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7105">PARTITION</text>
-         <rect x="51" y="7131" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="7129" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7149">PARTITIONS</text>
-         <rect x="51" y="7175" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="7173" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7193">PASSWORD</text>
-         <rect x="51" y="7219" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7217" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7237">PAUSE</text>
-         <rect x="51" y="7263" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="7261" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7281">PAUSED</text>
-         <rect x="51" y="7307" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="7305" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7325">PHYSICAL</text>
-         <rect x="51" y="7351" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="7349" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7369">PLAN</text>
-         <rect x="51" y="7395" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7393" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7413">PLANS</text>
-         <rect x="51" y="7439" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="7437" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7457">PRECEDING</text>
-         <rect x="51" y="7483" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="7481" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7501">PREPARE</text>
-         <rect x="51" y="7527" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="7525" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7545">PRESERVE</text>
-         <rect x="51" y="7571" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="7569" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7589">PRIORITY</text>
-         <rect x="51" y="7615" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="7613" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7633">PUBLIC</text>
-         <rect x="51" y="7659" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="7657" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7677">PUBLICATION</text>
-         <rect x="51" y="7703" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="7701" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7721">QUERIES</text>
-         <rect x="51" y="7747" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="7745" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7765">QUERY</text>
-         <rect x="51" y="7791" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="7789" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7809">RANGE</text>
-         <rect x="51" y="7835" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="7833" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7853">RANGES</text>
-         <rect x="51" y="7879" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="7877" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7897">READ</text>
-         <rect x="51" y="7923" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="7921" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7941">RECURRING</text>
-         <rect x="51" y="7967" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="7965" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7985">RECURSIVE</text>
-         <rect x="51" y="8011" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="8009" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8029">REF</text>
-         <rect x="51" y="8055" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="8053" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8073">REINDEX</text>
-         <rect x="51" y="8099" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="8097" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8117">RELEASE</text>
-         <rect x="51" y="8143" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8141" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8161">RENAME</text>
-         <rect x="51" y="8187" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="8185" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8205">REPEATABLE</text>
-         <rect x="51" y="8231" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="8229" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8249">REPLACE</text>
-         <rect x="51" y="8275" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="8273" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8293">RESET</text>
-         <rect x="51" y="8319" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="8317" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8337">RESTORE</text>
-         <rect x="51" y="8363" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="8361" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8381">RESTRICT</text>
-         <rect x="51" y="8407" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8405" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8425">RESUME</text>
-         <rect x="51" y="8451" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8449" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8469">RETRY</text>
-         <rect x="51" y="8495" width="160" height="32" rx="10"></rect>
-         <rect x="49" y="8493" width="160" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8513">REVISION_HISTORY</text>
+         <text class="terminal" x="59" y="7061">NOWAIT</text>
+         <rect x="51" y="7087" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7085" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7105">NULLS</text>
+         <rect x="51" y="7131" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="7129" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7149">IGNORE_FOREIGN_KEYS</text>
+         <rect x="51" y="7175" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="7173" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7193">OF</text>
+         <rect x="51" y="7219" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="7217" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7237">OFF</text>
+         <rect x="51" y="7263" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="7261" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7281">OIDS</text>
+         <rect x="51" y="7307" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="7305" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7325">OPERATOR</text>
+         <rect x="51" y="7351" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="7349" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7369">OPT</text>
+         <rect x="51" y="7395" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="7393" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7413">OPTION</text>
+         <rect x="51" y="7439" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="7437" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7457">OPTIONS</text>
+         <rect x="51" y="7483" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="7481" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7501">ORDINALITY</text>
+         <rect x="51" y="7527" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="7525" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7545">OTHERS</text>
+         <rect x="51" y="7571" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="7569" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7589">OVER</text>
+         <rect x="51" y="7615" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="7613" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7633">OWNED</text>
+         <rect x="51" y="7659" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="7657" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7677">OWNER</text>
+         <rect x="51" y="7703" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="7701" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7721">PARENT</text>
+         <rect x="51" y="7747" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7745" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7765">PARTIAL</text>
+         <rect x="51" y="7791" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="7789" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7809">PARTITION</text>
+         <rect x="51" y="7835" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="7833" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7853">PARTITIONS</text>
+         <rect x="51" y="7879" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="7877" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7897">PASSWORD</text>
+         <rect x="51" y="7923" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7921" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7941">PAUSE</text>
+         <rect x="51" y="7967" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="7965" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7985">PAUSED</text>
+         <rect x="51" y="8011" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="8009" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8029">PHYSICAL</text>
+         <rect x="51" y="8055" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8053" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8073">PLAN</text>
+         <rect x="51" y="8099" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="8097" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8117">PLANS</text>
+         <rect x="51" y="8143" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="8141" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8161">PRECEDING</text>
+         <rect x="51" y="8187" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="8185" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8205">PREPARE</text>
+         <rect x="51" y="8231" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="8229" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8249">PRESERVE</text>
+         <rect x="51" y="8275" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="8273" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8293">PRIORITY</text>
+         <rect x="51" y="8319" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="8317" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8337">PUBLIC</text>
+         <rect x="51" y="8363" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="8361" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8381">PUBLICATION</text>
+         <rect x="51" y="8407" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="8405" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8425">QUERIES</text>
+         <rect x="51" y="8451" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="8449" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8469">QUERY</text>
+         <rect x="51" y="8495" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="8493" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8513">RANGE</text>
          <rect x="51" y="8539" width="74" height="32" rx="10"></rect>
          <rect x="49" y="8537" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8557">REVOKE</text>
+         <text class="terminal" x="59" y="8557">RANGES</text>
          <rect x="51" y="8583" width="56" height="32" rx="10"></rect>
          <rect x="49" y="8581" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8601">ROLE</text>
-         <rect x="51" y="8627" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8625" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8645">ROLES</text>
-         <rect x="51" y="8671" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="8669" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8689">ROLLBACK</text>
-         <rect x="51" y="8715" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8713" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8733">ROLLUP</text>
-         <rect x="51" y="8759" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="8757" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8777">ROWS</text>
-         <rect x="51" y="8803" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="8801" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8821">RULE</text>
-         <rect x="51" y="8847" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="8845" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8865">RUNNING</text>
-         <rect x="51" y="8891" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="8889" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8909">SCHEDULE</text>
-         <rect x="51" y="8935" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="8933" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8953">SCHEDULES</text>
-         <rect x="51" y="8979" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="8977" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8997">SETTING</text>
-         <rect x="51" y="9023" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="9021" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9041">SETTINGS</text>
-         <rect x="51" y="9067" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="9065" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9085">STATUS</text>
-         <rect x="51" y="9111" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="9109" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9129">SAVEPOINT</text>
-         <rect x="51" y="9155" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="9153" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9173">SCATTER</text>
-         <rect x="51" y="9199" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="9197" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9217">SCHEMA</text>
-         <rect x="51" y="9243" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="9241" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9261">SCHEMAS</text>
-         <rect x="51" y="9287" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="9285" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9305">SCRUB</text>
-         <rect x="51" y="9331" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="9329" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9349">SEARCH</text>
-         <rect x="51" y="9375" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="9373" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9393">SECOND</text>
-         <rect x="51" y="9419" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="9417" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9437">SERIALIZABLE</text>
-         <rect x="51" y="9463" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="9461" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9481">SEQUENCE</text>
-         <rect x="51" y="9507" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="9505" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9525">SEQUENCES</text>
-         <rect x="51" y="9551" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="9549" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9569">SERVER</text>
-         <rect x="51" y="9595" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="9593" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9613">SESSION</text>
-         <rect x="51" y="9639" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="9637" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9657">SESSIONS</text>
-         <rect x="51" y="9683" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="9681" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9701">SET</text>
-         <rect x="51" y="9727" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="9725" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9745">SHARE</text>
-         <rect x="51" y="9771" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="9769" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9789">SHOW</text>
-         <rect x="51" y="9815" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="9813" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9833">SIMPLE</text>
-         <rect x="51" y="9859" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="9857" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9877">SKIP</text>
-         <rect x="51" y="9903" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="9901" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9921">SNAPSHOT</text>
-         <rect x="51" y="9947" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="9945" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9965">SPLIT</text>
-         <rect x="51" y="9991" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="9989" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10009">SQL</text>
-         <rect x="51" y="10035" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="10033" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10053">START</text>
-         <rect x="51" y="10079" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="10077" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10097">STATISTICS</text>
-         <rect x="51" y="10123" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="10121" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10141">STDIN</text>
-         <rect x="51" y="10167" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="10165" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10185">STORAGE</text>
-         <rect x="51" y="10211" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="10209" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10229">STORE</text>
-         <rect x="51" y="10255" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10253" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10273">STORED</text>
-         <rect x="51" y="10299" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="10297" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10317">STORING</text>
-         <rect x="51" y="10343" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="10341" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10361">STRICT</text>
-         <rect x="51" y="10387" width="124" height="32" rx="10"></rect>
-         <rect x="49" y="10385" width="124" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10405">SUBSCRIPTION</text>
-         <rect x="51" y="10431" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10429" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10449">SYNTAX</text>
-         <rect x="51" y="10475" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10473" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10493">SYSTEM</text>
-         <rect x="51" y="10519" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="10517" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10537">TABLES</text>
-         <rect x="51" y="10563" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="10561" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10581">TEMP</text>
-         <rect x="51" y="10607" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="10605" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10625">TEMPLATE</text>
-         <rect x="51" y="10651" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="10649" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10669">TEMPORARY</text>
-         <rect x="51" y="10695" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="10693" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10713">TENANT</text>
-         <rect x="51" y="10739" width="158" height="32" rx="10"></rect>
-         <rect x="49" y="10737" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10757">TESTING_RELOCATE</text>
-         <rect x="51" y="10783" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="10781" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10801">TEXT</text>
-         <rect x="51" y="10827" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="10825" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10845">TIES</text>
-         <rect x="51" y="10871" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="10869" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10889">TRACE</text>
-         <rect x="51" y="10915" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="10913" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10933">TRANSACTION</text>
-         <rect x="51" y="10959" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="10957" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10977">TRIGGER</text>
-         <rect x="51" y="11003" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="11001" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11021">TRUNCATE</text>
-         <rect x="51" y="11047" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="11045" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11065">TRUSTED</text>
-         <rect x="51" y="11091" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="11089" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11109">TYPE</text>
-         <rect x="51" y="11135" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="11133" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11153">THROTTLING</text>
-         <rect x="51" y="11179" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="11177" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11197">UNBOUNDED</text>
-         <rect x="51" y="11223" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="11221" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11241">UNCOMMITTED</text>
-         <rect x="51" y="11267" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="11265" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11285">UNKNOWN</text>
-         <rect x="51" y="11311" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="11309" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11329">UNLOGGED</text>
-         <rect x="51" y="11355" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="11353" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11373">UNSPLIT</text>
-         <rect x="51" y="11399" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="11397" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11417">UNTIL</text>
-         <rect x="51" y="11443" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="11441" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11461">UPDATE</text>
-         <rect x="51" y="11487" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="11485" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11505">UPSERT</text>
-         <rect x="51" y="11531" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="11529" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11549">USE</text>
-         <rect x="51" y="11575" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11573" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11593">USERS</text>
-         <rect x="51" y="11619" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="11617" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11637">VALID</text>
-         <rect x="51" y="11663" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="11661" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11681">VALIDATE</text>
-         <rect x="51" y="11707" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11705" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11725">VALUE</text>
-         <rect x="51" y="11751" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="11749" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11769">VARYING</text>
-         <rect x="51" y="11795" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="11793" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11813">VIEW</text>
-         <rect x="51" y="11839" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="11837" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11857">WITHIN</text>
-         <rect x="51" y="11883" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="11881" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11901">WITHOUT</text>
-         <rect x="51" y="11927" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11925" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11945">WRITE</text>
-         <rect x="51" y="11971" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="11969" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11989">YEAR</text>
-         <rect x="51" y="12015" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="12013" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12033">ZONE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h168 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m36 0 h10 m0 0 h198 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m134 0 h10 m0 0 h100 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m130 0 h10 m0 0 h104 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m110 0 h10 m0 0 h124 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m146 0 h10 m0 0 h88 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m112 0 h10 m0 0 h122 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m208 0 h10 m0 0 h26 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m122 0 h10 m0 0 h112 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m174 0 h10 m0 0 h60 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m234 0 h10 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m202 0 h10 m0 0 h32 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m190 0 h10 m0 0 h44 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m182 0 h10 m0 0 h52 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m58 0 h10 m0 0 h176 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m120 0 h10 m0 0 h114 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m146 0 h10 m0 0 h88 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m132 0 h10 m0 0 h102 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m40 0 h10 m0 0 h194 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m136 0 h10 m0 0 h98 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m128 0 h10 m0 0 h106 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m190 0 h10 m0 0 h44 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m38 0 h10 m0 0 h196 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m106 0 h10 m0 0 h128 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m114 0 h10 m0 0 h120 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m160 0 h10 m0 0 h74 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m78 0 h10 m0 0 h156 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m98 0 h10 m0 0 h136 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m66 0 h10 m0 0 h168 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m76 0 h10 m0 0 h158 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m116 0 h10 m0 0 h118 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m92 0 h10 m0 0 h142 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m102 0 h10 m0 0 h132 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m44 0 h10 m0 0 h190 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m60 0 h10 m0 0 h174 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m48 0 h10 m0 0 h186 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m100 0 h10 m0 0 h134 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m84 0 h10 m0 0 h150 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m68 0 h10 m0 0 h166 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m124 0 h10 m0 0 h110 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m70 0 h10 m0 0 h164 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m88 0 h10 m0 0 h146 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m104 0 h10 m0 0 h130 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m158 0 h10 m0 0 h76 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m52 0 h10 m0 0 h182 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m50 0 h10 m0 0 h184 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m118 0 h10 m0 0 h116 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m90 0 h10 m0 0 h144 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m54 0 h10 m0 0 h180 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m108 0 h10 m0 0 h126 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m122 0 h10 m0 0 h112 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m94 0 h10 m0 0 h140 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m96 0 h10 m0 0 h138 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m80 0 h10 m0 0 h154 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m72 0 h10 m0 0 h162 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m46 0 h10 m0 0 h188 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m62 0 h10 m0 0 h172 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m82 0 h10 m0 0 h152 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m74 0 h10 m0 0 h160 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m86 0 h10 m0 0 h148 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m64 0 h10 m0 0 h170 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m-264 -10 v20 m274 0 v-20 m-274 20 v24 m274 0 v-24 m-274 24 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m56 0 h10 m0 0 h178 m23 -12012 h-3"></path>
-         <polygon points="323 17 331 13 331 21"></polygon>
-         <polygon points="323 17 315 13 315 21"></polygon>
+         <text class="terminal" x="59" y="8601">READ</text>
+         <rect x="51" y="8627" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="8625" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8645">RECURRING</text>
+         <rect x="51" y="8671" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="8669" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8689">RECURSIVE</text>
+         <rect x="51" y="8715" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="8713" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8733">REF</text>
+         <rect x="51" y="8759" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="8757" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8777">REFRESH</text>
+         <rect x="51" y="8803" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="8801" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8821">REINDEX</text>
+         <rect x="51" y="8847" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="8845" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8865">RELEASE</text>
+         <rect x="51" y="8891" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8889" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8909">RENAME</text>
+         <rect x="51" y="8935" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="8933" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8953">REPEATABLE</text>
+         <rect x="51" y="8979" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="8977" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8997">REPLACE</text>
+         <rect x="51" y="9023" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="9021" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9041">RESET</text>
+         <rect x="51" y="9067" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="9065" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9085">RESTORE</text>
+         <rect x="51" y="9111" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="9109" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9129">RESTRICT</text>
+         <rect x="51" y="9155" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="9153" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9173">RESUME</text>
+         <rect x="51" y="9199" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9197" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9217">RETRY</text>
+         <rect x="51" y="9243" width="160" height="32" rx="10"></rect>
+         <rect x="49" y="9241" width="160" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9261">REVISION_HISTORY</text>
+         <rect x="51" y="9287" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="9285" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9305">REVOKE</text>
+         <rect x="51" y="9331" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="9329" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9349">ROLE</text>
+         <rect x="51" y="9375" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9373" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9393">ROLES</text>
+         <rect x="51" y="9419" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="9417" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9437">ROLLBACK</text>
+         <rect x="51" y="9463" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="9461" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9481">ROLLUP</text>
+         <rect x="51" y="9507" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="9505" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9525">ROWS</text>
+         <rect x="51" y="9551" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="9549" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9569">RULE</text>
+         <rect x="51" y="9595" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="9593" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9613">RUNNING</text>
+         <rect x="51" y="9639" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="9637" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9657">SCHEDULE</text>
+         <rect x="51" y="9683" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="9681" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9701">SCHEDULES</text>
+         <rect x="51" y="9727" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="9725" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9745">SETTING</text>
+         <rect x="51" y="9771" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="9769" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9789">SETTINGS</text>
+         <rect x="51" y="9815" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="9813" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9833">STATUS</text>
+         <rect x="51" y="9859" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="9857" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9877">SAVEPOINT</text>
+         <rect x="51" y="9903" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="9901" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9921">SCATTER</text>
+         <rect x="51" y="9947" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="9945" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9965">SCHEMA</text>
+         <rect x="51" y="9991" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="9989" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10009">SCHEMAS</text>
+         <rect x="51" y="10035" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="10033" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10053">SCRUB</text>
+         <rect x="51" y="10079" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="10077" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10097">SEARCH</text>
+         <rect x="51" y="10123" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="10121" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10141">SECOND</text>
+         <rect x="51" y="10167" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="10165" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10185">SERIALIZABLE</text>
+         <rect x="51" y="10211" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="10209" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10229">SEQUENCE</text>
+         <rect x="51" y="10255" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="10253" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10273">SEQUENCES</text>
+         <rect x="51" y="10299" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="10297" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10317">SERVER</text>
+         <rect x="51" y="10343" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="10341" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10361">SESSION</text>
+         <rect x="51" y="10387" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="10385" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10405">SESSIONS</text>
+         <rect x="51" y="10431" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="10429" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10449">SET</text>
+         <rect x="51" y="10475" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="10473" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10493">SHARE</text>
+         <rect x="51" y="10519" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="10517" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10537">SHOW</text>
+         <rect x="51" y="10563" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="10561" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10581">SIMPLE</text>
+         <rect x="51" y="10607" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="10605" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10625">SKIP</text>
+         <rect x="51" y="10651" width="238" height="32" rx="10"></rect>
+         <rect x="49" y="10649" width="238" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10669">SKIP_MISSING_FOREIGN_KEYS</text>
+         <rect x="51" y="10695" width="214" height="32" rx="10"></rect>
+         <rect x="49" y="10693" width="214" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10713">SKIP_MISSING_SEQUENCES</text>
+         <rect x="51" y="10739" width="274" height="32" rx="10"></rect>
+         <rect x="49" y="10737" width="274" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10757">SKIP_MISSING_SEQUENCE_OWNERS</text>
+         <rect x="51" y="10783" width="178" height="32" rx="10"></rect>
+         <rect x="49" y="10781" width="178" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10801">SKIP_MISSING_VIEWS</text>
+         <rect x="51" y="10827" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="10825" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10845">SNAPSHOT</text>
+         <rect x="51" y="10871" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="10869" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10889">SPLIT</text>
+         <rect x="51" y="10915" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="10913" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10933">SQL</text>
+         <rect x="51" y="10959" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="10957" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10977">START</text>
+         <rect x="51" y="11003" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="11001" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11021">STATISTICS</text>
+         <rect x="51" y="11047" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="11045" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11065">STDIN</text>
+         <rect x="51" y="11091" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="11089" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11109">STORAGE</text>
+         <rect x="51" y="11135" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="11133" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11153">STORE</text>
+         <rect x="51" y="11179" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11177" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11197">STORED</text>
+         <rect x="51" y="11223" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="11221" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11241">STORING</text>
+         <rect x="51" y="11267" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="11265" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11285">STRICT</text>
+         <rect x="51" y="11311" width="124" height="32" rx="10"></rect>
+         <rect x="49" y="11309" width="124" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11329">SUBSCRIPTION</text>
+         <rect x="51" y="11355" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11353" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11373">SYNTAX</text>
+         <rect x="51" y="11399" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11397" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11417">SYSTEM</text>
+         <rect x="51" y="11443" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="11441" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11461">TABLES</text>
+         <rect x="51" y="11487" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="11485" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11505">TEMP</text>
+         <rect x="51" y="11531" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="11529" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11549">TEMPLATE</text>
+         <rect x="51" y="11575" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="11573" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11593">TEMPORARY</text>
+         <rect x="51" y="11619" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="11617" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11637">TENANT</text>
+         <rect x="51" y="11663" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="11661" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11681">TESTING_RELOCATE</text>
+         <rect x="51" y="11707" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="11705" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11725">TEXT</text>
+         <rect x="51" y="11751" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="11749" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11769">TIES</text>
+         <rect x="51" y="11795" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="11793" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11813">TRACE</text>
+         <rect x="51" y="11839" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="11837" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11857">TRANSACTION</text>
+         <rect x="51" y="11883" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="11881" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11901">TRANSACTIONS</text>
+         <rect x="51" y="11927" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="11925" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11945">TRIGGER</text>
+         <rect x="51" y="11971" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="11969" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11989">TRUNCATE</text>
+         <rect x="51" y="12015" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="12013" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12033">TRUSTED</text>
+         <rect x="51" y="12059" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="12057" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12077">TYPE</text>
+         <rect x="51" y="12103" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="12101" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12121">TYPES</text>
+         <rect x="51" y="12147" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="12145" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12165">THROTTLING</text>
+         <rect x="51" y="12191" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="12189" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12209">UNBOUNDED</text>
+         <rect x="51" y="12235" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="12233" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12253">UNCOMMITTED</text>
+         <rect x="51" y="12279" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="12277" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12297">UNKNOWN</text>
+         <rect x="51" y="12323" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="12321" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12341">UNLOGGED</text>
+         <rect x="51" y="12367" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="12365" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12385">UNSPLIT</text>
+         <rect x="51" y="12411" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="12409" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12429">UNTIL</text>
+         <rect x="51" y="12455" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="12453" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12473">UPDATE</text>
+         <rect x="51" y="12499" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="12497" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12517">UPSERT</text>
+         <rect x="51" y="12543" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="12541" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12561">USE</text>
+         <rect x="51" y="12587" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="12585" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12605">USERS</text>
+         <rect x="51" y="12631" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="12629" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12649">VALID</text>
+         <rect x="51" y="12675" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="12673" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12693">VALIDATE</text>
+         <rect x="51" y="12719" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="12717" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12737">VALUE</text>
+         <rect x="51" y="12763" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="12761" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12781">VARYING</text>
+         <rect x="51" y="12807" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="12805" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12825">VIEW</text>
+         <rect x="51" y="12851" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="12849" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12869">VIEWACTIVITY</text>
+         <rect x="51" y="12895" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="12893" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12913">WITHIN</text>
+         <rect x="51" y="12939" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="12937" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12957">WITHOUT</text>
+         <rect x="51" y="12983" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="12981" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13001">WRITE</text>
+         <rect x="51" y="13027" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="13025" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13045">YEAR</text>
+         <rect x="51" y="13071" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="13069" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13089">ZONE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h208 m-314 0 h20 m294 0 h20 m-334 0 q10 0 10 10 m314 0 q0 -10 10 -10 m-324 10 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m36 0 h10 m0 0 h238 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m134 0 h10 m0 0 h140 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m130 0 h10 m0 0 h144 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m120 0 h10 m0 0 h154 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m110 0 h10 m0 0 h164 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m146 0 h10 m0 0 h128 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m176 0 h10 m0 0 h98 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m208 0 h10 m0 0 h66 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m174 0 h10 m0 0 h100 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m234 0 h10 m0 0 h40 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m202 0 h10 m0 0 h72 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m182 0 h10 m0 0 h92 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m50 0 h10 m0 0 h224 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m120 0 h10 m0 0 h154 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m146 0 h10 m0 0 h128 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m132 0 h10 m0 0 h142 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m40 0 h10 m0 0 h234 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m110 0 h10 m0 0 h164 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m128 0 h10 m0 0 h146 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m196 0 h10 m0 0 h78 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m134 0 h10 m0 0 h140 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m44 0 h10 m0 0 h230 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m160 0 h10 m0 0 h114 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m44 0 h10 m0 0 h230 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m238 0 h10 m0 0 h36 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m214 0 h10 m0 0 h60 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m274 0 h10 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m178 0 h10 m0 0 h96 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m124 0 h10 m0 0 h150 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m158 0 h10 m0 0 h116 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m50 0 h10 m0 0 h224 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m126 0 h10 m0 0 h148 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m23 -13068 h-3"></path>
+         <polygon points="363 17 371 13 371 21"></polygon>
+         <polygon points="363 17 355 13 355 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -5936,7 +6377,7 @@
             <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_name_keyword" href="#col_name_keyword">col_name_keyword:</a></p>
-      <svg width="260" height="2236">
+      <svg width="260" height="2280">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -5955,145 +6396,148 @@
          <rect x="51" y="179" width="86" height="32" rx="10"></rect>
          <rect x="49" y="177" width="86" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="197">BOOLEAN</text>
-         <rect x="51" y="223" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">CHAR</text>
-         <rect x="51" y="267" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">CHARACTER</text>
-         <rect x="51" y="311" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">CHARACTERISTICS</text>
-         <rect x="51" y="355" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="353" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="373">COALESCE</text>
-         <rect x="51" y="399" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="397" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="417">DEC</text>
-         <rect x="51" y="443" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="441" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="461">DECIMAL</text>
-         <rect x="51" y="487" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="485" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="505">EXISTS</text>
-         <rect x="51" y="531" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">EXTRACT</text>
-         <rect x="51" y="575" width="162" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="162" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">EXTRACT_DURATION</text>
-         <rect x="51" y="619" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">FLOAT</text>
-         <rect x="51" y="663" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">GEOGRAPHY</text>
-         <rect x="51" y="707" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">GEOMETRY</text>
-         <rect x="51" y="751" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">GREATEST</text>
-         <rect x="51" y="795" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">GROUPING</text>
-         <rect x="51" y="839" width="34" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">IF</text>
-         <rect x="51" y="883" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">IFERROR</text>
-         <rect x="51" y="927" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">IFNULL</text>
-         <rect x="51" y="971" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">INT</text>
-         <rect x="51" y="1015" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">INTEGER</text>
-         <rect x="51" y="1059" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">INTERVAL</text>
-         <rect x="51" y="1103" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">ISERROR</text>
-         <rect x="51" y="1147" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">LEAST</text>
-         <rect x="51" y="1191" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">NULLIF</text>
-         <rect x="51" y="1235" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1233" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">NUMERIC</text>
-         <rect x="51" y="1279" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">OUT</text>
-         <rect x="51" y="1323" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">OVERLAY</text>
-         <rect x="51" y="1367" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">POINT</text>
-         <rect x="51" y="1411" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">POLYGON</text>
-         <rect x="51" y="1455" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">POSITION</text>
-         <rect x="51" y="1499" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">PRECISION</text>
-         <rect x="51" y="1543" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">REAL</text>
+         <rect x="51" y="223" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">BOX2D</text>
+         <rect x="51" y="267" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">CHAR</text>
+         <rect x="51" y="311" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">CHARACTER</text>
+         <rect x="51" y="355" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">CHARACTERISTICS</text>
+         <rect x="51" y="399" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">COALESCE</text>
+         <rect x="51" y="443" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">DEC</text>
+         <rect x="51" y="487" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">DECIMAL</text>
+         <rect x="51" y="531" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">EXISTS</text>
+         <rect x="51" y="575" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">EXTRACT</text>
+         <rect x="51" y="619" width="162" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="162" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">EXTRACT_DURATION</text>
+         <rect x="51" y="663" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">FLOAT</text>
+         <rect x="51" y="707" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">GEOGRAPHY</text>
+         <rect x="51" y="751" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">GEOMETRY</text>
+         <rect x="51" y="795" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">GREATEST</text>
+         <rect x="51" y="839" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">GROUPING</text>
+         <rect x="51" y="883" width="34" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">IF</text>
+         <rect x="51" y="927" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">IFERROR</text>
+         <rect x="51" y="971" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">IFNULL</text>
+         <rect x="51" y="1015" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">INT</text>
+         <rect x="51" y="1059" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">INTEGER</text>
+         <rect x="51" y="1103" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">INTERVAL</text>
+         <rect x="51" y="1147" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">ISERROR</text>
+         <rect x="51" y="1191" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">LEAST</text>
+         <rect x="51" y="1235" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">NULLIF</text>
+         <rect x="51" y="1279" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">NUMERIC</text>
+         <rect x="51" y="1323" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">OUT</text>
+         <rect x="51" y="1367" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">OVERLAY</text>
+         <rect x="51" y="1411" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">POINT</text>
+         <rect x="51" y="1455" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">POLYGON</text>
+         <rect x="51" y="1499" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">POSITION</text>
+         <rect x="51" y="1543" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">PRECISION</text>
          <rect x="51" y="1587" width="54" height="32" rx="10"></rect>
          <rect x="49" y="1585" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">ROW</text>
-         <rect x="51" y="1631" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">SMALLINT</text>
-         <rect x="51" y="1675" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">STRING</text>
-         <rect x="51" y="1719" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">SUBSTRING</text>
-         <rect x="51" y="1763" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">TIME</text>
-         <rect x="51" y="1807" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">TIMETZ</text>
-         <rect x="51" y="1851" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="1849" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">TIMESTAMP</text>
-         <rect x="51" y="1895" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">TIMESTAMPTZ</text>
-         <rect x="51" y="1939" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">TREAT</text>
-         <rect x="51" y="1983" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">TRIM</text>
-         <rect x="51" y="2027" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">VALUES</text>
-         <rect x="51" y="2071" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">VARBIT</text>
-         <rect x="51" y="2115" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">VARCHAR</text>
-         <rect x="51" y="2159" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">VIRTUAL</text>
-         <rect x="51" y="2203" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">WORK</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m136 0 h10 m0 0 h26 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m56 0 h10 m0 0 h106 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m146 0 h10 m0 0 h16 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m106 0 h10 m0 0 h56 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m114 0 h10 m0 0 h48 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m23 -2200 h-3"></path>
+         <text class="terminal" x="59" y="1605">REAL</text>
+         <rect x="51" y="1631" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">ROW</text>
+         <rect x="51" y="1675" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">SMALLINT</text>
+         <rect x="51" y="1719" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">STRING</text>
+         <rect x="51" y="1763" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">SUBSTRING</text>
+         <rect x="51" y="1807" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">TIME</text>
+         <rect x="51" y="1851" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="1849" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1869">TIMETZ</text>
+         <rect x="51" y="1895" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">TIMESTAMP</text>
+         <rect x="51" y="1939" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">TIMESTAMPTZ</text>
+         <rect x="51" y="1983" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">TREAT</text>
+         <rect x="51" y="2027" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="2025" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2045">TRIM</text>
+         <rect x="51" y="2071" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="2069" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2089">VALUES</text>
+         <rect x="51" y="2115" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">VARBIT</text>
+         <rect x="51" y="2159" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">VARCHAR</text>
+         <rect x="51" y="2203" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">VIRTUAL</text>
+         <rect x="51" y="2247" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="2245" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2265">WORK</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m136 0 h10 m0 0 h26 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m42 0 h10 m0 0 h120 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m56 0 h10 m0 0 h106 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m146 0 h10 m0 0 h16 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m46 0 h10 m0 0 h116 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m106 0 h10 m0 0 h56 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m94 0 h10 m0 0 h68 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m34 0 h10 m0 0 h128 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m44 0 h10 m0 0 h118 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m86 0 h10 m0 0 h76 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m80 0 h10 m0 0 h82 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m82 0 h10 m0 0 h80 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m48 0 h10 m0 0 h114 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m64 0 h10 m0 0 h98 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m90 0 h10 m0 0 h72 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m96 0 h10 m0 0 h66 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m88 0 h10 m0 0 h74 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m100 0 h10 m0 0 h62 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m52 0 h10 m0 0 h110 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m68 0 h10 m0 0 h94 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m98 0 h10 m0 0 h64 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m114 0 h10 m0 0 h48 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h108 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m72 0 h10 m0 0 h90 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m70 0 h10 m0 0 h92 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m84 0 h10 m0 0 h78 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m78 0 h10 m0 0 h84 m-192 -10 v20 m202 0 v-20 m-202 20 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m62 0 h10 m0 0 h100 m23 -2244 h-3"></path>
          <polygon points="251 17 259 13 259 21"></polygon>
          <polygon points="251 17 243 13 243 21"></polygon>
       </svg>
@@ -6213,6 +6657,52 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#privilege_list" title="privilege_list">privilege_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_name_list" href="#type_name_list">type_name_list:</a></p>
+      <svg width="188" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#type_name" xlink:title="type_name">
+            <rect x="51" y="47" width="90" height="32"></rect>
+            <rect x="49" y="45" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">type_name</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m90 0 h10 m-130 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m110 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-110 0 h10 m24 0 h10 m0 0 h66 m23 44 h-3"></path>
+         <polygon points="179 61 187 57 187 65"></polygon>
+         <polygon points="179 61 171 57 171 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_type_stmt" title="drop_type_stmt">drop_type_stmt</a></li>
+            <li><a href="#target_types" title="target_types">target_types</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name" href="#schema_name">schema_name:</a></p>
+      <svg width="112" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
+         <polygon points="103 17 111 13 111 21"></polygon>
+         <polygon points="103 17 95 13 95 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_schema_stmt" title="alter_schema_stmt">alter_schema_stmt</a></li>
+            <li><a href="#alter_sequence_set_schema_stmt" title="alter_sequence_set_schema_stmt">alter_sequence_set_schema_stmt</a></li>
+            <li><a href="#alter_table_set_schema_stmt" title="alter_table_set_schema_stmt">alter_table_set_schema_stmt</a></li>
+            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
+            <li><a href="#alter_view_set_schema_stmt" title="alter_view_set_schema_stmt">alter_view_set_schema_stmt</a></li>
+            <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
+            <li><a href="#schema_name_list" title="schema_name_list">schema_name_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_list" href="#type_list">type_list:</a></p>
       <svg width="180" height="80">
@@ -6460,7 +6950,7 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_stmt" href="#alter_database_stmt">alter_database_stmt:</a></p>
-      <svg width="306" height="80">
+      <svg width="328" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -6474,9 +6964,19 @@
             <rect x="49" y="45" width="192" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="65">alter_zone_database_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m208 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m192 0 h10 m0 0 h16 m23 -44 h-3"></path>
-         <polygon points="297 17 305 13 305 21"></polygon>
-         <polygon points="297 17 289 13 289 21"></polygon>
+         <a xlink:href="#alter_database_owner" xlink:title="alter_database_owner">
+            <rect x="51" y="91" width="164" height="32"></rect>
+            <rect x="49" y="89" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">alter_database_owner</text>
+         </a>
+         <a xlink:href="#alter_database_to_schema_stmt" xlink:title="alter_database_to_schema_stmt">
+            <rect x="51" y="135" width="230" height="32"></rect>
+            <rect x="49" y="133" width="230" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">alter_database_to_schema_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m208 0 h10 m0 0 h22 m-270 0 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m192 0 h10 m0 0 h38 m-260 -10 v20 m270 0 v-20 m-270 20 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m164 0 h10 m0 0 h66 m-260 -10 v20 m270 0 v-20 m-270 20 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m230 0 h10 m23 -132 h-3"></path>
+         <polygon points="319 17 327 13 327 21"></polygon>
+         <polygon points="319 17 311 13 311 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -6519,7 +7019,7 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_schema_stmt" href="#alter_schema_stmt">alter_schema_stmt:</a></p>
-      <svg width="628" height="36">
+      <svg width="668" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -6534,27 +7034,38 @@
             <rect x="207" y="1" width="110" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="217" y="21">schema_name</text>
          </a>
-         <rect x="339" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="337" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="347" y="21">RENAME</text>
-         <rect x="433" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="431" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="441" y="21">TO</text>
+         <rect x="359" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="357" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="367" y="21">RENAME</text>
+         <rect x="453" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="451" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="461" y="21">TO</text>
          <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="491" y="3" width="110" height="32"></rect>
-            <rect x="489" y="1" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="499" y="21">schema_name</text>
+            <rect x="511" y="3" width="110" height="32"></rect>
+            <rect x="509" y="1" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="519" y="21">schema_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m110 0 h10 m3 0 h-3"></path>
-         <polygon points="619 17 627 13 627 21"></polygon>
-         <polygon points="619 17 611 13 611 21"></polygon>
+         <rect x="359" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="357" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="367" y="65">OWNER</text>
+         <rect x="451" y="47" width="38" height="32" rx="10"></rect>
+         <rect x="449" y="45" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="459" y="65">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="509" y="47" width="80" height="32"></rect>
+            <rect x="507" y="45" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="517" y="65">role_spec</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m20 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m110 0 h10 m-302 0 h20 m282 0 h20 m-322 0 q10 0 10 10 m302 0 q0 -10 10 -10 m-312 10 v24 m302 0 v-24 m-302 24 q0 10 10 10 m282 0 q10 0 10 -10 m-292 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h32 m23 -44 h-3"></path>
+         <polygon points="659 17 667 13 667 21"></polygon>
+         <polygon points="659 17 651 13 651 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_type_stmt" href="#alter_type_stmt">alter_type_stmt:</a></p>
-      <svg width="762" height="266">
+      <svg width="762" height="310">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
@@ -6626,7 +7137,18 @@
             <rect x="203" y="231" width="110" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="213" y="251">schema_name</text>
          </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-298 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m76 0 h10 m0 0 h10 m172 0 h10 m-710 0 h20 m690 0 h20 m-730 0 q10 0 10 10 m710 0 q0 -10 10 -10 m-720 10 v56 m710 0 v-56 m-710 56 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m74 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m-354 0 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v24 m354 0 v-24 m-354 24 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m0 0 h202 m20 -44 h222 m-700 -10 v20 m710 0 v-20 m-710 20 v68 m710 0 v-68 m-710 68 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m44 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h400 m23 -164 h-3"></path>
+         <rect x="45" y="277" width="72" height="32" rx="10"></rect>
+         <rect x="43" y="275" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="295">OWNER</text>
+         <rect x="137" y="277" width="38" height="32" rx="10"></rect>
+         <rect x="135" y="275" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="145" y="295">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="195" y="277" width="80" height="32"></rect>
+            <rect x="193" y="275" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="295">role_spec</text>
+         </a>
+         <path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-298 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m76 0 h10 m0 0 h10 m172 0 h10 m-710 0 h20 m690 0 h20 m-730 0 q10 0 10 10 m710 0 q0 -10 10 -10 m-720 10 v56 m710 0 v-56 m-710 56 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m74 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m-354 0 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v24 m354 0 v-24 m-354 24 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m0 0 h202 m20 -44 h222 m-700 -10 v20 m710 0 v-20 m-710 20 v68 m710 0 v-68 m-710 68 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m44 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h400 m-700 -10 v20 m710 0 v-20 m-710 20 v24 m710 0 v-24 m-710 24 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h440 m23 -208 h-3"></path>
          <polygon points="753 83 761 79 761 87"></polygon>
          <polygon points="753 83 745 79 745 87"></polygon>
       </svg>
@@ -7920,110 +8442,110 @@
             <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_table_stmt" href="#create_table_stmt">create_table_stmt:</a></p>
-      <svg width="756" height="134">
+      <svg width="678" height="134">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CREATE</text>
-         <a xlink:href="#opt_temp_create_table" xlink:title="opt_temp_create_table">
-            <rect x="121" y="3" width="168" height="32"></rect>
-            <rect x="119" y="1" width="168" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="129" y="21">opt_temp_create_table</text>
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">CREATE</text>
+         <a xlink:href="#opt_persistence_temp_table" xlink:title="opt_persistence_temp_table">
+            <rect x="123" y="3" width="202" height="32"></rect>
+            <rect x="121" y="1" width="202" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="131" y="21">opt_persistence_temp_table</text>
          </a>
-         <rect x="309" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="307" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="317" y="21">TABLE</text>
-         <rect x="411" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="409" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="419" y="53">IF</text>
-         <rect x="465" y="35" width="48" height="32" rx="10"></rect>
-         <rect x="463" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="473" y="53">NOT</text>
-         <rect x="533" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="531" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="541" y="53">EXISTS</text>
+         <rect x="345" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="343" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="353" y="21">TABLE</text>
+         <rect x="447" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="445" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="455" y="53">IF</text>
+         <rect x="501" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="499" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="53">NOT</text>
+         <rect x="569" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="567" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="577" y="53">EXISTS</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="641" y="3" width="94" height="32"></rect>
-            <rect x="639" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="649" y="21">table_name</text>
+            <rect x="25" y="101" width="94" height="32"></rect>
+            <rect x="23" y="99" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="33" y="119">table_name</text>
          </a>
-         <rect x="217" y="101" width="26" height="32" rx="10"></rect>
-         <rect x="215" y="99" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="225" y="119">(</text>
+         <rect x="139" y="101" width="26" height="32" rx="10"></rect>
+         <rect x="137" y="99" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="119">(</text>
          <a xlink:href="#opt_table_elem_list" xlink:title="opt_table_elem_list">
-            <rect x="263" y="101" width="144" height="32"></rect>
-            <rect x="261" y="99" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="271" y="119">opt_table_elem_list</text>
+            <rect x="185" y="101" width="144" height="32"></rect>
+            <rect x="183" y="99" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="119">opt_table_elem_list</text>
          </a>
-         <rect x="427" y="101" width="26" height="32" rx="10"></rect>
-         <rect x="425" y="99" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="435" y="119">)</text>
+         <rect x="349" y="101" width="26" height="32" rx="10"></rect>
+         <rect x="347" y="99" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="357" y="119">)</text>
          <a xlink:href="#opt_interleave" xlink:title="opt_interleave">
-            <rect x="473" y="101" width="112" height="32"></rect>
-            <rect x="471" y="99" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="481" y="119">opt_interleave</text>
+            <rect x="395" y="101" width="112" height="32"></rect>
+            <rect x="393" y="99" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="403" y="119">opt_interleave</text>
          </a>
          <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="605" y="101" width="124" height="32"></rect>
-            <rect x="603" y="99" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="613" y="119">opt_partition_by</text>
+            <rect x="527" y="101" width="124" height="32"></rect>
+            <rect x="525" y="99" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="535" y="119">opt_partition_by</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m168 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-562 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m26 0 h10 m0 0 h10 m144 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
-         <polygon points="747 115 755 111 755 119"></polygon>
-         <polygon points="747 115 739 111 739 119"></polygon>
+         <path class="line" d="m19 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m202 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-676 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m144 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
+         <polygon points="669 115 677 111 677 119"></polygon>
+         <polygon points="669 115 661 111 661 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_table_as_stmt" href="#create_table_as_stmt">create_table_as_stmt:</a></p>
-      <svg width="756" height="134">
+      <svg width="676" height="134">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="70" height="32" rx="10"></rect>
          <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">CREATE</text>
-         <a xlink:href="#opt_temp_create_table" xlink:title="opt_temp_create_table">
-            <rect x="121" y="3" width="168" height="32"></rect>
-            <rect x="119" y="1" width="168" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="129" y="21">opt_temp_create_table</text>
+         <a xlink:href="#opt_persistence_temp_table" xlink:title="opt_persistence_temp_table">
+            <rect x="121" y="3" width="202" height="32"></rect>
+            <rect x="119" y="1" width="202" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="129" y="21">opt_persistence_temp_table</text>
          </a>
-         <rect x="309" y="3" width="62" height="32" rx="10"></rect>
-         <rect x="307" y="1" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="317" y="21">TABLE</text>
-         <rect x="411" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="409" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="419" y="53">IF</text>
-         <rect x="465" y="35" width="48" height="32" rx="10"></rect>
-         <rect x="463" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="473" y="53">NOT</text>
-         <rect x="533" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="531" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="541" y="53">EXISTS</text>
+         <rect x="343" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="341" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="351" y="21">TABLE</text>
+         <rect x="445" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="443" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="453" y="53">IF</text>
+         <rect x="499" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="497" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="507" y="53">NOT</text>
+         <rect x="567" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="565" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="575" y="53">EXISTS</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="641" y="3" width="94" height="32"></rect>
-            <rect x="639" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="649" y="21">table_name</text>
+            <rect x="203" y="101" width="94" height="32"></rect>
+            <rect x="201" y="99" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="211" y="119">table_name</text>
          </a>
          <a xlink:href="#create_as_opt_col_list" xlink:title="create_as_opt_col_list">
-            <rect x="397" y="101" width="162" height="32"></rect>
-            <rect x="395" y="99" width="162" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="405" y="119">create_as_opt_col_list</text>
+            <rect x="317" y="101" width="162" height="32"></rect>
+            <rect x="315" y="99" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="325" y="119">create_as_opt_col_list</text>
          </a>
-         <rect x="579" y="101" width="38" height="32" rx="10"></rect>
-         <rect x="577" y="99" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="587" y="119">AS</text>
+         <rect x="499" y="101" width="38" height="32" rx="10"></rect>
+         <rect x="497" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="507" y="119">AS</text>
          <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="637" y="101" width="92" height="32"></rect>
-            <rect x="635" y="99" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="645" y="119">select_stmt</text>
+            <rect x="557" y="101" width="92" height="32"></rect>
+            <rect x="555" y="99" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="565" y="119">select_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m168 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-382 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m162 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
-         <polygon points="747 115 755 111 755 119"></polygon>
-         <polygon points="747 115 739 111 739 119"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m202 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-496 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m0 0 h10 m162 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
+         <polygon points="667 115 675 111 675 119"></polygon>
+         <polygon points="667 115 659 111 659 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -8071,7 +8593,7 @@
             <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_view_stmt" href="#create_view_stmt">create_view_stmt:</a></p>
-      <svg width="700" height="178">
+      <svg width="668" height="190">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -8079,57 +8601,60 @@
          <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">CREATE</text>
          <a xlink:href="#opt_temp" xlink:title="opt_temp">
-            <rect x="141" y="3" width="80" height="32"></rect>
-            <rect x="139" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="149" y="21">opt_temp</text>
+            <rect x="161" y="3" width="80" height="32"></rect>
+            <rect x="159" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="169" y="21">opt_temp</text>
          </a>
-         <rect x="241" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="239" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="249" y="21">VIEW</text>
-         <rect x="337" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="335" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="345" y="53">IF</text>
-         <rect x="391" y="35" width="48" height="32" rx="10"></rect>
-         <rect x="389" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="399" y="53">NOT</text>
-         <rect x="459" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="457" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="467" y="53">EXISTS</text>
-         <rect x="141" y="79" width="40" height="32" rx="10"></rect>
-         <rect x="139" y="77" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="149" y="97">OR</text>
-         <rect x="201" y="79" width="80" height="32" rx="10"></rect>
-         <rect x="199" y="77" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="209" y="97">REPLACE</text>
+         <rect x="161" y="47" width="120" height="32" rx="10"></rect>
+         <rect x="159" y="45" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="169" y="65">MATERIALIZED</text>
+         <rect x="321" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="319" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="329" y="21">VIEW</text>
+         <rect x="417" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="415" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="425" y="53">IF</text>
+         <rect x="471" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="469" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="479" y="53">NOT</text>
+         <rect x="539" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="537" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="547" y="53">EXISTS</text>
+         <rect x="141" y="91" width="40" height="32" rx="10"></rect>
+         <rect x="139" y="89" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="109">OR</text>
+         <rect x="201" y="91" width="80" height="32" rx="10"></rect>
+         <rect x="199" y="89" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="209" y="109">REPLACE</text>
          <a xlink:href="#opt_temp" xlink:title="opt_temp">
-            <rect x="301" y="79" width="80" height="32"></rect>
-            <rect x="299" y="77" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="309" y="97">opt_temp</text>
+            <rect x="301" y="91" width="80" height="32"></rect>
+            <rect x="299" y="89" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="309" y="109">opt_temp</text>
          </a>
-         <rect x="401" y="79" width="56" height="32" rx="10"></rect>
-         <rect x="399" y="77" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="409" y="97">VIEW</text>
+         <rect x="401" y="91" width="56" height="32" rx="10"></rect>
+         <rect x="399" y="89" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="409" y="109">VIEW</text>
          <a xlink:href="#view_name" xlink:title="view_name">
-            <rect x="587" y="3" width="92" height="32"></rect>
-            <rect x="585" y="1" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="595" y="21">view_name</text>
+            <rect x="241" y="157" width="92" height="32"></rect>
+            <rect x="239" y="155" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="249" y="175">view_name</text>
          </a>
          <a xlink:href="#opt_column_list" xlink:title="opt_column_list">
-            <rect x="385" y="145" width="118" height="32"></rect>
-            <rect x="383" y="143" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="393" y="163">opt_column_list</text>
+            <rect x="353" y="157" width="118" height="32"></rect>
+            <rect x="351" y="155" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="361" y="175">opt_column_list</text>
          </a>
-         <rect x="523" y="145" width="38" height="32" rx="10"></rect>
-         <rect x="521" y="143" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="531" y="163">AS</text>
+         <rect x="491" y="157" width="38" height="32" rx="10"></rect>
+         <rect x="489" y="155" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="499" y="175">AS</text>
          <a xlink:href="#select_stmt" xlink:title="select_stmt">
-            <rect x="581" y="145" width="92" height="32"></rect>
-            <rect x="579" y="143" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="589" y="163">select_stmt</text>
+            <rect x="549" y="157" width="92" height="32"></rect>
+            <rect x="547" y="155" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="557" y="175">select_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m-426 -32 h20 m426 0 h20 m-466 0 q10 0 10 10 m446 0 q0 -10 10 -10 m-456 10 v56 m446 0 v-56 m-446 56 q0 10 10 10 m426 0 q10 0 10 -10 m-436 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m56 0 h10 m0 0 h90 m20 -76 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-338 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
-         <polygon points="691 159 699 155 699 163"></polygon>
-         <polygon points="691 159 683 155 683 163"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m40 0 h10 m80 0 h10 m0 0 h40 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -44 h10 m56 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m-506 -32 h20 m506 0 h20 m-546 0 q10 0 10 10 m526 0 q0 -10 10 -10 m-536 10 v68 m526 0 v-68 m-526 68 q0 10 10 10 m506 0 q10 0 10 -10 m-516 10 h10 m40 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m56 0 h10 m0 0 h170 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 154 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
+         <polygon points="659 171 667 167 667 175"></polygon>
+         <polygon points="659 171 651 167 651 175"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -8272,24 +8797,21 @@
             <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cron_expr" href="#cron_expr">cron_expr:</a></p>
-      <svg width="380" height="80">
+      <svg width="340" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="100" height="32" rx="10"></rect>
          <rect x="29" y="1" width="100" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">RECURRING</text>
-         <rect x="171" y="3" width="64" height="32" rx="10"></rect>
-         <rect x="169" y="1" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="179" y="21">NEVER</text>
          <a xlink:href="#sconst_or_placeholder" xlink:title="sconst_or_placeholder">
-            <rect x="171" y="47" width="162" height="32"></rect>
-            <rect x="169" y="45" width="162" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="179" y="65">sconst_or_placeholder</text>
+            <rect x="151" y="3" width="162" height="32"></rect>
+            <rect x="149" y="1" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="159" y="21">sconst_or_placeholder</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m20 0 h10 m64 0 h10 m0 0 h98 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m23 -44 h-3"></path>
-         <polygon points="371 17 379 13 379 21"></polygon>
-         <polygon points="371 17 363 13 363 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m162 0 h10 m3 0 h-3"></path>
+         <polygon points="331 17 339 13 339 21"></polygon>
+         <polygon points="331 17 323 13 323 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -8636,35 +9158,38 @@
             <li><a href="#drop_ddl_stmt" title="drop_ddl_stmt">drop_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_view_stmt" href="#drop_view_stmt">drop_view_stmt:</a></p>
-      <svg width="674" height="68">
+      <svg width="688" height="134">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="58" height="32" rx="10"></rect>
          <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">DROP</text>
-         <rect x="109" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="107" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="117" y="21">VIEW</text>
-         <rect x="205" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="203" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="213" y="53">IF</text>
-         <rect x="259" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="257" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="267" y="53">EXISTS</text>
+         <rect x="129" y="35" width="120" height="32" rx="10"></rect>
+         <rect x="127" y="33" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="137" y="53">MATERIALIZED</text>
+         <rect x="289" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="287" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="297" y="21">VIEW</text>
+         <rect x="385" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="383" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="393" y="53">IF</text>
+         <rect x="439" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="437" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="447" y="53">EXISTS</text>
          <a xlink:href="#table_name_list" xlink:title="table_name_list">
-            <rect x="367" y="3" width="120" height="32"></rect>
-            <rect x="365" y="1" width="120" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="375" y="21">table_name_list</text>
+            <rect x="547" y="3" width="120" height="32"></rect>
+            <rect x="545" y="1" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="555" y="21">table_name_list</text>
          </a>
          <a xlink:href="#opt_drop_behavior" xlink:title="opt_drop_behavior">
-            <rect x="507" y="3" width="140" height="32"></rect>
-            <rect x="505" y="1" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="515" y="21">opt_drop_behavior</text>
+            <rect x="521" y="101" width="140" height="32"></rect>
+            <rect x="519" y="99" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="529" y="119">opt_drop_behavior</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m120 0 h10 m0 0 h10 m140 0 h10 m3 0 h-3"></path>
-         <polygon points="665 17 673 13 673 21"></polygon>
-         <polygon points="665 17 657 13 657 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m120 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-190 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m140 0 h10 m3 0 h-3"></path>
+         <polygon points="679 115 687 111 687 119"></polygon>
+         <polygon points="679 115 671 111 671 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -8816,7 +9341,30 @@
             <li><a href="#opt_lc_collate_clause" title="opt_lc_collate_clause">opt_lc_collate_clause</a></li>
             <li><a href="#opt_lc_ctype_clause" title="opt_lc_ctype_clause">opt_lc_ctype_clause</a></li>
             <li><a href="#opt_template_clause" title="opt_template_clause">opt_template_clause</a></li>
+            <li><a href="#role_spec" title="role_spec">role_spec</a></li>
             <li><a href="#string_or_placeholder" title="string_or_placeholder">string_or_placeholder</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="kv_option_list" href="#kv_option_list">kv_option_list:</a></p>
+      <svg width="180" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#kv_option" xlink:title="kv_option">
+            <rect x="51" y="47" width="82" height="32"></rect>
+            <rect x="49" y="45" width="82" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">kv_option</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m23 44 h-3"></path>
+         <polygon points="171 61 179 57 179 65"></polygon>
+         <polygon points="171 61 163 57 163 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_with_options" title="opt_with_options">opt_with_options</a></li>
+            <li><a href="#opt_with_schedule_options" title="opt_with_schedule_options">opt_with_schedule_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="table_elem" href="#table_elem">table_elem:</a></p>
       <svg width="436" height="212">
@@ -8882,30 +9430,6 @@
          </p><ul>
             <li><a href="#insert_column_list" title="insert_column_list">insert_column_list</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_conf_expr" href="#opt_conf_expr">opt_conf_expr:</a></p>
-      <svg width="270" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="26" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">(</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="97" y="23" width="80" height="32"></rect>
-            <rect x="95" y="21" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="105" y="41">name_list</text>
-         </a>
-         <rect x="197" y="23" width="26" height="32" rx="10"></rect>
-         <rect x="195" y="21" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="205" y="41">)</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h182 m-212 0 h20 m192 0 h20 m-232 0 q10 0 10 10 m212 0 q0 -10 10 -10 m-222 10 v12 m212 0 v-12 m-212 12 q0 10 10 10 m192 0 q10 0 10 -10 m-202 10 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m23 -32 h-3"></path>
-         <polygon points="261 5 269 1 269 9"></polygon>
-         <polygon points="261 5 253 1 253 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#on_conflict" title="on_conflict">on_conflict</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="session_var" href="#session_var">session_var:</a></p>
       <svg width="226" height="256">
          
@@ -8967,6 +9491,27 @@
             <li><a href="#set_csetting_stmt" title="set_csetting_stmt">set_csetting_stmt</a></li>
             <li><a href="#show_csettings_stmt" title="show_csettings_stmt">show_csettings_stmt</a></li>
             <li><a href="#var_set_list" title="var_set_list">var_set_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="restore_options_list" href="#restore_options_list">restore_options_list:</a></p>
+      <svg width="218" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#restore_options" xlink:title="restore_options">
+            <rect x="51" y="47" width="120" height="32"></rect>
+            <rect x="49" y="45" width="120" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">restore_options</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m120 0 h10 m-160 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m140 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-140 0 h10 m24 0 h10 m0 0 h96 m23 44 h-3"></path>
+         <polygon points="209 61 217 57 217 65"></polygon>
+         <polygon points="209 61 201 57 201 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_with_restore_options" title="opt_with_restore_options">opt_with_restore_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_scrub_options_clause" href="#opt_scrub_options_clause">opt_scrub_options_clause:</a></p>
       <svg width="408" height="56">
@@ -9333,6 +9878,7 @@
          </p><ul>
             <li><a href="#show_queries_stmt" title="show_queries_stmt">show_queries_stmt</a></li>
             <li><a href="#show_sessions_stmt" title="show_sessions_stmt">show_sessions_stmt</a></li>
+            <li><a href="#show_transactions_stmt" title="show_transactions_stmt">show_transactions_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_compact" href="#opt_compact">opt_compact:</a></p>
       <svg width="184" height="56">
@@ -9554,34 +10100,32 @@
             <li><a href="#complex_table_pattern" title="complex_table_pattern">complex_table_pattern</a></li>
             <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="kv_option" href="#kv_option">kv_option:</a></p>
-      <svg width="442" height="80">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="copy_options" href="#copy_options">copy_options:</a></p>
+      <svg width="440" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#name" xlink:title="name">
-            <rect x="51" y="3" width="54" height="32"></rect>
-            <rect x="49" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">name</text>
-         </a>
-         <rect x="51" y="47" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">SCONST</text>
-         <rect x="187" y="35" width="30" height="32" rx="10"></rect>
-         <rect x="185" y="33" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="195" y="53">=</text>
+         <rect x="51" y="3" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">DESTINATION</text>
+         <rect x="185" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="183" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="193" y="21">=</text>
          <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="237" y="35" width="158" height="32"></rect>
-            <rect x="235" y="33" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="245" y="53">string_or_placeholder</text>
+            <rect x="235" y="3" width="158" height="32"></rect>
+            <rect x="233" y="1" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="243" y="21">string_or_placeholder</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h22 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m40 -44 h10 m0 0 h218 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v12 m248 0 v-12 m-248 12 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m30 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"></path>
-         <polygon points="433 17 441 13 441 21"></polygon>
-         <polygon points="433 17 425 13 425 21"></polygon>
+         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">BINARY</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m114 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m158 0 h10 m-382 0 h20 m362 0 h20 m-402 0 q10 0 10 10 m382 0 q0 -10 10 -10 m-392 10 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m72 0 h10 m0 0 h270 m23 -44 h-3"></path>
+         <polygon points="431 17 439 13 439 21"></polygon>
+         <polygon points="431 17 423 13 423 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#kv_option_list" title="kv_option_list">kv_option_list</a></li>
+            <li><a href="#copy_options_list" title="copy_options_list">copy_options_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="db_object_name_component" href="#db_object_name_component">db_object_name_component:</a></p>
       <svg width="362" height="124">
@@ -9660,6 +10204,26 @@
             <li><a href="#target_name" title="target_name">target_name</a></li>
             <li><a href="#zone_name" title="zone_name">zone_name</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_name" href="#type_name">type_name:</a></p>
+      <svg width="184" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#db_object_name" xlink:title="db_object_name">
+            <rect x="31" y="3" width="126" height="32"></rect>
+            <rect x="29" y="1" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">db_object_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m126 0 h10 m3 0 h-3"></path>
+         <polygon points="175 17 183 13 183 21"></polygon>
+         <polygon points="175 17 167 13 167 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
+            <li><a href="#create_type_stmt" title="create_type_stmt">create_type_stmt</a></li>
+            <li><a href="#type_name_list" title="type_name_list">type_name_list</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="typename" href="#typename">typename:</a></p>
       <svg width="384" height="80">
          
@@ -9693,7 +10257,7 @@
             <li><a href="#type_list" title="type_list">type_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="transaction_mode" href="#transaction_mode">transaction_mode:</a></p>
-      <svg width="276" height="124">
+      <svg width="304" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -9712,9 +10276,14 @@
             <rect x="49" y="89" width="102" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="109">as_of_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m170 0 h10 m0 0 h8 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m102 0 h10 m0 0 h76 m23 -88 h-3"></path>
-         <polygon points="267 17 275 13 275 21"></polygon>
-         <polygon points="267 17 259 13 259 21"></polygon>
+         <a xlink:href="#transaction_deferrable_mode" xlink:title="transaction_deferrable_mode">
+            <rect x="51" y="135" width="206" height="32"></rect>
+            <rect x="49" y="133" width="206" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">transaction_deferrable_mode</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m0 0 h28 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m170 0 h10 m0 0 h36 m-236 -10 v20 m246 0 v-20 m-246 20 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m102 0 h10 m0 0 h104 m-236 -10 v20 m246 0 v-20 m-246 20 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m206 0 h10 m23 -132 h-3"></path>
+         <polygon points="295 17 303 13 303 21"></polygon>
+         <polygon points="295 17 287 13 287 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -10266,82 +10835,88 @@
             <li><a href="#alter_index_stmt" title="alter_index_stmt">alter_index_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_rename_view_stmt" href="#alter_rename_view_stmt">alter_rename_view_stmt:</a></p>
-      <svg width="648" height="134">
+      <svg width="676" height="134">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="62" height="32" rx="10"></rect>
          <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">VIEW</text>
-         <rect x="209" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="207" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="217" y="53">IF</text>
-         <rect x="263" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="261" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="271" y="53">EXISTS</text>
+         <rect x="133" y="35" width="120" height="32" rx="10"></rect>
+         <rect x="131" y="33" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="53">MATERIALIZED</text>
+         <rect x="293" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="291" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="301" y="21">VIEW</text>
+         <rect x="389" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="387" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="397" y="53">IF</text>
+         <rect x="443" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="441" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="451" y="53">EXISTS</text>
          <a xlink:href="#relation_expr" xlink:title="relation_expr">
-            <rect x="371" y="3" width="104" height="32"></rect>
-            <rect x="369" y="1" width="104" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="379" y="21">relation_expr</text>
+            <rect x="551" y="3" width="104" height="32"></rect>
+            <rect x="549" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="559" y="21">relation_expr</text>
          </a>
-         <rect x="495" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="493" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="503" y="21">RENAME</text>
-         <rect x="589" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="587" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="597" y="21">TO</text>
+         <rect x="405" y="101" width="74" height="32" rx="10"></rect>
+         <rect x="403" y="99" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="413" y="119">RENAME</text>
+         <rect x="499" y="101" width="38" height="32" rx="10"></rect>
+         <rect x="497" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="507" y="119">TO</text>
          <a xlink:href="#view_name" xlink:title="view_name">
-            <rect x="529" y="101" width="92" height="32"></rect>
-            <rect x="527" y="99" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="119">view_name</text>
+            <rect x="557" y="101" width="92" height="32"></rect>
+            <rect x="555" y="99" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="565" y="119">view_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-142 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m3 0 h-3"></path>
-         <polygon points="639 115 647 111 647 119"></polygon>
-         <polygon points="639 115 631 111 631 119"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-294 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
+         <polygon points="667 115 675 111 675 119"></polygon>
+         <polygon points="667 115 659 111 659 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_view_stmt" title="alter_view_stmt">alter_view_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_view_set_schema_stmt" href="#alter_view_set_schema_stmt">alter_view_set_schema_stmt:</a></p>
-      <svg width="656" height="134">
+      <svg width="740" height="134">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="31" y="3" width="62" height="32" rx="10"></rect>
          <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="39" y="21">ALTER</text>
-         <rect x="113" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="111" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="121" y="21">VIEW</text>
-         <rect x="209" y="35" width="34" height="32" rx="10"></rect>
-         <rect x="207" y="33" width="34" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="217" y="53">IF</text>
-         <rect x="263" y="35" width="68" height="32" rx="10"></rect>
-         <rect x="261" y="33" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="271" y="53">EXISTS</text>
+         <rect x="133" y="35" width="120" height="32" rx="10"></rect>
+         <rect x="131" y="33" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="53">MATERIALIZED</text>
+         <rect x="293" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="291" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="301" y="21">VIEW</text>
+         <rect x="389" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="387" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="397" y="53">IF</text>
+         <rect x="443" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="441" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="451" y="53">EXISTS</text>
          <a xlink:href="#relation_expr" xlink:title="relation_expr">
-            <rect x="371" y="3" width="104" height="32"></rect>
-            <rect x="369" y="1" width="104" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="379" y="21">relation_expr</text>
+            <rect x="551" y="3" width="104" height="32"></rect>
+            <rect x="549" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="559" y="21">relation_expr</text>
          </a>
-         <rect x="495" y="3" width="44" height="32" rx="10"></rect>
-         <rect x="493" y="1" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="503" y="21">SET</text>
-         <rect x="559" y="3" width="76" height="32" rx="10"></rect>
-         <rect x="557" y="1" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="567" y="21">SCHEMA</text>
+         <rect x="675" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="673" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="683" y="21">SET</text>
+         <rect x="507" y="101" width="76" height="32" rx="10"></rect>
+         <rect x="505" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="515" y="119">SCHEMA</text>
          <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="519" y="101" width="110" height="32"></rect>
-            <rect x="517" y="99" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="527" y="119">schema_name</text>
+            <rect x="603" y="101" width="110" height="32"></rect>
+            <rect x="601" y="99" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="611" y="119">schema_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-160 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m3 0 h-3"></path>
-         <polygon points="647 115 655 111 655 119"></polygon>
-         <polygon points="647 115 639 111 639 119"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-256 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m3 0 h-3"></path>
+         <polygon points="731 115 739 111 739 119"></polygon>
+         <polygon points="731 115 723 111 723 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -10528,6 +11103,85 @@
          </p><ul>
             <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_owner" href="#alter_database_owner">alter_database_owner:</a></p>
+      <svg width="622" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="223" y="3" width="122" height="32"></rect>
+            <rect x="221" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="21">database_name</text>
+         </a>
+         <rect x="365" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="363" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="21">OWNER</text>
+         <rect x="457" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="455" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="465" y="21">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="515" y="3" width="80" height="32"></rect>
+            <rect x="513" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="523" y="21">role_spec</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="613 17 621 13 621 21"></polygon>
+         <polygon points="613 17 605 13 605 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_to_schema_stmt" href="#alter_database_to_schema_stmt">alter_database_to_schema_stmt:</a></p>
+      <svg width="702" height="102">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="223" y="3" width="122" height="32"></rect>
+            <rect x="221" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="21">database_name</text>
+         </a>
+         <rect x="365" y="3" width="84" height="32" rx="10"></rect>
+         <rect x="363" y="1" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="21">CONVERT</text>
+         <rect x="469" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="467" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="477" y="21">TO</text>
+         <rect x="527" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="525" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="535" y="21">SCHEMA</text>
+         <rect x="623" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="621" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="631" y="21">WITH</text>
+         <rect x="461" y="69" width="72" height="32" rx="10"></rect>
+         <rect x="459" y="67" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="469" y="87">PARENT</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="553" y="69" width="122" height="32"></rect>
+            <rect x="551" y="67" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="561" y="87">database_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-264 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m72 0 h10 m0 0 h10 m122 0 h10 m3 0 h-3"></path>
+         <polygon points="693 83 701 79 701 87"></polygon>
+         <polygon points="693 83 685 79 685 87"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_zone_range_stmt" href="#alter_zone_range_stmt">alter_zone_range_stmt:</a></p>
       <svg width="464" height="36">
          
@@ -10616,49 +11270,32 @@
          </p><ul>
             <li><a href="#alter_partition_stmt" title="alter_partition_stmt">alter_partition_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name" href="#schema_name">schema_name:</a></p>
-      <svg width="112" height="36">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="role_spec" href="#role_spec">role_spec:</a></p>
+      <svg width="316" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#name" xlink:title="name">
-            <rect x="31" y="3" width="54" height="32"></rect>
-            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">name</text>
+         <a xlink:href="#non_reserved_word_or_sconst" xlink:title="non_reserved_word_or_sconst">
+            <rect x="51" y="3" width="218" height="32"></rect>
+            <rect x="49" y="1" width="218" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">non_reserved_word_or_sconst</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
-         <polygon points="103 17 111 13 111 21"></polygon>
-         <polygon points="103 17 95 13 95 21"></polygon>
+         <rect x="51" y="47" width="128" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">CURRENT_USER</text>
+         <rect x="51" y="91" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">SESSION_USER</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m218 0 h10 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m128 0 h10 m0 0 h90 m-248 -10 v20 m258 0 v-20 m-258 20 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m126 0 h10 m0 0 h92 m23 -88 h-3"></path>
+         <polygon points="307 17 315 13 315 21"></polygon>
+         <polygon points="307 17 299 13 299 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#alter_database_owner" title="alter_database_owner">alter_database_owner</a></li>
             <li><a href="#alter_schema_stmt" title="alter_schema_stmt">alter_schema_stmt</a></li>
-            <li><a href="#alter_sequence_set_schema_stmt" title="alter_sequence_set_schema_stmt">alter_sequence_set_schema_stmt</a></li>
-            <li><a href="#alter_table_set_schema_stmt" title="alter_table_set_schema_stmt">alter_table_set_schema_stmt</a></li>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
             <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
-            <li><a href="#alter_view_set_schema_stmt" title="alter_view_set_schema_stmt">alter_view_set_schema_stmt</a></li>
-            <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
-            <li><a href="#schema_name_list" title="schema_name_list">schema_name_list</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_name" href="#type_name">type_name:</a></p>
-      <svg width="184" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#db_object_name" xlink:title="db_object_name">
-            <rect x="31" y="3" width="126" height="32"></rect>
-            <rect x="29" y="1" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">db_object_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m126 0 h10 m3 0 h-3"></path>
-         <polygon points="175 17 183 13 183 21"></polygon>
-         <polygon points="175 17 167 13 167 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
-            <li><a href="#create_type_stmt" title="create_type_stmt">create_type_stmt</a></li>
-            <li><a href="#type_name_list" title="type_name_list">type_name_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_add_val_placement" href="#opt_add_val_placement">opt_add_val_placement:</a></p>
       <svg width="306" height="100">
@@ -10681,23 +11318,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with" href="#opt_with">opt_with:</a></p>
-      <svg width="156" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">WITH</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m23 -32 h-3"></path>
-         <polygon points="147 5 155 1 155 9"></polygon>
-         <polygon points="147 5 139 1 139 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#create_database_stmt" title="create_database_stmt">create_database_stmt</a></li>
-            <li><a href="#opt_role_options" title="opt_role_options">opt_role_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="role_options" href="#role_options">role_options:</a></p>
       <svg width="190" height="52">
@@ -11231,23 +11851,6 @@
          </p><ul>
             <li><a href="#create_index_stmt" title="create_index_stmt">create_index_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_concurrently" href="#opt_concurrently">opt_concurrently:</a></p>
-      <svg width="228" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">CONCURRENTLY</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m130 0 h10 m23 -32 h-3"></path>
-         <polygon points="219 5 227 1 227 9"></polygon>
-         <polygon points="219 5 211 1 211 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#create_index_stmt" title="create_index_stmt">create_index_stmt</a></li>
-            <li><a href="#drop_index_stmt" title="drop_index_stmt">drop_index_stmt</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_index_name" href="#opt_index_name">opt_index_name:</a></p>
       <svg width="142" height="36">
          
@@ -11444,8 +12047,8 @@
             <li><a href="#list_partition" title="list_partition">list_partition</a></li>
             <li><a href="#range_partition" title="range_partition">range_partition</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_temp_create_table" href="#opt_temp_create_table">opt_temp_create_table:</a></p>
-      <svg width="376" height="124">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_persistence_temp_table" href="#opt_persistence_temp_table">opt_persistence_temp_table:</a></p>
+      <svg width="376" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -11466,7 +12069,10 @@
          <rect x="205" y="91" width="56" height="32" rx="10"></rect>
          <rect x="203" y="89" width="56" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="213" y="109">TEMP</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m80 0 h10 m0 0 h198 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-288 10 h10 m64 0 h10 m0 0 h10 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -44 h10 m104 0 h10 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m56 0 h10 m0 0 h48 m43 -88 h-3"></path>
+         <rect x="51" y="135" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">UNLOGGED</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m80 0 h10 m0 0 h198 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-288 10 h10 m64 0 h10 m0 0 h10 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m40 -44 h10 m104 0 h10 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m56 0 h10 m0 0 h48 m-288 -54 v20 m318 0 v-20 m-318 20 v68 m318 0 v-68 m-318 68 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m96 0 h10 m0 0 h182 m23 -132 h-3"></path>
          <polygon points="367 17 375 13 375 21"></polygon>
          <polygon points="367 17 359 13 359 21"></polygon>
       </svg>
@@ -11554,26 +12160,7 @@
          </p><ul>
             <li><a href="#create_sequence_stmt" title="create_sequence_stmt">create_sequence_stmt</a></li>
             <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
-            <li><a href="#opt_temp_create_table" title="opt_temp_create_table">opt_temp_create_table</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="view_name" href="#view_name">view_name:</a></p>
-      <svg width="152" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="31" y="3" width="94" height="32"></rect>
-            <rect x="29" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">table_name</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m3 0 h-3"></path>
-         <polygon points="143 17 151 13 151 21"></polygon>
-         <polygon points="143 17 135 13 135 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_rename_view_stmt" title="alter_rename_view_stmt">alter_rename_view_stmt</a></li>
-            <li><a href="#create_view_stmt" title="create_view_stmt">create_view_stmt</a></li>
+            <li><a href="#opt_persistence_temp_table" title="opt_persistence_temp_table">opt_persistence_temp_table</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sequence_name" href="#sequence_name">sequence_name:</a></p>
       <svg width="184" height="36">
@@ -11612,26 +12199,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_sequence_stmt" title="create_sequence_stmt">create_sequence_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sconst_or_placeholder" href="#sconst_or_placeholder">sconst_or_placeholder:</a></p>
-      <svg width="216" height="80">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">SCONST</text>
-         <rect x="51" y="47" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">PLACEHOLDER</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m0 0 h42 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v24 m158 0 v-24 m-158 24 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m23 -44 h-3"></path>
-         <polygon points="207 17 215 13 215 21"></polygon>
-         <polygon points="207 17 199 13 199 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#cron_expr" title="cron_expr">cron_expr</a></li>
-            <li><a href="#opt_full_backup_clause" title="opt_full_backup_clause">opt_full_backup_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cte_list" href="#cte_list">cte_list:</a></p>
       <svg width="246" height="80">
@@ -11863,48 +12430,6 @@
             <li><a href="#drop_view_stmt" title="drop_view_stmt">drop_view_stmt</a></li>
             <li><a href="#opt_locked_rels" title="opt_locked_rels">opt_locked_rels</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name_list" href="#schema_name_list">schema_name_list:</a></p>
-      <svg width="208" height="80">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="51" y="47" width="110" height="32"></rect>
-            <rect x="49" y="45" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">schema_name</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m110 0 h10 m-150 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m130 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-130 0 h10 m24 0 h10 m0 0 h86 m23 44 h-3"></path>
-         <polygon points="199 61 207 57 207 65"></polygon>
-         <polygon points="199 61 191 57 191 65"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_name_list" href="#type_name_list">type_name_list:</a></p>
-      <svg width="188" height="80">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#type_name" xlink:title="type_name">
-            <rect x="51" y="47" width="90" height="32"></rect>
-            <rect x="49" y="45" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">type_name</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m90 0 h10 m-130 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m110 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-110 0 h10 m24 0 h10 m0 0 h66 m23 44 h-3"></path>
-         <polygon points="179 61 187 57 187 65"></polygon>
-         <polygon points="179 61 171 57 171 65"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#drop_type_stmt" title="drop_type_stmt">drop_type_stmt</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="non_reserved_word" href="#non_reserved_word">non_reserved_word:</a></p>
       <svg width="284" height="168">
          
@@ -11936,6 +12461,35 @@
          </p><ul>
             <li><a href="#explain_option_name" title="explain_option_name">explain_option_name</a></li>
             <li><a href="#non_reserved_word_or_sconst" title="non_reserved_word_or_sconst">non_reserved_word_or_sconst</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="kv_option" href="#kv_option">kv_option:</a></p>
+      <svg width="442" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="51" y="3" width="54" height="32"></rect>
+            <rect x="49" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">name</text>
+         </a>
+         <rect x="51" y="47" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SCONST</text>
+         <rect x="187" y="35" width="30" height="32" rx="10"></rect>
+         <rect x="185" y="33" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="195" y="53">=</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="237" y="35" width="158" height="32"></rect>
+            <rect x="235" y="33" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="245" y="53">string_or_placeholder</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m54 0 h10 m0 0 h22 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m40 -44 h10 m0 0 h218 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v12 m248 0 v-12 m-248 12 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m30 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"></path>
+         <polygon points="433 17 441 13 441 21"></polygon>
+         <polygon points="433 17 425 13 425 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#kv_option_list" title="kv_option_list">kv_option_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="column_def" href="#column_def">column_def:</a></p>
       <svg width="384" height="36">
@@ -12175,6 +12729,59 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#var_name" title="var_name">var_name</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="restore_options" href="#restore_options">restore_options:</a></p>
+      <svg width="574" height="344">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="71" y="3" width="208" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="208" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">ENCRYPTION_PASSPHRASE</text>
+         <rect x="71" y="47" width="82" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">INTO_DB</text>
+         <rect x="319" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="317" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="327" y="21">=</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="369" y="3" width="158" height="32"></rect>
+            <rect x="367" y="1" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="377" y="21">string_or_placeholder</text>
+         </a>
+         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">KMS</text>
+         <rect x="119" y="91" width="30" height="32" rx="10"></rect>
+         <rect x="117" y="89" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="109">=</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="169" y="91" width="212" height="32"></rect>
+            <rect x="167" y="89" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="177" y="109">string_or_placeholder_opt_list</text>
+         </a>
+         <rect x="51" y="135" width="238" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="238" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">SKIP_MISSING_FOREIGN_KEYS</text>
+         <rect x="51" y="179" width="214" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="214" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">SKIP_MISSING_SEQUENCES</text>
+         <rect x="51" y="223" width="274" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="274" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">SKIP_MISSING_SEQUENCE_OWNERS</text>
+         <rect x="51" y="267" width="178" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="178" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">SKIP_MISSING_VIEWS</text>
+         <rect x="51" y="311" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">DETACHED</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m208 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m82 0 h10 m0 0 h126 m20 -44 h10 m30 0 h10 m0 0 h10 m158 0 h10 m-516 0 h20 m496 0 h20 m-536 0 q10 0 10 10 m516 0 q0 -10 10 -10 m-526 10 v68 m516 0 v-68 m-516 68 q0 10 10 10 m496 0 q10 0 10 -10 m-506 10 h10 m48 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m212 0 h10 m0 0 h146 m-506 -10 v20 m516 0 v-20 m-516 20 v24 m516 0 v-24 m-516 24 q0 10 10 10 m496 0 q10 0 10 -10 m-506 10 h10 m238 0 h10 m0 0 h238 m-506 -10 v20 m516 0 v-20 m-516 20 v24 m516 0 v-24 m-516 24 q0 10 10 10 m496 0 q10 0 10 -10 m-506 10 h10 m214 0 h10 m0 0 h262 m-506 -10 v20 m516 0 v-20 m-516 20 v24 m516 0 v-24 m-516 24 q0 10 10 10 m496 0 q10 0 10 -10 m-506 10 h10 m274 0 h10 m0 0 h202 m-506 -10 v20 m516 0 v-20 m-516 20 v24 m516 0 v-24 m-516 24 q0 10 10 10 m496 0 q10 0 10 -10 m-506 10 h10 m178 0 h10 m0 0 h298 m-506 -10 v20 m516 0 v-20 m-516 20 v24 m516 0 v-24 m-516 24 q0 10 10 10 m496 0 q10 0 10 -10 m-506 10 h10 m92 0 h10 m0 0 h384 m23 -308 h-3"></path>
+         <polygon points="565 17 573 13 573 21"></polygon>
+         <polygon points="565 17 557 13 557 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#restore_options_list" title="restore_options_list">restore_options_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="scrub_option_list" href="#scrub_option_list">scrub_option_list:</a></p>
       <svg width="200" height="80">
@@ -13044,6 +13651,25 @@
          </p><ul>
             <li><a href="#transaction_mode" title="transaction_mode">transaction_mode</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="transaction_deferrable_mode" href="#transaction_deferrable_mode">transaction_deferrable_mode:</a></p>
+      <svg width="272" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">NOT</text>
+         <rect x="139" y="3" width="106" height="32" rx="10"></rect>
+         <rect x="137" y="1" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="21">DEFERRABLE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m106 0 h10 m3 0 h-3"></path>
+         <polygon points="263 17 271 13 271 21"></polygon>
+         <polygon points="263 17 255 13 255 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#transaction_mode" title="transaction_mode">transaction_mode</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_cmds" href="#alter_table_cmds">alter_table_cmds:</a></p>
       <svg width="220" height="80">
          
@@ -13140,7 +13766,7 @@
             <li><a href="#opt_sequence_option_list" title="opt_sequence_option_list">opt_sequence_option_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="role_option" href="#role_option">role_option:</a></p>
-      <svg width="230" height="256">
+      <svg width="294" height="784">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -13156,19 +13782,55 @@
          <rect x="51" y="135" width="86" height="32" rx="10"></rect>
          <rect x="49" y="133" width="86" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="153">NOLOGIN</text>
+         <rect x="51" y="179" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">CONTROLJOB</text>
+         <rect x="51" y="223" width="134" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">NOCONTROLJOB</text>
+         <rect x="51" y="267" width="176" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="176" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">CONTROLCHANGEFEED</text>
+         <rect x="51" y="311" width="196" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="196" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">NOCONTROLCHANGEFEED</text>
+         <rect x="51" y="355" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">CREATEDB</text>
+         <rect x="51" y="399" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">NOCREATEDB</text>
+         <rect x="51" y="443" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">CREATELOGIN</text>
+         <rect x="51" y="487" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">NOCREATELOGIN</text>
+         <rect x="51" y="531" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">VIEWACTIVITY</text>
+         <rect x="51" y="575" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">NOVIEWACTIVITY</text>
+         <rect x="51" y="619" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">CANCELQUERY</text>
+         <rect x="51" y="663" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">NOCANCELQUERY</text>
          <a xlink:href="#password_clause" xlink:title="password_clause">
-            <rect x="51" y="179" width="130" height="32"></rect>
-            <rect x="49" y="177" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">password_clause</text>
+            <rect x="51" y="707" width="130" height="32"></rect>
+            <rect x="49" y="705" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="725">password_clause</text>
          </a>
          <a xlink:href="#valid_until_clause" xlink:title="valid_until_clause">
-            <rect x="51" y="223" width="132" height="32"></rect>
-            <rect x="49" y="221" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="241">valid_until_clause</text>
+            <rect x="51" y="751" width="132" height="32"></rect>
+            <rect x="49" y="749" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="769">valid_until_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m106 0 h10 m0 0 h26 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m128 0 h10 m0 0 h4 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m64 0 h10 m0 0 h68 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m86 0 h10 m0 0 h46 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m130 0 h10 m0 0 h2 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m23 -220 h-3"></path>
-         <polygon points="221 17 229 13 229 21"></polygon>
-         <polygon points="221 17 213 13 213 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m106 0 h10 m0 0 h90 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m128 0 h10 m0 0 h68 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m64 0 h10 m0 0 h132 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m86 0 h10 m0 0 h110 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m112 0 h10 m0 0 h84 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m134 0 h10 m0 0 h62 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m176 0 h10 m0 0 h20 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m196 0 h10 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m90 0 h10 m0 0 h106 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m110 0 h10 m0 0 h86 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m116 0 h10 m0 0 h80 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m136 0 h10 m0 0 h60 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m122 0 h10 m0 0 h74 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m142 0 h10 m0 0 h54 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m120 0 h10 m0 0 h76 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m142 0 h10 m0 0 h54 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m130 0 h10 m0 0 h66 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m132 0 h10 m0 0 h64 m23 -748 h-3"></path>
+         <polygon points="285 17 293 13 293 21"></polygon>
+         <polygon points="285 17 277 13 277 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -14816,7 +15478,7 @@
             <li><a href="#transaction_user_priority" title="transaction_user_priority">transaction_user_priority</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_cmd" href="#alter_table_cmd">alter_table_cmd:</a></p>
-      <svg width="1082" height="748">
+      <svg width="1082" height="792">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -15034,7 +15696,18 @@
             <rect x="49" y="713" width="96" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="733">partition_by</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m74 0 h10 m20 0 h10 m92 0 h10 m0 0 h16 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m108 0 h10 m20 -44 h10 m106 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m106 0 h10 m0 0 h432 m-1024 0 h20 m1004 0 h20 m-1044 0 q10 0 10 10 m1024 0 q0 -10 10 -10 m-1034 10 v68 m1024 0 v-68 m-1024 68 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m92 0 h10 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v56 m520 0 v-56 m-520 56 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h176 m20 -76 h396 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v100 m1024 0 v-100 m-1024 100 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m62 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m106 0 h10 m20 0 h10 m152 0 h10 m0 0 h432 m-624 0 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m58 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m74 0 h10 m0 0 h50 m20 -44 h342 m-614 -10 v20 m624 0 v-20 m-624 20 v68 m624 0 v-68 m-624 68 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m44 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h396 m-614 -10 v20 m624 0 v-20 m-624 20 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m106 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m172 0 h10 m-882 -176 h20 m882 0 h20 m-922 0 q10 0 10 10 m902 0 q0 -10 10 -10 m-912 10 v200 m902 0 v-200 m-902 200 q0 10 10 10 m882 0 q10 0 10 -10 m-892 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m-994 -230 v20 m1024 0 v-20 m-1024 20 v244 m1024 0 v-244 m-1024 244 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m58 0 h10 m20 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m106 0 h10 m0 0 h36 m-476 0 h20 m456 0 h20 m-496 0 q10 0 10 10 m476 0 q0 -10 10 -10 m-486 10 v56 m476 0 v-56 m-476 56 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m126 0 h10 m20 -76 h10 m140 0 h10 m0 0 h270 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v132 m1024 0 v-132 m-1024 132 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m86 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m126 0 h10 m0 0 h624 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m174 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m94 0 h10 m0 0 h632 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m96 0 h10 m0 0 h888 m23 -712 h-3"></path>
+         <rect x="51" y="759" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="757" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="777">OWNER</text>
+         <rect x="143" y="759" width="38" height="32" rx="10"></rect>
+         <rect x="141" y="757" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="151" y="777">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="201" y="759" width="80" height="32"></rect>
+            <rect x="199" y="757" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="209" y="777">role_spec</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m74 0 h10 m20 0 h10 m92 0 h10 m0 0 h16 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m108 0 h10 m20 -44 h10 m106 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m106 0 h10 m0 0 h432 m-1024 0 h20 m1004 0 h20 m-1044 0 q10 0 10 10 m1024 0 q0 -10 10 -10 m-1034 10 v68 m1024 0 v-68 m-1024 68 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m92 0 h10 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v56 m520 0 v-56 m-520 56 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h176 m20 -76 h396 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v100 m1024 0 v-100 m-1024 100 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m62 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m106 0 h10 m20 0 h10 m152 0 h10 m0 0 h432 m-624 0 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m58 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m74 0 h10 m0 0 h50 m20 -44 h342 m-614 -10 v20 m624 0 v-20 m-624 20 v68 m624 0 v-68 m-624 68 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m44 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h396 m-614 -10 v20 m624 0 v-20 m-624 20 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m106 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m172 0 h10 m-882 -176 h20 m882 0 h20 m-922 0 q10 0 10 10 m902 0 q0 -10 10 -10 m-912 10 v200 m902 0 v-200 m-902 200 q0 10 10 10 m882 0 q10 0 10 -10 m-892 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m-994 -230 v20 m1024 0 v-20 m-1024 20 v244 m1024 0 v-244 m-1024 244 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m58 0 h10 m20 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m106 0 h10 m0 0 h36 m-476 0 h20 m456 0 h20 m-496 0 q10 0 10 10 m476 0 q0 -10 10 -10 m-486 10 v56 m476 0 v-56 m-476 56 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m126 0 h10 m20 -76 h10 m140 0 h10 m0 0 h270 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v132 m1024 0 v-132 m-1024 132 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m86 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m126 0 h10 m0 0 h624 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m174 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m94 0 h10 m0 0 h632 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m96 0 h10 m0 0 h888 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h754 m23 -756 h-3"></path>
          <polygon points="1073 17 1081 13 1081 21"></polygon>
          <polygon points="1073 17 1065 13 1065 21"></polygon>
       </svg>
@@ -16300,38 +16973,41 @@
             <li><a href="#const_typename" title="const_typename">const_typename</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="const_geo" href="#const_geo">const_geo:</a></p>
-      <svg width="692" height="100">
+      <svg width="732" height="144">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">GEOGRAPHY</text>
-         <rect x="51" y="47" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">GEOMETRY</text>
-         <rect x="217" y="35" width="26" height="32" rx="10"></rect>
-         <rect x="215" y="33" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="225" y="53">(</text>
+         <rect x="71" y="3" width="106" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">GEOGRAPHY</text>
+         <rect x="71" y="47" width="94" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">GEOMETRY</text>
+         <rect x="237" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="235" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="245" y="53">(</text>
          <a xlink:href="#geo_shape_type" xlink:title="geo_shape_type">
-            <rect x="263" y="35" width="126" height="32"></rect>
-            <rect x="261" y="33" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="271" y="53">geo_shape_type</text>
+            <rect x="283" y="35" width="126" height="32"></rect>
+            <rect x="281" y="33" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="291" y="53">geo_shape_type</text>
          </a>
-         <rect x="429" y="67" width="24" height="32" rx="10"></rect>
-         <rect x="427" y="65" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="437" y="85">,</text>
+         <rect x="449" y="67" width="24" height="32" rx="10"></rect>
+         <rect x="447" y="65" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="457" y="85">,</text>
          <a xlink:href="#signed_iconst" xlink:title="signed_iconst">
-            <rect x="473" y="67" width="106" height="32"></rect>
-            <rect x="471" y="65" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="481" y="85">signed_iconst</text>
+            <rect x="493" y="67" width="106" height="32"></rect>
+            <rect x="491" y="65" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="501" y="85">signed_iconst</text>
          </a>
-         <rect x="619" y="35" width="26" height="32" rx="10"></rect>
-         <rect x="617" y="33" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="627" y="53">)</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m106 0 h10 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m94 0 h10 m0 0 h12 m40 -44 h10 m0 0 h438 m-468 0 h20 m448 0 h20 m-488 0 q10 0 10 10 m468 0 q0 -10 10 -10 m-478 10 v12 m468 0 v-12 m-468 12 q0 10 10 10 m448 0 q10 0 10 -10 m-458 10 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m24 0 h10 m0 0 h10 m106 0 h10 m20 -32 h10 m26 0 h10 m23 -32 h-3"></path>
-         <polygon points="683 17 691 13 691 21"></polygon>
-         <polygon points="683 17 675 13 675 21"></polygon>
+         <rect x="639" y="35" width="26" height="32" rx="10"></rect>
+         <rect x="637" y="33" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="647" y="53">)</text>
+         <rect x="51" y="111" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="109" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="129">BOX2D</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m106 0 h10 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m94 0 h10 m0 0 h12 m40 -44 h10 m0 0 h438 m-468 0 h20 m448 0 h20 m-488 0 q10 0 10 10 m468 0 q0 -10 10 -10 m-478 10 v12 m468 0 v-12 m-468 12 q0 10 10 10 m448 0 q10 0 10 -10 m-458 10 h10 m26 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m24 0 h10 m0 0 h10 m106 0 h10 m20 -32 h10 m26 0 h10 m-654 -32 h20 m654 0 h20 m-694 0 q10 0 10 10 m674 0 q0 -10 10 -10 m-684 10 v88 m674 0 v-88 m-674 88 q0 10 10 10 m654 0 q10 0 10 -10 m-664 10 h10 m68 0 h10 m0 0 h566 m23 -108 h-3"></path>
+         <polygon points="723 17 731 13 731 21"></polygon>
+         <polygon points="723 17 715 13 715 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>

--- a/v20.2/create-table-as.md
+++ b/v20.2/create-table-as.md
@@ -78,7 +78,7 @@ table td:first-child {
  `family_def` | An optional [column family definition](column-families.html). Column family names must be unique within the table but can have the same name as columns, constraints, or indexes.
  `create_as_constraint_def` | An optional [primary key constraint](primary-key.html).
  `select_stmt` | A [selection query](selection-queries.html) to provide the data.
- `opt_temp_create_table` |  Defines the table as a session-scoped temporary table. For more information, see [Temporary Tables](temporary-tables.html).<br>**Support for temporary tables is experimental**. The interface and output are subject to change.
+ `opt_persistence_temp_table` |  Defines the table as a session-scoped temporary table. For more information, see [Temporary Tables](temporary-tables.html).<br>**Support for temporary tables is experimental**. The interface and output are subject to change.
 
 ## Limitations
 

--- a/v20.2/create-table.md
+++ b/v20.2/create-table.md
@@ -29,10 +29,10 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
   {% include {{ page.version.version }}/sql/diagrams/create_table.html %}
 </div>
 
-**opt_temp_create_table ::=**
+**opt_persistence_temp_table ::=**
 
 <div>
-  {% include {{ page.version.version }}/sql/diagrams/opt_temp_create_table.html %}
+  {% include {{ page.version.version }}/sql/diagrams/opt_persistence_temp_table.html %}
 </div>
 
 **column_def ::=**
@@ -88,7 +88,7 @@ Parameter | Description
 `table_constraint` | An optional, comma-separated list of [table-level constraints](constraints.html). Constraint names must be unique within the table but can have the same name as columns, column families, or indexes.
 `opt_interleave` | You can potentially optimize query performance by [interleaving tables](interleave-in-parent.html), which changes how CockroachDB stores your data.<br>{{site.data.alerts.callout_info}}[Hash-sharded indexes](indexes.html#hash-sharded-indexes) cannot be interleaved.{{site.data.alerts.end}}
 `opt_partition_by` | An [enterprise-only](enterprise-licensing.html) option that lets you define table partitions at the row level. You can define table partitions by list or by range. See [Define Table Partitions](partitioning.html) for more information.
-`opt_temp_create_table` |  Defines the table as a session-scoped temporary table. For more information, see [Temporary Tables](temporary-tables.html).<br><br>**Support for temporary tables is [experimental](experimental-features.html#temporary-objects)**.
+`opt_persistence_temp_table` |  Defines the table as a session-scoped temporary table. For more information, see [Temporary Tables](temporary-tables.html).<br><br>**Support for temporary tables is [experimental](experimental-features.html#temporary-objects)**.
 
 ## Table-level replication
 

--- a/v20.2/temporary-tables.md
+++ b/v20.2/temporary-tables.md
@@ -6,7 +6,7 @@ toc: true
 
  CockroachDB supports session-scoped temporary tables (also called "temp tables"). Unlike [persistent tables](create-table.html), temp tables can only be accessed from the session in which they were created, and they are dropped at the end of the session.
 
-To create a temp table, add [`TEMP`/`TEMPORARY`](sql-grammar.html#opt_temp_create_table) to a [`CREATE TABLE`](create-table.html) or [`CREATE TABLE AS`](create-table-as.html) statement. For full syntax details, see the [`CREATE TABLE`](create-table.html#synopsis) and [`CREATE TABLE AS`](create-table-as.html#synopsis) pages. For example usage, see [Examples](#examples).
+To create a temp table, add `TEMP`/`TEMPORARY` to a [`CREATE TABLE`](create-table.html) or [`CREATE TABLE AS`](create-table-as.html) statement. For full syntax details, see the [`CREATE TABLE`](create-table.html#synopsis) and [`CREATE TABLE AS`](create-table-as.html#synopsis) pages. For example usage, see [Examples](#examples).
 
 {{site.data.alerts.callout_danger}}
 **This is an experimental feature**. The interface and output are subject to change. For details, see the tracking issue [cockroachdb/cockroach#46260](https://github.com/cockroachdb/cockroach/issues/46260).


### PR DESCRIPTION
This PR will fix the broken links in #8222 and #7964, and future PRs with SQL syntax diagram links.

- Updated stmt_block diagram (full SQL grammar diagram).
- Updated some links to grammar entities that no longer exist in the current.
- Updated temp table diagram to match existing grammar.