### PR TITLE
Cross-database foreign key and view references disallowed by default.

### DIFF
--- a/v20.2/add-constraint.md
+++ b/v20.2/add-constraint.md
@@ -159,6 +159,10 @@ Using `ON DELETE CASCADE` will ensure that when the referenced row is deleted, a
 > ALTER TABLE vehicles ADD CONSTRAINT users_fk FOREIGN KEY (city, owner_id) REFERENCES users (city, id) ON DELETE CASCADE;
 ~~~
 
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v20.2:</span> By default, referenced columns must be in the same database as the referencing foreign key column. To enable cross-database foreign key references, set the `sql.cross_db_fks.enabled` [cluster setting](cluster-settings.html) to `true`.
+{{site.data.alerts.end}}
+
 ### Drop and add a primary key constraint
 
 Suppose that you want to add `name` to the composite primary key of the `users` table, [without creating a secondary index of the existing primary key](#changing-primary-keys-with-add-constraint-primary-key).

--- a/v20.2/create-view.md
+++ b/v20.2/create-view.md
@@ -6,6 +6,10 @@ toc: true
 
 The `CREATE VIEW` statement creates a new [view](views.html), which is a stored query represented as a virtual table.
 
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v20.2:</span> By default, views created in a database cannot reference objects in a different database. To enable cross-database references for views, set the `sql.cross_db_views.enabled` [cluster setting](cluster-settings.html) to `true`.
+{{site.data.alerts.end}}
+
 {% include {{{ page.version.version }}/misc/schema-change-stmt-note.md %}
 
 ## Required privileges

--- a/v20.2/foreign-key.md
+++ b/v20.2/foreign-key.md
@@ -32,6 +32,7 @@ For example, given an `orders` table and a `customers` table, if you create a co
 
 - Referenced columns must contain only unique sets of values. This means the `REFERENCES` clause must use exactly the same columns as a [`UNIQUE`](unique.html) or [`PRIMARY KEY`](primary-key.html) constraint on the referenced table. For example, the clause `REFERENCES tbl (C, D)` requires `tbl` to have either the constraint `UNIQUE (C, D)` or `PRIMARY KEY (C, D)`.
 - In the `REFERENCES` clause, if you specify a table but no columns, CockroachDB references the table's primary key. In these cases, the `FOREIGN KEY` constraint and the referenced table's primary key must contain the same number of columns.
+- <span class="version-tag">New in v20.2:</span> By default, referenced columns must be in the same database as the referencing foreign key column. To enable cross-database foreign key references, set the `sql.cross_db_fks.enabled` [cluster setting](cluster-settings.html) to `true`.
 - Referenced columns must be [indexed](indexes.html). There are a number of ways to meet this requirement:
 
     - You can create indexes explicitly using the [`INDEX`](create-table.html#create-a-table-with-secondary-and-inverted-indexes) clause of `CREATE TABLE`.

--- a/v20.2/views.md
+++ b/v20.2/views.md
@@ -6,6 +6,9 @@ toc: true
 
 A view is a stored [selection query](selection-queries.html) and provides a shorthand name for it. CockroachDB's views are **dematerialized**: they do not store the results of the underlying queries. Instead, the underlying query is executed anew every time the view is used.
 
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v20.2:</span> By default, views created in a database cannot reference objects in a different database. To enable cross-database references for views, set the `sql.cross_db_views.enabled` [cluster setting](cluster-settings.html) to `true`.
+{{site.data.alerts.end}}
 
 ## Why use views?
 


### PR DESCRIPTION
Fixes #8503. 

Added notes to Views, `CREATE VIEW`, Foreign Keys, `ADD CONSTRAINT` docs.