### PR TITLE
draft v20.2.0-beta.2 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -51,10 +51,10 @@ release_info:
     start_time: 2020-08-31 11:01:26.34274101 +0000 UTC
   v20.2:
     name: v20.2.0
-    version: v20.2.0-beta.1
+    version: v20.2.0-beta.2
     docker_image: cockroachdb/cockroach-unstable
-    build_time: 2020/09/14 11:00:26 (go1.13.4)
-    start_time: 2020-09-14 11:01:26.34274101 +0000 UTC
+    build_time: 2020/09/24 11:00:26 (go1.13.4)
+    start_time: 2020-09-24 11:01:26.34274101 +0000 UTC
 
 
 include: ["_redirects"]

--- a/_config_base.yml
+++ b/_config_base.yml
@@ -53,8 +53,8 @@ release_info:
     name: v20.2.0
     version: v20.2.0-beta.2
     docker_image: cockroachdb/cockroach-unstable
-    build_time: 2020/09/24 11:00:26 (go1.13.4)
-    start_time: 2020-09-24 11:01:26.34274101 +0000 UTC
+    build_time: 2020/09/25 11:00:26 (go1.13.4)
+    start_time: 2020-09-25 11:01:26.34274101 +0000 UTC
 
 
 include: ["_redirects"]

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -185,6 +185,8 @@
       no_windows: true
 - title: Testing releases
   releases:
+    - date: September 24, 2020
+      version: v20.2.0-beta.2
     - date: September 14, 2020
       version: v20.2.0-beta.1
     - date: August 25, 2020

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -185,7 +185,7 @@
       no_windows: true
 - title: Testing releases
   releases:
-    - date: September 24, 2020
+    - date: September 25, 2020
       version: v20.2.0-beta.2
     - date: September 14, 2020
       version: v20.2.0-beta.1

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -36,7 +36,7 @@
         {
           "title": "Latest v20.2 Beta",
           "urls": [
-            "/releases/v20.2.0-beta.1.html"
+            "/releases/v20.2.0-beta.2.html"
           ]
         },
         {

--- a/releases/v20.2.0-beta.2.md
+++ b/releases/v20.2.0-beta.2.md
@@ -40,10 +40,10 @@ $ docker pull cockroachdb/cockroach-unstable:v20.2.0-beta.2
 
 ### Security updates
 
-- A new experimental flag `--accept-sql-without-tls` has been introduced for [`cockroach start`](cockroach-start.html) and [`cockroach-start-single-node`](cockroach-start-single-node.html). When specified, a secure node will also accept secure SQL connections without TLS. When this flag is enabled:
+- A new experimental flag `--accept-sql-without-tls` has been introduced for [`cockroach start`](../v20.2/cockroach-start.html) and [`cockroach-start-single-node`](../v20.2/cockroach-start-single-node.html). When specified, a secure node will also accept secure SQL connections without TLS. When this flag is enabled:
 
-  - Node-to-node connections still use TLS: the server must still be started with `--certs-dir` and valid [TLS cert configuration](authentication.html) for nodes. 
-  - Client [authentication](authentication.html) (spoof protection) and [authorization](authorization.html) (access control and privilege escalation prevention) are performed by CockroachDB as usual, subject to the HBA configuration (for AuthN) and SQL privileges (for AuthZ). 
+  - Node-to-node connections still use TLS: the server must still be started with `--certs-dir` and valid [TLS cert configuration](../v20.2/authentication.html) for nodes. 
+  - Client [authentication](../v20.2/authentication.html) (spoof protection) and [authorization](../v20.2/authorization.html) (access control and privilege escalation prevention) are performed by CockroachDB as usual, subject to the HBA configuration (for authentication) and SQL privileges (for authorization). 
   - Transport-level security (integrity and confidentiality) for client connections must then be provided by the operator outside of CockroachDB—for example, by using a private network or VPN dedicated to CockroachDB and its client app(s). 
   - The flag only applies to the SQL interface. TLS is still required for the HTTP endpoint (unless `--unencrypted-localhost-http` is passed) and for the RPC endpoint.
 
@@ -51,7 +51,8 @@ $ docker pull cockroachdb/cockroach-unstable:v20.2.0-beta.2
 
 		<ol><li>Ensure the cluster ugprade is finalized.</li>
 		<li>Set up the HBA configuration to reject `host` connections for any network other than the one that has been secured.</li>
-		<li>Add the command-line flag and restart the nodes. Note that even when the flag is supplied, clients can still negotiate TLS and present a valid TLS certificate to identify themselves (at least under the default HBA configuration). Finally, this flag is experimental and its ergonomics will likely change in a later version. <a href="https://github.com/cockroachdb/cockroach/pull/54198">#54198</a></li></ol>
+		<li>Add the command-line flag and restart the nodes. Note that even when the flag is supplied, clients can still negotiate TLS and present a valid TLS certificate to identify themselves (at least under the default HBA configuration).</li></ol>
+    Finally, this flag is experimental and its ergonomics will likely change in a later version. <a href="https://github.com/cockroachdb/cockroach/pull/54198">#54198</a>
 
 ### SQL language changes
 
@@ -61,20 +62,20 @@ $ docker pull cockroachdb/cockroach-unstable:v20.2.0-beta.2
 
 ### Command-line changes
 
-- It is now possible to use password authentication over non-TLS connections with `cockroach` client CLI commands that use only SQL, e.g., [`cockroach sql`](cockroach-sql.html) or [`cockroach node ls`](cockroach-node.html). [#54198][#54198]
+- It is now possible to use password authentication over non-TLS connections with `cockroach` client CLI commands that use only SQL, e.g., [`cockroach sql`](../v20.2/cockroach-sql.html) or [`cockroach node ls`](../v20.2/cockroach-node.html). [#54198][#54198]
 
 ### Bug fixes
 
 - Fixed a "no binding for WithID" internal error when using `WITH RECURSIVE` in queries with placeholders. [#54063][#54063]
 - Fixed a bug whereby a crash during WAL rotation could cause CockroachDB to error on restart reporting corruption. [#54185][#54185]
-- Previously, [`RESTORE`](restore.html)s that were cancelled could crash a node. This is now fixed. [#54289][#54289]
-- Fixed two bugs when attempting to [add constraints](constraints.html#add-constraints) in the same transaction in which the table was created: Adding a `NOT NULL` constraint no longer fails with the error `check ... does not exist`, and adding a `NOT VALID` foreign key constraint no longer fails with the internal error `table descriptor is not valid: duplicate constraint name`. [#54287][#54287]
+- Previously, [`RESTORE`](../v20.2/restore.html)s that were cancelled could crash a node. This is now fixed. [#54289][#54289]
+- Fixed two bugs when attempting to [add constraints](../v20.2/constraints.html#add-constraints) in the same transaction in which the table was created: Adding a `NOT NULL` constraint no longer fails with the error `check ... does not exist`, and adding a `NOT VALID` foreign key constraint no longer fails with the internal error `table descriptor is not valid: duplicate constraint name`. [#54287][#54287]
 - Fixed a bug that could lead to out of memory errors when dropping large numbers of tables at high frequency. [#54286][#54286]
-- Fixed a bug introduced in a v20.2 alpha release where incorrect caching could incur extra writes to the store during [`RESTORE`](restore.html) on user-defined schemas. [#54296][#54296]
+- Fixed a bug introduced in a v20.2 alpha release where incorrect caching could incur extra writes to the store during [`RESTORE`](../v20.2/restore.html) on user-defined schemas. [#54296][#54296]
 
 ### Doc updates
 
-- Added guidance on performing large deletes with [`DELETE`](delete.html). [#7999](#7999)
+- Added guidance on performing large deletes with [`DELETE`](../v20.2/delete.html). [#7999][#7999]
 
 ### Contributors
 

--- a/releases/v20.2.0-beta.2.md
+++ b/releases/v20.2.0-beta.2.md
@@ -4,7 +4,7 @@ toc: true
 summary: Additions and changes in CockroachDB version v20.2.0-beta.2 since version v20.2.0-beta.1
 ---
 
-## September 24, 2020
+## September 25, 2020
 
 Get future release notes emailed to you:
 

--- a/releases/v20.2.0-beta.2.md
+++ b/releases/v20.2.0-beta.2.md
@@ -1,0 +1,103 @@
+---
+title: What&#39;s New in v20.2.0-beta.2
+toc: true
+summary: Additions and changes in CockroachDB version v20.2.0-beta.2 since version v20.2.0-beta.1
+---
+
+## September 24, 2020
+
+Get future release notes emailed to you:
+
+<div class="hubspot-install-form install-form-1 clearfix">
+    <script>
+        hbspt.forms.create({
+            css: '',
+            cssClass: 'install-form',
+            portalId: '1753393',
+            formId: '39686297-81d2-45e7-a73f-55a596a8d5ff',
+            formInstanceId: 1,
+            target: '.install-form-1'
+        });
+    </script>
+</div>
+
+### Downloads
+
+<div id="os-tabs" class="clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.0-beta.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.0-beta.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.0-beta.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.0-beta.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+### Docker image
+
+{% include copy-clipboard.html %}
+~~~shell
+$ docker pull cockroachdb/cockroach-unstable:v20.2.0-beta.2
+~~~
+
+
+### Security updates
+
+- A new experimental flag `--accept-sql-without-tls` has been introduced for [`cockroach start`](cockroach-start.html) and [`cockroach-start-single-node`](cockroach-start-single-node.html). When specified, a secure node will also accept secure SQL connections without TLS. When this flag is enabled:
+
+  - Node-to-node connections still use TLS: the server must still be started with `--certs-dir` and valid [TLS cert configuration](authentication.html) for nodes. 
+  - Client [authentication](authentication.html) (spoof protection) and [authorization](authorization.html) (access control and privilege escalation prevention) are performed by CockroachDB as usual, subject to the HBA configuration (for AuthN) and SQL privileges (for AuthZ). 
+  - Transport-level security (integrity and confidentiality) for client connections must then be provided by the operator outside of CockroachDB—for example, by using a private network or VPN dedicated to CockroachDB and its client app(s). 
+  - The flag only applies to the SQL interface. TLS is still required for the HTTP endpoint (unless `--unencrypted-localhost-http` is passed) and for the RPC endpoint.
+
+		To introduce this feature into an existing cluster: 
+
+		<ol><li>Ensure the cluster ugprade is finalized.</li>
+		<li>Set up the HBA configuration to reject `host` connections for any network other than the one that has been secured.</li>
+		<li>Add the command-line flag and restart the nodes. Note that even when the flag is supplied, clients can still negotiate TLS and present a valid TLS certificate to identify themselves (at least under the default HBA configuration). Finally, this flag is experimental and its ergonomics will likely change in a later version. <a href="https://github.com/cockroachdb/cockroach/pull/54198">#54198</a></li></ol>
+
+### SQL language changes
+
+- Previously, certain SQL commands sent over the PostgreSQL FE/BE protocol that were too big would error opaquely. This is now resolved for non-`PREPARE` related statements, clearly error messaging instead. [#54067][#54067]
+- Databases being restored will now be in the offline state, invisible to users, until the data has been restored. This is the same as the existing behavior for restored tables. (This change is also applied to enums and user-defined schemas being restored, which is a change relative to only the v20.2 alpha releases.) [#54296][#54296]
+- Implemented the `ST_SnapToGrid` [builtin](../v20.2/functions-and-operators.html#built-in-functions). [#54054][#54054]
+
+### Command-line changes
+
+- It is now possible to use password authentication over non-TLS connections with `cockroach` client CLI commands that use only SQL, e.g., [`cockroach sql`](cockroach-sql.html) or [`cockroach node ls`](cockroach-node.html). [#54198][#54198]
+
+### Bug fixes
+
+- Fixed a "no binding for WithID" internal error when using `WITH RECURSIVE` in queries with placeholders. [#54063][#54063]
+- Fixed a bug whereby a crash during WAL rotation could cause CockroachDB to error on restart reporting corruption. [#54185][#54185]
+- Previously, [`RESTORE`](restore.html)s that were cancelled could crash a node. This is now fixed. [#54289][#54289]
+- Fixed two bugs when attempting to [add constraints](constraints.html#add-constraints) in the same transaction in which the table was created: Adding a `NOT NULL` constraint no longer fails with the error `check ... does not exist`, and adding a `NOT VALID` foreign key constraint no longer fails with the internal error `table descriptor is not valid: duplicate constraint name`. [#54287][#54287]
+- Fixed a bug that could lead to out of memory errors when dropping large numbers of tables at high frequency. [#54286][#54286]
+- Fixed a bug introduced in a v20.2 alpha release where incorrect caching could incur extra writes to the store during [`RESTORE`](restore.html) on user-defined schemas. [#54296][#54296]
+
+### Doc updates
+
+- Added guidance on performing large deletes with [`DELETE`](delete.html). [#7999](#7999)
+
+### Contributors
+
+This release includes 22 merged PRs by 14 authors.
+
+[#54054]: https://github.com/cockroachdb/cockroach/pull/54054
+[#54061]: https://github.com/cockroachdb/cockroach/pull/54061
+[#54063]: https://github.com/cockroachdb/cockroach/pull/54063
+[#54065]: https://github.com/cockroachdb/cockroach/pull/54065
+[#54067]: https://github.com/cockroachdb/cockroach/pull/54067
+[#54185]: https://github.com/cockroachdb/cockroach/pull/54185
+[#54198]: https://github.com/cockroachdb/cockroach/pull/54198
+[#54267]: https://github.com/cockroachdb/cockroach/pull/54267
+[#54286]: https://github.com/cockroachdb/cockroach/pull/54286
+[#54287]: https://github.com/cockroachdb/cockroach/pull/54287
+[#54289]: https://github.com/cockroachdb/cockroach/pull/54289
+[#54296]: https://github.com/cockroachdb/cockroach/pull/54296
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[1a0ad39f7]: https://github.com/cockroachdb/cockroach/commit/1a0ad39f7
+[1c3b46c0e]: https://github.com/cockroachdb/cockroach/commit/1c3b46c0e
+[334b72d97]: https://github.com/cockroachdb/cockroach/commit/334b72d97
+[9d63a6348]: https://github.com/cockroachdb/cockroach/commit/9d63a6348
+[b17574537]: https://github.com/cockroachdb/cockroach/commit/b17574537
+[ceb88ac12]: https://github.com/cockroachdb/cockroach/commit/ceb88ac12
+[f6527759d]: https://github.com/cockroachdb/cockroach/commit/f6527759d
+[#7999]: https://github.com/cockroachdb/docs/pull/7999


### PR DESCRIPTION
Fixes #7980. 

[v20.2.0-beta.2](https://github.com/cockroachdb/cockroach/issues/54369) is currently qualifying and scheduled for release Sept 24, 2020.