### PR TITLE
Fix docs custom 404 page and reword messaging

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -3689,4 +3689,22 @@ a.accordion-toggle {
   color: #497EDA;
   font-weight: 900; }
 
+.page-not-found {
+  width: 60%;
+  margin: 0 auto;
+  padding: 50px;
+  text-align: center; }
+
+#page-not-found-heading {
+  color: #212B36;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  line-height: 32px; }
+
+#page-not-found-body {
+  color: #637282;
+  font-size: 14px;
+  letter-spacing: 0.1px;
+  line-height: 22px; }
+
 /*# sourceMappingURL=customstyles.css.map */

--- a/css/customstyles.scss
+++ b/css/customstyles.scss
@@ -621,3 +621,24 @@ a.accordion-toggle {
   color: #497EDA;
   font-weight: 900;
 }
+
+.page-not-found {
+  width: 60%;
+  margin: 0 auto;
+  padding: 50px;
+  text-align: center;
+}
+
+#page-not-found-heading {
+  color: #212B36;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  line-height: 32px;
+}
+
+#page-not-found-body {
+  color: #637282;
+  font-size: 14px;
+  letter-spacing: 0.1px;
+  line-height: 22px;
+}

--- a/netlify/build
+++ b/netlify/build
@@ -9,6 +9,7 @@ bundle install
 build _config_cockroachdb.yml
 
 cp _site/docs/_redirects _site/_redirects
+cp _site/docs/404.html _site/404.html
 cat _site/docs/cockroachcloud/_redirects >> _site/_redirects
 
 # Run Algolia if building master

--- a/v20.1/404.md
+++ b/v20.1/404.md
@@ -1,19 +1,15 @@
 ---
-title: Page Not Found
 description: "Page not found."
 sitemap: false
 search: exclude
 related_pages: none
 toc: false
+contribute: false
+feedback: false
 ---  
 
+<div class="page-not-found">
+  <p id="page-not-found-heading">Whoops!</p>
 
-{%comment%}
-<script type="text/javascript">
-  var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = '{{ site.url }}'
-</script>
-<script type="text/javascript"
-  src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
-</script>
-{%endcomment%}
+  <p id="page-not-found-body">We can't find the page you are looking for. You may have typed the wrong address or found a broken link.</p>
+</div>


### PR DESCRIPTION
Fixes #4908 and #8076.

The custom 404 image is a stretch goal so I haven't attempted it with this PR.

Please preview the new 404 page here: https://deploy-preview-8415--cockroachdb-docs.netlify.app/docs/stable/404.html

You will not be able to see the page above by going to a broken link via preview site, because the way Netlify redirects, it will send you from a preview broken link to the 404 page in production. But you **can** use the Netlify preview site to verify that broken links are being redirected to the 404 page in production, which is an improvement over current behavior (see #4908).

I think this is one PR that we should make live immediately instead of waiting for all style updates. This is because the current 404 functionality is broken (see #4908), so we are essentially fixing a bug that affects users today.