### PR TITLE
Fix docker pull command for stable releases

### DIFF
--- a/releases/v19.1.7.md
+++ b/releases/v19.1.7.md
@@ -38,7 +38,7 @@ Get future release notes emailed to you:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-stable:v19.1.7
+$ docker pull cockroachdb/cockroach:v19.1.7
 ~~~
 
 ### Bug fixes

--- a/releases/v2.1.11.md
+++ b/releases/v2.1.11.md
@@ -33,7 +33,7 @@ Get future release notes emailed to you:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-stable:v2.1.11
+$ docker pull cockroachdb/cockroach:v2.1.11
 ~~~
 
 ### Admin UI changes

--- a/releases/v20.1.7.md
+++ b/releases/v20.1.7.md
@@ -34,7 +34,7 @@ Get future release notes emailed to you:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-stable:v20.1.7
+$ docker pull cockroachdb/cockroach:v20.1.7
 ~~~
 
 ### Security updates

--- a/releases/v20.1.8.md
+++ b/releases/v20.1.8.md
@@ -34,7 +34,7 @@ Get future release notes emailed to you:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-stable:v20.1.8
+$ docker pull cockroachdb/cockroach:v20.1.8
 ~~~
 
 ### Bug fixes


### PR DESCRIPTION
In a few places, we were using `cockroach/cockroach-stable:<version>`.
`cockroach-stable` isn't valid. It should just be
`cockroach/cockroach:<version>`.

Fixes #8730.