### PR TITLE
Remove version switcher from docs homepage

### DIFF
--- a/_includes/version-nav.html
+++ b/_includes/version-nav.html
@@ -1,20 +1,6 @@
 <div class="version-nav-wrapper">
   <div class="version-nav">
-    <!-- <a
-      class="version-nav__link version-nav__link--crdb {% unless site.cockroachcloud %}version-nav__link--active{% endunless %}"
-      href="{% if site.cockroachcloud %}{{ "/../stable/" | relative_url }}{% else %}{{ "/stable/" | relative_url }}{% endif %}"
-    >
-      <span class="version-nav__link-text version-nav__link-text--crdb" ></span>
-    </a>
-
-    <a
-      class="version-nav__link version-nav__link--managed {% if site.cockroachcloud %}version-nav__link--active{% endif %}"
-      href="{% if site.cockroachcloud %}{{ "/stable/" | relative_url }}{% else %}{{ "/cockroachcloud/stable/" | relative_url }}{% endif %}"
-      data-proofer-ignore
-    >
-      <span class="version-nav__link-text version-nav__link-text--managed"></span>
-    </a> -->
-    {% unless site.cockroachcloud %}
+    {% unless page.homepage %}
       {% if page.version %}
         {% include version-switcher.html %}
       {% endif %}


### PR DESCRIPTION
Fixes #8063.

@lnhsingh, @Amruta-Ranade, @jseldess: This PR removes the version switcher from the Docs homepage, which I believe was requested by Amruta.

While making this change, I noticed that there are CRDB pages linked from the CC part of the sidenav, namely the pages under "Use Your Cluster" > "Migrate Data." Those will have the version switcher displayed, since they are actually CRDB pages and not CC pages. Is that fine? Note that this is similar to the issue affecting breadcrumbs. When the same pages are linked from multiple sidenav locations, breadcrumbs will not work as expected.