### PR TITLE
update rolling upgrades guidance

### DIFF
--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -81,7 +81,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
         > \q
         ~~~
 
-1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. For a cluster with 3 pods, the partition value should be 2:
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -247,7 +247,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     > \q
     ~~~
 
-1. Decrement the partition value by 1:
+1. Decrement the partition value by 1 to allow the next pod in the cluster to update:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -270,8 +270,6 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     --set statefulset.updateStrategy.rollingUpdate.partition=1 \
     ~~~
     </section>
-
-    This allows the next pod in the cluster to update. 
 
 1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).
 

--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -101,7 +101,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=2 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=2
     ~~~
     </section>
 

--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -35,7 +35,6 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
         ~~~
         </section>
 
-
     {% else %}
 
     1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
@@ -68,21 +67,45 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% endif %}
 
-    2. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
+    1. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > SET CLUSTER SETTING cluster.preserve_downgrade_option = '19.2';
         ~~~
 
-    3. Exit the SQL shell and delete the temporary pod:
+    1. Exit the SQL shell and delete the temporary pod:
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > \q
         ~~~
 
-2. Kick off the upgrade process by changing the desired Docker image:
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. For a cluster with 3 pods, the partition value should be 2:
+
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch statefulset cockroachdb \
+    -p='{"spec":{"updateStrategy":{"type":"RollingUpdate","rollingUpdate":{"partition":2}}}}'
+    ~~~
+
+    ~~~
+    statefulset.apps/cockroachdb patched
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm upgrade \
+    my-release \
+    cockroachdb/cockroachdb \
+    --set statefulset.updateStrategy.rollingUpdate.partition=2 \
+    ~~~
+    </section>
+
+1. Kick off the upgrade process by changing the desired Docker image:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -118,7 +141,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     ~~~
     </section>
 
-3. If you then check the status of your cluster's pods, you should see them being restarted:
+1. Check the status of your cluster's pods. You should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -130,8 +153,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     NAME            READY     STATUS        RESTARTS   AGE
     cockroachdb-0   1/1       Running       0          2m
     cockroachdb-1   1/1       Running       0          2m
-    cockroachdb-2   1/1       Running       0          2m
-    cockroachdb-3   0/1       Terminating   0          1m
+    cockroachdb-2   0/1       Terminating   0          1m
     ...
     ~~~
     </section>
@@ -141,8 +163,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     NAME                                READY     STATUS              RESTARTS   AGE
     my-release-cockroachdb-0            1/1       Running             0          2m
     my-release-cockroachdb-1            1/1       Running             0          3m
-    my-release-cockroachdb-2            1/1       Running             0          3m
-    my-release-cockroachdb-3            0/1       ContainerCreating   0          25s
+    my-release-cockroachdb-2            0/1       ContainerCreating   0          25s
     my-release-cockroachdb-init-nwjkh   0/1       ContainerCreating   0          6s
     ...
     ~~~
@@ -152,7 +173,109 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     {{site.data.alerts.end}}
     </section>    
 
-4. This will continue until all of the pods have restarted and are running the new image. To check the image of each pod to determine whether they've all be upgraded, run:
+1. After the pod has been restarted with the new image, get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+    {% if page.secure == true %}
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure \-- ./cockroach sql \
+    --certs-dir=/cockroach-certs \
+    --host=cockroachdb-public
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure \
+    -- ./cockroach sql \
+    --certs-dir=/cockroach-certs \
+    --host=my-release-cockroachdb-public
+    ~~~
+    </section>
+
+    {% else %}
+
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl run cockroachdb -it \
+    --image=cockroachdb/cockroach \
+    --rm \
+    --restart=Never \
+    -- sql \
+    --insecure \
+    --host=cockroachdb-public
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl run cockroachdb -it \
+    --image=cockroachdb/cockroach \
+    --rm \
+    --restart=Never \
+    -- sql \
+    --insecure \
+    --host=my-release-cockroachdb-public
+    ~~~
+    </section>    
+    {% endif %}
+
+1. Run the following SQL query to verify that the number of underreplicated ranges is zero:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    SELECT sum((metrics->>'ranges.underreplicated')::DECIMAL)::INT AS ranges_underreplicated FROM crdb_internal.kv_store_status;
+    ~~~
+
+    ~~~
+      ranges_underreplicated
+    --------------------------
+                           0
+    (1 row)        
+    ~~~
+
+    This indicates that it is safe to proceed to the next pod.
+
+1. Exit the SQL shell:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > \q
+    ~~~
+
+1. Decrement the partition value by 1:
+
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch statefulset cockroachdb \
+    -p='{"spec":{"updateStrategy":{"type":"RollingUpdate","rollingUpdate":{"partition":1}}}}'
+    ~~~
+
+    ~~~
+    statefulset.apps/cockroachdb patched
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm upgrade \
+    my-release \
+    cockroachdb/cockroachdb \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    ~~~
+    </section>
+
+    This allows the next pod in the cluster to update. 
+
+1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).
+
+1. Check the image of each pod to confirm that all have been upgraded:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -165,7 +288,6 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     cockroachdb-0   cockroachdb/cockroach:{{page.release_info.version}}
     cockroachdb-1   cockroachdb/cockroach:{{page.release_info.version}}
     cockroachdb-2   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-3   cockroachdb/cockroach:{{page.release_info.version}}
     ...
     ~~~
     </section>
@@ -175,16 +297,14 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     my-release-cockroachdb-0    cockroachdb/cockroach:{{page.release_info.version}}
     my-release-cockroachdb-1    cockroachdb/cockroach:{{page.release_info.version}}
     my-release-cockroachdb-2    cockroachdb/cockroach:{{page.release_info.version}}
-    my-release-cockroachdb-3    cockroachdb/cockroach:{{page.release_info.version}}
     ...
     ~~~
     </section>
 
-    You can also check the CockroachDB version of each node in the Admin UI:
+    You can also check the CockroachDB version of each node in the [Admin UI](admin-ui-cluster-overview-page.html#node-details).
 
-    <img src="{{ 'images/v20.1/kubernetes-upgrade.png' | relative_url }}" alt="Version in UI after upgrade" style="max-width:100%" />
 
-5. Finish the upgrade.
+1. Finish the upgrade.
 
     {{site.data.alerts.callout_info}}
     This step is relevant only when upgrading from v19.2.x to v20.1. For upgrades within the v19.2.x series, skip this step.

--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -81,7 +81,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
         > \q
         ~~~
 
-1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the update strategy defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -105,7 +105,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     ~~~
     </section>
 
-1. Kick off the upgrade process by changing the desired Docker image:
+1. Kick off the upgrade process by changing the Docker image used in the CockroachDB StatefulSet:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -81,7 +81,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
         > \q
         ~~~
 
-1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the update strategy defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -105,7 +105,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     ~~~
     </section>
 
-1. Kick off the upgrade process by changing the desired Docker image:
+1. Kick off the upgrade process by changing the Docker image used in the CockroachDB StatefulSet:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -1,6 +1,6 @@
-As new versions of CockroachDB are released, it's strongly recommended to upgrade to newer versions in order to pick up bug fixes, performance improvements, and new features. The [general CockroachDB upgrade documentation](upgrade-cockroach-version.html) provides best practices for how to prepare for and execute upgrades of CockroachDB clusters, but the mechanism of actually stopping and restarting processes in Kubernetes is somewhat special.
+It is strongly recommended that you regularly upgrade your CockroachDB version in order to pick up bug fixes, performance improvements, and new features. The [CockroachDB upgrade documentation](upgrade-cockroach-version.html) describes how to perform a "rolling upgrade" of a CockroachDB cluster by stopping and restarting nodes one at a time. This is to ensure that the cluster remains available during the upgrade.
 
-Kubernetes knows how to carry out a safe rolling upgrade process of the CockroachDB nodes. When you tell it to change the Docker image used in the CockroachDB StatefulSet, Kubernetes will go one-by-one, stopping a node, restarting it with the new image, and waiting for it to be ready to receive client requests before moving on to the next one. For more information, see [the Kubernetes documentation](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets).
+The corresponding process on Kubernetes is a [staged update](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update), in which the Docker image is updated in the CockroachDB StatefulSet and then applied to the pods one at a time.
 
 1. Decide how the upgrade will be finalized.
 
@@ -35,7 +35,6 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
         ~~~
         </section>
 
-
     {% else %}
 
     1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
@@ -68,21 +67,45 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% endif %}
 
-    2. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
+    1. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html):
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > SET CLUSTER SETTING cluster.preserve_downgrade_option = '19.2';
         ~~~
 
-    3. Exit the SQL shell and delete the temporary pod:
+    1. Exit the SQL shell and delete the temporary pod:
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > \q
         ~~~
 
-2. Kick off the upgrade process by changing the desired Docker image:
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. For a cluster with 3 pods, the partition value should be 2:
+
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch statefulset cockroachdb \
+    -p='{"spec":{"updateStrategy":{"type":"RollingUpdate","rollingUpdate":{"partition":2}}}}'
+    ~~~
+
+    ~~~
+    statefulset.apps/cockroachdb patched
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm upgrade \
+    my-release \
+    cockroachdb/cockroachdb \
+    --set statefulset.updateStrategy.rollingUpdate.partition=2 \
+    ~~~
+    </section>
+
+1. Kick off the upgrade process by changing the desired Docker image:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -118,7 +141,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     ~~~
     </section>
 
-3. If you then check the status of your cluster's pods, you should see them being restarted:
+1. Check the status of your cluster's pods. You should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -130,8 +153,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     NAME            READY     STATUS        RESTARTS   AGE
     cockroachdb-0   1/1       Running       0          2m
     cockroachdb-1   1/1       Running       0          2m
-    cockroachdb-2   1/1       Running       0          2m
-    cockroachdb-3   0/1       Terminating   0          1m
+    cockroachdb-2   0/1       Terminating   0          1m
     ...
     ~~~
     </section>
@@ -141,8 +163,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     NAME                                READY     STATUS              RESTARTS   AGE
     my-release-cockroachdb-0            1/1       Running             0          2m
     my-release-cockroachdb-1            1/1       Running             0          3m
-    my-release-cockroachdb-2            1/1       Running             0          3m
-    my-release-cockroachdb-3            0/1       ContainerCreating   0          25s
+    my-release-cockroachdb-2            0/1       ContainerCreating   0          25s
     my-release-cockroachdb-init-nwjkh   0/1       ContainerCreating   0          6s
     ...
     ~~~
@@ -152,7 +173,109 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     {{site.data.alerts.end}}
     </section>    
 
-4. This will continue until all of the pods have restarted and are running the new image. To check the image of each pod to determine whether they've all be upgraded, run:
+1. After the pod has been restarted with the new image, get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+    {% if page.secure == true %}
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure \-- ./cockroach sql \
+    --certs-dir=/cockroach-certs \
+    --host=cockroachdb-public
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure \
+    -- ./cockroach sql \
+    --certs-dir=/cockroach-certs \
+    --host=my-release-cockroachdb-public
+    ~~~
+    </section>
+
+    {% else %}
+
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl run cockroachdb -it \
+    --image=cockroachdb/cockroach \
+    --rm \
+    --restart=Never \
+    -- sql \
+    --insecure \
+    --host=cockroachdb-public
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl run cockroachdb -it \
+    --image=cockroachdb/cockroach \
+    --rm \
+    --restart=Never \
+    -- sql \
+    --insecure \
+    --host=my-release-cockroachdb-public
+    ~~~
+    </section>    
+    {% endif %}
+
+1. Run the following SQL query to verify that the number of underreplicated ranges is zero:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    SELECT sum((metrics->>'ranges.underreplicated')::DECIMAL)::INT AS ranges_underreplicated FROM crdb_internal.kv_store_status;
+    ~~~
+
+    ~~~
+      ranges_underreplicated
+    --------------------------
+                           0
+    (1 row)        
+    ~~~
+
+    This indicates that it is safe to proceed to the next pod.
+
+1. Exit the SQL shell:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > \q
+    ~~~
+
+1. Decrement the partition value by 1:
+
+    <section class="filter-content" markdown="1" data-scope="manual">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch statefulset cockroachdb \
+    -p='{"spec":{"updateStrategy":{"type":"RollingUpdate","rollingUpdate":{"partition":1}}}}'
+    ~~~
+
+    ~~~
+    statefulset.apps/cockroachdb patched
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="helm">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm upgrade \
+    my-release \
+    cockroachdb/cockroachdb \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    ~~~
+    </section>
+
+    This allows the next pod in the cluster to update. 
+
+1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).
+
+1. Check the image of each pod to confirm that all have been upgraded:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -165,7 +288,6 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     cockroachdb-0   cockroachdb/cockroach:{{page.release_info.version}}
     cockroachdb-1   cockroachdb/cockroach:{{page.release_info.version}}
     cockroachdb-2   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-3   cockroachdb/cockroach:{{page.release_info.version}}
     ...
     ~~~
     </section>
@@ -175,16 +297,13 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
     my-release-cockroachdb-0    cockroachdb/cockroach:{{page.release_info.version}}
     my-release-cockroachdb-1    cockroachdb/cockroach:{{page.release_info.version}}
     my-release-cockroachdb-2    cockroachdb/cockroach:{{page.release_info.version}}
-    my-release-cockroachdb-3    cockroachdb/cockroach:{{page.release_info.version}}
     ...
     ~~~
     </section>
 
-    You can also check the CockroachDB version of each node in the Admin UI:
+    You can also check the CockroachDB version of each node in the [Admin UI](admin-ui-cluster-overview-page.html#node-details).
 
-    <img src="{{ 'images/v20.2/kubernetes-upgrade.png' | relative_url }}" alt="Version in UI after upgrade" style="max-width:100%" />
-
-5. Finish the upgrade.
+1. Finish the upgrade.
 
     {{site.data.alerts.callout_info}}
     This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.
@@ -250,14 +369,14 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 
     {% endif %}
 
-    2. Re-enable auto-finalization:
+    1. Re-enable auto-finalization:
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > RESET CLUSTER SETTING cluster.preserve_downgrade_option;
         ~~~
 
-    3. Exit the SQL shell and delete the temporary pod:
+    1. Exit the SQL shell and delete the temporary pod:
 
         {% include copy-clipboard.html %}
         ~~~ sql

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -81,7 +81,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
         > \q
         ~~~
 
-1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. For a cluster with 3 pods, the partition value should be 2:
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the `updateStrategy` defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -247,7 +247,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     > \q
     ~~~
 
-1. Decrement the partition value by 1:
+1. Decrement the partition value by 1 to allow the next pod in the cluster to update:
 
     <section class="filter-content" markdown="1" data-scope="manual">
     {% include copy-clipboard.html %}
@@ -270,8 +270,6 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     --set statefulset.updateStrategy.rollingUpdate.partition=1 \
     ~~~
     </section>
-
-    This allows the next pod in the cluster to update. 
 
 1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).
 

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -101,7 +101,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     $ helm upgrade \
     my-release \
     cockroachdb/cockroachdb \
-    --set statefulset.updateStrategy.rollingUpdate.partition=2 \
+    --set statefulset.updateStrategy.rollingUpdate.partition=2
     ~~~
     </section>
 

--- a/v20.1/admin-ui-overview.md
+++ b/v20.1/admin-ui-overview.md
@@ -35,7 +35,7 @@ The Admin UI is accessible from every node at `http://<host>:<http-port>`, or `h
 
 - If you included the [`--http-addr`](cockroach-start.html#networking) flag when starting nodes, use the IP address/hostname and port specified by that flag.
 - If you didn't include the [`--http-addr`](cockroach-start.html#networking) flag when starting nodes, use the IP address/hostname specified by the [`--listen-addr`](cockroach-start.html#networking) flag and port `8080`.
-- If you are running a [secure cluster](#admin-ui-security), use `https` instead of `http`.
+- If you are running a [secure cluster](#admin-ui-security), use `https` instead of `http`. You will also need to [create a user with a password](create-user.html#create-a-user-with-a-password) to log in.
 
 {{site.data.alerts.callout_success}}
 For guidance on accessing the Admin UI in the context of cluster deployment, see [Start a Local Cluster](start-a-local-cluster.html) and [Manual Deployment](manual-deployment.html).

--- a/v20.1/upgrade-cockroach-version.md
+++ b/v20.1/upgrade-cockroach-version.md
@@ -234,7 +234,7 @@ We recommend creating scripts to perform these steps instead of performing them 
 
 1. After the node has rejoined the cluster, ensure that the node is ready to accept a SQL connection.
 
-    Unless there are tens of thousands of ranges on the node, it's usually sufficient to wait at least one minute. To be certain that the node is ready, run the following command:
+    Unless there are tens of thousands of ranges on the node, it's usually sufficient to wait one minute. To be certain that the node is ready, run the following command:
 
     {% include copy-clipboard.html %}
     ~~~ shell

--- a/v20.1/upgrade-cockroach-version.md
+++ b/v20.1/upgrade-cockroach-version.md
@@ -120,8 +120,6 @@ Note that this behavior is specific to upgrades from v19.2 to v20.1; it does not
 {{site.data.alerts.callout_success}}
 We recommend creating scripts to perform these steps instead of performing them manually. Also, if you are running CockroachDB on Kubernetes, see our documentation on [single-cluster](orchestrate-cockroachdb-with-kubernetes.html#upgrade-the-cluster) and/or [multi-cluster](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html#upgrade-the-cluster) orchestrated deployments for upgrade guidance instead.
 {{site.data.alerts.end}}
-
-1. [Access the Admin UI](admin-ui-overview.html#admin-ui-access) and note the [memory usage](admin-ui-cluster-overview-page.html#node-details) of the node. The node should have a similar value after it rejoins the cluster.
   
 1. Drain and stop the node using one of the following methods:
     
@@ -225,8 +223,6 @@ We recommend creating scripts to perform these steps instead of performing them 
 
 1. Verify the node has rejoined the cluster through its output to [`stdout`](cockroach-start.html#standard-output) or through the [Admin UI](admin-ui-cluster-overview-page.html#node-status). 
 
-    The node should have at least 70% of the [memory usage](admin-ui-cluster-overview-page.html#node-details) you observed before stopping the node.
-
 1. If you use `cockroach` in your `$PATH`, you can remove the old binary:
 
     {% include copy-clipboard.html %}
@@ -245,7 +241,7 @@ We recommend creating scripts to perform these steps instead of performing them 
     cockroach sql -e 'select 1'
     ~~~
 
-    The command should complete. If it hangs, the node is not yet ready.
+    The command will automatically wait to complete until the node is ready.
 
 1. Repeat these steps for the next node.
 

--- a/v20.1/upgrade-cockroach-version.md
+++ b/v20.1/upgrade-cockroach-version.md
@@ -121,10 +121,12 @@ Note that this behavior is specific to upgrades from v19.2 to v20.1; it does not
 We recommend creating scripts to perform these steps instead of performing them manually. Also, if you are running CockroachDB on Kubernetes, see our documentation on [single-cluster](orchestrate-cockroachdb-with-kubernetes.html#upgrade-the-cluster) and/or [multi-cluster](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html#upgrade-the-cluster) orchestrated deployments for upgrade guidance instead.
 {{site.data.alerts.end}}
 
+1. [Access the Admin UI](admin-ui-overview.html#admin-ui-access) and note the [memory usage](admin-ui-cluster-overview-page.html#node-details) of the node. The node should have a similar value after it rejoins the cluster.
+  
 1. Drain and stop the node using one of the following methods:
     
     {% include {{ page.version.version }}/prod-deployment/node-shutdown.md %}
-    
+
     Verify that the process has stopped:
 
     {% include copy-clipboard.html %}
@@ -199,6 +201,10 @@ We recommend creating scripts to perform these steps instead of performing them 
     </div>
 
 1. Start the node to have it rejoin the cluster.
+    
+    {{site.data.alerts.callout_danger}}
+    For maximum availability, do not wait more than a few minutes before restarting the node with the new binary. See [this open issue](https://github.com/cockroachdb/cockroach/issues/37906) for context.
+    {{site.data.alerts.end}}
 
     Without a process manager like `systemd`, re-run the [`cockroach start`](cockroach-start.html) command that you used to start the node initially, for example:
 
@@ -217,11 +223,9 @@ We recommend creating scripts to perform these steps instead of performing them 
     $ systemctl start <systemd config filename>
     ~~~
 
-1. Verify the node has rejoined the cluster through its output to `stdout` or through the [Admin UI](admin-ui-overview.html).
+1. Verify the node has rejoined the cluster through its output to [`stdout`](cockroach-start.html#standard-output) or through the [Admin UI](admin-ui-cluster-overview-page.html#node-status). 
 
-    {{site.data.alerts.callout_info}}
-    To access the Admin UI for a secure cluster, [create a user with a password](create-user.html#create-a-user-with-a-password). Then open a browser and go to `https://<any node's external IP address>:8080`. On accessing the Admin UI, you will see a Login screen, where you will need to enter your username and password.
-    {{site.data.alerts.end}}
+    The node should have at least 70% of the [memory usage](admin-ui-cluster-overview-page.html#node-details) you observed before stopping the node.
 
 1. If you use `cockroach` in your `$PATH`, you can remove the old binary:
 
@@ -232,7 +236,18 @@ We recommend creating scripts to perform these steps instead of performing them 
 
     If you leave versioned binaries on your servers, you do not need to do anything.
 
-1. Wait at least one minute after the node has rejoined the cluster, and then repeat these steps for the next node.
+1. After the node has rejoined the cluster, ensure that the node is ready to accept a SQL connection.
+
+    Unless there are tens of thousands of ranges on the node, it's usually sufficient to wait at least one minute. To be certain that the node is ready, run the following command:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    cockroach sql -e 'select 1'
+    ~~~
+
+    The command should complete. If it hangs, the node is not yet ready.
+
+1. Repeat these steps for the next node.
 
 ## Step 5. Finish the upgrade
 

--- a/v20.2/admin-ui-overview.md
+++ b/v20.2/admin-ui-overview.md
@@ -35,7 +35,7 @@ The Admin UI is accessible from every node at `http://<host>:<http-port>`, or `h
 
 - If you included the [`--http-addr`](cockroach-start.html#networking) flag when starting nodes, use the IP address/hostname and port specified by that flag.
 - If you didn't include the [`--http-addr`](cockroach-start.html#networking) flag when starting nodes, use the IP address/hostname specified by the [`--listen-addr`](cockroach-start.html#networking) flag and port `8080`.
-- If you are running a [secure cluster](#admin-ui-security), use `https` instead of `http`.
+- If you are running a [secure cluster](#admin-ui-security), use `https` instead of `http`. You will also need to [create a user with a password](create-user.html#create-a-user-with-a-password) to log in.
 
 {{site.data.alerts.callout_success}}
 For guidance on accessing the Admin UI in the context of cluster deployment, see [Start a Local Cluster](start-a-local-cluster.html) and [Manual Deployment](manual-deployment.html).

--- a/v20.2/upgrade-cockroach-version.md
+++ b/v20.2/upgrade-cockroach-version.md
@@ -81,8 +81,6 @@ For each node in your cluster, complete the following steps. Be sure to upgrade 
 We recommend creating scripts to perform these steps instead of performing them manually. Also, if you are running CockroachDB on Kubernetes, see our documentation on [single-cluster](orchestrate-cockroachdb-with-kubernetes.html#upgrade-the-cluster) and/or [multi-cluster](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html#upgrade-the-cluster) orchestrated deployments for upgrade guidance instead.
 {{site.data.alerts.end}}
 
-1. [Access the Admin UI](admin-ui-overview.html#admin-ui-access) and note the [memory usage](admin-ui-cluster-overview-page.html#node-details) of the node. The node should have a similar value after it rejoins the cluster.
-  
 1. Drain and stop the node using one of the following methods:
     
     {% include {{ page.version.version }}/prod-deployment/node-shutdown.md %}
@@ -185,8 +183,6 @@ We recommend creating scripts to perform these steps instead of performing them 
 
 1. Verify the node has rejoined the cluster through its output to [`stdout`](cockroach-start.html#standard-output) or through the [Admin UI](admin-ui-cluster-overview-page.html#node-status). 
 
-    The node should have at least 70% of the [memory usage](admin-ui-cluster-overview-page.html#node-details) you observed before stopping the node.
-
 1. If you use `cockroach` in your `$PATH`, you can remove the old binary:
 
     {% include copy-clipboard.html %}
@@ -205,7 +201,7 @@ We recommend creating scripts to perform these steps instead of performing them 
     cockroach sql -e 'select 1'
     ~~~
 
-    The command should complete. If it hangs, the node is not yet ready.
+    The command will automatically wait to complete until the node is ready.
 
 1. Repeat these steps for the next node.
 

--- a/v20.2/upgrade-cockroach-version.md
+++ b/v20.2/upgrade-cockroach-version.md
@@ -194,7 +194,7 @@ We recommend creating scripts to perform these steps instead of performing them 
 
 1. After the node has rejoined the cluster, ensure that the node is ready to accept a SQL connection.
 
-    Unless there are tens of thousands of ranges on the node, it's usually sufficient to wait at least one minute. To be certain that the node is ready, run the following command:
+    Unless there are tens of thousands of ranges on the node, it's usually sufficient to wait one minute. To be certain that the node is ready, run the following command:
 
     {% include copy-clipboard.html %}
     ~~~ shell


### PR DESCRIPTION
Fixes #6319.

- For non-orchestrated deployments, this uses guidance from @knz on determining that a node is ready to accept SQL and the next node can be stopped.
- For K8s deployments, uses the guidance from @DuskEagle in the linked issue.

@DuskEagle for the Kubernetes section, it seems the partition would have to be removed from the StatefulSet after the upgrade? Otherwise wouldn't any updates to the STS only affect a single pod? Can you advise on how this would be done?

Also, I am not 100% certain the Helm command is correct. Will need to test.