### PR TITLE
Added note about histograms on ARRAY-typed columns (20.1 backport)

### DIFF
--- a/v20.1/cost-based-optimizer.md
+++ b/v20.1/cost-based-optimizer.md
@@ -80,6 +80,10 @@ For instructions showing how to manually generate statistics, see the examples i
 
 By default, the optimizer collects histograms for all index columns (specifically the first column in each index) during automatic statistics collection. If a single column statistic is explicitly requested using manual invocation of [`CREATE STATISTICS`](create-statistics.html), a histogram will be collected, regardless of whether or not the column is part of an index.
 
+{{site.data.alerts.callout_info}}
+CockroachDB does not support histograms on [`ARRAY`-typed](array.html) columns. As a result, statistics created on `ARRAY`-typed columns do not include histograms.
+{{site.data.alerts.end}}
+
 If you are an advanced user and need to disable histogram collection for troubleshooting or performance tuning reasons, change the [`sql.stats.histogram_collection.enabled` cluster setting](cluster-settings.html) by running [`SET CLUSTER SETTING`](set-cluster-setting.html) as follows:
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
Fixes #7415. 

This PR is identical to #8609, but in v20.1 docs. 