### PR TITLE
Removed note on downgrading with precision types

### DIFF
--- a/v20.1/interval.md
+++ b/v20.1/interval.md
@@ -60,10 +60,6 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 
 For example, specifying an `INTERVAL` value as `INTERVAL(3)` truncates the time precision to milliseconds.
 
-{{site.data.alerts.callout_info}}
-All `INTERVAL` values specified with precision will retain their precision in the event of a downgrade to a version of CockroachDB that does not fully support `INTERVAL` precision. All `INTERVAL` values inserted after the downgrade will be stored with full precision (microseconds).
-{{site.data.alerts.end}}
-
 ## Duration fields
 
 <span class="version-tag">New in v20.1:</span> CockroachDB supports duration fields for `INTERVAL` values. You can specify `SECOND`, `MINUTE`, `HOUR`, or `DAY` units of duration in the form `INTERVAL ... <unit>` or `INTERVAL ... <unit> TO <unit>`.

--- a/v20.1/time.md
+++ b/v20.1/time.md
@@ -71,10 +71,6 @@ A `TIMETZ` column supports values up to 12 bytes in width, but the total storage
 
 You can use an [`ALTER COLUMN ... SET DATA TYPE`](alter-column.html) statement to change the precision level of a `TIME`-typed column. If there is already a non-default precision level specified for the column, the precision level can only be changed to an equal or greater precision level. For an example, see [Create a table with a `TIME`-typed column, with precision](#create-a-table-with-a-time-typed-column-with-precision).
 
-{{site.data.alerts.callout_info}}
-If you downgrade to a version of CockroachDB that does not support precision for `TIME`/`TIMETZ` values, all `TIME`/`TIMETZ` values previously specified with precision will be stored with full precision.
-{{site.data.alerts.end}}
-
 ## Examples
 
 ### Create a table with a `TIME`-typed column

--- a/v20.1/timestamp.md
+++ b/v20.1/timestamp.md
@@ -76,10 +76,6 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 
 You can use an [`ALTER COLUMN ... SET DATA TYPE`](alter-column.html) statement to change the precision level of a `TIMESTAMP`/`TIMESTAMPTZ`-typed column. If there is already a non-default precision level specified for the column, the precision level can only be changed to an equal or greater precision level. For an example, see [Create a table with a `TIMESTAMP`-typed column, with precision](#create-a-table-with-a-timestamp-typed-column-with-precision).
 
-{{site.data.alerts.callout_info}}
-If you downgrade to a version of CockroachDB that does not support precision for `TIMESTAMP`/`TIMESTAMPTZ` values, all `TIMESTAMP`/`TIMESTAMPTZ` values previously specified with precision will be stored with full precision.
-{{site.data.alerts.end}}
-
 ## Examples
 
 ### Create a table with a `TIMESTAMPTZ`-typed column

--- a/v20.2/interval.md
+++ b/v20.2/interval.md
@@ -60,10 +60,6 @@ An `INTERVAL` column supports values up to 24 bytes in width, but the total stor
 
 For example, specifying an `INTERVAL` value as `INTERVAL(3)` truncates the time precision to milliseconds.
 
-{{site.data.alerts.callout_info}}
-All `INTERVAL` values specified with precision will retain their precision in the event of a downgrade to a version of CockroachDB that does not fully support `INTERVAL` precision. All `INTERVAL` values inserted after the downgrade will be stored with full precision (microseconds).
-{{site.data.alerts.end}}
-
 ## Duration fields
 
  CockroachDB supports duration fields for `INTERVAL` values. You can specify `SECOND`, `MINUTE`, `HOUR`, or `DAY` units of duration in the form `INTERVAL ... <unit>` or `INTERVAL ... <unit> TO <unit>`.

--- a/v20.2/time.md
+++ b/v20.2/time.md
@@ -69,10 +69,6 @@ A `TIMETZ` column supports values up to 12 bytes in width, but the total storage
 
 You can use an [`ALTER COLUMN ... SET DATA TYPE`](alter-column.html) statement to change the precision level of a `TIME`-typed column. If there is already a non-default precision level specified for the column, the precision level can only be changed to an equal or greater precision level. For an example, see [Create a table with a `TIME`-typed column, with precision](#create-a-table-with-a-time-typed-column-with-precision).
 
-{{site.data.alerts.callout_info}}
-If you downgrade to a version of CockroachDB that does not support precision for `TIME`/`TIMETZ` values, all `TIME`/`TIMETZ` values previously specified with precision will be stored with full precision.
-{{site.data.alerts.end}}
-
 ## Examples
 
 ### Create a table with a `TIME`-typed column

--- a/v20.2/timestamp.md
+++ b/v20.2/timestamp.md
@@ -78,10 +78,6 @@ A `TIMESTAMP`/`TIMESTAMPTZ` column supports values up to 12 bytes in width, but 
 
 You can use an [`ALTER COLUMN ... SET DATA TYPE`](alter-column.html) statement to change the precision level of a `TIMESTAMP`/`TIMESTAMPTZ`-typed column. If there is already a non-default precision level specified for the column, the precision level can only be changed to an equal or greater precision level. For an example, see [Create a table with a `TIMESTAMP`-typed column, with precision](#create-a-table-with-a-timestamp-typed-column-with-precision).
 
-{{site.data.alerts.callout_info}}
-If you downgrade to a version of CockroachDB that does not support precision for `TIMESTAMP`/`TIMESTAMPTZ` values, all `TIMESTAMP`/`TIMESTAMPTZ` values previously specified with precision will be stored with full precision.
-{{site.data.alerts.end}}
-
 ## Examples
 
 ### Create a table with a `TIMESTAMPTZ`-typed column


### PR DESCRIPTION
Fixes  #7607.

Removed note about precision on downgrades from `INTERVAL`, `TIME`, and `TIMESTAMP` pages.