### PR TITLE
pg_extension links and updates to virtual schema links

### DIFF
--- a/v20.2/alter-schema.md
+++ b/v20.2/alter-schema.md
@@ -86,7 +86,7 @@ Because you are executing the `ALTER SCHEMA` command as a non-owner of the schem
 > CREATE SCHEMA org_one;
 ~~~
 
-To verify that the owner is now `root`, query the [`pg_catalog.pg_namespace` and `pg_catalog.pg_users` tables](sql-name-resolution.html#databases-with-special-names):
+To verify that the owner is now `root`, query the `pg_catalog.pg_namespace` and `pg_catalog.pg_users` tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -173,7 +173,7 @@ Now, suppose that you want to change the owner of the schema `org_one` to an exi
 > ALTER SCHEMA org_one OWNER TO max;
 ~~~
 
-To verify that the owner is now `max`, query the [`pg_catalog.pg_namespace` and `pg_catalog.pg_users` tables](sql-name-resolution.html#databases-with-special-names):
+To verify that the owner is now `max`, query the `pg_catalog.pg_namespace` and `pg_catalog.pg_users` tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.2/convert-to-schema.md
+++ b/v20.2/convert-to-schema.md
@@ -34,7 +34,7 @@ Parameter | Description
 A database cannot be converted to a schema if:
 
 - The database is the [current database](sql-name-resolution.html#current-database).
-- The database has a child schema other than the [`public` schema](sql-name-resolution.html#databases-with-special-names).
+- The database has a child schema other than the `public` schema.
 
 ## Example
 

--- a/v20.2/owner-to.md
+++ b/v20.2/owner-to.md
@@ -61,7 +61,7 @@ To change the owner of a database, the current owner (in this case, `root`) must
 > ALTER DATABASE movr OWNER TO max;
 ~~~
 
-To verify that the owner is now `max`, query the [`pg_catalog.pg_database` and `pg_catalog.pg_roles` tables](sql-name-resolution.html#databases-with-special-names):
+To verify that the owner is now `max`, query the `pg_catalog.pg_database` and `pg_catalog.pg_roles` tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -96,7 +96,7 @@ To change the owner of a table, the current owner (in this case, `root`) must be
 > ALTER TABLE promo_codes OWNER TO max;
 ~~~
 
-To verify that the owner is now `max`, query the [`pg_catalog.pg_tables` table](sql-name-resolution.html#databases-with-special-names):
+To verify that the owner is now `max`, query the `pg_catalog.pg_tables` table:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.2/sql-name-resolution.md
+++ b/v20.2/sql-name-resolution.md
@@ -22,7 +22,7 @@ A CockroachDB cluster can store multiple databases. Each database can store mult
 
 When you first [start a cluster](start-a-local-cluster.html), a number of [preloaded databases](show-databases.html#preloaded-databases) and schemas are included, including the `defaultdb` database and the `public` schema. By default, objects (e.g., tables) are stored in the preloaded `public` schema, in the [current database](#current-database) (`defaultdb`, by default).
 
-In addition to the `public` schema, CockroachDB supports a fixed set of virtual schemas, available in every database, that provide ancillary, non-stored data to client applications. For example, [`information_schema`](information-schema.html) is provided for compatibility with the SQL standard.
+In addition to the `public` schema, CockroachDB supports a fixed set of virtual schemas, available in every database, that provide ancillary, non-stored data to client applications. For example, [`information_schema`](information-schema.html) is provided for compatibility with the SQL standard, and `pg_catalog` and [`pg_extension`](spatial-glossary.html#spatial-system-tables) are provided for compatibility with PostgreSQL.
 
 To create a new database, use a [`CREATE DATABASE`](create-database.html) statement. To create a new schema, use a [`CREATE SCHEMA`](create-schema.html) statement. The list of all databases can be obtained with [`SHOW DATABASES`](show-databases.html). The list of all schemas for a given database can be obtained with [`SHOW SCHEMAS`](show-schemas.html). The list of all objects for a given schema can be obtained with other `SHOW` statements.
 
@@ -213,7 +213,7 @@ When resolving a partially qualified name with just one component
 prefix, CockroachDB will look up a schema with the given prefix name
 first, and only look up a database with that name if the schema lookup
 fails. This matters in the (likely uncommon) case where you wish your
-database to be called `information_schema`, `public`, `pg_catalog`
+database to be called `information_schema`, `public`, `pg_catalog`, [`pg_extension`](spatial-glossary.html#spatial-system-tables),
 or `crdb_internal`.
 
 For example:


### PR DESCRIPTION
Fixes #7623.

`pg_extension` is already documented in the context of our spatial features (see #7946).

- Added `pg_extension` to general list of virtual schemas on SQL namespace page.
- Removed erroneous links to "Special database names" section. (This section just warns about naming tables after virtual schemas, and says nothing about the virtual schemas).


We have a gap in our docs re: virtual schemas. See https://github.com/cockroachdb/docs/issues/8706.