### PR TITLE
Updates to RENAME TABLE page

### DIFF
--- a/v19.2/alter-table.md
+++ b/v19.2/alter-table.md
@@ -26,7 +26,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`PARTITION BY`](partition-by.html)  | Partition, re-partition, or un-partition a table ([Enterprise-only](enterprise-licensing.html)). | Yes
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns. | Yes
 [`RENAME CONSTRAINT`](rename-constraint.html) | Change constraints columns. | Yes
-[`RENAME TABLE`](rename-table.html) | Change the names of tables. | No
+[`RENAME TO`](rename-table.html) | Change the names of tables. | No
 [`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table. | No
 [`UNSPLIT AT`](unsplit-at.html) | <span class="version-tag">New in v19.2:</span> Remove a range split enforcement at a specified row in the table. | No
 [`VALIDATE CONSTRAINT`](validate-constraint.html) | Check whether values in a column match a [constraint](constraints.html) on the column. | Yes

--- a/v19.2/rename-table.md
+++ b/v19.2/rename-table.md
@@ -1,12 +1,14 @@
 ---
-title: RENAME TABLE
-summary: The RENAME TABLE statement changes the name of a table.
+title: ALTER TABLE ... RENAME TO
+summary: The ALTER TABLE ... RENAME TO statement changes the name of a table.
 toc: true
 ---
 
-The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table. It can also be used to move a table from one database to another.
+The `RENAME TO` [statement](sql-statements.html) is part of [`ALTER TABLE`](alter-table.html), and changes the name of a table. It can also be used to move a table from one database to another.
 
-{{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_danger}}
 Table renames **are not transactional**. For more information, see [Table renaming considerations](#table-renaming-considerations).

--- a/v20.1/alter-table.md
+++ b/v20.1/alter-table.md
@@ -27,7 +27,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`PARTITION BY`](partition-by.html)  | Partition, re-partition, or un-partition a table ([Enterprise-only](enterprise-licensing.html)). | Yes
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns. | Yes
 [`RENAME CONSTRAINT`](rename-constraint.html) | Change constraints columns. | Yes
-[`RENAME TABLE`](rename-table.html) | Change the names of tables. | No
+[`RENAME TO`](rename-table.html) | Change the names of tables. | No
 [`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table. | No
 [`UNSPLIT AT`](unsplit-at.html) | Remove a range split enforcement at a specified row in the table. | No
 [`VALIDATE CONSTRAINT`](validate-constraint.html) | Check whether values in a column match a [constraint](constraints.html) on the column. | Yes

--- a/v20.1/rename-table.md
+++ b/v20.1/rename-table.md
@@ -1,12 +1,14 @@
 ---
-title: RENAME TABLE
-summary: The RENAME TABLE statement changes the name of a table.
+title: ALTER TABLE ... RENAME TO
+summary: The ALTER TABLE ... RENAME TO statement changes the name of a table.
 toc: true
 ---
 
-The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table. It can also be used to move a table from one database to another.
+The `RENAME TO` [statement](sql-statements.html) is part of [`ALTER TABLE`](alter-table.html), and changes the name of a table. It can also be used to move a table from one database to another.
 
-{{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_danger}}
 Table renames **are not transactional**. For more information, see [Table renaming considerations](#table-renaming-considerations).

--- a/v20.2/alter-table.md
+++ b/v20.2/alter-table.md
@@ -26,7 +26,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`PARTITION BY`](partition-by.html)  | Partition, re-partition, or un-partition a table ([Enterprise-only](enterprise-licensing.html)). | Yes
 [`RENAME COLUMN`](rename-column.html) | Change the names of columns. | Yes
 [`RENAME CONSTRAINT`](rename-constraint.html) | Change constraints columns. | Yes
-[`RENAME TABLE`](rename-table.html) | Change the names of tables. | No
+[`RENAME TO`](rename-table.html) | Change the names of tables. | No
 [`SET SCHEMA`](set-schema.html) | <span class="version-tag">New in v20.2</span>: Change the [schema](sql-name-resolution.html#logical-schemas-and-namespaces) of a table. | No
 [`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table. | No
 [`UNSPLIT AT`](unsplit-at.html) | Remove a range split enforcement at a specified row in the table. | No

--- a/v20.2/rename-table.md
+++ b/v20.2/rename-table.md
@@ -1,12 +1,18 @@
 ---
-title: RENAME TABLE
-summary: The RENAME TABLE statement changes the name of a table.
+title: ALTER TABLE ... RENAME TO
+summary: The ALTER TABLE ... RENAME TO statement changes the name of a table.
 toc: true
 ---
 
-The `RENAME TABLE` [statement](sql-statements.html) changes the name of a table. It can also be used to move a table from one database to another.
+The `RENAME TO` [statement](sql-statements.html) is part of [`ALTER TABLE`](alter-table.html), and changes the name of a table.
 
-{{site.data.alerts.callout_info}}It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_success}}
+`ALTER TABLE ... RENAME TO` can be used to move a table from one database to another, but it cannot be used to move a table from one schema to another. To change a table's schema, use [`SET SCHEMA`](set-schema.html).
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_info}}
+It is not possible to rename a table referenced by a view. For more details, see <a href="views.html#view-dependencies">View Dependencies</a>.
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_danger}}
 Table renames **are not transactional**. For more information, see [Table renaming considerations](#table-renaming-considerations).


### PR DESCRIPTION
Fixes #8129. 

- Updated the `RENAME TABLE` pages for 19.2, 20.1, and 20.2 to correctly refer to the statement as `ALTER TABLE ... RENAME TO` (`RENAME TABLE` is not a statement). 
- Made some minor formatting changes to 19.2, 20.1, and 20.2 `RENAME TABLE` pages.
- Added a note about the limitation on changing schemas with a table rename statement.

In the future, we should avoid mislabeling statements. Another instance of this is with `RENAME DATABASE`, which is not a statement (it should be `ALTER TABLE ... RENAME TO`).