### PR TITLE
Moved release note on #50254 (sql: remove constant folding visitor) to Backward-incompatible section

### DIFF
--- a/releases/v20.2.0-alpha.2.md
+++ b/releases/v20.2.0-alpha.2.md
@@ -42,6 +42,7 @@ $ docker pull cockroachdb/cockroach-unstable:v20.2.0-alpha.2
 - The [`SHOW RANGE FOR ROW`](../v20.2/show-range-for-row.html) statement now takes a tuple of the row's index columns instead of the full column set of the row. [#50479][#50479] {% comment %}doc{% endcomment %}
 - Previously, issuing a `SIGTERM` signal twice or after another signal initiated a hard shutdown for a node. Now the first `SIGTERM` signal initiates a graceful shutdown and further occurrences of `SIGTERM` are ignored. To initiate a hard shutdown, issue `SIGINT` two times (or issue a `SIGINT` signal once after a `SIGTERM` signal). [#50539][#50539] {% comment %}doc{% endcomment %}
 - Specifying the same option multiple times in the `WITH` clause of the [`BACKUP`](../v20.2/backup.html) statement now results in an error message. Additionally, quoted option names are not allowed anymore. [#50723][#50723] {% comment %}doc{% endcomment %}
+- For expression typing involving only operations on constant literals, each constant literal is now assigned a [`type`](../v20.2/data-types.html) before calculation. Previously, a `type` was assigned only to the final result. [#50254][#50254] {% comment %}doc{% endcomment %}
 
 ### Security updates
 
@@ -98,7 +99,6 @@ $ docker pull cockroachdb/cockroach-unstable:v20.2.0-alpha.2
 - `RegClass` expressions are now tracked as dependencies in views. For example, `CREATE VIEW v AS SELECT 't'::regclass;` will now add a dependency on table `t` for view `v`. [#50213][#50213] {% comment %}doc{% endcomment %}
 - Sequences passed as a string argument into views are now tracked as a dependency. For example, `CREATE VIEW v AS SELECT nextval('s')` will now add a dependency on sequence `s`. [#50103][#50103] {% comment %}doc{% endcomment %}
 - Fixed an error for the `ALTER COLUMN TYPE` statement for situations where the data matches byte for byte but CockroachDB needs to validate the `INT8` -> `INT4` conversion. [#50278][#50278]
-- For expression typing involving only operations on constant literals, each constant literal is now assigned a [`type`](../v20.2/data-types.html) before calculation. Previously, a `type` was assigned only to the final result. [#50254][#50254] {% comment %}doc{% endcomment %}
 - Previously, `infinity` evaluated to a negative value, `-292277022365-05-08T08:17:07Z`. Now `infinity` is the maximum supported timestamp in Postgres that is not infinity. Likewise, `-infinity` is the smallest supported value. Note that this work-in-progress feature currently does not behave exactly like `infinity` in Postgres. [#50311][#50311] {% comment %}doc{% endcomment %}
 - The `CHAR` column [`type`](../v20.2/data-types.html) will now truncate the trailing space characters in line with Postgres. Existing stored `CHAR` entries with spaces at the end of the `CHAR` column [`type`](../v20.2/data-types.html) will no longer return rows with trailing space characters. Use the `LIKE` query to find and modify these rows. [#50492][#50492] {% comment %}doc{% endcomment %}
 - Disabled arrays in non-inverted indexes. [#50662][#50662] {% comment %}doc{% endcomment %}


### PR DESCRIPTION
Fixes  #7857.