### PR TITLE
Added v20.1.4 and v20.1.5 release notes back to the releases index

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -3,6 +3,12 @@
     - date: Sep 24, 2020
       version: v20.1.6
       latest: true
+    - date: Aug 31, 2020
+      version: v20.1.5
+      withdrawn: true
+    - date: Aug 3, 2020
+      version: v20.1.4
+      withdrawn: true
     - date: Jun 29, 2020
       version: v20.1.3
     - date: Jun 17, 2020

--- a/advisories/a54418.md
+++ b/advisories/a54418.md
@@ -25,7 +25,7 @@ This regression is critical as it could silently corrupt SQL data without remedi
 
 ## Impact
 
-All deployments running CockroachDB v20.1.4 and v20.1.5 are affected. Cockroach Labs has issued a fix in [v20.1.6](../releases/v20.1.6.html). All of the other supported releases (v19.1.X, v19.2.X, v20.1.0-20.1.3) are not impacted.
+All deployments running CockroachDB [v20.1.4 release](../releases/v20.1.4.html) and [v20.1.5 release](../releases/v20.1.5.html) are affected. Cockroach Labs has issued a fix in [v20.1.6](../releases/v20.1.6.html). All of the other supported releases (v19.1.X, v19.2.X, v20.1.0-20.1.3) are not impacted.
 
 Questions about any technical alert can be directed to our [support team](https://support.cockroachlabs.com/).
 


### PR DESCRIPTION
In #8435, I removed the v20.1.4 and v20.1.5 release notes from the releases index. This PR adds them back, with the `withdrawn` attribute set to `true`. This replaces the download link with a "Withdrawn" element in the page.