### PR TITLE
update Production Checklist numbers

### DIFF
--- a/v19.2/recommended-production-settings.md
+++ b/v19.2/recommended-production-settings.md
@@ -40,9 +40,13 @@ Before deploying to production, test and tune your hardware setup for your appli
 
 #### CPU and memory
 
-Each node should have **at least 2 vCPUs**. For best performance, we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
+Each node should have **at least 2 vCPUs**. For best performance, we recommend at least 4 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
+
+      {{site.data.alerts.callout_info}}
+      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using phsyical hardware rather than cloud instances.
+      {{site.data.alerts.end}}
 
       {{site.data.alerts.callout_info}}
       The benefits to having more RAM decrease as the number of vCPUs increases.
@@ -62,7 +66,7 @@ Underprovisioning RAM results in reduced performance (due to reduced caching and
 
 We recommend provisioning volumes with **60 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The maximum recommended storage capacity per node is 2 TiB, regardless of the number of vCPUs.
+- The maximum recommended storage capacity per node is 1 TiB, regardless of the number of vCPUs.
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 

--- a/v19.2/recommended-production-settings.md
+++ b/v19.2/recommended-production-settings.md
@@ -45,7 +45,7 @@ Each node should have **at least 2 vCPUs**. For best performance, we recommend a
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
       {{site.data.alerts.callout_info}}
-      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using phsyical hardware rather than cloud instances.
+      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using physical hardware rather than cloud instances.
       {{site.data.alerts.end}}
 
       {{site.data.alerts.callout_info}}

--- a/v20.1/recommended-production-settings.md
+++ b/v20.1/recommended-production-settings.md
@@ -40,9 +40,13 @@ Before deploying to production, test and tune your hardware setup for your appli
 
 #### CPU and memory
 
-Each node should have **at least 2 vCPUs**. For best performance, we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
+Each node should have **at least 2 vCPUs**. For best performance, we recommend at least 4 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
+
+      {{site.data.alerts.callout_info}}
+      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using phsyical hardware rather than cloud instances.
+      {{site.data.alerts.end}}
 
       {{site.data.alerts.callout_info}}
       The benefits to having more RAM decrease as the number of vCPUs increases.
@@ -60,9 +64,9 @@ Underprovisioning RAM results in reduced performance (due to reduced caching and
 
 #### Storage
 
-We recommend provisioning volumes with **60 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **150 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The maximum recommended storage capacity per node is 4 TiB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
+- The maximum recommended storage capacity per node is 2.5 TiB, regardless of the number of vCPUs.
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 

--- a/v20.1/recommended-production-settings.md
+++ b/v20.1/recommended-production-settings.md
@@ -45,7 +45,7 @@ Each node should have **at least 2 vCPUs**. For best performance, we recommend a
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
       {{site.data.alerts.callout_info}}
-      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using phsyical hardware rather than cloud instances.
+      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using physical hardware rather than cloud instances.
       {{site.data.alerts.end}}
 
       {{site.data.alerts.callout_info}}

--- a/v20.2/recommended-production-settings.md
+++ b/v20.2/recommended-production-settings.md
@@ -40,9 +40,13 @@ Before deploying to production, test and tune your hardware setup for your appli
 
 #### CPU and memory
 
-Each node should have **at least 2 vCPUs**. For best performance, we recommend between 4 and 32 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
+Each node should have **at least 2 vCPUs**. For best performance, we recommend at least 4 vCPUs per node. Provision **4 GiB of RAM per vCPU**.
 
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
+
+      {{site.data.alerts.callout_info}}
+      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using phsyical hardware rather than cloud instances.
+      {{site.data.alerts.end}}
 
       {{site.data.alerts.callout_info}}
       The benefits to having more RAM decrease as the number of vCPUs increases.
@@ -60,9 +64,9 @@ Underprovisioning RAM results in reduced performance (due to reduced caching and
 
 #### Storage
 
-We recommend provisioning volumes with **60 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
+We recommend provisioning volumes with **150 GiB per vCPU**. It's fine to have less storage per vCPU if your workload does not have significant capacity needs.
 
-- The maximum recommended storage capacity per node is 4 TiB, regardless of the number of vCPUs. See [Node density testing configuration](#node-density-testing-configuration).
+- The maximum recommended storage capacity per node is 2.5 TiB, regardless of the number of vCPUs.
 
 - Use dedicated volumes for the CockroachDB [store](architecture/storage-layer.html). Do not share the store volume with any other I/O activity.
 

--- a/v20.2/recommended-production-settings.md
+++ b/v20.2/recommended-production-settings.md
@@ -45,7 +45,7 @@ Each node should have **at least 2 vCPUs**. For best performance, we recommend a
 - To optimize for throughput, use larger nodes with up to 32 vCPUs. To further increase throughput, add more nodes to the cluster instead of increasing node size. 
 
       {{site.data.alerts.callout_info}}
-      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using phsyical hardware rather than cloud instances.
+      Based on internal testing, 32 vCPUs is a sweet spot for OLTP workloads. It is not a hard limit, especially for deployments using physical hardware rather than cloud instances.
       {{site.data.alerts.end}}
 
       {{site.data.alerts.callout_info}}


### PR DESCRIPTION
Updates numbers first added in #7739.

Thread: https://cockroachlabs.slack.com/archives/C013VDTRA30/p1600109555012800

- @a-entin You mentioned that versions prior to 20.1 have a 1 TB/node storage capacity limit, per conversations with Raphael. We previously had 2 TB documented. Just wanted to note that I've adjusted that number down for 19.2.
- Added back wording on 32 vCPUs as an OLTP "sweet spot" and clarified that this is not a hard limit.