### PR TITLE
Add PARTITION prefix in sample query

### DIFF
--- a/v19.1/partitioning.md
+++ b/v19.1/partitioning.md
@@ -117,16 +117,16 @@ Indexes can also be partitioned, but are not required to be. Each partition is r
 {% include copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE foo (a STRING PRIMARY KEY, b STRING) PARTITION BY LIST (a) (
-    bar VALUES IN ('bar'),
-    default VALUES IN (DEFAULT)
+    PARTITION bar VALUES IN ('bar'),
+    PARTITION default VALUES IN (DEFAULT)
 );
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ sql
 CREATE INDEX foo_b_idx ON foo (b) PARTITION BY LIST (b) (
-    baz VALUES IN ('baz'),
-    default VALUES IN (DEFAULT)
+    PARTITION baz VALUES IN ('baz'),
+    PARTITION default VALUES IN (DEFAULT)
 );
 ~~~
 

--- a/v2.0/partitioning.md
+++ b/v2.0/partitioning.md
@@ -115,12 +115,12 @@ Indexes can also be partitioned, but are not required to be. Each partition is r
 
 ~~~ sql
 CREATE TABLE foo (a STRING PRIMARY KEY, b STRING) PARTITION BY LIST (a) (
-    bar VALUES IN ('bar'),
-    default VALUES IN (DEFAULT)
+    PARTITION bar VALUES IN ('bar'),
+    PARTITION default VALUES IN (DEFAULT)
 );
 CREATE INDEX foo_b_idx ON foo (b) PARTITION BY LIST (b) (
-    baz VALUES IN ('baz'),
-    default VALUES IN (DEFAULT)
+    PARTITION baz VALUES IN ('baz'),
+    PARTITION default VALUES IN (DEFAULT)
 );
 ~~~
 

--- a/v2.1/partitioning.md
+++ b/v2.1/partitioning.md
@@ -117,16 +117,16 @@ Indexes can also be partitioned, but are not required to be. Each partition is r
 {% include copy-clipboard.html %}
 ~~~ sql
 CREATE TABLE foo (a STRING PRIMARY KEY, b STRING) PARTITION BY LIST (a) (
-    bar VALUES IN ('bar'),
-    default VALUES IN (DEFAULT)
+    PARTITION bar VALUES IN ('bar'),
+    PARTITION default VALUES IN (DEFAULT)
 );
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ sql
 CREATE INDEX foo_b_idx ON foo (b) PARTITION BY LIST (b) (
-    baz VALUES IN ('baz'),
-    default VALUES IN (DEFAULT)
+    PARTITION baz VALUES IN ('baz'),
+    PARTITION default VALUES IN (DEFAULT)
 );
 ~~~
 


### PR DESCRIPTION
Add `PARTITION` keyword for partition using secondary index documentation. Link: https://www.cockroachlabs.com/docs/v19.1/partitioning#partition-using-secondary-index

Fixes #4964 