### PR TITLE
Document spatial file type conversion tools

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -780,6 +780,88 @@
             ]
           },
           {
+            "title": "Migrate from Shapefiles",
+            "urls": [
+              "/${VERSION}/migrate-from-shapefiles.html"
+            ]
+          },
+          {
+            "title": "Migrate from OpenStreetMap",
+            "urls": [
+              "/${VERSION}/migrate-from-openstreetmap.html"
+            ]
+          },
+          {
+            "title": "Migrate from GeoJSON",
+            "urls": [
+              "/${VERSION}/migrate-from-geojson.html"
+            ]
+          },
+          {
+            "title": "Migrate from GeoPackage",
+            "urls": [
+              "/${VERSION}/migrate-from-geopackage.html"
+            ]
+          }
+        ]
+      },
+      {
+        "title": "Maintain",
+        "items": [
+          {
+            "title": "Upgrade to CockroachDB v20.2",
+            "urls": [
+              "/${VERSION}/upgrade-cockroach-version.html"
+            ]
+          },
+          {
+            "title": "Online Schema Changes",
+            "urls": [
+              "/${VERSION}/online-schema-changes.html"
+            ]
+          },
+          {
+            "title": "Manage Long-Running Queries",
+            "urls": [
+              "/${VERSION}/manage-long-running-queries.html"
+            ]
+          },
+          {
+            "title": "Decommission Nodes",
+            "urls": [
+              "/${VERSION}/remove-nodes.html"
+            ]
+          },
+          {
+            "title": "Back up and Restore Data",
+            "items": [
+              {
+                "title": "Overview",
+                "urls": [
+                  "/${VERSION}/backup-and-restore.html"
+                ]
+              },
+              {
+                "title": "Advanced Options",
+                "urls": [
+                  "/${VERSION}/backup-and-restore-advanced-options.html"
+                ]
+              }
+            ]
+          },
+          {
+            "title": "Create a File Server for <code>IMPORT</code>/<code>BACKUP</code>",
+            "urls": [
+              "/${VERSION}/create-a-file-server.html"
+            ]
+          },
+          {
+            "title": "Rotate Security Certificates",
+            "urls": [
+              "/${VERSION}/rotate-certificates.html"
+            ]
+          },
+          {
             "title": "Import Performance Best Practices",
             "urls": [
               "/${VERSION}/import-performance-best-practices.html"

--- a/v20.2/migrate-from-geojson.md
+++ b/v20.2/migrate-from-geojson.md
@@ -1,0 +1,100 @@
+---
+title: Migrate from GeoJSON
+summary: Learn how to migrate data from GeoJSON into a CockroachDB cluster.
+toc: true
+---
+
+<span class="version-tag">New in v20.2</span>: CockroachDB supports efficiently storing and querying [spatial data](spatial-data.html).
+
+This page has instructions for migrating data from the [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) format into CockroachDB using [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) and [`IMPORT`][import].
+
+In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/dataset/underground-storage-tank-working).
+
+## Before You Begin
+
+To follow along with the example below, you will need the following prerequisites:
+
+- CockroachDB Spatial [installed](install-cockroachdb-spatial.html) and [running](start-a-local-cluster.html)
+- [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html)
+- [Python 3](https://www.python.org)
+
+## Step 1. Download the GeoJSON data
+
+First, download the storage tank GeoJSON data:
+
+{% include copy-clipboard.html %}
+~~~ shell
+wget -O tanks.geojson https://geodata.vermont.gov/datasets/986155613c5743239e7b1980b45bbf36_162.geojson
+~~~
+
+## Step 2. Convert the GeoJSON data to SQL
+
+Next, convert the GeoJSON data to SQL using the following `ogr2ogr` command:
+
+{% include copy-clipboard.html %}
+~~~ shell
+ogr2ogr -f PGDUMP tanks.sql -lco LAUNDER=NO -lco DROP_TABLE=OFF tanks.geojson
+~~~
+
+## Step 3. Host the files where the cluster can access them
+
+Each node in the CockroachDB cluster needs to have access to the files being imported.  There are several ways for the cluster to access the data; for a complete list of the types of storage [`IMPORT`][import] can pull from, see [import file locations](import.html#import-file-location).
+
+For local testing, you can [start a local file server](create-a-file-server.html).  The following command will start a local file server listening on port 3000:
+
+{% include copy-clipboard.html %}
+~~~ shell
+python3 -m http.server 3000
+~~~
+
+## Step 4. Prepare the database
+
+Next, create a database to hold the storage tank data:
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach sql --insecure
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE DATABASE IF NOT EXISTS tanks;
+USE tanks;
+~~~
+
+## Step 5. Import the SQL
+
+Since the file is being served from a local server and is formatted as Postgres-compatible SQL, we can import the data using the following [`IMPORT PGDUMP`](import.html#import-a-postgres-database-dump) statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+IMPORT PGDUMP ('http://localhost:3000/tanks.sql');
+~~~
+
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  588555793549328385 | succeeded |                  1 | 2709 |          2709 | 822504
+(1 row)
+~~~
+
+## See also
+
+- [`IMPORT`][import]
+- [Working with Spatial Data](spatial-data.html)
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migrate from GeoPackage](migrate-from-geopackage.html)
+- [Migration Overview](migration-overview.html)
+- [Migrate from MySQL][mysql]
+- [Migrate from Postgres][postgres]
+- [SQL Dump (Export)](cockroach-dump.html)
+- [Back Up and Restore Data](backup-and-restore.html)
+- [Use the Built-in SQL Client](cockroach-sql.html)
+- [Other Cockroach Commands](cockroach-commands.html)
+
+<!-- Reference Links -->
+
+[postgres]: migrate-from-postgres.html
+[mysql]: migrate-from-mysql.html
+[import]: import.html

--- a/v20.2/migrate-from-geopackage.md
+++ b/v20.2/migrate-from-geopackage.md
@@ -1,0 +1,112 @@
+---
+title: Migrate from GeoPackages
+summary: Learn how to migrate data from GeoPackages into a CockroachDB cluster.
+toc: true
+build_for: [cockroachdb]
+---
+
+<span class="version-tag">New in v20.2</span>: CockroachDB supports efficiently storing and querying [spatial data](spatial-data.html).
+
+This page has instructions for migrating data from the [GeoPackage](https://geopackage.org) format into CockroachDB using [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) and [`IMPORT`][import].
+
+In the example below we will import a data set with [the locations of natural springs in the state of Minnesota (USA)](https://gisdata.mn.gov/dataset/env-mn-springs-inventory) that is made available via [gisdata.mn.gov](https://gisdata.mn.gov).
+
+## Before You Begin
+
+To follow along with the example below, you will need the following prerequisites:
+
+- CockroachDB Spatial [installed](install-cockroachdb-spatial.html) and [running](start-a-local-cluster.html)
+- [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html)
+- [Python 3](https://www.python.org)
+
+## Step 1. Download the GeoPackage data
+
+First, download the zip file containing the spring location data:
+
+{% include copy-clipboard.html %}
+~~~ shell
+wget https://resources.gisdata.mn.gov/pub/gdrs/data/pub/us_mn_state_dnr/env_mn_springs_inventory/gpkg_env_mn_springs_inventory.zip
+~~~
+
+Next, unzip the file:
+
+{% include copy-clipboard.html %}
+~~~ shell
+unzip gpkg_env_mn_springs_inventory.zip
+~~~
+
+## Step 2. Convert the GeoPackage data to SQL
+
+To load the GeoPackage into CockroachDB, we must first convert it to SQL using the `ogr2ogr` tool.
+
+{% include copy-clipboard.html %}
+~~~ shell
+ogr2ogr -f PGDUMP springs.sql -lco LAUNDER=NO -lco DROP_TABLE=OFF env_mn_springs_inventory.gpkg
+~~~
+
+This particular data set emits a warning  due to some date formatting.
+
+~~~
+Warning 1: Non-conformant content for record 1 in column field_ch_1, 2017/05/04, successfully parsed
+~~~
+
+## Step 3. Host the files where the cluster can access them
+
+Each node in the CockroachDB cluster needs to have access to the files being imported.  There are several ways for the cluster to access the data; for a complete list of the types of storage [`IMPORT`][import] can pull from, see [import file locations](import.html#import-file-location).
+
+For local testing, you can [start a local file server](create-a-file-server.html).  The following command will start a local file server listening on port 3000:
+
+{% include copy-clipboard.html %}
+~~~ shell
+python3 -m http.server 3000
+~~~
+
+## Step 4. Prepare the database
+
+Next, create a database to hold the natural spring location data:
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach sql --insecure
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE DATABASE springs;
+USE springs;
+~~~
+
+## Step 5. Import the SQL
+
+Since the file is being served from a local server and is formatted as Postgres-compatible SQL, we can import the data using the following [`IMPORT PGDUMP`](import.html#import-a-postgres-database-dump) statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+IMPORT PGDUMP ('http://localhost:3000/springs.sql');
+~~~
+
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries |  bytes
+---------------------+-----------+--------------------+------+---------------+----------
+  589053379352526849 | succeeded |                  1 | 5124 |          5124 | 2449139
+(1 row)
+~~~
+
+## See also
+
+- [`IMPORT`][import]
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migration Overview](migration-overview.html)
+- [Migrate from MySQL][mysql]
+- [Migrate from Postgres][postgres]
+- [SQL Dump (Export)](cockroach-dump.html)
+- [Back Up and Restore Data](backup-and-restore.html)
+- [Use the Built-in SQL Client](cockroach-sql.html)
+- [Other Cockroach Commands](cockroach-commands.html)
+
+<!-- Reference Links -->
+
+[postgres]: migrate-from-postgres.html
+[mysql]: migrate-from-mysql.html
+[import]: import.html

--- a/v20.2/migrate-from-openstreetmap.md
+++ b/v20.2/migrate-from-openstreetmap.md
@@ -1,0 +1,141 @@
+---
+title: Migrate from OpenStreetMap
+summary: Learn how to migrate data from the OpenStreetMap pbf format into a CockroachDB cluster.
+toc: true
+---
+
+<span class="version-tag">New in v20.2</span>: CockroachDB supports efficiently storing and querying [spatial data](spatial-data.html).
+
+This page has instructions for migrating data from [OpenStreetMap](https://www.openstreetmap.org) `.pbf` data files into CockroachDB using [`osm2pgsql`](https://github.com/openstreetmap/osm2pgsql/) and [`IMPORT`][import].
+
+In the example below we will import the [OSM data for Australia](https://download.geofabrik.de/australia-oceania/australia.html) that is available from [GeoFabrik GmbH](http://www.geofabrik.de/data/shapefiles.html).
+
+## Before You Begin
+
+To follow along with the example below, you will need the following prerequisites:
+
+- CockroachDB Spatial [installed](install-cockroachdb-spatial.html) and [running](start-a-local-cluster.html)
+- [`osm2pgsql`](https://github.com/openstreetmap/osm2pgsql/)
+
+## Step 1. Download the OpenStreetMap data
+
+First, download the OSM data:
+
+{% include copy-clipboard.html %}
+~~~ shell
+wget https://download.geofabrik.de/australia-oceania/australia-latest.osm.pbf
+~~~
+
+## Step 2. Prepare the database
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach sql --insecure
+~~~
+
+Next, create a database to hold the Australia map data:
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE DATABASE IF NOT EXISTS australia;
+USE australia;
+~~~
+
+## Step 3. Import the OpenStreetMap data
+
+Run the `osm2pgsql` command shown below to convert the OSM data and import it into the `australia` database. The arguments to `osm2pgsql` shown below assume a [locally running insecure cluster](start-a-local-cluster.html) and may need to be changed depending on your system. You may also need to tweak the cache setting (`-C`) depending on your system's hardware.
+
+{% include copy-clipboard.html %}
+~~~ shell
+osm2pgsql -C 2048 -d australia -U root -H localhost -P 26257 australia-latest.osm.pbf
+~~~
+
+This will take a few (30+) minutes to run on a laptop, and there will be a lot of output. A successful run will look something like the following:
+
+~~~
+osm2pgsql version 1.3.0
+
+Allocating memory for dense node cache
+Allocating dense node cache in one big chunk
+Allocating memory for sparse node cache
+Sharing dense sparse
+Node-cache: cache=2048MB, maxblocks=32768*65536, allocation method=3
+Using built-in tag processing pipeline
+Using projection SRS 3857 (Spherical Mercator)
+WARNING:  setting session var "synchronous_commit" is a no-op
+WARNING:  setting session var "synchronous_commit" is a no-op
+Setting up table: planet_osm_point
+NOTICE:  UNLOGGED TABLE will behave as a regular table in CockroachDB
+NOTICE:  storage parameter "autovacuum_enabled = 'off'" is ignored
+WARNING:  setting session var "synchronous_commit" is a no-op
+Setting up table: planet_osm_line
+NOTICE:  UNLOGGED TABLE will behave as a regular table in CockroachDB
+NOTICE:  storage parameter "autovacuum_enabled = 'off'" is ignored
+WARNING:  setting session var "synchronous_commit" is a no-op
+Setting up table: planet_osm_polygon
+NOTICE:  UNLOGGED TABLE will behave as a regular table in CockroachDB
+NOTICE:  storage parameter "autovacuum_enabled = 'off'" is ignored
+WARNING:  setting session var "synchronous_commit" is a no-op
+Setting up table: planet_osm_roads
+NOTICE:  UNLOGGED TABLE will behave as a regular table in CockroachDB
+NOTICE:  storage parameter "autovacuum_enabled = 'off'" is ignored
+
+Reading in file: australia-latest.osm.pbf
+Using PBF parser.
+Processing: Node(66994k 411.0k/s) Way(4640k 7.13k/s) Relation(124777 1313.4/s)  parse time: 909s
+Node stats: total(66994811), max(7888181047) in 163s
+Way stats: total(4640490), max(845495883) in 651s
+Relation stats: total(124777), max(11596803) in 95s
+Sorting data and creating indexes for planet_osm_point
+node cache: stored: 66994811(100.00%), storage efficiency: 50.93% (dense blocks: 800, sparse nodes: 62492547), hit rate: 100.00%
+Sorting data and creating indexes for planet_osm_line
+Sorting data and creating indexes for planet_osm_polygon
+Sorting data and creating indexes for planet_osm_roads
+Using native order for clustering
+Using native order for clustering
+Using native order for clustering
+Using native order for clustering
+Copying planet_osm_roads to cluster by geometry finished
+Creating geometry index on planet_osm_roads
+Copying planet_osm_point to cluster by geometry finished
+Creating geometry index on planet_osm_point
+Creating indexes on planet_osm_roads finished
+Copying planet_osm_polygon to cluster by geometry finished
+Creating geometry index on planet_osm_polygon
+All indexes on planet_osm_roads created in 318s
+Completed planet_osm_roads
+Copying planet_osm_line to cluster by geometry finished
+Creating geometry index on planet_osm_line
+Creating indexes on planet_osm_point finished
+All indexes on planet_osm_point created in 1084s
+Completed planet_osm_point
+Creating indexes on planet_osm_polygon finished
+All indexes on planet_osm_polygon created in 1897s
+Completed planet_osm_polygon
+Creating indexes on planet_osm_line finished
+All indexes on planet_osm_line created in 1961s
+Completed planet_osm_line
+
+Osm2pgsql took 2879s overall
+~~~
+
+## See also
+
+- [`IMPORT`][import]
+- [Working with Spatial Data](spatial-data.html)
+- [Migrate from GeoPackages](migrate-from-geopackage.html)
+- [Migrate from GeoJSON](migrate-from-geojson.html)
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migration Overview](migration-overview.html)
+- [Migrate from MySQL][mysql]
+- [Migrate from Postgres][postgres]
+- [SQL Dump (Export)](cockroach-dump.html)
+- [Back Up and Restore Data](backup-and-restore.html)
+- [Use the Built-in SQL Client](cockroach-sql.html)
+- [Other Cockroach Commands](cockroach-commands.html)
+
+<!-- Reference Links -->
+
+[postgres]: migrate-from-postgres.html
+[mysql]: migrate-from-mysql.html
+[import]: import.html

--- a/v20.2/migrate-from-shapefiles.md
+++ b/v20.2/migrate-from-shapefiles.md
@@ -1,0 +1,119 @@
+---
+title: Migrate from Shapefiles
+summary: Learn how to migrate data from ESRI Shapefiles into a CockroachDB cluster.
+toc: true
+---
+
+<span class="version-tag">New in v20.2</span>: CockroachDB supports efficiently storing and querying [spatial data](spatial-data.html).
+
+This page has instructions for migrating data from ESRI [Shapefiles](spatial-glossary.html#shapefile) into CockroachDB using [`shp2pgsql`](https://manpages.debian.org/stretch/postgis/shp2pgsql.1.en.html) and [`IMPORT`][import].
+
+{{site.data.alerts.callout_success}}
+We are using `shp2pgsql` in the example below, but [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) could also be used, e.g.
+`ogr2ogr -f PGDUMP file.sql -lco LAUNDER=NO -lco DROP_TABLE=OFF file.shp`
+{{site.data.alerts.end}}
+
+In the example below we will import a [tornadoes data set](https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip) that is [available from the US National Weather Service](https://www.spc.noaa.gov/gis/svrgis/) (NWS).
+
+{{site.data.alerts.callout_info}}
+Please refer to the documentation of your GIS software for instructions on exporting GIS data to Shapefiles.
+{{site.data.alerts.end}}
+
+## Before You Begin
+
+To follow along with the example below, you will need the following prerequisites:
+
+- CockroachDB Spatial [installed](install-cockroachdb-spatial.html) and [running](start-a-local-cluster.html)
+- [`shp2pgsql`](https://manpages.debian.org/stretch/postgis/shp2pgsql.1.en.html)
+- [Python 3](https://www.python.org)
+
+## Step 1. Download the Shapefile data
+
+First, download and unzip the tornado data:
+
+{% include copy-clipboard.html %}
+~~~ shell
+wget https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip
+~~~
+
+{% include copy-clipboard.html %}
+~~~ shell
+unzip 1950-2018-torn-initpoint.zip
+~~~
+
+{% include copy-clipboard.html %}
+~~~ shell
+cd 1950-2018-torn-initpoint/
+~~~
+
+## Step 2. Convert the Shapefile data to SQL
+
+To load the tornado Shapefile into CockroachDB, we must first convert it to SQL using the `shp2pgsql` tool:
+
+{% include copy-clipboard.html %}
+~~~ shell
+shp2pgsql 1950-2018-torn-initpoint.shp > tornado-points.sql &
+~~~
+
+## Step 3. Host the files where the cluster can access them
+
+Each node in the CockroachDB cluster needs to have access to the files being imported. There are several ways for the cluster to access the data; for a complete list of the types of storage [`IMPORT`][import] can pull from, see [import file locations](import.html#import-file-location).
+
+For local testing, you can [start a local file server](create-a-file-server.html). The following command will start a local file server listening on port 3000:
+
+{% include copy-clipboard.html %}
+~~~ shell
+python3 -m http.server 3000
+~~~
+
+## Step 4. Prepare the database
+
+Next, create a `tornadoes` database to store the data in, and switch to it:
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach sql --insecure
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE DATABASE IF NOT EXISTS tornadoes;
+USE tornadoes;
+~~~
+
+## Step 5. Import the SQL
+
+Since the file is being served from a local server and is formatted as Postgres-compatible SQL, we can import the data using the following [`IMPORT PGDUMP`](import.html#import-a-postgres-database-dump) statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+IMPORT PGDUMP ('http://localhost:3000/tornado-points.sql');
+~~~
+
+~~~
+        job_id       |  status   | fraction_completed | rows  | index_entries |  bytes
+---------------------+-----------+--------------------+-------+---------------+-----------
+  584874782851497985 | succeeded |                  1 | 63645 |             0 | 18287213
+(1 row)
+~~~
+
+## See also
+
+- [`IMPORT`][import]
+- [Working with Spatial Data](spatial-data.html)
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Migrate from GeoJSON](migrate-from-geojson.html)
+- [Migrate from GeoPackage](migrate-from-geopackage.html)
+- [Migration Overview](migration-overview.html)
+- [Migrate from MySQL][mysql]
+- [Migrate from Postgres][postgres]
+- [SQL Dump (Export)](cockroach-dump.html)
+- [Back Up and Restore Data](backup-and-restore.html)
+- [Use the Built-in SQL Client](cockroach-sql.html)
+- [Other Cockroach Commands](cockroach-commands.html)
+
+<!-- Reference Links -->
+
+[postgres]: migrate-from-postgres.html
+[mysql]: migrate-from-mysql.html
+[import]: import.html

--- a/v20.2/migration-overview.md
+++ b/v20.2/migration-overview.md
@@ -10,12 +10,16 @@ CockroachDB supports [importing](import.html) data from the following databases:
 
 - MySQL
 - Oracle (using CSV)
-- Postgres
+- Postgres (and <span class="version-tag">New in v20.2</span>: PostGIS)
 
 and from the following data formats:
 
 - CSV/TSV
 - Avro
+- <span class="version-tag">New in v20.2</span>: ESRI Shapefiles (`.shp`) (using `shp2pgsql`)
+- <span class="version-tag">New in v20.2</span>: OpenStreetMap data files (`.pbf`) (using `osm2pgsql`)
+- <span class="version-tag">New in v20.2</span>: GeoPackage data files (`.gpkg`) (using `ogr2ogr`)
+- <span class="version-tag">New in v20.2</span>: GeoJSON data files (`.geojson`) (using `ogr2ogr`)
 
 This page lists general considerations to be aware of as you plan your migration to CockroachDB.
 
@@ -26,6 +30,10 @@ In addition to the information listed below, see the following pages for specifi
 - [Migrate from MySQL][mysql]
 - [Migrate from CSV][csv]
 - [Migrate from Avro][avro]
+- [Migrate from Shapefiles][shp]
+- [Migrate from OpenStreetMap][pbf]
+- [Migrate from GeoPackage][gpkg]
+- [Migrate from GeoPackage][geojson]
 
 {% include {{ page.version.version }}/misc/import-perf.md %}
 
@@ -68,3 +76,7 @@ Above a certain size, many data types such as [`STRING`](string.html)s, [`DECIMA
 [csv]: migrate-from-csv.html
 [import]: import.html
 [avro]: migrate-from-avro.html
+[shp]: migrate-from-shapefiles.html
+[pbf]: migrate-from-openstreetmap.html
+[gpkg]: migrate-from-geopackage.html
+[geojson]: migrate-from-geojson.html

--- a/v20.2/spatial-data.md
+++ b/v20.2/spatial-data.md
@@ -332,6 +332,11 @@ If you encounter behavior that you think is due to a performance issue, please g
 
 ## See also
 
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migrate from GeoJSON](migrate-from-geojson.html)
+- [Migrate from GeoPackage](migrate-from-geopackage.html)
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Spatial and GIS Glossary of Terms](spatial-glossary.html)
+- [Spatial functions](functions-and-operators.html#geospatial-functions)
 - [Troubleshooting overview](troubleshooting-overview.html)
 - [Support resources](support-resources.html)
-- [Geospatial functions](functions-and-operators.html#geospatial-functions)

--- a/v20.2/spatial-features.md
+++ b/v20.2/spatial-features.md
@@ -14,4 +14,8 @@ This documentation is still being worked on for the 20.2 release. For now, see t
 
 - [Working with Spatial Data](spatial-data.html)
 - [Spatial and GIS Glossary of Terms](spatial-glossary.html)
-- [Geospatial functions](functions-and-operators.html#geospatial-functions)
+- [Spatial functions](functions-and-operators.html#geospatial-functions)
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migrate from GeoJSON](migrate-from-geojson.html)
+- [Migrate from GeoPackage](migrate-from-geopackage.html)
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)

--- a/v20.2/spatial-glossary.md
+++ b/v20.2/spatial-glossary.md
@@ -209,5 +209,10 @@ This section has information about the representation of geometric and geographi
 ## See also
 
 - [Working with Spatial Data](spatial-data.html)
-- [Geospatial functions](functions-and-operators.html#geospatial-functions)
-- [Spatial Features](spatial-features.html)
+- [Spatial functions](functions-and-operators.html#geospatial-functions)
+- [Spatial Features Overview](spatial-features.html)
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migrate from GeoJSON](migrate-from-geojson.html)
+- [Migrate from GeoPackage](migrate-from-geopackage.html)
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Spatial and GIS Glossary of Terms](spatial-glossary.html)


### PR DESCRIPTION
Fixes #7933.

Summary of changes:

- Add 'Migrate to *' pages for each of:

  - Shapefile (.shp)

  - GeoJSON (.json)

  - OpenStreetmap (.pbf)

  - GeoPackage (.gpkg)

- For each of the above new pages, we document:

  - How to get the data from original format X to format Y (usually
    format Y is something we can slurp in with `IMPORT PGDUMP`)

  - Which tool(s) are used for the process

- Finally, we try to link everything amongst each other and the various
  already existing Spatial pages (glossary, etc.), in addition to
  whatever work is needed to weave these changes into the larger docs
  site in general (links, TOC updates, etc.)