### PR TITLE
add execution statistics to statements page

### DIFF
--- a/v20.2/admin-ui-statements-page.md
+++ b/v20.2/admin-ui-statements-page.md
@@ -166,6 +166,13 @@ By default, the logical plan for each fingerprint is sampled every 5 minutes. Yo
 Service latency can be affected by network latency, which is displayed for your cluster on the [Network Latency](admin-ui-network-latency-page.html) page.
 {{site.data.alerts.end}}
 
+**Other Execution Statistics** displays the following statistics.
+
+Parameter | Description
+----------|------------
+Rows Read | The number of rows read by the statement. The gray bar indicates the mean number of rows read. The blue bar indicates one standard deviation from the mean.
+Disk Bytes Read | The size of the data read by the statement. The gray bar indicates the mean number of bytes read. The blue bar indicates one standard deviation from the mean.
+
 The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Make Queries Fast](make-queries-fast.html#cluster-topology)).
 
 Parameter | Description


### PR DESCRIPTION
Fixes #8205.

BTW @jordanlewis @dhartunian, this table was mostly empty  (only the header row appeared) on `cockroach demo`. The Rows Read and Disk Bytes Read only appear, for me, on `ALTER TABLE` statements, but the values are 0. Is this expected when running demo?