### PR TITLE
Documented `--redact-logs` flag

### DIFF
--- a/v20.2/cockroach-debug-merge-logs.md
+++ b/v20.2/cockroach-debug-merge-logs.md
@@ -9,7 +9,7 @@ key: debug-merge-logs.html
 The `cockroach debug merge-logs` [command](cockroach-commands.html) merges log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node. You can use it in conjunction with logs collected using the [`debug zip`](https://www.cockroachlabs.com/docs/stable/cockroach-debug-zip.html) command to aid in debugging.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug merge-log` can contain highly sensitive, unanonymized information, such as usernames, passwords, and possibly your table's data. You should share this data only with Cockroach Labs developers and only after determining the most secure method of delivery.
+The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Subcommands

--- a/v20.2/cockroach-debug-merge-logs.md
+++ b/v20.2/cockroach-debug-merge-logs.md
@@ -9,7 +9,7 @@ key: debug-merge-logs.html
 The `cockroach debug merge-logs` [command](cockroach-commands.html) merges log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node. You can use it in conjunction with logs collected using the [`debug zip`](https://www.cockroachlabs.com/docs/stable/cockroach-debug-zip.html) command to aid in debugging.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
+The file produced by `cockroach debug zip` can contain highly [sensitive, identifiable information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Subcommands
@@ -31,7 +31,7 @@ Flag | Description
 `--filter` | Limit the results to the specified regular expression
 `--from` | Start time for the time range filter.
 `--to` | End time for the time range filter.
-`--redact` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed above) collected by the `debug zip` command may still contain sensitive information.
+`--redact` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files.
 
 ## Example
 
@@ -74,7 +74,7 @@ You can redact sensitive information from the merged logs:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-cockroach debug merge-logs --redact debug/nodes/*/logs/* 
+cockroach debug merge-logs --redact debug/nodes/*/logs/*
 ~~~
 
 ## See also

--- a/v20.2/cockroach-debug-merge-logs.md
+++ b/v20.2/cockroach-debug-merge-logs.md
@@ -9,7 +9,7 @@ key: debug-merge-logs.html
 The `cockroach debug merge-logs` [command](cockroach-commands.html) merges log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node. You can use it in conjunction with logs collected using the [`debug zip`](https://www.cockroachlabs.com/docs/stable/cockroach-debug-zip.html) command to aid in debugging.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
+The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Subcommands
@@ -31,7 +31,7 @@ Flag | Description
 `--filter` | Limit the results to the specified regular expression
 `--from` | Start time for the time range filter.
 `--to` | End time for the time range filter.
-`--redact-logs` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed above) collected by the `debug zip` command may still contain sensitive information.
+`--redact` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed above) collected by the `debug zip` command may still contain sensitive information.
 
 ## Example
 
@@ -74,7 +74,7 @@ You can redact sensitive information from the merged logs:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-cockroach debug merge-logs debug/nodes/*/logs/* --redact-logs
+cockroach debug merge-logs --redact debug/nodes/*/logs/* 
 ~~~
 
 ## See also

--- a/v20.2/cockroach-debug-merge-logs.md
+++ b/v20.2/cockroach-debug-merge-logs.md
@@ -31,6 +31,7 @@ Flag | Description
 `--filter` | Limit the results to the specified regular expression
 `--from` | Start time for the time range filter.
 `--to` | End time for the time range filter.
+`--redact-logs` | Redact sensitive PII data from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed ablve) collected by the `debug zip` command may still contain sensitive information.
 
 ## Example
 

--- a/v20.2/cockroach-debug-merge-logs.md
+++ b/v20.2/cockroach-debug-merge-logs.md
@@ -9,7 +9,7 @@ key: debug-merge-logs.html
 The `cockroach debug merge-logs` [command](cockroach-commands.html) merges log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node. You can use it in conjunction with logs collected using the [`debug zip`](https://www.cockroachlabs.com/docs/stable/cockroach-debug-zip.html) command to aid in debugging.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
+The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Subcommands
@@ -31,7 +31,7 @@ Flag | Description
 `--filter` | Limit the results to the specified regular expression
 `--from` | Start time for the time range filter.
 `--to` | End time for the time range filter.
-`--redact-logs` | Redact sensitive PII data from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed ablve) collected by the `debug zip` command may still contain sensitive information.
+`--redact-logs` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed above) collected by the `debug zip` command may still contain sensitive information.
 
 ## Example
 
@@ -68,6 +68,13 @@ You can also filter the merged logs for a regular expression:
 {% include copy-clipboard.html %}
 ~~~ shell
 cockroach debug merge-logs debug/nodes/*/logs/* --filter="RUNNING IN INSECURE MODE"
+~~~
+
+You can redact sensitive information from the merged logs:
+
+{% include copy-clipboard.html %}
+~~~ shell
+cockroach debug merge-logs debug/nodes/*/logs/* --redact-logs
 ~~~
 
 ## See also

--- a/v20.2/cockroach-debug-merge-logs.md
+++ b/v20.2/cockroach-debug-merge-logs.md
@@ -9,7 +9,7 @@ key: debug-merge-logs.html
 The `cockroach debug merge-logs` [command](cockroach-commands.html) merges log files from multiple nodes into a single time-ordered stream of messages with an added per-message prefix to indicate the corresponding node. You can use it in conjunction with logs collected using the [`debug zip`](https://www.cockroachlabs.com/docs/stable/cockroach-debug-zip.html) command to aid in debugging.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly [sensitive, identifiable information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
+The file produced by `cockroach debug zip` can contain highly [sensitive, identifiable information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`--redact`](#example) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Subcommands

--- a/v20.2/cockroach-debug-zip.md
+++ b/v20.2/cockroach-debug-zip.md
@@ -99,19 +99,40 @@ If you need to troubleshoot this command's behavior, you can also change its [lo
 
 ### Generate a debug zip file
 
-{% include copy-clipboard.html %}
-~~~ shell
-# Generate the debug zip file for an insecure cluster:
-$ cockroach debug zip ./cockroach-data/logs/debug.zip --insecure --host=200.100.50.25
-~~~
+Generate the debug zip file for an insecure cluster:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-# Generate the debug zip file for a secure cluster:
+$ cockroach debug zip ./cockroach-data/logs/debug.zip --insecure --host=200.100.50.25
+~~~
+
+Generate the debug zip file for a secure cluster:
+
+{% include copy-clipboard.html %}
+~~~ shell
 $ cockroach debug zip ./cockroach-data/logs/debug.zip --host=200.100.50.25
 ~~~
 
 {{site.data.alerts.callout_info}}Secure examples assume you have the appropriate certificates in the default certificate directory, <code>${HOME}/.cockroach-certs/</code>.{{site.data.alerts.end}}
+
+### Redact sensitive information from the logs
+
+Example of a log string without redaction enabled:
+
+~~~
+server/server.go:1423 ⋮ password of user ‹admin› was set to ‹"s3cr34?!@x_"›
+~~~
+
+Enable log redaction:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach debug zip ./cockroach-data/logs/debug.zip -- redact-logs --insecure --host=200.100.50.25
+~~~
+
+~~~
+server/server.go:1423 ⋮ password of user ‹×› was set to ‹×›
+~~~
 
 ## See also
 

--- a/v20.2/cockroach-debug-zip.md
+++ b/v20.2/cockroach-debug-zip.md
@@ -81,6 +81,7 @@ Flag | Description
 `--port`<br>`-p` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
 `--nodes` | <span class="version-tag">New in v20.2:</span> Specify nodes to inspect as a comma-separated list or range of node IDs. For example:<br><br>`--nodes=1,10,13-15`
 `--exclude-nodes` | <span class="version-tag">New in v20.2:</span> Specify nodes to exclude from inspection as a comma-separated list or range of node IDs. For example:<br><br>`--nodes=1,10,13-15`
+`--redact-logs` | Redact sensitive PII data from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed ablve) collected by the `debug zip` command may still contain sensitive information.
 
 ### Client connection
 

--- a/v20.2/cockroach-debug-zip.md
+++ b/v20.2/cockroach-debug-zip.md
@@ -81,7 +81,7 @@ Flag | Description
 `--port`<br>`-p` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
 `--nodes` | <span class="version-tag">New in v20.2:</span> Specify nodes to inspect as a comma-separated list or range of node IDs. For example:<br><br>`--nodes=1,10,13-15`
 `--exclude-nodes` | <span class="version-tag">New in v20.2:</span> Specify nodes to exclude from inspection as a comma-separated list or range of node IDs. For example:<br><br>`--nodes=1,10,13-15`
-`--redact-logs` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed ablve) collected by the `debug zip` command may still contain sensitive information.
+`--redact-logs` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed above) collected by the `debug zip` command may still contain sensitive information.
 
 ### Client connection
 

--- a/v20.2/cockroach-debug-zip.md
+++ b/v20.2/cockroach-debug-zip.md
@@ -30,7 +30,7 @@ The `cockroach debug zip` [command](cockroach-commands.html) connects to your cl
 Additionally, you can run the [`debug merge-logs`](cockroach-debug-merge-logs.html) command to merge the collected logs in one file, making it easier to parse them to locate an issue with your cluster.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly [sensitive, identifiable information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
+The file produced by `cockroach debug zip` can contain highly [sensitive, identifiable information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`--redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Details

--- a/v20.2/cockroach-debug-zip.md
+++ b/v20.2/cockroach-debug-zip.md
@@ -30,7 +30,7 @@ The `cockroach debug zip` [command](cockroach-commands.html) connects to your cl
 Additionally, you can run the [`debug merge-logs`](cockroach-debug-merge-logs.html) command to merge the collected logs in one file, making it easier to parse them to locate an issue with your cluster.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
+The file produced by `cockroach debug zip` can contain highly [sensitive, identifiable information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Details

--- a/v20.2/cockroach-debug-zip.md
+++ b/v20.2/cockroach-debug-zip.md
@@ -30,7 +30,7 @@ The `cockroach debug zip` [command](cockroach-commands.html) connects to your cl
 Additionally, you can run the [`debug merge-logs`](cockroach-debug-merge-logs.html) command to merge the collected logs in one file, making it easier to parse them to locate an issue with your cluster.
 
 {{site.data.alerts.callout_danger}}
-The file produced by `cockroach debug zip` can contain highly sensitive, unanonymized information, such as usernames, hashed passwords, and possibly your table's data. You should share this data only with Cockroach Labs developers and only after determining the most secure method of delivery.
+The file produced by `cockroach debug zip` can contain highly [sensitive, unanonymized information](debug-and-error-logs.html#redacted-logs), such as usernames, hashed passwords, and possibly your table's data. You can use the [`redact-logs`](#redact-sensitive-information-from-the-logs) flag to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs.
 {{site.data.alerts.end}}
 
 ## Details
@@ -81,7 +81,7 @@ Flag | Description
 `--port`<br>`-p` | The server port to connect to. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
 `--nodes` | <span class="version-tag">New in v20.2:</span> Specify nodes to inspect as a comma-separated list or range of node IDs. For example:<br><br>`--nodes=1,10,13-15`
 `--exclude-nodes` | <span class="version-tag">New in v20.2:</span> Specify nodes to exclude from inspection as a comma-separated list or range of node IDs. For example:<br><br>`--nodes=1,10,13-15`
-`--redact-logs` | Redact sensitive PII data from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed ablve) collected by the `debug zip` command may still contain sensitive information.
+`--redact-logs` | Redact [sensitive data](debug-and-error-logs.html#redacted-logs) from the log files. Note that this flag removes sensitive information only from the log files. The other items (listed ablve) collected by the `debug zip` command may still contain sensitive information.
 
 ### Client connection
 

--- a/v20.2/debug-and-error-logs.md
+++ b/v20.2/debug-and-error-logs.md
@@ -112,6 +112,23 @@ These logging flags are used with [`cockroach` commands](cockroach-commands.html
 
 {% include {{ page.version.version }}/misc/logging-flags.md %}
 
+## Redacted logs
+
+If you contact CockroachDB Support for troubleshooting help, you might be asked to run [`cockroach debug zip`](cockroach-debug-zip.html) and share the resulting file with the CockroachDB team. The log files created by `cockroach debug zip` may contain highly sensitive, unanonymized information, such as usernames, hashed passwords, and possibly your table's data.
+
+<span class="version-tag">New in v20.2</span> You can run `cockroach debug zip` with the [`redact-logs` flag](cockroach-debug-zip.html#redact-sensitive-information-from-the-logs) to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs. Redactable sensitive data includes but is not limited to:
+
+- Stored values
+- Text of SQL statements, especially the values embedded therein
+- Result rows
+- The dynamic part of error messages that includes application-provided parameters.
+- IP addresses or hostnames
+- Database, schema, table, or column names
+- Cluster IDs
+- File names of stored data or log files
+- User/role names
+- Hashed passwords
+
 ## See also
 
 - [SQL logging](query-behavior-troubleshooting.html#sql-logging)

--- a/v20.2/debug-and-error-logs.md
+++ b/v20.2/debug-and-error-logs.md
@@ -114,7 +114,7 @@ These logging flags are used with [`cockroach` commands](cockroach-commands.html
 
 ## Redacted logs
 
-If you contact CockroachDB Support for troubleshooting help, you might be asked to run [`cockroach debug zip`](cockroach-debug-zip.html) and share the resulting file with the CockroachDB team. The log files created by `cockroach debug zip` may contain highly sensitive, unanonymized information, such as usernames, hashed passwords, and possibly your table's data.
+If you contact CockroachDB Support for troubleshooting help, you might be asked to run [`cockroach debug zip`](cockroach-debug-zip.html) and share the resulting file with the CockroachDB team. The log files created by `cockroach debug zip` may contain highly sensitive, identifiable information, such as usernames, hashed passwords, and possibly your table's data.
 
 <span class="version-tag">New in v20.2</span> You can run `cockroach debug zip` with the [`redact-logs` flag](cockroach-debug-zip.html#redact-sensitive-information-from-the-logs) to redact the sensitive data out of log files and crash reports before sharing them with Cockroach Labs. Redactable sensitive data includes but is not limited to:
 


### PR DESCRIPTION
Closes #7490 and #8395

Documented the `--redact-logs` flag for `debug-zip` and `debug-merge-logs` commands. Did not document the `redactable-logs` flag for `cockroach start`, `cockroach start-single-node`, and `cockroach demo` because the flag is now enabled by default and no longer needs user input.

Added an example to redact logs and the sample output. Not sure if we need to elaborate on the logging format - IMO, it needs to be a follow-up docs project that's bigger than just redacted logs.