### PR TITLE
Tweak sql and demo docs

### DIFF
--- a/_includes/v19.2/sql/movr-statements-geo-partitioned-replicas.md
+++ b/_includes/v19.2/sql/movr-statements-geo-partitioned-replicas.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--geo-partitioned-replicas` flag](cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas). This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](topology-geo-partitioned-replicas.html) applied to the `movr` database.
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--geo-partitioned-replicas` flag](cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning). This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](topology-geo-partitioned-replicas.html) applied to the `movr` database.
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v20.1/sql/movr-statements-geo-partitioned-replicas.md
+++ b/_includes/v20.1/sql/movr-statements-geo-partitioned-replicas.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--geo-partitioned-replicas` flag](cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas). This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](topology-geo-partitioned-replicas.html) applied to the `movr` database.
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--geo-partitioned-replicas` flag](cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning). This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](topology-geo-partitioned-replicas.html) applied to the `movr` database.
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v20.2/sql/movr-statements-geo-partitioned-replicas.md
+++ b/_includes/v20.2/sql/movr-statements-geo-partitioned-replicas.md
@@ -2,7 +2,7 @@
 
 The following examples use MovR, a fictional vehicle-sharing application, to demonstrate CockroachDB SQL statements. For more information about the MovR example application and dataset, see [MovR: A Global Vehicle-sharing App](movr.html).
 
-To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--geo-partitioned-replicas` flag](cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas). This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](topology-geo-partitioned-replicas.html) applied to the `movr` database.
+To follow along, run [`cockroach demo`](cockroach-demo.html) with the [`--geo-partitioned-replicas` flag](cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning). This command opens an interactive SQL shell to a temporary, 9-node in-memory cluster with the [Geo-Partitioned Replicas Topology](topology-geo-partitioned-replicas.html) applied to the `movr` database.
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/_includes/v20.2/sql/shell-commands.md
+++ b/_includes/v20.2/sql/shell-commands.md
@@ -1,0 +1,16 @@
+The following commands can be used within the interactive SQL shell:
+
+Command | Usage
+--------|------------
+`\?`<br>`help` | View this help within the shell.
+`\q`<br>`quit`<br>`exit`<br>`ctrl-d` | Exit the shell.<br><br>When no text follows the prompt, `ctrl-c` exits the shell as well; otherwise, `ctrl-c` clears the line.
+`\!` | Run an external command and print its results to `stdout`. [See an example](cockroach-sql.html#run-external-commands-from-the-sql-shell).
+<code>&#92;&#124;</code> | Run the output of an external command as SQL statements. [See an example](cockroach-sql.html#run-external-commands-from-the-sql-shell).
+`\set <option>`<br>`\unset <option>` | Enable or disable a client-side option. For more details, see [Client-side options](#client-side-options).<br><br>You can also use the [`--set` flag](#general) to enable or disable client-side options before starting the SQL shell.
+`\show` | During a multi-line statement or transaction, show the SQL entered so far.
+`\h <statement>`<br>`\hf <function>` | View help for specific SQL statements or functions. See [SQL shell help](#help) for more details.
+`\l` | List all databases in the CockroachDB cluster. This command is equivalent to [`SHOW DATABASES`](show-databases.html).
+`\dt`<br>`d` | Show the tables of the current schema in the current database. These commands are equivalent to [`SHOW TABLES`](show-tables.html).
+`\dT` | <span class="version-tag">New in v20.2:</span> Show the [user-defined types](enum.html) in the current database. This command is equivalent to [`SHOW TYPES`](show-types.html).
+`\du` | List the users for all databases. This command is equivalent to [`SHOW USERS`](show-users.html).
+`\d <table>` | Show details about columns in the specified table. This command is equivalent to [`SHOW COLUMNS`](show-columns.html).

--- a/_includes/v20.2/sql/shell-help.md
+++ b/_includes/v20.2/sql/shell-help.md
@@ -1,0 +1,45 @@
+Within the SQL shell, you can get interactive help about statements and functions:
+
+Command | Usage
+--------|------
+`\h`<br>`??` | List all available SQL statements, by category.
+`\hf` | List all available SQL functions, in alphabetical order.
+`\h <statement>`<br>or `<statement> ?` | View help for a specific SQL statement.
+`\hf <function>`<br>or `<function> ?` | View help for a specific SQL function.
+
+#### Examples
+
+~~~ sql
+> \h UPDATE
+~~~
+
+~~~
+Command:     UPDATE
+Description: update rows of a table
+Category:    data manipulation
+Syntax:
+UPDATE <tablename> [[AS] <name>] SET ... [WHERE <expr>] [RETURNING <exprs...>]
+
+See also:
+  SHOW TABLES
+  INSERT
+  UPSERT
+  DELETE
+  https://www.cockroachlabs.com/docs/v2.1/update.html
+~~~
+
+~~~ sql
+> \hf uuid_v4
+~~~
+
+~~~
+Function:    uuid_v4
+Category:    built-in functions
+Returns a UUID.
+
+Signature          Category
+uuid_v4() -> bytes [ID Generation]
+
+See also:
+  https://www.cockroachlabs.com/docs/v2.1/functions-and-operators.html
+~~~

--- a/_includes/v20.2/sql/shell-options.md
+++ b/_includes/v20.2/sql/shell-options.md
@@ -1,0 +1,14 @@
+- To view option descriptions and how they are currently set, use `\set` without any options.
+- To enable or disable an option, use `\set <option> <value>` or `\unset <option> <value>`. You can also use the form `<option>=<value>`.
+- If an option accepts a boolean value:
+    - `\set <option>` without `<value>` is equivalent to `\set <option> true`, and `\unset <option>` without `<value>` is equivalent to `\set <option> false`.
+    - `on` and `0` are aliases for `true`, and `off` and `1` are aliases for `false`.
+
+Client Options | Description
+---------------|------------
+<a name="sql-option-auto-trace"></a> `auto_trace` | For every statement executed, the shell also produces the trace for that statement in a separate result below. A trace is also produced in case the statement produces a SQL error.<br><br>**Default:** `off`<br><br>To enable this option, run `\set auto_trace on`.
+<a name="sql-option-check-syntax"></a> `check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br /><br />**Default:** `true` for [interactive sessions](cockroach-sql.html#session-and-output-types); `false` otherwise.<br><br>To disable this option, run `\unset check_syntax`.
+<a name="sql-option-display-format"></a> `display_format` | How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `table`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `table` for sessions that [output on a terminal](cockroach-sql.html#session-and-output-types); `tsv` otherwise<br /><br />To change this option, run `\set display_format <format>`. [See an example](cockroach-sql.html#make-the-output-of-show-statements-selectable).
+`echo` | Reveal the SQL statements sent implicitly by the SQL shell.<br><br>**Default:** `false`<br><br>To enable this option, run `\set echo`. [See an example](cockroach-sql.html#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility).
+<a name="sql-option-errexit"></a> `errexit` | Exit the SQL shell upon encountering an error.<br /><br />**Default:** `false` for [interactive sessions](cockroach-sql.html#session-and-output-types); `true` otherwise<br><br>To enable this option, run `\set errexit`.
+`show_times` | Reveal the time a query takes to complete.<br><br>**Default:** `true`<br><br>To disable this option, run `\unset show_times`.

--- a/_includes/v20.2/sql/shell-shortcuts.md
+++ b/_includes/v20.2/sql/shell-shortcuts.md
@@ -1,0 +1,1 @@
+The SQL shell supports many shortcuts, such as `ctrl-r` for searching the shell history. For full details, see this [Readline Shortcut](https://github.com/chzyer/readline/blob/master/doc/shortcut.md) reference.

--- a/releases/v19.2.0-rc.1.md
+++ b/releases/v19.2.0-rc.1.md
@@ -57,7 +57,7 @@ $ docker pull cockroachdb/cockroach-unstable:v19.2.0-rc.1
 
 - Clarified epoch-based vs. expiration-based leases in the [Replication Layer](../v19.2/architecture/replication-layer.html#epoch-based-leases-table-data) architecture documentation. [#5578][#5578]
 - Updated the list of [Enterprise features](../v19.2/enterprise-licensing.html). [#5599][#5599]
-- Documented the new [`--geo-partitioned-replicas` flag of the `cockroach demo` command](../v19.2/cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas), which starts a 9-node in-memory cluster with the [Geo-Partitioned Replicas](../v19.2/topology-geo-partitioned-replicas.html) data topology applied to the `movr` database. This lets you quickly simulate one of the most effective data topology patterns for getting low latency in a multi-region cluster. [#5587][#5587]  
+- Documented the new [`--geo-partitioned-replicas` flag of the `cockroach demo` command](../v19.2/cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning), which starts a 9-node in-memory cluster with the [Geo-Partitioned Replicas](../v19.2/topology-geo-partitioned-replicas.html) data topology applied to the `movr` database. This lets you quickly simulate one of the most effective data topology patterns for getting low latency in a multi-region cluster. [#5587][#5587]  
 
 ### Contributors
 

--- a/v19.2/cockroach-demo.md
+++ b/v19.2/cockroach-demo.md
@@ -230,7 +230,7 @@ $ cockroach demo --with-load
 
 This command starts a demo cluster with the `movr` database preloaded and then inserts rows into each table in the `movr` database. You can monitor the workload progress on the [Admin UI](admin-ui-overview-dashboard.html#sql-queries).
 
-### Run `cockroach demo` with geo-partitioned replicas
+### Start a multi-region demo cluster with automatic geo-partitioning
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v19.2/query-replication-reports.md
+++ b/v19.2/query-replication-reports.md
@@ -411,7 +411,7 @@ The `system.replication_critical_localities` report contains which of your local
 
 That said, a locality being critical is not necessarily a bad thing as long as you are aware of it. What matters is that [you configure the topology of your cluster to get the resiliency you expect](topology-patterns.html).
 
-By default, the [movr demo cluster](cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas) has some ranges in critical localities. This is expected because it follows the [geo-partitioned replicas topology pattern](topology-geo-partitioned-replicas.html), which ties data for latency-sensitive queries to specific geographies at the cost of data unavailability during a region-wide failure.
+By default, the [movr demo cluster](cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning) has some ranges in critical localities. This is expected because it follows the [geo-partitioned replicas topology pattern](topology-geo-partitioned-replicas.html), which ties data for latency-sensitive queries to specific geographies at the cost of data unavailability during a region-wide failure.
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.1/cockroach-demo.md
+++ b/v20.1/cockroach-demo.md
@@ -301,7 +301,7 @@ This command starts a demo cluster with the `movr` database preloaded and then i
 
 <span class="version-tag">New in v20.1:</span> When running a multi-node demo cluster, load is balanced across all nodes.
 
-### Run `cockroach demo` with geo-partitioned replicas
+### Start a multi-region demo cluster with automatic geo-partitioning
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v20.1/query-replication-reports.md
+++ b/v20.1/query-replication-reports.md
@@ -417,7 +417,7 @@ The `system.replication_critical_localities` report contains which of your local
 
 That said, a locality being critical is not necessarily a bad thing as long as you are aware of it. What matters is that [you configure the topology of your cluster to get the resiliency you expect](topology-patterns.html).
 
-By default, the [movr demo cluster](cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas) has some ranges in critical localities. This is expected because it follows the [geo-partitioned replicas topology pattern](topology-geo-partitioned-replicas.html), which ties data for latency-sensitive queries to specific geographies at the cost of data unavailability during a region-wide failure.
+By default, the [movr demo cluster](cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning) has some ranges in critical localities. This is expected because it follows the [geo-partitioned replicas topology pattern](topology-geo-partitioned-replicas.html), which ties data for latency-sensitive queries to specific geographies at the cost of data unavailability during a region-wide failure.
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.2/cockroach-demo.md
+++ b/v20.2/cockroach-demo.md
@@ -1,58 +1,89 @@
 ---
 title: cockroach demo
-summary: Use cockroach demo to open a SQL shell to a temporary, in-memory, single-node CockroachDB cluster.
+summary: Use cockroach demo to open a SQL shell to a temporary, in-memory, CockroachDB cluster.
 toc: true
 ---
 
-The `cockroach demo` [command](cockroach-commands.html) starts a temporary, in-memory CockroachDB cluster, a preloaded dataset, and opens an [interactive SQL shell](cockroach-sql.html) to the cluster. All [SQL shell commands, client-side options, help, and shortcuts](cockroach-sql.html#sql-shell) supported by the `cockroach sql` command are also supported by the `cockroach demo` command.
+The `cockroach demo` [command](cockroach-commands.html) starts a temporary, in-memory CockroachDB cluster of one or more nodes, with or without a preloaded dataset, and opens an interactive SQL shell to the cluster.
 
-The in-memory cluster persists only as long as the SQL shell is open. As soon as the shell is exited, the cluster and all its data are permanently destroyed. This command is therefore recommended only as an easy way to experiment with the CockroachDB SQL dialect.
-
-Each instance of `cockroach demo` loads a temporary [enterprise license](https://www.cockroachlabs.com/get-cockroachdb) that expires after an hour. To prevent the loading of a temporary license, set the `--disable-demo-license` flag.
+- All [SQL shell](#sql-shell) commands, client-side options, help, and shortcuts supported by the [`cockroach sql`](cockroach-sql.html) command are also supported by `cockroach demo`.
+- The in-memory cluster persists only as long as the SQL shell is open. As soon as the shell is exited, the cluster and all its data are permanently destroyed. This command is therefore recommended only as an easy way to experiment with the CockroachDB SQL dialect.
+- Each instance of `cockroach demo` loads a temporary [enterprise license](https://www.cockroachlabs.com/get-cockroachdb) that expires after an hour. To prevent the loading of a temporary license, set the `--disable-demo-license` flag.
 
 ## Synopsis
 
-Start an in-memory cluster and open an interactive SQL shell:
-
-~~~ shell
-$ cockroach demo <flags>
-~~~
-
-Start an in-memory cluster with a preloaded dataset and open an interactive SQL shell:
-
-~~~ shell
-$ cockroach demo <dataset> <flags>
-~~~
-
-Start an in-memory cluster in secure mode and open an interactive SQL shell:
-
-~~~ shell
-$ cockroach demo --insecure=false <other flags>
-~~~
-
-Execute SQL from the command line against an in-memory cluster:
-
-~~~ shell
-$ cockroach demo --execute="<sql statement>;<sql statement>" --execute="<sql-statement>" <flags>
-~~~
-
-Exit the interactive SQL shell and stop the in-memory cluster:
-
-~~~ shell
-$ \q
-ctrl-d
-~~~
-
-View help:
+View help for `cockroach demo`:
 
 ~~~ shell
 $ cockroach demo --help
 ~~~
 
+Start a single-node demo cluster with the `movr` dataset pre-loaded:
+
+~~~ shell
+$ cockroach demo <flags>
+~~~
+
+Load a different dataset into a demo cluster:
+
+~~~ shell
+$ cockroach demo <dataset> <flags>
+~~~
+
+Run the `movr` workload against a demo cluster:
+
+~~~ shell
+$ cockroach demo --with-load <other flags>
+~~~
+
+Execute SQL from the command line against a demo cluster
+
+~~~ shell
+$ cockroach demo --execute="<sql statement>;<sql statement>" --execute="<sql-statement>" <other flags>
+~~~
+
+Start a multi-node demo cluster:
+
+~~~ shell
+$ cockroach demo --nodes=<number of nodes> <other flags>
+~~~
+
+Start a multi-region demo cluster with automatic geo-partitioning
+
+~~~ shell
+$ cockroach demo --geo-partitioned-replicas <other flags>
+~~~
+
+Start a multi-region demo cluster with manually defined localities
+
+~~~ shell
+$ cockroach demo --nodes=<number of nodes> --demo-locality=<key:value pair per node> <other flags>
+~~~
+
+Stop a demo cluster:
+
+~~~ sql
+> \q
+~~~
+
+~~~ sql
+> quit
+~~~
+
+~~~ sql
+> exit
+~~~
+
+~~~ shell
+ctrl-d
+~~~
+
+
 ## Datasets
 
 {{site.data.alerts.callout_success}}
-To start a demo cluster without a pre-loaded dataset, pass the `--empty` flag.
+By default, the `movr` dataset is pre-loaded into a demo cluster. To load a different dataset, use [`cockroach demo <dataset>`](#load-a-sample-dataset-into-a-demo-cluster). To start a demo cluster without a pre-loaded dataset, pass the `--empty` flag.
+
 {{site.data.alerts.end}}
 
 Workload | Description
@@ -67,6 +98,8 @@ Workload | Description
 
 ## Flags
 
+### General
+
 The `demo` command supports the following general-use flags.
 
 Flag | Description
@@ -74,46 +107,86 @@ Flag | Description
 `--cache` | For each demo node, the total size for caches. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit, for example: <br><br>`--cache=.25`<br>`--cache=25%`<br>`--cache=1000000000 ----> 1000000000 bytes`<br>`--cache=1GB ----> 1000000000 bytes`<br>`--cache=1GiB ----> 1073741824 bytes` <br><br>**Default:** `64MiB`
 `--demo-locality` | Specify [locality](cockroach-start.html#locality) information for each demo node. The input is a colon-separated list of key-value pairs, where the i<sup>th</sup> pair is the locality setting for the i<sup>th</sup> demo cockroach node.<br><br>For example, the following option assigns node 1's region to `us-east1` and availability zone to `1`, node 2's region to `us-east2` and availability zone to `2`, and node 3's region to `us-east3` and availability zone to `3`:<br><br>`--demo-locality=region=us-east1,az=1:region=us-east1,az=2:region=us-east1,az=3`<br><br>By default, `cockroach demo` uses sample region (`region`) and availability zone (`az`) replica localities for each node specified with the `--nodes` flag.
 `--disable-demo-license` |  Start the demo cluster without loading a temporary [enterprise license](https://www.cockroachlabs.com/get-cockroachdb) that expires after an hour.<br><br>Setting the `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING` environment variable will also prevent the loading of a temporary license, along with preventing the sharing of anonymized [diagnostic details](diagnostics-reporting.html) with Cockroach Labs.
-`--echo-sql` | Reveal the SQL statements sent implicitly by the command-line utility. This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](cockroach-sql.html#commands).
+`--echo-sql` | Reveal the SQL statements sent implicitly by the command-line utility. This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](#commands).
 `--empty` | Start the demo cluster without a pre-loaded dataset.
 `--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons.<br><br>If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).
-`--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `table`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `table` for sessions that [output on a terminal](cockroach-sql.html#session-and-output-types); `tsv` otherwise<br /><br />This flag corresponds to the `display_format` [client-side option](cockroach-sql.html#client-side-options) for use in interactive sessions.
+`--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `table`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `table` for sessions that [output on a terminal](cockroach-sql.html#session-and-output-types); `tsv` otherwise<br /><br />This flag corresponds to the `display_format` [client-side option](#client-side-options) for use in interactive sessions.
 `--geo-partitioned-replicas` | Start a 9-node demo cluster with the [Geo-Partitioned Replicas](topology-geo-partitioned-replicas.html) topology pattern applied to the [`movr`](movr.html) database.
 `--insecure` |  Set this to `false` to start the demo cluster in secure mode using TLS certificates to encrypt network communication. `--insecure=false` gives you an easy way test out CockroachDB [authorization features](authorization.html) and also creates a password (`admin`) for the `root` user for logging into the Admin UI.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
 `--max-sql-memory` | For each demo node, the maximum in-memory storage capacity for temporary SQL data, including prepared queries and intermediate data rows during query execution. This can be a percentage (notated as a decimal or with `%`) or any bytes-based unit, for example:<br><br>`--max-sql-memory=.25`<br>`--max-sql-memory=25%`<br>`--max-sql-memory=10000000000 ----> 1000000000 bytes`<br>`--max-sql-memory=1GB ----> 1000000000 bytes`<br>`--max-sql-memory=1GiB ----> 1073741824 bytes`<br><br>**Default:** `128MiB`
 `--nodes` | Specify the number of in-memory nodes to create for the demo.<br><br>**Default:** 1
 `--safe-updates` | Disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`.<br><br>**Default:** `true` for [interactive sessions](cockroach-sql.html#session-and-output-types); `false` otherwise<br><br>Potentially unsafe SQL statements can also be allowed/disallowed for an entire session via the `sql_safe_updates` [session variable](set-vars.html).
-`--set` | Set a [client-side option](cockroach-sql.html#client-side-options) before starting the SQL shell or executing SQL statements from the command line via `--execute`. This flag may be specified multiple times, once per option.<br><br>After starting the SQL shell, the `\set` and `unset` commands can be use to enable and disable client-side options as well.
+`--set` | Set a [client-side option](#client-side-options) before starting the SQL shell or executing SQL statements from the command line via `--execute`. This flag may be specified multiple times, once per option.<br><br>After starting the SQL shell, the `\set` and `unset` commands can be use to enable and disable client-side options as well.
 `--with-load` |  Run a demo [`movr`](movr.html) workload against the preloaded `movr` database.<br><br> When running a multi-node demo cluster, load is balanced across all nodes.
 
-## Logging
+### Logging
 
 By default, the `demo` command logs errors to `stderr`.
 
 If you need to troubleshoot this command's behavior, you can change its [logging behavior](debug-and-error-logs.html).
 
-## Connecting to the demo cluster
+## SQL shell
 
-When the SQL shell connects to the demo cluster at startup, it prints a welcome text with some tips and cluster details. Most of these details resemble the [welcome text](cockroach-sql.html#welcome-message) that is printed when connecting `cockroach sql` to a permanent cluster. `cockroach demo` also includes some URLs to connect to the [Admin UI](admin-ui-overview.html) with a web browser, or directly to the cluster with a URL [connection parameter](connection-parameters.html) across a [Unix domain socket connection](cockroach-sql.html#connect-to-a-cluster-listening-for-unix-domain-socket-connections) or a standard TCP connection.
+### Welcome text
+
+When the SQL shell connects to the demo cluster at startup, it prints a welcome text with some tips and cluster details. Most of these details resemble the [welcome text](cockroach-sql.html#welcome-message) that is printed when connecting `cockroach sql` to a permanent cluster. `cockroach demo` also includes some [connection parameters](#connection-parameters) for connecting to the Admin UI or for connecting another SQL client to the demo cluster.
 
 ~~~ shell
 #
 # Welcome to the CockroachDB demo database!
 #
-...
+# You are connected to a temporary, in-memory CockroachDB cluster of 1 node.
+#
+# This demo session will attempt to enable enterprise features
+# by acquiring a temporary license from Cockroach Labs in the background.
+# To disable this behavior, set the environment variable
+# COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING=true.
+#
+# Beginning initialization of the movr dataset, please wait...
+#
+# The cluster has been preloaded with the "movr" dataset
+# (MovR is a fictional vehicle sharing company).
+#
+# Reminder: your changes to data stored in the demo session will not be saved!
 #
 # Connection parameters:
-#   (console) http://127.0.0.1:53538
-#   (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fpg%2FT%2Fdemo282557495&port=26257
-#   (sql/tcp) postgres://root:admin@127.0.0.1:53540?sslmode=require
+#   (console) http://127.0.0.1:59403
+#   (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo635924269&port=26257
+#   (sql/tcp) postgres://root:admin@127.0.0.1:59405?sslmode=require
 #
 #
 # The user "root" with password "admin" has been created. Use it to access the Web UI!
 #
-...
+# Server version: CockroachDB CCL v20.2.0 (x86_64-apple-darwin19.6.0, built , go1.14.4) (same version as client)
+# Cluster ID: d4055073-8b30-490b-97bf-39ced0cd6471
+# Organization: Cockroach Demo
+#
+# Enter \? for a brief introduction.
+##
 ~~~
 
- To return the client connection URLs for all nodes in a demo cluster from within the SQL shell, use the client-side `\demo ls` command:
+### Connection parameters
+
+The SQL shell welcome text includes connection parameters for accessing the Admin UI and for connecting other SQL clients to the demo cluster:
+
+~~~
+# Connection parameters:
+#   (console) http://127.0.0.1:50037
+#   (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo294284060&port=26257
+#   (sql/tcp) postgres://root:admin@127.0.0.1:50039?sslmode=require
+~~~
+
+Parameter | Description
+----------|------------
+`console` | Use this link to access a local [Admin UI](admin-ui-overview.html). To login, use the `root` user with password `admin`.
+`sql` | Use this connection URL to establish a [Unix domain socket connection](cockroach-sql.html#connect-to-a-cluster-listening-for-unix-domain-socket-connections) with a client that is installed on the same machine.
+`sql/tcp` | Use this connection URL for standard sql/tcp connections from other SQL clients such as [`cockroach sql`](cockroach-sql.html).
+
+{{site.data.alerts.callout_info}}
+You do not need to create or specify node and client certificates in `sql` or `sql/tcp` connection URLs.
+{{site.data.alerts.end}}
+
+When running a multi-node demo cluster, use the `\demo ls` [shell command](#commands) to list the connection parameters for all nodes:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -122,68 +195,112 @@ When the SQL shell connects to the demo cluster at startup, it prints a welcome 
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:53538
-  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fpg%2FT%2Fdemo282557495&port=26257
-  (sql/tcp) postgres://root:admin@127.0.0.1:53540?sslmode=require
+  (console) http://127.0.0.1:50037
+  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo294284060&port=26257
+  (sql/tcp) postgres://root:admin@127.0.0.1:50039?sslmode=require
 
 node 2:
-  (console) http://127.0.0.1:53783
-  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fpg%2FT%2Fdemo282557495&port=26258
-  (sql/tcp) postgres://root:admin@127.0.0.1:53785?sslmode=require
+  (console) http://127.0.0.1:50040
+  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo294284060&port=26258
+  (sql/tcp) postgres://root:admin@127.0.0.1:50042?sslmode=require
 
 node 3:
-  (console) http://127.0.0.1:53789
-  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fpg%2FT%2Fdemo282557495&port=26259
-  (sql/tcp) postgres://root:admin@127.0.0.1:53791?sslmode=require
-
-...
+  (console) http://127.0.0.1:50048
+  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo294284060&port=26259
+  (sql/tcp) postgres://root:admin@127.0.0.1:50050?sslmode=require
 ~~~
 
-{{site.data.alerts.callout_info}}
-The `\demo ls` command is **experimental feature**. The interface and output are subject to change.
-{{site.data.alerts.end}}
+### Commands
 
-### Admin UI
+- [General](#general)
+- [Demo-specific](#demo-specific)
 
-`cockroach demo` serves a local [Admin UI](admin-ui-overview.html) at the **console** link. For the duration of the cluster, you can navigate to this link to monitor the cluster's activity in the Admin UI. To login, you can use the `root` user with password `admin`.
+#### General
 
-### URL connection parameters
+{% include {{ page.version.version }}/sql/shell-commands.md %}
 
-You can connect to the demo cluster using a URL connection parameter (e.g., with the [`cockroach sql --url`](cockroach-sql.html#client-connection) command). To establish a [Unix domain socket connection](cockroach-sql.html#connect-to-a-cluster-listening-for-unix-domain-socket-connections) with a client that is installed on the same machine, use the **sql** URL . For standard TCP connections, use the **sql/tcp** URL.
+#### Demo-specific
 
-{{site.data.alerts.callout_info}}
-You do not need to create or specify node and client certificates in the connection URL to a secure demo cluster.
-{{site.data.alerts.end}}
+`cockroach demo` offers the following additional shell commands. Note that these commands are **experimental** and their interface and output are subject to change.
+
+Command | Usage
+--------|------
+`\demo ls` | List the demo nodes and their connection URLs.
+`\demo shutdown <node number>` | Shuts down a node in a multi-node demo cluster.<br><br>This command simulates stopping a node that can be restarted. [See an example](#shut-down-and-restart-nodes-in-a-multi-node-demo-cluster).
+`\demo restart <node number>` | Restarts a node in a multi-node demo cluster. [See an example](#shut-down-and-restart-nodes-in-a-multi-node-demo-cluster).
+`\demo decommission <node number>` | Decommissions a node in a multi-node demo cluster.<br><br>This command simulates [decommissioning a node](remove-nodes.html).
+`\demo recommission <node number>` | Recommissions a decommissioned node in a multi-node demo cluster.
+
+### Client-side options
+
+{% include {{ page.version.version }}/sql/shell-options.md %}
+
+### Help
+
+{% include {{ page.version.version }}/sql/shell-help.md %}
+
+### Shortcuts
+
+{% include {{ page.version.version }}/sql/shell-shortcuts.md %}
 
 ## Diagnostics reporting
 
 By default, `cockroach demo` shares anonymous usage details with Cockroach Labs. To opt out, set the [`diagnostics.reporting.enabled`](diagnostics-reporting.html#after-cluster-initialization) [cluster setting](cluster-settings.html) to `false`. You can also opt out by setting the [`COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING`](diagnostics-reporting.html#at-cluster-initialization) environment variable to `false` before running `cockroach demo`.
 
-## Shutting down and restarting nodes
-
- You can shut down and restart individual nodes in a multi-node demo cluster with the `\demo` SQL shell command.
-
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
-
-Command | Description
-----------------|------------
-`\demo shutdown <node number>` | Shuts down a node.<br><br>This command simulates stopping a node that can be restarted. It is similar to [`cockroach quit`](cockroach-quit.html).
-`\demo restart <node number>` | Restarts a node that has been shut down.
-`\demo decommission <node number>` | Decommissions a node.<br><br>This command simulates [decommissioning a node](remove-nodes.html). It is similar to [`cockroach quit --decommission`](cockroach-quit.html#general).
-`\demo recommission <node number>` | Recommissions a decommissioned node.
-
-For examples, see [Shut down and restart nodes](cockroach-demo.html#shut-down-and-restart-nodes).
-
 ## Examples
 
 In these examples, we demonstrate how to start a shell with `cockroach demo`. For more SQL shell features, see the [`cockroach sql` examples](cockroach-sql.html#examples).
 
-### Start an interactive SQL shell
+### Start a single-node demo cluster
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach demo
 ~~~
+
+By default, `cockroach demo` loads the `movr` dataset in to the demo cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW TABLES;
+~~~
+
+~~~
+  schema_name |         table_name         | type  | owner | estimated_row_count
+--------------+----------------------------+-------+-------+----------------------
+  public      | promo_codes                | table | demo  |                   0
+  public      | rides                      | table | demo  |                   0
+  public      | user_promo_codes           | table | demo  |                   0
+  public      | users                      | table | demo  |                   0
+  public      | vehicle_location_histories | table | demo  |                   0
+  public      | vehicles                   | table | demo  |                   0
+(6 rows)
+~~~
+
+You can query the pre-loaded data:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT name FROM users LIMIT 10;
+~~~
+
+~~~
+         name
+-----------------------
+  Tyler Dalton
+  Dillon Martin
+  Deborah Carson
+  David Stanton
+  Maria Weber
+  Brian Campbell
+  Carl Mcguire
+  Jennifer Sanders
+  Cindy Medina
+  Daniel Hernandez MD
+(10 rows)
+~~~
+
+You can also create and query new tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -214,16 +331,20 @@ $ cockroach demo
 (1 row)
 ~~~
 
-{% include copy-clipboard.html %}
-~~~ sql
-> \q
-~~~
-
-### Load a sample dataset and start an interactive SQL shell
+### Start a multi-node demo cluster
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach demo movr --nodes=3 --demo-locality=region=us-east1:region=us-central1:region=us-west1
+$ cockroach demo --nodes=3
+~~~
+
+### Load a sample dataset into a demo cluster
+
+By default, `cockroach demo` loads the `movr` dataset in to the demo cluster. To pre-load any of the other [available datasets](#datasets) using `cockroach demo <dataset>`. For example, to load the `ycsb` dataset:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach demo ycsb
 ~~~
 
 {% include copy-clipboard.html %}
@@ -232,39 +353,24 @@ $ cockroach demo movr --nodes=3 --demo-locality=region=us-east1:region=us-centra
 ~~~
 
 ~~~
-  schema_name |         table_name         | type  | owner | estimated_row_count
---------------+----------------------------+-------+-------+----------------------
-  public      | promo_codes                | table | demo  |                1000
-  public      | rides                      | table | demo  |                 500
-  public      | user_promo_codes           | table | demo  |                   0
-  public      | users                      | table | demo  |                  50
-  public      | vehicle_location_histories | table | demo  |                1000
-  public      | vehicles                   | table | demo  |                  15
-(6 rows)
+  schema_name | table_name | type  | owner | estimated_row_count
+--------------+------------+-------+-------+----------------------
+  public      | usertable  | table | demo  |                   0
+(1 row)
 ~~~
+
+### Run load against a demo cluster
 
 {% include copy-clipboard.html %}
-~~~ sql
-> SELECT * FROM users WHERE city = 'new york';
+~~~ shell
+$ cockroach demo --with-load
 ~~~
 
-~~~
-                   id                  |   city   |       name       |           address           | credit_card
-+--------------------------------------+----------+------------------+-----------------------------+-------------+
-  00000000-0000-4000-8000-000000000000 | new york | Robert Murphy    | 99176 Anderson Mills        | 8885705228
-  051eb851-eb85-4ec0-8000-000000000001 | new york | James Hamilton   | 73488 Sydney Ports Suite 57 | 8340905892
-  0a3d70a3-d70a-4d80-8000-000000000002 | new york | Judy White       | 18580 Rosario Ville Apt. 61 | 2597958636
-  0f5c28f5-c28f-4c00-8000-000000000003 | new york | Devin Jordan     | 81127 Angela Ferry Apt. 8   | 5614075234
-  147ae147-ae14-4b00-8000-000000000004 | new york | Catherine Nelson | 1149 Lee Alley              | 0792553487
-(5 rows)
-~~~
+This command starts a demo cluster with the `movr` database preloaded and then inserts rows into each table in the `movr` database. You can monitor the workload progress on the [Admin UI](admin-ui-overview-dashboard.html#sql-queries).
 
-{% include copy-clipboard.html %}
-~~~ sql
-> \q
-~~~
+When running a multi-node demo cluster, load is balanced across all nodes.
 
-### Execute SQL from the command-line
+### Execute SQL from the command-line against a demo cluster
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -290,18 +396,44 @@ INSERT 1
 (1 row)
 ~~~
 
-### Run `cockroach demo` with a workload
+### Connect an additional SQL client to the demo cluster
+
+In addition to the interactive SQL shell that opens when you run `cockroach demo`, you can use the [connection parameters](#connection-parameters) in the welcome text to connect additional SQL clients to the cluster.
+
+First, use `\demo ls` to list the connection parameters for each node in the demo cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> \demo ls
+~~~
+
+~~~
+node 1:
+  (console) http://127.0.0.1:54880
+  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo200406637&port=26257
+  (sql/tcp) postgres://root:admin@127.0.0.1:54882?sslmode=require
+
+node 2:
+  (console) http://127.0.0.1:54883
+  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo200406637&port=26258
+  (sql/tcp) postgres://root:admin@127.0.0.1:54885?sslmode=require
+
+node 3:
+  (console) http://127.0.0.1:54891
+  (sql)     postgres://root:admin@?host=%2Fvar%2Ffolders%2Fk1%2Fr048yqpd7_9337rgxm9vb_gw0000gn%2FT%2Fdemo200406637&port=26259
+  (sql/tcp) postgres://root:admin@127.0.0.1:54893?sslmode=require
+~~~
+
+Then open a new terminal and run [`cockroach sql`](cockroach-sql.html) with the `--url` flag set to the `sql/tcp` connection URL of the node to which you want to connect:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach demo --nodes=3 --with-load
+$ cockroach sql --url='postgres://root:admin@127.0.0.1:54885?sslmode=require'
 ~~~
 
-This command starts a demo cluster with the `movr` database preloaded and then inserts rows into each table in the `movr` database. You can monitor the workload progress on the [Admin UI](admin-ui-overview-dashboard.html#sql-queries).
+You can also use this URL to connect an application to the demo cluster.  
 
- When running a multi-node demo cluster, load is balanced across all nodes.
-
-### Run `cockroach demo` with geo-partitioned replicas
+### Start a multi-region demo cluster with automatic geo-partitioning
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -310,13 +442,11 @@ $ cockroach demo --geo-partitioned-replicas
 
 This command starts a 9-node demo cluster with the `movr` database preloaded, and [partitions](partitioning.html) and [zone constraints](configure-replication-zones.html) applied to the primary and secondary indexes. For more information, see the [Geo-Partitioned Replicas](topology-geo-partitioned-replicas.html) topology pattern.
 
-### Shut down and restart nodes
+### Shut down and restart nodes in a multi-node demo cluster
 
-If you start a demo cluster with multiple nodes, you can use the [`\demo`](cockroach-demo.html#shutting-down-and-restarting-nodes) shell command to shut down and restart individual nodes in the demo cluster.
+In a multi-node demo cluster, you can use `\demo` [shell commands](#commands) to shut down, restart, decommission, and recommission individual nodes.
 
 {% include {{ page.version.version }}/misc/experimental-warning.md %}
-
-For example, if you start a demo cluster with the following command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v20.2/cockroach-gen.md
+++ b/v20.2/cockroach-gen.md
@@ -182,7 +182,7 @@ First, start up [a demo cluster](cockroach-demo.html):
 $ cockroach demo
 ~~~
 
-Then, pipe the output from `cockroach gen` to [the URL to the demo cluster](cockroach-demo.html#url-connection-parameters):
+Then, pipe the output from `cockroach gen` to [the URL to the demo cluster](cockroach-demo.html#connection-parameters):
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v20.2/cockroach-sql.md
+++ b/v20.2/cockroach-sql.md
@@ -36,15 +36,18 @@ $ cockroach sql <flags> < file-containing-statements.sql
 
 Exit the interactive SQL shell:
 
-~~~ shell
-$ \q
+~~~ sql
+> \q
 ~~~
-~~~ shell
-$ quit
+
+~~~ sql
+> quit
 ~~~
-~~~ shell
-$ exit
+
+~~~ sql
+> exit
 ~~~
+
 ~~~ shell
 ctrl-d
 ~~~
@@ -133,91 +136,19 @@ The **Version** and **Cluster ID** details are particularly noteworthy:
 
 ### Commands
 
-The following commands can be used within the interactive SQL shell:
-
-Command | Usage
---------|------------
-`\?`<br>`help` | View this help within the shell.
-`\q`<br>`quit`<br>`exit`<br>`ctrl-d` | Exit the shell.<br><br>When no text follows the prompt, `ctrl-c` exits the shell as well; otherwise, `ctrl-c` clears the line.
-`\!` | Run an external command and print its results to `stdout`. See the [example](#run-external-commands-from-the-sql-shell) below.
-<code>&#92;&#124;</code> | Run the output of an external command as SQL statements. See the [example](#run-external-commands-from-the-sql-shell) below.
-`\set <option>`<br>`\unset <option>` | Enable or disable a client-side option. For more details, see [Client-side options](#client-side-options).<br><br>You can also use the [`--set` flag](#general) to enable or disable client-side options before starting the SQL shell.
-`\show` | During a multi-line statement or transaction, show the SQL entered so far.
-`\h <statement>`<br>`\hf <function>` | View help for specific SQL statements or functions. See [SQL shell help](#help) for more details.
-`\l` | List all databases in the CockroachDB cluster. This command is equivalent to [`SHOW DATABASES`](show-databases.html).
-`\dt`<br>`d` | Show the tables of the current schema in the current database. These commands are equivalent to [`SHOW TABLES`](show-tables.html).
-`\dT` | <span class="version-tag">New in v20.2:</span> Show the [user-defined types](enum.html) in the current database. This command is equivalent to [`SHOW TYPES`](show-types.html).
-`\du` | List the users for all databases. This command is equivalent to [`SHOW USERS`](show-users.html).
-`\d <table>` | Show details about columns in the specified table. This command is equivalent to [`SHOW COLUMNS`](show-columns.html).
+{% include {{ page.version.version }}/sql/shell-commands.md %}
 
 ### Client-side options
 
-- To view option descriptions and how they are currently set, use `\set` without any options.
-- To enable or disable an option, use `\set <option> <value>` or `\unset <option> <value>`. You can also use the form `<option>=<value>`.
-- If an option accepts a boolean value:
-    - `\set <option>` without `<value>` is equivalent to `\set <option> true`, and `\unset <option>` without `<value>` is equivalent to `\set <option> false`.
-    - `on` and `0` are aliases for `true`, and `off` and `1` are aliases for `false`.
-
-Client Options | Description
----------------|------------
-<a name="sql-option-auto-trace"></a> `auto_trace` | For every statement executed, the shell also produces the trace for that statement in a separate result below. A trace is also produced in case the statement produces a SQL error.<br><br>**Default:** `off`<br><br>To enable this option, run `\set auto_trace on`.
-<a name="sql-option-check-syntax"></a> `check_syntax` | Validate SQL syntax. This ensures that a typo or mistake during user entry does not inconveniently abort an ongoing transaction previously started from the interactive shell.<br /><br />**Default:** `true` for [interactive sessions](#session-and-output-types); `false` otherwise.<br><br>To disable this option, run `\unset check_syntax`.
-<a name="sql-option-display-format"></a> `display_format` | How to display table rows printed within the interactive SQL shell. Possible values: `tsv`, `csv`, `table`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `table` for sessions that [output on a terminal](#session-and-output-types); `tsv` otherwise<br /><br />To change this option, run `\set display_format <format>`. For a demonstration, see the [example](#make-the-output-of-show-statements-selectable) below.
-`echo` | Reveal the SQL statements sent implicitly by the SQL shell.<br><br>**Default:** `false`<br><br>To enable this option, run `\set echo`. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.
-<a name="sql-option-errexit"></a> `errexit` | Exit the SQL shell upon encountering an error.<br /><br />**Default:** `false` for [interactive sessions](#session-and-output-types); `true` otherwise<br><br>To enable this option, run `\set errexit`.
-`show_times` | Reveal the time a query takes to complete.<br><br>**Default:** `true`<br><br>To disable this option, run `\unset show_times`.
+{% include {{ page.version.version }}/sql/shell-options.md %}
 
 ### Help
 
-Within the SQL shell, you can get interactive help about statements and functions:
-
-Command | Usage
---------|------
-`\h`<br>`??` | List all available SQL statements, by category.
-`\hf` | List all available SQL functions, in alphabetical order.
-`\h <statement>`<br>or `<statement> ?` | View help for a specific SQL statement.
-`\hf <function>`<br>or `<function> ?` | View help for a specific SQL function.
-
-#### Examples
-
-~~~ sql
-> \h UPDATE
-~~~
-
-~~~
-Command:     UPDATE
-Description: update rows of a table
-Category:    data manipulation
-Syntax:
-UPDATE <tablename> [[AS] <name>] SET ... [WHERE <expr>] [RETURNING <exprs...>]
-
-See also:
-  SHOW TABLES
-  INSERT
-  UPSERT
-  DELETE
-  https://www.cockroachlabs.com/docs/v2.1/update.html
-~~~
-
-~~~ sql
-> \hf uuid_v4
-~~~
-
-~~~
-Function:    uuid_v4
-Category:    built-in functions
-Returns a UUID.
-
-Signature          Category
-uuid_v4() -> bytes [ID Generation]
-
-See also:
-  https://www.cockroachlabs.com/docs/v2.1/functions-and-operators.html
-~~~
+{% include {{ page.version.version }}/sql/shell-help.md %}
 
 ### Shortcuts
 
-The SQL shell supports many shortcuts, such as `ctrl-r` for searching the shell history. For full details, see this [Readline Shortcut](https://github.com/chzyer/readline/blob/master/doc/shortcut.md) reference.
+{% include {{ page.version.version }}/sql/shell-shortcuts.md %}
 
 ### Error messages and `SQLSTATE` codes
 

--- a/v20.2/query-replication-reports.md
+++ b/v20.2/query-replication-reports.md
@@ -417,7 +417,7 @@ The `system.replication_critical_localities` report contains which of your local
 
 That said, a locality being critical is not necessarily a bad thing as long as you are aware of it. What matters is that [you configure the topology of your cluster to get the resiliency you expect](topology-patterns.html).
 
-By default, the [movr demo cluster](cockroach-demo.html#run-cockroach-demo-with-geo-partitioned-replicas) has some ranges in critical localities. This is expected because it follows the [geo-partitioned replicas topology pattern](topology-geo-partitioned-replicas.html), which ties data for latency-sensitive queries to specific geographies at the cost of data unavailability during a region-wide failure.
+By default, the [movr demo cluster](cockroach-demo.html#start-a-multi-region-demo-cluster-with-automatic-geo-partitioning) has some ranges in critical localities. This is expected because it follows the [geo-partitioned replicas topology pattern](topology-geo-partitioned-replicas.html), which ties data for latency-sensitive queries to specific geographies at the cost of data unavailability during a region-wide failure.
 
 {% include copy-clipboard.html %}
 ~~~ sql


### PR DESCRIPTION
- Use includes for SQL shell reference across both pages.
- Supplement the demo SQL shell reference with connection parameters
  and additional commands.
- Refactor the demo examples, including a new example for connecting
  additional SQL clients to a demo cluster.

Fixes #7638
Fixes #5414
Fixes #7643