### PR TITLE
doc: add new initial code-of-conduct file (#5653)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,12 +8,12 @@ When posting or participating in a community event or online forum, please use t
 - Be specific and detailed. Include relevant details in your inquiries (eg. versions, error messages, deployment environment, etc.), and 
   avoid asking off-topic questions in existing discussion threads.
 - Share experiences and knowledge publicly. Everyone can benefit from the exchange of knowledge, so we encourage all community members to 
-  share their experience in public channels (at events, on the [forum](https://forum.cockroachlabs.com/), [GitHub](https://github.com/cockroachdb), [StackOverflow](https://stackoverflow.com/search?q=cockroachdb), etc.).
+  share their experience in public channels (at events, on the [forum](https://forum.cockroachlabs.com/), [GitHub](https://github.com/cockroachdb), [StackOverflow](https://stackoverflow.com/search?q=cockroachdb), [Slack](https://cockroa.ch/slack), etc.).
 - Collaborate and help each other. If someone lacks knowledge in a particular area, help to educate and collaborate with them.
 - Have patience. Many community members are volunteers, and it may take some time to get a response to your question.
 - Be kind and respectful. Communication should be positive and constructive. Every design or implementation choice carries a trade-off and numerous costs, and there is seldom a right answer.
 - Be good to each other. We will exclude you from interaction if you insult, demean, or harass anyone. 
-  We interpret the term “harassment” as defined in the [Citizen Code of Conduct](http://citizencodeofconduct.org/). Likewise any spamming, trolling, or baiting is not welcome.
+  Likewise any spamming, trolling, or baiting is not welcome.
 - Finally, if you notice or are experiencing violations of this code of conduct or harassment of any kind, please reach out to **`@jseldess`** on GitHub or email  **`docs@cockroachlabs.com`** to help resolve the situation. 
     
   Thank you for helping make this a helpful and a welcoming community.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# CockroachDB Docs
+
+## Code of Conduct 
+
+We value the participation of everyone in the CockroachDB community and want to create an environment that is welcoming, enjoyable, and fulfilling. 
+When posting or participating in a community event or online forum, please use the following guidelines:
+
+- Be specific and detailed. Include relevant details in your inquiries (eg. versions, error messages, deployment environment, etc.), and 
+  avoid asking off-topic questions in existing discussion threads.
+- Share experiences and knowledge publicly. Everyone can benefit from the exchange of knowledge, so we encourage all community members to 
+  share their experience in public channels (at events, on the [forum](https://forum.cockroachlabs.com/), [GitHub](https://github.com/cockroachdb), [StackOverflow](https://stackoverflow.com/search?q=cockroachdb), etc.).
+- Collaborate and help each other. If someone lacks knowledge in a particular area, help to educate and collaborate with them.
+- Have patience. Many community members are volunteers, and it may take some time to get a response to your question.
+- Be kind and respectful. Communication should be positive and constructive. Every design or implementation choice carries a trade-off and numerous costs, and there is seldom a right answer.
+- Be good to each other. We will exclude you from interaction if you insult, demean, or harass anyone. 
+  We interpret the term “harassment” as defined in the [Citizen Code of Conduct](http://citizencodeofconduct.org/). Likewise any spamming, trolling, or baiting is not welcome.
+- Finally, if you notice or are experiencing violations of this code of conduct or harassment of any kind, please reach out to **`@jseldess`** on GitHub or email  **`docs@cockroachlabs.com`** to help resolve the situation. 
+    
+  Thank you for helping make this a helpful and a welcoming community.
+    
+  Adapted from the [MongoDB Code of Conduct](https://www.mongodb.com/community-code-of-conduct) and the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ Want a topic added to the docs? Need additional details or clarification? See an
 ## Write Docs
 
 Want to contribute to the docs? See [CONTRIBUTING](CONTRIBUTING.md) for details about setting yourself up and getting started.
+
+## Resources
+
+- [Code of conduct](CODE_OF_CONDUCT.md)
+- [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
- added a new initial Code of Conduct file for CockroachDB Docs.

Closes #8604 