### PR TITLE
ALTER TABLE ... OWNER TO and ALTER DATABASE ... OWNER TO

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -1333,6 +1333,12 @@
     		    ]
     		  },
     		  {
+    		    "title": "<code>OWNER TO</code>",
+    		    "urls": [
+    		      "/${VERSION}/owner-to.html"
+    		    ]
+    		  },
+    		  {
     		    "title": "<code>PARTITION BY</code> (Enterprise)",
     		    "urls": [
     		      "/${VERSION}/partition-by.html"

--- a/v20.2/alter-database.md
+++ b/v20.2/alter-database.md
@@ -14,6 +14,7 @@ Subcommand | Description
 -----------|------------
 [`CONFIGURE ZONE`](configure-zone.html) | [Configure replication zones](configure-replication-zones.html) for a database.
 [`CONVERT TO SCHEMA`](convert-to-schema.html) | <span class="version-tag">New in v20.2</span>: Convert a [database](create-database.html) to a [schema](sql-name-resolution.html).
+[`OWNER TO`](owner-to.html) | <span class="version-tag">New in v20.2</span>: Change the owner of a database.
 [`RENAME`](rename-database.html) | Change the name of a database.
 
 ## Viewing schema changes

--- a/v20.2/alter-schema.md
+++ b/v20.2/alter-schema.md
@@ -10,7 +10,7 @@ toc: true
 
 ~~~
 ALTER SCHEMA ... RENAME TO <newschemaname>
-ALTER SCHEMA ... OWNER TO {<newowner> | CURRENT_USER | SESSION_USER }
+ALTER SCHEMA ... OWNER TO <newowner>
 ~~~
 
 ### Parameters
@@ -18,7 +18,7 @@ ALTER SCHEMA ... OWNER TO {<newowner> | CURRENT_USER | SESSION_USER }
 Parameter | Description
 ----------|------------
 `RENAME TO ...` | Rename the schema. The new schema name must be unique within the current database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
-`OWNER TO ...` | Change the owner of the schema. You can specify the new owner by name or with the [`CURRENT_USER` or `SESSION_USER` keywords](functions-and-operators.html#special-syntax-forms).
+`OWNER TO ...` | Change the owner of the schema.
 
 ## Required privileges
 

--- a/v20.2/alter-table.md
+++ b/v20.2/alter-table.md
@@ -23,6 +23,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`DROP COLUMN`](drop-column.html) | Remove columns from tables. | Yes
 [`DROP CONSTRAINT`](drop-constraint.html) | Remove constraints from columns. | Yes
 [`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Enable per-table audit logs. | Yes
+[`OWNER TO`](owner-to.html) | <span class="version-tag">New in v20.2</span>: Change the owner of the table.
 [`PARTITION BY`](partition-by.html)  | Partition, re-partition, or un-partition a table ([Enterprise-only](enterprise-licensing.html)). | Yes
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns. | Yes
 [`RENAME CONSTRAINT`](rename-constraint.html) | Change constraints columns. | Yes

--- a/v20.2/create-schema.md
+++ b/v20.2/create-schema.md
@@ -17,7 +17,7 @@ Only members of the `admin` role can create new schemas. By default, the `root` 
 ## Syntax
 
 ~~~
-CREATE SCHEMA [IF NOT EXISTS] { <schemaname> | [<schemaname>] AUTHORIZATION {user_name | CURRENT_USER | SESSION_USER} }
+CREATE SCHEMA [IF NOT EXISTS] { <schemaname> | [<schemaname>] AUTHORIZATION <user_name> }
 ~~~
 
 ### Parameters
@@ -26,7 +26,7 @@ Parameter | Description
 ----------|------------
 `IF NOT EXISTS` | Create a new schema only if a schema of the same name does not already exist within the current database. If one does exist, do not return an error.
 `schemaname` | The name of the schema to create, which must be unique within the current database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
-`AUTHORIZATION ...` | Optionally identify a user to be the owner of the schema. You can specify the owner by name, or with the [`CURRENT_USER` or `SESSION_USER` keywords](functions-and-operators.html#special-syntax-forms).<br><br>If a `CREATE SCHEMA` statement has an `AUTHORIZATION` clause, but no `schemaname`, the schema will be named after the specified owner of the schema. If a `CREATE SCHEMA` statement does not have an `AUTHORIZATION` clause, the user executing the statement will be named the owner.
+`AUTHORIZATION ...` | Optionally identify a user to be the owner of the schema.<br><br>If a `CREATE SCHEMA` statement has an `AUTHORIZATION` clause, but no `schemaname`, the schema will be named after the specified owner of the schema. If a `CREATE SCHEMA` statement does not have an `AUTHORIZATION` clause, the user executing the statement will be named the owner.
 
 ## Example
 

--- a/v20.2/owner-to.md
+++ b/v20.2/owner-to.md
@@ -1,0 +1,119 @@
+---
+title: OWNER TO
+summary: The OWNER TO subcommand changes the owner of an object.
+toc: true
+---
+
+<span class="version-tag">New in v20.2</span>: `OWNER TO` is a subcommand of [`ALTER DATABASE`](alter-database.html), [`ALTER TABLE`](alter-table.html), [`ALTER SCHEMA`](alter-schema.html), and [`ALTER TYPE`](alter-type.html), and is used to change the owner of an object in a cluster.
+
+{{site.data.alerts.callout_info}}
+This page documents `ALTER DATABASE ... OWNER TO` and `ALTER TABLE ... OWNER TO`. For details on the `ALTER SCHEMA ... OWNER TO` and `ALTER TYPE ... OWNER TO`, see the [`ALTER SCHEMA`](alter-schema.html) and [`ALTER TYPE`](alter-type.html) pages.
+{{site.data.alerts.end}}
+
+## Required privileges
+
+- To change the owner of a database, the user must be the current owner of the database, and a member of the new owner [role](authorization.html#roles). The user must also have the `CREATEDB` [privilege](authorization.html#assign-privileges).
+- To change the owner of a table, the user must be the current owner of the table, and a member of the new owner [role](authorization.html#roles). The new owner role must also have the `CREATE` [privilege](authorization.html#assign-privileges) on the schema to which the table belongs.
+
+## Syntax
+
+### Databases
+
+~~~
+ALTER DATABASE <name> OWNER TO <newowner>
+~~~
+
+### Tables
+
+~~~
+ALTER TABLE <name> OWNER TO <newowner>
+~~~
+
+## Parameters
+
+Parameter | Description
+----------|------------
+`name` | The name of the table or database.
+`newowner` | The name of the new owner.
+
+## Examples
+
+{% include {{page.version.version}}/sql/movr-statements.md %}
+
+### Change a database's owner
+
+Suppose that you want to change the owner of the `movr` database to a new user named `max`.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE USER IF NOT EXISTS max WITH PASSWORD "roach";
+~~~
+
+To change the owner of a database, the current owner (in this case, `root`) must belong to the role of the new owner (in this case, `max`):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> GRANT max TO root;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER DATABASE movr OWNER TO max;
+~~~
+
+To verify that the owner is now `max`, query the [`pg_catalog.pg_database` and `pg_catalog.pg_roles` tables](sql-name-resolution.html#databases-with-special-names):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT rolname FROM pg_catalog.pg_database d JOIN pg_catalog.pg_roles r ON d.datdba = r.oid WHERE datname = 'movr';
+~~~
+
+~~~
+  rolname
+-----------
+  max
+(1 row)
+~~~
+
+### Change a table's owner
+
+Suppose that you want to change the owner of the `rides` table to a new user named `max`.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE USER IF NOT EXISTS max WITH PASSWORD "roach";
+~~~
+
+To change the owner of a table, the current owner (in this case, `root`) must belong to the role of the new owner (in this case, `max`):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> GRANT max TO root;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE promo_codes OWNER TO max;
+~~~
+
+To verify that the owner is now `max`, query the [`pg_catalog.pg_tables` table](sql-name-resolution.html#databases-with-special-names):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT tableowner FROM pg_catalog.pg_tables WHERE tablename = 'promo_codes';
+~~~
+
+~~~
+  tableowner
+--------------
+  max
+(1 row)
+~~~
+
+## See also
+
+- [`CREATE DATABASE`](create-database.html)
+- [`SHOW DATABASES`](show-databases.html)
+- [`CREATE TABLE`](create-table.html)
+- [`SHOW TABLES`](show-tables.html)
+- [Other SQL Statements](sql-statements.html)


### PR DESCRIPTION
Fixes #8300.  
Fixes #8316. 

- Added `OWNER TO` page.

In the future, we should look into knocking subcommands down a level in the ToC. For example, placing a page like `OWNER TO` beneath `ALTER TABLE`.