### PR TITLE
Technical advisory 54418

### DIFF
--- a/_data/advisories.yml
+++ b/_data/advisories.yml
@@ -1,3 +1,7 @@
+- advisory: 54418
+  summary: Incorrect behavior with large batch UPSERTs
+  versions: 20.1.4, 20.1.5
+  date: September 21, 2020
 - advisory: 50587
   summary: TRUNCATE prevents table renaming
   versions: 19.1.0-19.1.10, 19.2.0-19.2.8

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,12 +1,8 @@
 - title: Production releases
   releases:
-    - date: Aug 31, 2020
-      version: v20.1.5
-      latest: true
-    - date: Aug 3, 2020
-      version: v20.1.4
     - date: Jun 29, 2020
       version: v20.1.3
+      latest: true
     - date: Jun 17, 2020
       version: v20.1.2
     - date: May 26, 2020

--- a/advisories/a54418.md
+++ b/advisories/a54418.md
@@ -1,0 +1,33 @@
+---
+title: Technical Advisory 54418
+summary: Incorrect behavior with large batch UPSERTs
+toc: true
+---
+
+Publication date: September 21, 2020.
+
+## Description
+
+CockroachDB introduced a bug in the [v20.1.4 release](../releases/v20.1.4.html) that affects [`UPSERT`](../v20.1/upsert.html) and [`INSERT … ON CONFLICT DO UPDATE SET x = excluded.x`](../v20.1/insert.html#on-conflict-clause) statements involving more than 10,000 rows.
+
+- The execution of a single `UPSERT` statement will stop, without a visible error, after reaching 10,000 rows. The reported number of affected rows will be incorrect, reported as 0.
+- Executing a single `UPSERT … RETURNING` statement will return at most 10,000 rows.
+
+This bug was introduced in [#51944][#51944], which was intended to correct a previously-identified error in `UPSERT` handling. A fix has been committed ([#54418][#54418]) and will be available in the [v20.1.6 release](../releases.html).
+
+## Statement
+
+To track this issue, see [#54418][#54418], the pull request correcting the aforementioned bugs.
+
+## Mitigation
+
+This regression is critical as it may silently corrupt SQL data without remediation. All unaffected customers are urged to skip releases v20.1.4 and v20.1.5 or ensure their application code processes at most 10000 rows per `UPSERT` statement. Customers running versions v20.1.4 or v20.1.5 are strongly encouraged to upgrade to [v20.1.6](../releases.html).
+
+## Impact
+
+All deployments running CockroachDB v20.1.4 and v20.1.5 are affected. Cockroach Labs has issued a fix that will be available in the next maintenance release. All of the other supported releases (v19.1.X, v19.2.X, v20.1.0-20.1.3) are not impacted.
+
+Questions about any technical alert can be directed to our [support team](https://support.cockroachlabs.com/).
+
+[#51944]: https://github.com/cockroachdb/cockroach/pull/51944
+[#54418]: https://github.com/cockroachdb/cockroach/pull/54418

--- a/advisories/index.md
+++ b/advisories/index.md
@@ -1,12 +1,12 @@
 ---
 title: Technical Advisories
-summary: Advisories about important security, stability, and data integrity aspects of CockroachDB.
+summary: Advisories about important security and stability aspects of CockroachDB.
 toc: true
 redirect_from: /advisories.html
 ---
 
 Technical advisories report major issues with CockroachDB that may
-impact security, stability, or data integrity in production environments.
+impact security or stability in production environments.
 
 Users are invited to evaluate advisories and consider the recommended
 mitigation actions independently from their version upgrade schedule.

--- a/releases/v20.1.4.md
+++ b/releases/v20.1.4.md
@@ -21,22 +21,11 @@ Get future release notes emailed to you:
     </script>
 </div>
 
-### Downloads
+{{site.data.alerts.callout_danger}}
+CockroachDB introduced a critical bug in the v20.1.4 release that affects [`UPSERT`](../v20.1/upsert.html) and [`INSERT … ON CONFLICT DO UPDATE SET x = excluded.x`](../v20.1/insert.html#on-conflict-clause) statements involving more than 10,000 rows. All deployments running CockroachDB v20.1.4 and v20.1.5 are affected.
 
-<div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.4.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.4.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.4.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.4.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
-</div>
-
-### Docker image
-
-{% include copy-clipboard.html %}
-~~~shell
-$ docker pull cockroachdb/cockroach:v20.1.4
-~~~
-
+For more information, see [Technical Advisory 54418](../advisories/a54418.html).
+{{site.data.alerts.end}}
 
 ### General changes
 

--- a/releases/v20.1.5.md
+++ b/releases/v20.1.5.md
@@ -21,22 +21,11 @@ Get future release notes emailed to you:
     </script>
 </div>
 
-### Downloads
+{{site.data.alerts.callout_danger}}
+CockroachDB introduced a critical bug in the [v20.1.4 release](../releases/v20.1.4.html) that affects [`UPSERT`](../v20.1/upsert.html) and [`INSERT … ON CONFLICT DO UPDATE SET x = excluded.x`](../v20.1/insert.html#on-conflict-clause) statements involving more than 10,000 rows. All deployments running CockroachDB v20.1.4 and v20.1.5 are affected.
 
-<div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.5.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.5.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.5.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.1.5.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
-</div>
-
-### Docker image
-
-{% include copy-clipboard.html %}
-~~~shell
-$ docker pull cockroachdb/cockroach-unstable:v20.1.5
-~~~
-
+For more information, see [Technical Advisory 54418](../advisories/a54418.html).
+{{site.data.alerts.end}}
 
 ### SQL language changes
 


### PR DESCRIPTION
Fixes #8430. 

As-is, this can go out ahead of [release v20.1.6](https://github.com/cockroachdb/cockroach/issues/54507).
When v20.1.6 release notes and download links are published, we should update these pages to point to the v20.1.6 release.