### PR TITLE
MATERIALIZED/NON MATERIALIZED syntax for CTE WITH clause

### DIFF
--- a/_includes/v20.2/sql/diagrams/with_clause.html
+++ b/_includes/v20.2/sql/diagrams/with_clause.html
@@ -1,53 +1,80 @@
-<div><svg width="765" height="481">
+<div><svg width="1046" height="528">
 <polygon points="9 17 1 13 1 21"></polygon>
 <polygon points="17 17 9 13 9 21"></polygon>
 <rect x="31" y="3" width="58" height="32" rx="10"></rect>
 <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
 <text class="terminal" x="39" y="21">WITH</text>
-<rect x="129" y="35" width="98" height="32" rx="10"></rect>
-<rect x="127" y="33" width="98" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="137" y="53">RECURSIVE</text><a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
-<rect x="45" y="189" width="134" height="32"></rect>
-<rect x="43" y="187" width="134" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="53" y="207">table_alias_name</text></a><rect x="219" y="189" width="26" height="32" rx="10"></rect>
-<rect x="217" y="187" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="227" y="207">(</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
-<rect x="285" y="189" width="56" height="32"></rect>
-<rect x="283" y="187" width="56" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="293" y="207">name</text></a><rect x="285" y="145" width="24" height="32" rx="10"></rect>
-<rect x="283" y="143" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="293" y="163">,</text>
-<rect x="381" y="189" width="26" height="32" rx="10"></rect>
-<rect x="379" y="187" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="389" y="207">)</text>
-<rect x="447" y="189" width="38" height="32" rx="10"></rect>
-<rect x="445" y="187" width="38" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="455" y="207">AS</text>
-<rect x="505" y="189" width="26" height="32" rx="10"></rect>
-<rect x="503" y="187" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="513" y="207">(</text><a xlink:href="sql-grammar.html#preparable_stmt" xlink:title="preparable_stmt">
-<rect x="551" y="189" width="126" height="32"></rect>
-<rect x="549" y="187" width="126" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="559" y="207">preparable_stmt</text></a><rect x="697" y="189" width="26" height="32" rx="10"></rect>
-<rect x="695" y="187" width="26" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="705" y="207">)</text>
+<rect x="129" y="35" width="96" height="32" rx="10"></rect>
+<rect x="127" y="33" width="96" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="137" y="53">RECURSIVE</text>
+<a xlink:href="sql-grammar.html#table_alias_name" xlink:title="table_alias_name">
+<rect x="45" y="189" width="132" height="32"></rect>
+<rect x="43" y="187" width="132" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="53" y="207">table_alias_name</text>
+</a>
+<rect x="217" y="189" width="26" height="32" rx="10"></rect>
+<rect x="215" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="225" y="207">(</text>
+<a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="283" y="189" width="54" height="32"></rect>
+<rect x="281" y="187" width="54" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="291" y="207">name</text>
+</a>
+<rect x="283" y="145" width="24" height="32" rx="10"></rect>
+<rect x="281" y="143" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="291" y="163">,</text>
+<rect x="377" y="189" width="26" height="32" rx="10"></rect>
+<rect x="375" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="385" y="207">)</text>
+<rect x="443" y="189" width="38" height="32" rx="10"></rect>
+<rect x="441" y="187" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="451" y="207">AS</text>
+<rect x="541" y="253" width="48" height="32" rx="10"></rect>
+<rect x="539" y="251" width="48" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="549" y="271">NOT</text>
+<rect x="629" y="221" width="120" height="32" rx="10"></rect>
+<rect x="627" y="219" width="120" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="637" y="239">MATERIALIZED</text>
+<rect x="789" y="189" width="26" height="32" rx="10"></rect>
+<rect x="787" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="797" y="207">(</text>
+<a xlink:href="sql-grammar.html#preparable_stmt" xlink:title="preparable_stmt">
+<rect x="835" y="189" width="124" height="32"></rect>
+<rect x="833" y="187" width="124" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="843" y="207">preparable_stmt</text>
+</a>
+<rect x="979" y="189" width="26" height="32" rx="10"></rect>
+<rect x="977" y="187" width="26" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="987" y="207">)</text>
 <rect x="45" y="101" width="24" height="32" rx="10"></rect>
 <rect x="43" y="99" width="24" height="32" class="terminal" rx="10"></rect>
-<text class="terminal" x="53" y="119">,</text><a xlink:href="sql-grammar.html#insert_stmt" xlink:title="insert_stmt">
-<rect x="615" y="271" width="92" height="32"></rect>
-<rect x="613" y="269" width="92" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="289">insert_stmt</text></a><a xlink:href="sql-grammar.html#update_stmt" xlink:title="update_stmt">
-<rect x="615" y="315" width="102" height="32"></rect>
-<rect x="613" y="313" width="102" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="333">update_stmt</text></a><a xlink:href="sql-grammar.html#delete_stmt" xlink:title="delete_stmt">
-<rect x="615" y="359" width="96" height="32"></rect>
-<rect x="613" y="357" width="96" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="377">delete_stmt</text></a><a xlink:href="sql-grammar.html#upsert_stmt" xlink:title="upsert_stmt">
-<rect x="615" y="403" width="98" height="32"></rect>
-<rect x="613" y="401" width="98" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="421">upsert_stmt</text></a><a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
-<rect x="615" y="447" width="94" height="32"></rect>
-<rect x="613" y="445" width="94" height="32" class="nonterminal"></rect>
-<text class="nonterminal" x="623" y="465">select_stmt</text></a><path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m98 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-266 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m134 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m20 44 h10 m26 0 h10 m-228 0 h20 m208 0 h20 m-248 0 q10 0 10 10 m228 0 q0 -10 10 -10 m-238 10 v14 m228 0 v-14 m-228 14 q0 10 10 10 m208 0 q10 0 10 -10 m-218 10 h10 m0 0 h198 m20 -34 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m-718 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m698 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-698 0 h10 m24 0 h10 m0 0 h654 m22 88 l2 0 m2 0 l2 0 m2 0 l2 0 m-192 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m92 0 h10 m0 0 h10 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m96 0 h10 m0 0 h6 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m98 0 h10 m0 0 h4 m-132 -10 v20 m142 0 v-20 m-142 20 v24 m142 0 v-24 m-142 24 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m94 0 h10 m0 0 h8 m23 -176 h-3"></path>
-<polygon points="755 285 763 281 763 289"></polygon>
-<polygon points="755 285 747 281 747 289"></polygon></svg></div>
+<text class="terminal" x="53" y="119">,</text>
+<a xlink:href="sql-grammar.html#insert_stmt" xlink:title="insert_stmt">
+<rect x="899" y="319" width="92" height="32"></rect>
+<rect x="897" y="317" width="92" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="907" y="337">insert_stmt</text>
+</a>
+<a xlink:href="sql-grammar.html#update_stmt" xlink:title="update_stmt">
+<rect x="899" y="363" width="100" height="32"></rect>
+<rect x="897" y="361" width="100" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="907" y="381">update_stmt</text>
+</a>
+<a xlink:href="sql-grammar.html#delete_stmt" xlink:title="delete_stmt">
+<rect x="899" y="407" width="96" height="32"></rect>
+<rect x="897" y="405" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="907" y="425">delete_stmt</text>
+</a>
+<a xlink:href="sql-grammar.html#upsert_stmt" xlink:title="upsert_stmt">
+<rect x="899" y="451" width="96" height="32"></rect>
+<rect x="897" y="449" width="96" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="907" y="469">upsert_stmt</text>
+</a>
+<a xlink:href="sql-grammar.html#select_stmt" xlink:title="select_stmt">
+<rect x="899" y="495" width="92" height="32"></rect>
+<rect x="897" y="493" width="92" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="907" y="513">select_stmt</text>
+</a>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-264 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m132 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m54 0 h10 m-94 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m74 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-74 0 h10 m24 0 h10 m0 0 h30 m20 44 h10 m26 0 h10 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v14 m226 0 v-14 m-226 14 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m0 0 h196 m20 -34 h10 m38 0 h10 m20 0 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-238 10 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m120 0 h10 m20 -32 h10 m26 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m26 0 h10 m-1000 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m980 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-980 0 h10 m24 0 h10 m0 0 h936 m22 88 l2 0 m2 0 l2 0 m2 0 l2 0 m-190 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m92 0 h10 m0 0 h8 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m96 0 h10 m0 0 h4 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m96 0 h10 m0 0 h4 m-130 -10 v20 m140 0 v-20 m-140 20 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m92 0 h10 m0 0 h8 m23 -176 h-3"></path>
+<polygon points="1037 333 1045 329 1045 337"></polygon>
+<polygon points="1037 333 1029 329 1029 337"></polygon>
+</svg></div>

--- a/v20.2/common-table-expressions.md
+++ b/v20.2/common-table-expressions.md
@@ -28,6 +28,7 @@ Parameter | Description
 `table_alias_name` | The name to use to refer to the common table expression from the accompanying query or statement.
 `name` | A name for one of the columns in the newly defined common table expression.
 `preparable_stmt` | The statement or subquery to use as common table expression.
+`MATERIALIZED`/`NOT MATERIALIZED` | <span class="version-tag">New in v20.2:</span> Override the optimizer's decision to materialize (i.e., store the results) of the common table expression.
 
 ## Overview
 

--- a/v20.2/common-table-expressions.md
+++ b/v20.2/common-table-expressions.md
@@ -28,7 +28,7 @@ Parameter | Description
 `table_alias_name` | The name to use to refer to the common table expression from the accompanying query or statement.
 `name` | A name for one of the columns in the newly defined common table expression.
 `preparable_stmt` | The statement or subquery to use as common table expression.
-`MATERIALIZED`/`NOT MATERIALIZED` | <span class="version-tag">New in v20.2:</span> Override the optimizer's decision to materialize (i.e., store the results) of the common table expression.
+`MATERIALIZED`/`NOT MATERIALIZED` | <span class="version-tag">New in v20.2:</span> Override the [optimizer](cost-based-optimizer.html)'s decision to materialize (i.e., store the results) of the common table expression. By default, the optimizer materializes the common table expression if it affects other objects in the database, or if it is used in the query multiple times.
 
 ## Overview
 


### PR DESCRIPTION
Fixes #7616.

- Updated WITH clause diagram
- Added `MATERIALIZED`/`NON MATERIALIZED` to WITH clause syntax parameters.

Note: I figured we don't want to encourage users to change what the optimizer decides to do, so I didn't add an example.