### PR TITLE
v20.2 session variables update

### DIFF
--- a/_includes/v20.1/misc/session-vars.html
+++ b/_includes/v20.1/misc/session-vars.html
@@ -120,6 +120,18 @@
 
   <tr>
    <td>
+    <code>enable_insert_fast_path</code>
+   </td>
+   <td>Indicates whether CockroachDB will use a specialized execution operator for inserting into a table. We recommend leaving this setting <code>on</code>.</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>enable_zigzag_join</code>
    </td>
    <td>Indicates whether the <a href="cost-based-optimizer.html">cost-based optimizer</a> will plan certain queries using a zig-zag merge join algorithm, which searches for the desired intersection by jumping back and forth between the indexes based on the fact that after constraining indexes, they share an ordering. </td>
@@ -429,6 +441,30 @@
 
   <tr>
    <td>
+    <code>default_tablespace</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code></code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>idle_in_transaction_session_timeout</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>0</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>integer_datetimes</code>
    </td>
    <td>(Reserved; exposed only for ORM compatibility.)</td>
@@ -446,6 +482,18 @@
    <td>(Reserved; exposed only for ORM compatibility.)</td>
    <td>
     <code>postgres</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>lock_timeout</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>0</code>
    </td>
    <td>No</td>
    <td>Yes</td>
@@ -477,6 +525,18 @@
 
   <tr>
    <td>
+    <code>row_security</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>standard_conforming_strings</code>
    </td>
    <td>(Reserved; exposed only for ORM compatibility.)</td>
@@ -496,6 +556,18 @@
     <code>UTF8</code>
    </td>
    <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>synchronize_seqscans</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>No</td>
    <td>Yes</td>
   </tr>
 

--- a/_includes/v20.2/misc/session-vars.html
+++ b/_includes/v20.2/misc/session-vars.html
@@ -107,6 +107,18 @@
 
   <tr>
    <td>
+    <code>disallow_full_table_scans</code>
+   </td>
+   <td><span class="version-tag">New in v20.2</span>: If set to <code>on</code>, all queries that have planned a full table or full secondary index scan will return an error message. This setting does not apply to internal queries, which may plan full table or index scans without checking the session variable.</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>distsql</code>
    </td>
    <td>The query distribution mode for the session. By default, CockroachDB determines which queries are faster to execute if distributed across multiple nodes, and all other queries are run through the gateway node.</td>
@@ -123,6 +135,18 @@
     <code>enable_implicit_select_for_update</code>
    </td>
    <td> Indicates whether <a href="update.html"><code>UPDATE</code></a> statements acquire locks using the <code>FOR UPDATE</code> locking mode during their initial row scan, which improves performance for contended workloads.  For more information about how <code>FOR UPDATE</code> locking works, see the documentation for <a href="select-for-update.html"><code>SELECT FOR UPDATE</code></a>.</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>enable_insert_fast_path</code>
+   </td>
+   <td>Indicates whether CockroachDB will use a specialized execution operator for inserting into a table. We recommend leaving this setting <code>on</code>.</td>
    <td>
     <code>on</code>
    </td>
@@ -165,8 +189,30 @@
   </tr>
 
   <tr>
+   <td><code>foreign_key_cascades_limit</code></td>
+   <td><span class="version-tag">New in v20.2</span>: Limits the number of <a href="foreign-key.html">cascading operations</a> that run as part of a single query.</td>
+   <td>
+    <code>10000</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
    <td><code>idle_in_session_timeout</code></td>
    <td>Automatically terminates sessions that idle past the specified threshold. When set to <code>0</code>, the session will not timeout.</td>
+   <td>
+    <code>0</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>idle_in_transaction_session_timeout</code>
+   </td>
+   <td><span class="version-tag">New in v20.2</span>: Automatically terminates sessions that are idle in a transaction past the specified threshold. When set to <code>0</code>, the session will not timeout.</td>
    <td>
     <code>0</code>
    </td>
@@ -211,7 +257,7 @@
 
   <tr>
    <td>
-    <code>prefer_lookup_joins_for_fk</code>
+    <code>prefer_lookup_joins_for_fks</code>
    </td>
    <td><span class="version-tag">New in v20.2</span>: If <code>on</code>, the optimizer prefers <a href="joins.html#lookup-joins"><code>lookup joins</code></a> to <a href="joins.html#merge-joins"><code>merge joins</code></a> when performing <a href="foreign-key.html"><code>foreign key</code></a> checks.</td>
    <td>
@@ -489,6 +535,30 @@
 
   <tr>
    <td>
+    <code>default_tablespace</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code></code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>enable_seqscan</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>integer_datetimes</code>
    </td>
    <td>(Reserved; exposed only for ORM compatibility.)</td>
@@ -506,6 +576,18 @@
    <td>(Reserved; exposed only for ORM compatibility.)</td>
    <td>
     <code>postgres</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>lock_timeout</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>0</code>
    </td>
    <td>No</td>
    <td>Yes</td>
@@ -537,6 +619,18 @@
 
   <tr>
    <td>
+    <code>row_security</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>standard_conforming_strings</code>
    </td>
    <td>(Reserved; exposed only for ORM compatibility.)</td>
@@ -554,6 +648,30 @@
    <td>(Reserved; exposed only for ORM compatibility.)</td>
    <td>
     <code>UTF8</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>synchronize_seqscans</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>on</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>synchronous_commit</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>on</code>
    </td>
    <td>Yes</td>
    <td>Yes</td>

--- a/_includes/v20.2/misc/session-vars.html
+++ b/_includes/v20.2/misc/session-vars.html
@@ -38,6 +38,18 @@
 
   <tr>
    <td>
+    <code>client_min_messages</code>
+   </td>
+   <td>The severity level of notices displayed in the <a href="cockroach-sql.html">SQL shell</a>. Accepted values include <code>debug5</code>, <code>debug4</code>, <code>debug3</code>, <code>debug2</code>, <code>debug1</code>, <code>log</code>, <code>notice</code>, <code>warning</code>, and <code>error</code>.</td>
+   <td>
+    <code>notice</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>crdb_version</code>
    </td>
    <td>The version of CockroachDB.</td>
@@ -504,18 +516,6 @@
    <td>(Reserved; exposed only for ORM compatibility.)</td>
    <td>
     <code>UTF8</code>
-   </td>
-   <td>No</td>
-   <td>Yes</td>
-  </tr>
-
-  <tr>
-   <td>
-    <code>client_min_messages</code>
-   </td>
-   <td>(Reserved; exposed only for ORM compatibility.)</td>
-   <td>
-    <code>notice</code>
    </td>
    <td>No</td>
    <td>Yes</td>

--- a/v20.2/cost-based-optimizer.md
+++ b/v20.2/cost-based-optimizer.md
@@ -164,7 +164,7 @@ If it is not possible to use the algorithm specified in the hint, an error is si
 {{site.data.alerts.callout_info}}
 With queries on [interleaved tables](interleave-in-parent.html), the optimizer might choose to use a merge join to perform a [foreign key](foreign-key.html) check when a lookup join would be more optimal.
 
-<span class="version-tag">New in v20.2:</span> To make the optimizer prefer lookup joins to merge joins when performing foreign key checks, set the `prefer_lookup_joins_for_fk` [session variable](set-vars.html) to `on`.
+<span class="version-tag">New in v20.2:</span> To make the optimizer prefer lookup joins to merge joins when performing foreign key checks, set the `prefer_lookup_joins_for_fks` [session variable](set-vars.html) to `on`.
 {{site.data.alerts.end}}
 
 ### Additional considerations

--- a/v20.2/joins.md
+++ b/v20.2/joins.md
@@ -143,7 +143,7 @@ You can override the use of lookup joins using [join hints](cost-based-optimizer
 {{site.data.alerts.callout_info}}
 With queries on [interleaved tables](interleave-in-parent.html), the [optimizer](cost-based-optimizer.html) might choose to use a merge join to perform a [foreign key](foreign-key.html) check when a lookup join would be more optimal.
 
-<span class="version-tag">New in v20.2:</span> To make the optimizer prefer lookup joins to merge joins when performing foreign key checks, set the `prefer_lookup_joins_for_fk` [session variable](set-vars.html) to `on`.
+<span class="version-tag">New in v20.2:</span> To make the optimizer prefer lookup joins to merge joins when performing foreign key checks, set the `prefer_lookup_joins_for_fks` [session variable](set-vars.html) to `on`.
 {{site.data.alerts.end}}
 
 The output of [`EXPLAIN (VERBOSE)`](explain.html#verbose-option) shows whether `equality cols are key` for lookup joins, which means that the lookup columns form a key in the target table such that each lookup has at most one result.


### PR DESCRIPTION
Fixes #8148.
Fixes #8319. 
Fixes #7614.

This PR adds the new v20.2 session variables to the list of exposed session variables in the v20.2 docs. 

The PR also includes the following fixes:

- Updates to the session variables in v20.1 and v20.2 that were added in previous CRDB versions, but were not previously documented (https://github.com/cockroachdb/cockroach/pull/37333, https://github.com/cockroachdb/cockroach/pull/35116, https://github.com/cockroachdb/cockroach/pull/42914, https://github.com/cockroachdb/cockroach/pull/48333)
- Changed `prefer_lookup_joins_for_fk` to `prefer_lookup_joins_for_fks`, to reflect the true name of the variable.

Adding @otan as primary engineering reviewer, but feel free to add anyone else.