### PR TITLE
Use include for enterprise feature callout, where possible

### DIFF
--- a/_includes/enterprise-feature.md
+++ b/_includes/enterprise-feature.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+This is an [enterprise-only](enterprise-licensing.html) feature. [Request a 30-day trial license](https://www.cockroachlabs.com/get-cockroachdb) to try it out.
+{{site.data.alerts.end}}

--- a/_includes/v20.1/zone-configs/create-a-replication-zone-for-a-secondary-index.md
+++ b/_includes/v20.1/zone-configs/create-a-replication-zone-for-a-secondary-index.md
@@ -2,9 +2,7 @@
 The [Cost-based Optimizer](cost-based-optimizer.html) can take advantage of replication zones for secondary indexes when optimizing queries. For more information, see [Cost-based optimizer - preferring the nearest index](cost-based-optimizer.html#preferring-the-nearest-index).
 {{site.data.alerts.end}}
 
-{{site.data.alerts.callout_info}}
-This is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 The [secondary indexes](indexes.html) on a table will automatically use the replication zone for the table. However, with an enterprise license, you can add distinct replication zones for secondary indexes.
 

--- a/_includes/v20.1/zone-configs/create-a-replication-zone-for-a-table-partition.md
+++ b/_includes/v20.1/zone-configs/create-a-replication-zone-for-a-table-partition.md
@@ -1,6 +1,4 @@
-{{site.data.alerts.callout_info}}
-This is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 Once [partitions have been defined for a table or a secondary index](partition-by.html), to control replication for a partition, use `ALTER PARTITION <partition> OF INDEX <table@index> CONFIGURE ZONE`:
 

--- a/_includes/v20.2/zone-configs/create-a-replication-zone-for-a-secondary-index.md
+++ b/_includes/v20.2/zone-configs/create-a-replication-zone-for-a-secondary-index.md
@@ -2,9 +2,7 @@
 The [Cost-based Optimizer](cost-based-optimizer.html) can take advantage of replication zones for secondary indexes when optimizing queries. For more information, see [Cost-based optimizer - preferring the nearest index](cost-based-optimizer.html#preferring-the-nearest-index).
 {{site.data.alerts.end}}
 
-{{site.data.alerts.callout_info}}
-This is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 The [secondary indexes](indexes.html) on a table will automatically use the replication zone for the table. However, with an enterprise license, you can add distinct replication zones for secondary indexes.
 

--- a/_includes/v20.2/zone-configs/create-a-replication-zone-for-a-table-partition.md
+++ b/_includes/v20.2/zone-configs/create-a-replication-zone-for-a-table-partition.md
@@ -1,6 +1,4 @@
-{{site.data.alerts.callout_info}}
-This is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 Once [partitions have been defined for a table or a secondary index](partition-by.html), to control replication for a partition, use `ALTER PARTITION <partition> OF INDEX <table@index> CONFIGURE ZONE`:
 

--- a/v20.1/alter-partition.md
+++ b/v20.1/alter-partition.md
@@ -4,8 +4,6 @@ summary: Use the ALTER PARTITION statement to configure the replication zone for
 toc: true
 ---
 
-The `ALTER PARTITION` [statement](sql-statements.html) is used to configure replication zones for partitions. See the [`CONFIGURE ZONE`](configure-zone.html) subcommand for more details.
+The `ALTER PARTITION` [statement](sql-statements.html) is used to configure replication zones for [Partitioning](partitioning.html). See the [`CONFIGURE ZONE`](configure-zone.html) subcommand for more details.
 
-{{site.data.alerts.callout_info}}
-[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}

--- a/v20.1/enable-node-map.md
+++ b/v20.1/enable-node-map.md
@@ -4,12 +4,6 @@ summary: Learn how to enable the node map in the Admin UI.
 toc: true
 ---
 
-{{site.data.alerts.callout_info}}
-On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
-
-The Node Map is an [enterprise-only](enterprise-licensing.html) feature. However, you can [request a trial license](https://www.cockroachlabs.com/get-cockroachdb/) to try it out. 
-{{site.data.alerts.end}}
-
 The **Node Map** is useful for:
 
 - Visualizing the geographic configuration of a multi-region cluster on a world map.
@@ -17,6 +11,12 @@ The **Node Map** is useful for:
 - Drilling down to individual nodes for monitoring health and performance.
 
 This page walks you through the process of setting up and enabling the Node Map.
+
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
+{% include enterprise-feature.md %}
 
 <img src="{{ 'images/v20.1/admin-ui-node-map-navigation3.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
@@ -159,7 +159,7 @@ Let's say you want to navigate to Node 2, which is in datacenter `us-east-1a` in
 
 ### Node Map not displayed
 
-The Node Map requires an [enterprise license](enterprise-licensing.html). 
+The Node Map requires an [enterprise license](enterprise-licensing.html).
 
 All nodes in the cluster must be assigned [localities](cockroach-start.html#locality). To be displayed on the world map, localities must be [assigned a corresponding latitude and longitude](#step-3-set-the-latitudes-and-longitudes-for-the-localities).
 
@@ -175,7 +175,7 @@ The Localities debug page displays the following:
 
 ### World Map not displayed for all locality levels
 
-The world map is displayed only when [localities are assigned latitude/longitude coordinates](#step-3-set-the-latitudes-and-longitudes-for-the-localities). 
+The world map is displayed only when [localities are assigned latitude/longitude coordinates](#step-3-set-the-latitudes-and-longitudes-for-the-localities).
 
 If a locality (e.g., region) is not assigned latitude/longitude coordinates, it is displayed using the latitude/longitude of any lower-level localities it contains (e.g., datacenter). If no coordinates are available, localities are plotted in a circular layout.
 

--- a/v20.1/gssapi_authentication.md
+++ b/v20.1/gssapi_authentication.md
@@ -6,9 +6,7 @@ toc: true
 
 CockroachDB supports the Generic Security Services API (GSSAPI) with Kerberos authentication.
 
-{{site.data.alerts.callout_info}}
-GSSAPI authentication is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 ## Requirements
 

--- a/v20.1/show-partitions.md
+++ b/v20.1/show-partitions.md
@@ -6,9 +6,7 @@ toc: true
 
 Use the `SHOW PARTITIONS` [statement](sql-statements.html) to view details about existing [partitions](partitioning.html).
 
-{{site.data.alerts.callout_info}}
-[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 {% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
 

--- a/v20.2/alter-partition.md
+++ b/v20.2/alter-partition.md
@@ -4,8 +4,6 @@ summary: Use the ALTER PARTITION statement to configure the replication zone for
 toc: true
 ---
 
-The `ALTER PARTITION` [statement](sql-statements.html) is used to configure replication zones for partitions. See the [`CONFIGURE ZONE`](configure-zone.html) subcommand for more details.
+The `ALTER PARTITION` [statement](sql-statements.html) is used to configure replication zones for [partitioning](partitioning.html). See the [`CONFIGURE ZONE`](configure-zone.html) subcommand for more details.
 
-{{site.data.alerts.callout_info}}
-[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}

--- a/v20.2/enable-node-map.md
+++ b/v20.2/enable-node-map.md
@@ -4,12 +4,6 @@ summary: Learn how to enable the node map in the Admin UI.
 toc: true
 ---
 
-{{site.data.alerts.callout_info}}
-On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
-
-The Node Map is an [enterprise-only](enterprise-licensing.html) feature. However, you can [request a trial license](https://www.cockroachlabs.com/get-cockroachdb/) to try it out. 
-{{site.data.alerts.end}}
-
 The **Node Map** is useful for:
 
 - Visualizing the geographic configuration of a multi-region cluster on a world map.
@@ -17,6 +11,12 @@ The **Node Map** is useful for:
 - Drilling down to individual nodes for monitoring health and performance.
 
 This page walks you through the process of setting up and enabling the Node Map.
+
+{{site.data.alerts.callout_info}}
+On a secure cluster, this area of the Admin UI can only be accessed by an `admin` user. See [Admin UI access](admin-ui-overview.html#admin-ui-access).
+{{site.data.alerts.end}}
+
+{% include enterprise-feature.md %}
 
 <img src="{{ 'images/v20.2/admin-ui-node-map-navigation3.png' | relative_url }}" alt="CockroachDB Admin UI" style="border:1px solid #eee;max-width:100%" />
 
@@ -159,7 +159,7 @@ Let's say you want to navigate to Node 2, which is in datacenter `us-east-1a` in
 
 ### Node Map not displayed
 
-The Node Map requires an [enterprise license](enterprise-licensing.html). 
+The Node Map requires an [enterprise license](enterprise-licensing.html).
 
 All nodes in the cluster must be assigned [localities](cockroach-start.html#locality). To be displayed on the world map, localities must be [assigned a corresponding latitude and longitude](#step-3-set-the-latitudes-and-longitudes-for-the-localities).
 
@@ -175,7 +175,7 @@ The Localities debug page displays the following:
 
 ### World Map not displayed for all locality levels
 
-The world map is displayed only when [localities are assigned latitude/longitude coordinates](#step-3-set-the-latitudes-and-longitudes-for-the-localities). 
+The world map is displayed only when [localities are assigned latitude/longitude coordinates](#step-3-set-the-latitudes-and-longitudes-for-the-localities).
 
 If a locality (e.g., region) is not assigned latitude/longitude coordinates, it is displayed using the latitude/longitude of any lower-level localities it contains (e.g., datacenter). If no coordinates are available, localities are plotted in a circular layout.
 

--- a/v20.2/gssapi_authentication.md
+++ b/v20.2/gssapi_authentication.md
@@ -6,9 +6,7 @@ toc: true
 
 CockroachDB supports the Generic Security Services API (GSSAPI) with Kerberos authentication.
 
-{{site.data.alerts.callout_info}}
-GSSAPI authentication is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 ## Requirements
 

--- a/v20.2/show-partitions.md
+++ b/v20.2/show-partitions.md
@@ -6,9 +6,7 @@ toc: true
 
 Use the `SHOW PARTITIONS` [statement](sql-statements.html) to view details about existing [partitions](partitioning.html).
 
-{{site.data.alerts.callout_info}}
-[Partitioning](partitioning.html) is an [enterprise-only](enterprise-licensing.html) feature.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 {% include {{page.version.version}}/sql/crdb-internal-partitions.md %}
 


### PR DESCRIPTION
Also confirmed that these callouts are not longer red warnings.

Fixes #7095.