### PR TITLE
Clean up and elevate the CC quickstart

### DIFF
--- a/_includes/cockroachcloud/use-cockroachcloud-instead.md
+++ b/_includes/cockroachcloud/use-cockroachcloud-instead.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_success}}
+To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the <a href="../cockroachcloud/quickstart.html">Quickstart</a>.
+{{site.data.alerts.end}}

--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -3,241 +3,235 @@
   "is_top_level": true,
   "items": [
     {
-      "title": "Quickstart with a Free Cluster",
-      "urls": [
-	"/cockroachcloud/quickstart.html"
-      ]
-    },
-    {
       "title": "Get Started",
       "items": [
-	{
-	  "title": "Create a New CockroachCloud Cluster",
-	  "urls": [
-	      "/cockroachcloud/create-your-cluster.html"
-	  ]
-	},
-  {
-	  "title": "Connect to Your Cluster",
-	  "urls": [
-	      "/cockroachcloud/connect-to-your-cluster.html"
-	  ]
-	},
-	{
-	  "title": "Learn CockroachDB SQL",
-	  "urls": [
-	    "/cockroachcloud/learn-cockroachdb-sql.html"
-	  ]
-	},
-	{
-	  "title": "Build a 'Hello World' app",
-	  "items": [
-	    {
-	      "title": "Django",
-	      "urls": [
-		"/cockroachcloud/build-a-python-app-with-cockroachdb-django.html"
-	      ]
-	    }
-	  ]
-	}
+      	{
+      	  "title": "Create a CockroachCloud Cluster",
+      	  "urls": [
+      	    "/cockroachcloud/create-your-cluster.html"
+      	  ]
+      	},
+        {
+      	  "title": "Connect to Your Cluster",
+      	  "urls": [
+      	    "/cockroachcloud/connect-to-your-cluster.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Learn CockroachDB SQL",
+      	  "urls": [
+      	    "/cockroachcloud/learn-cockroachdb-sql.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Build a 'Hello World' app",
+      	  "items": [
+      	    {
+      	      "title": "Django",
+      	      "urls": [
+      		      "/cockroachcloud/build-a-python-app-with-cockroachdb-django.html"
+      	      ]
+      	    }
+      	  ]
+      	}
       ]
     },
     {
       "title": "Use Your Cluster",
       "items": [
-	{
-	  "title": "Secure Your Cluster",
-	  "items": [
-	    {
-	      "title": "Security Overview",
-	      "urls": [
-		"/cockroachcloud/security-overview.html"
-	      ]
-	    },
-	    {
-	      "title": "Authentication",
-	      "urls": [
-		"/cockroachcloud/authentication.html"
-	      ]
-	    },
-	    {
-	      "title": "Authorization",
-	      "urls": [
-		"/cockroachcloud/authorization.html"
-	      ]
-	    },
-	    {
-	      "title": "SQL Audit Logging",
-	      "urls": [
-		"/cockroachcloud/sql-audit-logging.html"
-	      ]
-	    }
-	  ]
-	},
-	{
-	  "title": "Migrate Data",
-	  "items": [
-	    {
-	      "title": "Migration Overview",
-	      "urls": [
-		"/stable/migration-overview.html"
-	      ]
-	    },
-	    {
-	      "title": "Migrate from Oracle",
-	      "urls": [
-		"/stable/migrate-from-oracle.html"
-	      ]
-	    },
-	    {
-	      "title": "Migrate from Postgres",
-	      "urls": [
-		"/stable/migrate-from-postgres.html"
-	      ]
-	    },
-	    {
-	      "title": "Migrate from MySQL",
-	      "urls": [
-		"/stable/migrate-from-mysql.html"
-	      ]
-	    },
-	    {
-	      "title": "Migrate from CSV",
-	      "urls": [
-		"/stable/migrate-from-csv.html"
-	      ]
-	    },
-	    {
-	      "title": "Migrate from Avro",
-	      "urls": [
-		"/stable/migrate-from-avro.html"
-	      ]
-	    },
-            {
-              "title": "Import Performance Best Practices",
-              "urls": [
-                "/stable/import-performance-best-practices.html"
-              ]
-            }
-	  ]
-	},
-	{
-	  "title": "Tune Performance",
-	  "urls": [
-	    "/stable/performance-best-practices-overview.html"
-	  ]
-	},
-	{
-	  "title": "Move into Production",
-	  "urls": [
-	    "/cockroachcloud/production-checklist.html"
-	  ]
-	},
-	{
-	  "title": "Monitor Your Cluster",
-	  "urls": [
-	    "/cockroachcloud/monitoring-page.html"
-	  ]
-	},
-	{
-	  "title": "Troubleshoot Your Cluster",
-	  "urls": [
-	    "/cockroachcloud/troubleshooting-page.html"
-	  ]
-	},
-	{
-	  "title": "Manage Your Cluster",
-	  "urls": [
-	    "/cockroachcloud/cluster-management.html"
-	  ]
-	},
-	{
-	  "title": "Restore Data from a Backup",
-	  "urls": [
-	    "/cockroachcloud/backups-page.html"
-	  ]
-	},
-	{
-	  "title": "Upgrade Your Cluster",
-	  "items": [
-	    {
-	      "title": "Upgrade Policy",
-	      "urls": [
-		"/cockroachcloud/upgrade-policy.html"
-	      ]
-	    },
-	    {
-	      "title": "Upgrade to v20.1",
-	      "urls": [
-		"/cockroachcloud/upgrade-to-v20.1.html"
-	      ]
-	    }
-	  ]
-	}
+      	{
+      	  "title": "Secure Your Cluster",
+      	  "items": [
+      	    {
+      	      "title": "Security Overview",
+      	      "urls": [
+      		      "/cockroachcloud/security-overview.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Authentication",
+      	      "urls": [
+      		      "/cockroachcloud/authentication.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Authorization",
+      	      "urls": [
+      		      "/cockroachcloud/authorization.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "SQL Audit Logging",
+      	      "urls": [
+      		      "/cockroachcloud/sql-audit-logging.html"
+      	      ]
+      	    }
+      	  ]
+      	},
+      	{
+      	  "title": "Migrate Data",
+      	  "items": [
+      	    {
+      	      "title": "Migration Overview",
+      	      "urls": [
+      		      "/stable/migration-overview.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Migrate from Oracle",
+      	      "urls": [
+      		      "/stable/migrate-from-oracle.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Migrate from Postgres",
+      	      "urls": [
+      		      "/stable/migrate-from-postgres.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Migrate from MySQL",
+      	      "urls": [
+      		      "/stable/migrate-from-mysql.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Migrate from CSV",
+      	      "urls": [
+      		      "/stable/migrate-from-csv.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Migrate from Avro",
+      	      "urls": [
+      		      "/stable/migrate-from-avro.html"
+      	      ]
+      	    },
+                  {
+                    "title": "Import Performance Best Practices",
+                    "urls": [
+                      "/stable/import-performance-best-practices.html"
+                    ]
+                  }
+      	  ]
+      	},
+      	{
+      	  "title": "Tune Performance",
+      	  "urls": [
+      	    "/stable/performance-best-practices-overview.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Move into Production",
+      	  "urls": [
+      	    "/cockroachcloud/production-checklist.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Monitor Your Cluster",
+      	  "urls": [
+      	    "/cockroachcloud/monitoring-page.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Troubleshoot Your Cluster",
+      	  "urls": [
+      	    "/cockroachcloud/troubleshooting-page.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Manage Your Cluster",
+      	  "urls": [
+      	    "/cockroachcloud/cluster-management.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Restore Data from a Backup",
+      	  "urls": [
+      	    "/cockroachcloud/backups-page.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Upgrade Your Cluster",
+      	  "items": [
+      	    {
+      	      "title": "Upgrade Policy",
+      	      "urls": [
+      		       "/cockroachcloud/upgrade-policy.html"
+      	      ]
+      	    },
+      	    {
+      	      "title": "Upgrade to v20.1",
+      	      "urls": [
+      		       "/cockroachcloud/upgrade-to-v20.1.html"
+      	      ]
+      	    }
+      	  ]
+      	}
       ]
     },
     {
       "title": "Manage Console Access",
       "urls": [
-	"/cockroachcloud/console-access-management.html"
+	       "/cockroachcloud/console-access-management.html"
       ]
     },
     {
       "title": "Tutorials",
       "items": [
-	{
-	  "title": "Deploy a Python To-Do App with Flask, Kubernetes, and CockroachCloud",
-	  "urls": [
-	    "/cockroachcloud/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.html"
-	  ]
-	},
-	{
-	  "title": "Stream a Changefeed to Snowflake",
-	  "urls": [
-	    "/cockroachcloud/stream-changefeed-to-snowflake-aws.html"
-	  ]
-	}
+      	{
+      	  "title": "Deploy a Python To-Do App with Flask, Kubernetes, and CockroachCloud",
+      	  "urls": [
+      	    "/cockroachcloud/deploy-a-python-to-do-app-with-flask-kubernetes-and-cockroachcloud.html"
+      	  ]
+      	},
+      	{
+      	  "title": "Stream a Changefeed to Snowflake",
+      	  "urls": [
+      	    "/cockroachcloud/stream-changefeed-to-snowflake-aws.html"
+      	  ]
+      	}
       ]
     },
     {
       "title": "FAQs",
       "urls": [
-	"/cockroachcloud/frequently-asked-questions.html"
+	       "/cockroachcloud/frequently-asked-questions.html"
       ]
     },
     {
       "title": "Releases",
       "items": [
-	{
-	  "title": "July 2020",
-	  "urls": [
-	    "/releases/cockroachcloud-07062020.html"
-	  ]
-	},
-	{
-	  "title": "June 2020",
-	  "urls": [
-	    "/releases/cockroachcloud-06112020.html"
-	  ]
-	},
-	{
-	  "title": "May 2020",
-	  "urls": [
-	    "/releases/cockroachcloud-05042020.html"
-	  ]
-	},
-	{
-	  "title": "April 2020",
-	  "urls": [
-	    "/releases/cockroachcloud-04062020.html"
-	  ]
-	},
-	{
-	  "title": "March 2020",
-	  "urls": [
-	    "/releases/cockroachcloud-03022020.html"
-	  ]
-	}
+      	{
+      	  "title": "July 2020",
+      	  "urls": [
+      	    "/releases/cockroachcloud-07062020.html"
+      	  ]
+      	},
+      	{
+      	  "title": "June 2020",
+      	  "urls": [
+      	    "/releases/cockroachcloud-06112020.html"
+      	  ]
+      	},
+      	{
+      	  "title": "May 2020",
+      	  "urls": [
+      	    "/releases/cockroachcloud-05042020.html"
+      	  ]
+      	},
+      	{
+      	  "title": "April 2020",
+      	  "urls": [
+      	    "/releases/cockroachcloud-04062020.html"
+      	  ]
+      	},
+      	{
+      	  "title": "March 2020",
+      	  "urls": [
+      	    "/releases/cockroachcloud-03022020.html"
+      	  ]
+      	}
       ]
     }
   ]

--- a/_includes/sidebar-data-v1.0.json
+++ b/_includes/sidebar-data-v1.0.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v1.1.json
+++ b/_includes/sidebar-data-v1.1.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v19.1.json
+++ b/_includes/sidebar-data-v19.1.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v19.2.json
+++ b/_includes/sidebar-data-v19.2.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v2.0.json
+++ b/_includes/sidebar-data-v2.0.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v2.1.json
+++ b/_includes/sidebar-data-v2.1.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -29,8 +29,8 @@
               {
                 "title": "From Binary",
                 "urls": [
-                  "/${VERSION}/start-a-local-cluster.html",
-                  "/${VERSION}/secure-a-cluster.html"
+                  "/${VERSION}/secure-a-cluster.html",
+                  "/${VERSION}/start-a-local-cluster.html"
                 ]
               },
               {

--- a/_includes/sidebar-data-v20.1.json
+++ b/_includes/sidebar-data-v20.1.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -1,4 +1,11 @@
 [
+  {
+    "title": "Quickstart",
+    "is_top_level": true,
+    "urls": [
+      "/cockroachcloud/quickstart.html"
+    ]
+  },
   {% include sidebar-data-cockroachcloud.json %},
   {
     "title": "CockroachDB",

--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -30,8 +30,8 @@
               {
                 "title": "From Binary",
                 "urls": [
-                  "/${VERSION}/start-a-local-cluster.html",
-                  "/${VERSION}/secure-a-cluster.html"
+                  "/${VERSION}/secure-a-cluster.html",
+                  "/${VERSION}/start-a-local-cluster.html"
                 ]
               },
               {

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -8,8 +8,8 @@ redirect_from:
 
 This page walks you through the process of creating a CockroachCloud cluster.
 
-{{site.data.alerts.callout_info}}
-To create and connect to a 30-day free CockroachCloud cluster and run your first query, see the [Quickstart guide](quickstart.html).
+{{site.data.alerts.callout_success}}
+To create and connect to a 30-day free CockroachCloud cluster and run your first query, see the [Quickstart](quickstart.html).
 {{site.data.alerts.end}}
 
 ## Before you begin

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -70,33 +70,47 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
 
 1. [Download the CockroachDB binary](../stable/install-cockroachdb.html):
 
-    For Mac:
+    <div class="filters clearfix">
+      <button class="filter-button page-level" data-scope="mac">Mac</button>
+      <button class="filter-button page-level" data-scope="linux">Linux</button>
+    </div>
+
+    <section class="filter-content" markdown="1" data-scope="mac">
     {% include copy-clipboard.html %}
     ~~~ shell
     $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.darwin-10.9-amd64.tgz \
     | tar -xJ
     ~~~
+    </section>
 
-    For Linux:
+    <section class="filter-content" markdown="1" data-scope="linux">
     {% include copy-clipboard.html %}
     ~~~ shell
     $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
     | tar  xvz
     ~~~
+    </section>
 
 2. Copy the binary into the `PATH` so it's easy to run the SQL client from any location:
 
-    For Mac:
+    <div class="filters clearfix">
+      <button class="filter-button page-level" data-scope="mac">Mac</button>
+      <button class="filter-button page-level" data-scope="linux">Linux</button>
+    </div>
+
+    <section class="filter-content" markdown="1" data-scope="mac">
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cp -i cockroach-{{ page.release_info.version }}.darwin-10.9-amd64/cockroach /usr/local/bin/
     ~~~
+    </section>
 
-    For Linux:
+    <section class="filter-content" markdown="1" data-scope="linux">
     {% include copy-clipboard.html %}
     ~~~ shell
     $ sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
     ~~~
+    </section>
 
 3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-4-get-the-connection-string).
 
@@ -104,14 +118,16 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach workload init movr 'postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
+    $ cockroach workload init movr \
+    'postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
     ~~~
 
 4. Use the built-in SQL client to view the database:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --url='postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
+    $ cockroach sql \
+    --url='postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
     ~~~
 
     {% include copy-clipboard.html %}
@@ -150,7 +166,7 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
     (6 rows)
     ~~~
 
-## What's next
+## What's next?
 
 Learn more:
 

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -1,18 +1,20 @@
 ---
-title: CockroachCloud Quickstart
+title: Quickstart with CockroachCloud
 summary: Learn how to create and use your CockroachCloud cluster.
 toc: true
 redirect_from:
 - ../stable/cockroachcloud-quickstart.html
 ---
 
-This page shows you how to create and connect to a 30-day free CockroachCloud cluster and run your first query.
+This page shows you how to deploy a free CockroachDB cluster on CockroachCloud. You'll use a 30-day free trial code to create the cluster and a sample workload to connect and run your first query.
+
+To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/start-a-local-cluster.html).
 
 ## Before you begin
 
 If you haven't already, [sign up for a CockroachCloud account](https://cockroachlabs.cloud/signup).
 
-## Create a free CockroachCloud cluster
+## Step 1. Create a free cluster
 
 For this tutorial, we will create a 3-node GCP cluster in the `us-west` region.
 
@@ -36,16 +38,14 @@ Your cluster will be created in approximately 20-30 minutes. Watch this [Getting
 
 Once your cluster is created, you will be redirected to the **Cluster Overview** page.
 
-## Get the connection string
-
-### Step 1. Create a SQL user
+## Step 2. Create a SQL user
 
 1. In the left navigation bar, click **SQL Users**.
 2. Click **Add User**. The **Add User** modal displays.
 3. Enter a **Username** and **Password**.
 4. Click **Save**.
 
-### Step 2. Authorize your network
+## Step 3. Authorize your network
 
 1. In the left navigation bar, click **Networking**.
 2. Click **Add Network**. The **Add Network** modal displays.
@@ -53,10 +53,10 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 4. To allow the network to access the cluster's Admin UI and to use the CockroachDB client to access the databases, select the **Admin UI to monitor the cluster** and **CockroachDB Client to access the databases** checkboxes.
 5. Click **Apply**.
 
-### Step 3. Get the connection string
+## Step 4. Get the connection string
 
 1. In the top-right corner of the Console, click the **Connect** button. The **Connect** modal displays.
-2. From the **User** dropdown, select the SQL user you created in [Step 1. Create a SQL user](#step-1-create-a-sql-user).
+2. From the **User** dropdown, select the SQL user you created in [Step 2. Create a SQL user](#step-2-create-a-sql-user).
 3. Verify that the `us-west2 GCP` region and `default_db` database are selected.
 4. Click **Continue**. The **Connect** tab is displayed.
 5. Click **Connection string** to get the connection string for your cluster.
@@ -64,8 +64,7 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 7. Click the name of the `ca.crt` file to download the CA certificate to your local machine.
 8. Move the downloaded `ca.crt` file to the `certs` directory.
 
-
-## Connect to the cluster and run your first query
+## Step 5. Run your first query
 
 For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run the first query. On your local machine:
 
@@ -99,9 +98,9 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
     $ sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
     ~~~
 
-3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-3-get-the-connection-string).
+3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-4-get-the-connection-string).
 
-    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 1](#step-1-create-a-sql-user). Replace the `<certs_dir>` placeholder with the path to the `certs` directory that you created in [Step 3](#step-3-get-the-connection-string).
+    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 2](#step-2-create-a-sql-user). Replace the `<certs_dir>` placeholder with the path to the `certs` directory that you created in [Step 4](#step-4-get-the-connection-string).
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -151,12 +150,16 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
     (6 rows)
     ~~~
 
-## Before you move into production
-
-Before using your free cluster in production, make sure you have [authorized the network](connect-to-your-cluster.html#step-1-authorize-your-network) from which your app will access the cluster. Also, download the `ca.crt` file to every machine from which you want to [connect to the cluster](connect-to-your-cluster.html#step-3-select-a-connection-method).
-
 ## What's next
 
-- [Create your new CockroachCloud cluster](create-your-cluster.html)
-- [Secure your cluster](security-overview.html)
-- [Build a "Hello, World" app](build-a-python-app-with-cockroachdb-django.html)
+Learn more:
+
+- Use the [built-in SQL client](connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to connect to your cluster and [learn CockroachDB SQL](learn-cockroachdb-sql.html).
+- Build a ["Hello World" app with the Django framework](build-a-python-app-with-cockroachdb-django.html), or [install another client framework](../stable/install-client-drivers.html) for your preferred language.
+- Use a local cluster to [explore CockroachDB capabilities like fault tolerance and automated repair](../stable/demo-fault-tolerance-and-recovery.html).
+
+Before you move into production:
+
+- [Authorize the network](connect-to-your-cluster.html#step-1-authorize-your-network) from which your app will access the cluster.
+- Download the `ca.crt` file to every machine from which you want to [connect to the cluster](connect-to-your-cluster.html#step-3-select-a-connection-method).
+- Review the [production checklist](production-checklist.html).

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -8,7 +8,7 @@ redirect_from:
 
 This page shows you how to deploy a free CockroachDB cluster on CockroachCloud. You'll use a 30-day free trial code to create the cluster and a sample workload to connect and run your first query.
 
-To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/start-a-local-cluster.html).
+To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/secure-a-cluster.html).
 
 ## Before you begin
 

--- a/v20.1/deploy-cockroachdb-on-aws-insecure.md
+++ b/v20.1/deploy-cockroachdb-on-aws-insecure.md
@@ -13,7 +13,9 @@ ssh-link: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 
 This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Amazon's AWS EC2 platform, using AWS's managed load balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.1/deploy-cockroachdb-on-aws.md
+++ b/v20.1/deploy-cockroachdb-on-aws.md
@@ -16,6 +16,8 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.1/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v20.1/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -13,7 +13,9 @@ ssh-link: https://www.digitalocean.com/community/tutorials/how-to-connect-to-you
 
 This page shows you how to deploy an insecure multi-node CockroachDB cluster on Digital Ocean, using Digital Ocean's managed load balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.1/deploy-cockroachdb-on-digital-ocean.md
+++ b/v20.1/deploy-cockroachdb-on-digital-ocean.md
@@ -15,6 +15,8 @@ This page shows you how to deploy a secure multi-node CockroachDB cluster on Dig
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v20.1/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -13,7 +13,9 @@ ssh-link: https://cloud.google.com/compute/docs/instances/connecting-to-instance
 
 This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Google Cloud Platform's Compute Engine (GCE), using Google's TCP Proxy Load Balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.1/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v20.1/deploy-cockroachdb-on-google-cloud-platform.md
@@ -15,6 +15,8 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v20.1/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -13,7 +13,9 @@ ssh-link: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-crea
 
 This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Microsoft Azure, using Azure's managed load balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.1/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v20.1/deploy-cockroachdb-on-microsoft-azure.md
@@ -15,6 +15,8 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements
@@ -73,7 +75,7 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 - Run at least 3 nodes to [ensure survivability](recommended-production-settings.html#topology).
 
 - Use compute-optimized [F-series](https://docs.microsoft.com/en-us/azure/virtual-machines/fsv2-series) VMs with [Premium Storage](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage) or local SSD storage with a Linux filesystem such as `ext4` (not the Windows `ntfs` filesystem). For example, Cockroach Labs has used `Standard_F16s_v2` VMs (16 vCPUs and 32 GiB of RAM per VM) for internal testing.
-    
+
     - If you choose local SSD storage, on reboot, the VM can come back with the `ntfs` filesystem. Be sure your automation monitors for this and reformats the disk to the Linux filesystem you chose initially.
 
 - **Do not** use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on a single core. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.

--- a/v20.1/deploy-cockroachdb-on-premises-insecure.md
+++ b/v20.1/deploy-cockroachdb-on-premises-insecure.md
@@ -14,7 +14,9 @@ redirect_from: manual-deployment-insecure.html
 
 This tutorial shows you how to manually deploy an insecure multi-node CockroachDB cluster on multiple machines, using [HAProxy](http://www.haproxy.org/) load balancers to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.1/deploy-cockroachdb-on-premises.md
+++ b/v20.1/deploy-cockroachdb-on-premises.md
@@ -15,6 +15,8 @@ This tutorial shows you how to manually deploy a secure multi-node CockroachDB c
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.1/install-cockroachdb-linux.html
+++ b/v20.1/install-cockroachdb-linux.html
@@ -14,6 +14,8 @@ key: install-cockroachdb.html
 
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 <div id="download-the-binary-linux" class="install-option">
   <h2>Download the Binary</h2>
 

--- a/v20.1/install-cockroachdb-mac.html
+++ b/v20.1/install-cockroachdb-mac.html
@@ -14,6 +14,8 @@ key: install-cockroachdb.html
 
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 <div id="use-homebrew" class="install-option">
   <h2>Use Homebrew</h2>
   <ol>

--- a/v20.1/install-cockroachdb-windows.html
+++ b/v20.1/install-cockroachdb-windows.html
@@ -14,6 +14,8 @@ key: install-cockroachdb.html
 
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 <div id="download-the-binary-windows" class="install-option">
   <h2>Download the executable</h2>
 

--- a/v20.1/manual-deployment.md
+++ b/v20.1/manual-deployment.md
@@ -13,7 +13,7 @@ Use the following guides to deploy CockroachDB manually on-premises or on popula
 - [Google Cloud Platform (GCE)](deploy-cockroachdb-on-google-cloud-platform.html)
 - [Microsoft Azure](deploy-cockroachdb-on-microsoft-azure.html)
 
-{{site.data.alerts.callout_success}}If you're just getting started with CockroachDB, you might want <a href="start-a-local-cluster.html">use a local cluster</a> to learn the basics of the database.{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## See also
 

--- a/v20.1/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v20.1/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -14,7 +14,7 @@ On top of CockroachDB's built-in automation, you can use a third-party [orchestr
 This page walks you through a simple demonstration, using the open-source [Kubernetes](http://kubernetes.io/) orchestration system. Using either the CockroachDB [Helm](https://helm.sh/) chart or a few configuration files, you'll quickly create a 3-node local cluster. You'll run some SQL commands against the cluster and then simulate node failure, watching how Kubernetes auto-restarts without the need for any manual intervention. You'll then scale the cluster with a single command before shutting the cluster down, again with a single command.
 
 {{site.data.alerts.callout_info}}
-To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html).
+To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}

--- a/v20.1/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v20.1/orchestrate-a-local-cluster-with-kubernetes.md
@@ -16,7 +16,7 @@ On top of CockroachDB's built-in automation, you can use a third-party [orchestr
 This page walks you through a simple demonstration, using the open-source [Kubernetes](http://kubernetes.io/) orchestration system. Using either the CockroachDB [Helm](https://helm.sh/) chart or a few configuration files, you'll quickly create a 3-node local cluster. You'll run some SQL commands against the cluster and then simulate node failure, watching how Kubernetes auto-restarts without the need for any manual intervention. You'll then scale the cluster with a single command before shutting the cluster down, again with a single command.
 
 {{site.data.alerts.callout_info}}
-To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html).
+To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -10,13 +10,11 @@ toc_not_nested: true
   <button class="filter-button current"><strong>Insecure</strong></button>
 </div>
 
-This page shows you how to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster in a single [Kubernetes](http://kubernetes.io/) cluster, using the [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) feature directly or via the [Helm](https://helm.sh/) Kubernetes package manager.
+This page shows you how to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster in a single [Kubernetes](http://kubernetes.io/) cluster, using the [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) feature directly or via the [Helm](https://helm.sh/) Kubernetes package manager. If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
 
-To deploy across multiple Kubernetes clusters in different geographic regions instead, see [Kubernetes Multi-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
+To deploy across multiple Kubernetes clusters in different geographic regions, see [Kubernetes Multi-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html) instead. Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
 
-{{site.data.alerts.callout_danger}}
-If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -15,6 +15,8 @@ This page shows you how to orchestrate the deployment, management, and monitorin
 
 To deploy across multiple Kubernetes clusters in different geographic regions instead, see [Kubernetes Multi-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.

--- a/v20.1/orchestration.md
+++ b/v20.1/orchestration.md
@@ -14,7 +14,7 @@ Use the following guides to run CockroachDB with popular open-source orchestrati
 - [Docker Swarm Deployment](orchestrate-cockroachdb-with-docker-swarm.html)
 - [Mesosphere DC/OS Deployment](orchestrate-cockroachdb-with-mesosphere-insecure.html)
 
-{{site.data.alerts.callout_success}}If you're just getting started with CockroachDB, you might want to <a href="orchestrate-a-local-cluster-with-kubernetes.html">orchestrate a local cluster</a> to learn the basics of the database.{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## See also
 

--- a/v20.1/secure-a-cluster.md
+++ b/v20.1/secure-a-cluster.md
@@ -6,20 +6,19 @@ asciicast: true
 ---
 
 <div class="filters filters-big clearfix">
-    <a href="start-a-local-cluster.html"><button class="filter-button">Insecure</button></a>
     <a href="secure-a-cluster.html"><button class="filter-button current"><strong>Secure</strong></button></a>
+    <a href="start-a-local-cluster.html"><button class="filter-button">Insecure</button></a>
 </div>
 
 Once you've [installed CockroachDB](install-cockroachdb.html), it's simple to run a secure multi-node cluster locally, using [TLS certificates](cockroach-cert.html) to encrypt network communication.
 
-{{site.data.alerts.callout_info}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.1/start-a-local-cluster-in-docker-linux.md
+++ b/v20.1/start-a-local-cluster-in-docker-linux.md
@@ -13,14 +13,13 @@ asciicast: true
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run an insecure multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_danger}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.1/start-a-local-cluster-in-docker-mac.md
+++ b/v20.1/start-a-local-cluster-in-docker-mac.md
@@ -14,14 +14,13 @@ redirect_from: start-a-local-cluster-in-docker.html
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run an insecure multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_danger}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.1/start-a-local-cluster-in-docker-windows.md
+++ b/v20.1/start-a-local-cluster-in-docker-windows.md
@@ -13,14 +13,13 @@ asciicast: true
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run an insecure multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_danger}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
 
 ## Step 1. Create a bridge network
 

--- a/v20.1/start-a-local-cluster.md
+++ b/v20.1/start-a-local-cluster.md
@@ -7,20 +7,19 @@ asciicast: true
 ---
 
 <div class="filters filters-big clearfix">
-    <a href="start-a-local-cluster.html"><button class="filter-button current"><strong>Insecure</strong></button></a>
     <a href="secure-a-cluster.html"><button class="filter-button">Secure</button></a>
+    <a href="start-a-local-cluster.html"><button class="filter-button current"><strong>Insecure</strong></button></a>
 </div>
 
 Once you've [installed CockroachDB](install-cockroachdb.html), it's simple to run an insecure multi-node cluster locally.
 
-{{site.data.alerts.callout_info}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: Update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.2/deploy-cockroachdb-on-aws-insecure.md
+++ b/v20.2/deploy-cockroachdb-on-aws-insecure.md
@@ -13,7 +13,9 @@ ssh-link: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 
 This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Amazon's AWS EC2 platform, using AWS's managed load balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.2/deploy-cockroachdb-on-aws.md
+++ b/v20.2/deploy-cockroachdb-on-aws.md
@@ -16,6 +16,8 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.2/deploy-cockroachdb-on-digital-ocean-insecure.md
+++ b/v20.2/deploy-cockroachdb-on-digital-ocean-insecure.md
@@ -13,7 +13,9 @@ ssh-link: https://www.digitalocean.com/community/tutorials/how-to-connect-to-you
 
 This page shows you how to deploy an insecure multi-node CockroachDB cluster on Digital Ocean, using Digital Ocean's managed load balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.2/deploy-cockroachdb-on-digital-ocean.md
+++ b/v20.2/deploy-cockroachdb-on-digital-ocean.md
@@ -15,6 +15,8 @@ This page shows you how to deploy a secure multi-node CockroachDB cluster on Dig
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.2/deploy-cockroachdb-on-google-cloud-platform-insecure.md
+++ b/v20.2/deploy-cockroachdb-on-google-cloud-platform-insecure.md
@@ -13,7 +13,9 @@ ssh-link: https://cloud.google.com/compute/docs/instances/connecting-to-instance
 
 This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Google Cloud Platform's Compute Engine (GCE), using Google's TCP Proxy Load Balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.2/deploy-cockroachdb-on-google-cloud-platform.md
+++ b/v20.2/deploy-cockroachdb-on-google-cloud-platform.md
@@ -15,6 +15,8 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.2/deploy-cockroachdb-on-microsoft-azure-insecure.md
+++ b/v20.2/deploy-cockroachdb-on-microsoft-azure-insecure.md
@@ -13,7 +13,9 @@ ssh-link: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-crea
 
 This page shows you how to manually deploy an insecure multi-node CockroachDB cluster on Microsoft Azure, using Azure's managed load balancing service to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.2/deploy-cockroachdb-on-microsoft-azure.md
+++ b/v20.2/deploy-cockroachdb-on-microsoft-azure.md
@@ -15,6 +15,8 @@ This page shows you how to manually deploy a secure multi-node CockroachDB clust
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements
@@ -73,7 +75,7 @@ To enable this in Azure, you must create a Resource Group, Virtual Network, and 
 - Run at least 3 nodes to [ensure survivability](recommended-production-settings.html#topology).
 
 - Use compute-optimized [F-series](https://docs.microsoft.com/en-us/azure/virtual-machines/fsv2-series) VMs with [Premium Storage](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/premium-storage) or local SSD storage with a Linux filesystem such as `ext4` (not the Windows `ntfs` filesystem). For example, Cockroach Labs has used `Standard_F16s_v2` VMs (16 vCPUs and 32 GiB of RAM per VM) for internal testing.
-    
+
     - If you choose local SSD storage, on reboot, the VM can come back with the `ntfs` filesystem. Be sure your automation monitors for this and reformats the disk to the Linux filesystem you chose initially.
 
 - **Do not** use ["burstable" B-series](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/b-series-burstable) VMs, which limit the load on a single core. Also, Cockroach Labs has experienced data corruption issues on A-series VMs and irregular disk performance on D-series VMs, so we recommend avoiding those as well.

--- a/v20.2/deploy-cockroachdb-on-premises-insecure.md
+++ b/v20.2/deploy-cockroachdb-on-premises-insecure.md
@@ -14,7 +14,9 @@ redirect_from: manual-deployment-insecure.html
 
 This tutorial shows you how to manually deploy an insecure multi-node CockroachDB cluster on multiple machines, using [HAProxy](http://www.haproxy.org/) load balancers to distribute client traffic.
 
-{{site.data.alerts.callout_danger}}If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select <strong>Secure</strong> above for instructions.{{site.data.alerts.end}}
+If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
+
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.2/deploy-cockroachdb-on-premises.md
+++ b/v20.2/deploy-cockroachdb-on-premises.md
@@ -15,6 +15,8 @@ This tutorial shows you how to manually deploy a secure multi-node CockroachDB c
 
 If you are only testing CockroachDB, or you are not concerned with protecting network communication with TLS encryption, you can use an insecure cluster instead. Select **Insecure** above for instructions.
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 ### Requirements

--- a/v20.2/install-cockroachdb-linux.html
+++ b/v20.2/install-cockroachdb-linux.html
@@ -14,6 +14,8 @@ key: install-cockroachdb.html
 
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 {{site.data.alerts.callout_success}}
 <span class="version-tag">New in v20.2</span>: For instructions showing how to install CockroachDB with support for storing and querying spatial data, see <a href="install-cockroachdb-spatial.html#linux">Install CockroachDB Spatial</a>.
 {{site.data.alerts.end}}

--- a/v20.2/install-cockroachdb-mac.html
+++ b/v20.2/install-cockroachdb-mac.html
@@ -14,6 +14,8 @@ key: install-cockroachdb.html
 
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 {{site.data.alerts.callout_success}}
 <span class="version-tag">New in v20.2</span>: For instructions showing how to install CockroachDB with support for storing and querying spatial data, see <a href="install-cockroachdb-spatial.html#mac">Install CockroachDB Spatial</a>.
 {{site.data.alerts.end}}

--- a/v20.2/install-cockroachdb-windows.html
+++ b/v20.2/install-cockroachdb-windows.html
@@ -14,6 +14,8 @@ key: install-cockroachdb.html
 
 <p>See <a href="../releases/{{page.release_info.version}}.html" class="mac-releasenotes-download" id="mac-releasenotes-download-{{page.version.version}}" data-eventcategory="mac-releasenotes-download">Release Notes</a> for what's new in the latest release, {{ page.release_info.version }}. To upgrade to this release from an older version, see <a href="upgrade-cockroach-version.html">Cluster Upgrade</a>.</p>
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 <div id="download-the-binary-windows" class="install-option">
   <h2>Download the executable</h2>
 

--- a/v20.2/manual-deployment.md
+++ b/v20.2/manual-deployment.md
@@ -13,7 +13,7 @@ Use the following guides to deploy CockroachDB manually on-premises or on popula
 - [Google Cloud Platform (GCE)](deploy-cockroachdb-on-google-cloud-platform.html)
 - [Microsoft Azure](deploy-cockroachdb-on-microsoft-azure.html)
 
-{{site.data.alerts.callout_success}}If you're just getting started with CockroachDB, you might want <a href="start-a-local-cluster.html">use a local cluster</a> to learn the basics of the database.{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## See also
 

--- a/v20.2/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v20.2/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -14,7 +14,7 @@ On top of CockroachDB's built-in automation, you can use a third-party [orchestr
 This page walks you through a simple demonstration, using the open-source [Kubernetes](http://kubernetes.io/) orchestration system. Using either the CockroachDB [Helm](https://helm.sh/) chart or a few configuration files, you'll quickly create a 3-node local cluster. You'll run some SQL commands against the cluster and then simulate node failure, watching how Kubernetes auto-restarts without the need for any manual intervention. You'll then scale the cluster with a single command before shutting the cluster down, again with a single command.
 
 {{site.data.alerts.callout_info}}
-To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html).
+To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}

--- a/v20.2/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v20.2/orchestrate-a-local-cluster-with-kubernetes.md
@@ -16,7 +16,7 @@ On top of CockroachDB's built-in automation, you can use a third-party [orchestr
 This page walks you through a simple demonstration, using the open-source [Kubernetes](http://kubernetes.io/) orchestration system. Using either the CockroachDB [Helm](https://helm.sh/) chart or a few configuration files, you'll quickly create a 3-node local cluster. You'll run some SQL commands against the cluster and then simulate node failure, watching how Kubernetes auto-restarts without the need for any manual intervention. You'll then scale the cluster with a single command before shutting the cluster down, again with a single command.
 
 {{site.data.alerts.callout_info}}
-To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html).
+To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -10,13 +10,11 @@ toc_not_nested: true
   <button class="filter-button current"><strong>Insecure</strong></button>
 </div>
 
-This page shows you how to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster in a single [Kubernetes](http://kubernetes.io/) cluster, using the [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) feature directly or via the [Helm](https://helm.sh/) Kubernetes package manager.
+This page shows you how to orchestrate the deployment, management, and monitoring of an insecure 3-node CockroachDB cluster in a single [Kubernetes](http://kubernetes.io/) cluster, using the [StatefulSet](http://kubernetes.io/docs/concepts/abstractions/controllers/statefulsets/) feature directly or via the [Helm](https://helm.sh/) Kubernetes package manager. If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
 
 To deploy across multiple Kubernetes clusters in different geographic regions instead, see [Kubernetes Multi-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
 
-{{site.data.alerts.callout_danger}}
-If you plan to use CockroachDB in production, we strongly recommend using a secure cluster instead. Select **Secure** above for instructions.
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -15,6 +15,8 @@ This page shows you how to orchestrate the deployment, management, and monitorin
 
 To deploy across multiple Kubernetes clusters in different geographic regions instead, see [Kubernetes Multi-Cluster Deployment](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html). Also, for details about potential performance bottlenecks to be aware of when running CockroachDB in Kubernetes and guidance on how to optimize your deployment for better performance, see [CockroachDB Performance on Kubernetes](kubernetes-performance.html).
 
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
+
 ## Before you begin
 
 Before getting started, it's helpful to review some Kubernetes-specific terminology and current limitations.

--- a/v20.2/orchestration.md
+++ b/v20.2/orchestration.md
@@ -14,7 +14,7 @@ Use the following guides to run CockroachDB with popular open-source orchestrati
 - [Docker Swarm Deployment](orchestrate-cockroachdb-with-docker-swarm.html)
 - [Mesosphere DC/OS Deployment](orchestrate-cockroachdb-with-mesosphere-insecure.html)
 
-{{site.data.alerts.callout_success}}If you're just getting started with CockroachDB, you might want to <a href="orchestrate-a-local-cluster-with-kubernetes.html">orchestrate a local cluster</a> to learn the basics of the database.{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## See also
 

--- a/v20.2/secure-a-cluster.md
+++ b/v20.2/secure-a-cluster.md
@@ -6,20 +6,19 @@ asciicast: true
 ---
 
 <div class="filters filters-big clearfix">
-    <a href="start-a-local-cluster.html"><button class="filter-button">Insecure</button></a>
     <a href="secure-a-cluster.html"><button class="filter-button current"><strong>Secure</strong></button></a>
+    <a href="start-a-local-cluster.html"><button class="filter-button">Insecure</button></a>
 </div>
 
 Once you've [installed CockroachDB](install-cockroachdb.html), it's simple to run a secure multi-node cluster locally, using [TLS certificates](cockroach-cert.html) to encrypt network communication.
 
-{{site.data.alerts.callout_info}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.2/start-a-local-cluster-in-docker-linux.md
+++ b/v20.2/start-a-local-cluster-in-docker-linux.md
@@ -13,14 +13,13 @@ asciicast: true
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run an insecure multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_danger}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.2/start-a-local-cluster-in-docker-mac.md
+++ b/v20.2/start-a-local-cluster-in-docker-mac.md
@@ -14,14 +14,13 @@ redirect_from: start-a-local-cluster-in-docker.html
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run an insecure multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_danger}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.

--- a/v20.2/start-a-local-cluster-in-docker-windows.md
+++ b/v20.2/start-a-local-cluster-in-docker-windows.md
@@ -13,14 +13,13 @@ asciicast: true
 
 Once you've [installed the official CockroachDB Docker image](install-cockroachdb.html), it's simple to run an insecure multi-node cluster across multiple Docker containers on a single host, using Docker volumes to persist node data.
 
-{{site.data.alerts.callout_danger}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed the official CockroachDB Docker image](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster in containers, use an orchestration tool like Kubernetes or Docker Swarm. See [Orchestration](orchestration.html) for more details, and review the [Production Checklist](recommended-production-settings.html).
 
 ## Step 1. Create a bridge network
 

--- a/v20.2/start-a-local-cluster.md
+++ b/v20.2/start-a-local-cluster.md
@@ -7,20 +7,19 @@ asciicast: true
 ---
 
 <div class="filters filters-big clearfix">
-    <a href="start-a-local-cluster.html"><button class="filter-button current"><strong>Insecure</strong></button></a>
     <a href="secure-a-cluster.html"><button class="filter-button">Secure</button></a>
+    <a href="start-a-local-cluster.html"><button class="filter-button current"><strong>Insecure</strong></button></a>
 </div>
 
 Once you've [installed CockroachDB](install-cockroachdb.html), it's simple to run an insecure multi-node cluster locally.
 
-{{site.data.alerts.callout_info}}
-Running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
-{{site.data.alerts.end}}
+{% include cockroachcloud/use-cockroachcloud-instead.md %}
 
 ## Before you begin
 
 - Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 - For quick SQL testing or app development, consider [running a single-node cluster](cockroach-start-single-node.html) instead.
+- Note that running multiple nodes on a single host is useful for testing CockroachDB, but it's not suitable for production. To run a physically distributed cluster, see [Manual Deployment](manual-deployment.html) or [Orchestrated Deployment](orchestration.html), and review the [Production Checklist](recommended-production-settings.html).
 
 <!-- TODO: Update the asciicast
 Also, feel free to watch this process in action before going through the steps yourself. Note that you can copy commands directly from the video, and you can use **<** and **>** to go back and forward.
@@ -68,8 +67,8 @@ Also, feel free to watch this process in action before going through the steps y
     - The `--insecure` flag makes communication unencrypted.
     - Since this is a purely local cluster, `--listen-addr=localhost:26257` and `--http-addr=localhost:8080` tell the node to listen only on `localhost`, with port `26257` used for internal and client traffic and port `8080` used for HTTP requests from the Admin UI.
     - The `--store` flag indicates the location where the node's data and logs are stored.
-    - The `--join` flag specifies the addresses and ports of the nodes that will initially comprise your cluster. You'll use this exact `--join` flag when starting other nodes as well. 
-    
+    - The `--join` flag specifies the addresses and ports of the nodes that will initially comprise your cluster. You'll use this exact `--join` flag when starting other nodes as well.
+
         {% include {{ page.version.version }}/prod-deployment/join-flag-single-region.md %}
     - The `--background` flag starts the `cockroach` process in the background so you can continue using the same terminal for other operations.
 


### PR DESCRIPTION
- Clean up the tutorial itself: intro, step numbering, step
  titles, next steps.
- Move the page to the top level, above CC and CRDB sections.
  Since CC is the way we want users to start, this feels like
  a good experiment. I included a link to starting a local
  cluster, for users who want that. It's unfortunate that
  users need to wait up to 30 min for the cluster, but this
  will get better with free tier.

We'll soon have an in-browser quickstart. At that point, I'd
like to call that out as a CTA, etc.