### PR TITLE
Removed limitation on ordered aggregations

### DIFF
--- a/_includes/v19.2/sql/disk-spilling-ops.md
+++ b/_includes/v19.2/sql/disk-spilling-ops.md
@@ -1,6 +1,6 @@
 - Global [sorts](query-order.html)
 - [Window functions](window-functions.html)
-- [Unordered aggregations](query-order.html#processing-order-during-aggregations)
+- [Unordered aggregations](query-order.html)
 - [Hash joins](joins.html#hash-joins)
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 

--- a/v19.2/query-order.md
+++ b/v19.2/query-order.md
@@ -271,21 +271,6 @@ of deletes](#sorting-the-output-of-deletes).
 
 {% include {{page.version.version}}/misc/sorting-delete-output.md %}
 
-## Processing order during aggregations
-
-CockroachDB currently processes aggregations (e.g., `SELECT ... GROUP BY`)
-in non-deterministic order.
-
-For most aggregation functions, like `MIN`, `MAX`,
-`COUNT`, the order does not matter anyway because the functions are commutative
-and produce the same result regardless. However, for the few aggregation
-functions that are not commutative (e.g., `array_agg()`, `json_agg()`,
-and `concat_agg()`), this implies the result of the aggregation will not be
-deterministic.
-
-This is a [known limitation](https://github.com/cockroachdb/cockroach/issues/23620)
-that may be lifted in the future.
-
 ## See also
 
 - [Selection Queries](selection-queries.html)

--- a/v20.1/query-order.md
+++ b/v20.1/query-order.md
@@ -277,21 +277,6 @@ of deletes](#sorting-the-output-of-deletes).
 
 {% include {{page.version.version}}/misc/sorting-delete-output.md %}
 
-## Processing order during aggregations
-
-CockroachDB currently processes aggregations (e.g., `SELECT ... GROUP BY`)
-in non-deterministic order.
-
-For most aggregation functions, like `MIN`, `MAX`,
-`COUNT`, the order does not matter anyway because the functions are commutative
-and produce the same result regardless. However, for the few aggregation
-functions that are not commutative (e.g., `array_agg()`, `json_agg()`,
-and `concat_agg()`), this implies the result of the aggregation will not be
-deterministic.
-
-This is a [known limitation](https://github.com/cockroachdb/cockroach/issues/23620)
-that may be lifted in the future.
-
 ## See also
 
 - [Selection Queries](selection-queries.html)

--- a/v20.1/vectorized-execution.md
+++ b/v20.1/vectorized-execution.md
@@ -60,7 +60,7 @@ By default, vectorized execution is disabled for the following memory-intensive 
 
 - Global [sorts](query-order.html)
 - [Window functions](window-functions.html)
-- [Unordered aggregations](query-order.html#processing-order-during-aggregations)
+- [Unordered aggregations](query-order.html)
 - [Hash joins](joins.html#hash-joins)
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 

--- a/v20.2/query-order.md
+++ b/v20.2/query-order.md
@@ -277,21 +277,6 @@ of deletes](#sorting-the-output-of-deletes).
 
 {% include {{page.version.version}}/misc/sorting-delete-output.md %}
 
-## Processing order during aggregations
-
-CockroachDB currently processes aggregations (e.g., `SELECT ... GROUP BY`)
-in non-deterministic order.
-
-For most aggregation functions, like `MIN`, `MAX`,
-`COUNT`, the order does not matter anyway because the functions are commutative
-and produce the same result regardless. However, for the few aggregation
-functions that are not commutative (e.g., `array_agg()`, `json_agg()`,
-and `concat_agg()`), this implies the result of the aggregation will not be
-deterministic.
-
-This is a [known limitation](https://github.com/cockroachdb/cockroach/issues/23620)
-that may be lifted in the future.
-
 ## See also
 
 - [Selection Queries](selection-queries.html)

--- a/v20.2/vectorized-execution.md
+++ b/v20.2/vectorized-execution.md
@@ -51,7 +51,7 @@ For detailed examples of vectorized query execution for hash and merge joins, se
 The following operations require [memory buffering](https://en.wikipedia.org/wiki/Data_buffer) during execution:
 
 - Global [sorts](query-order.html)
-- [Unordered aggregations](query-order.html#processing-order-during-aggregations)
+- [Unordered aggregations](query-order.html)
 - [Hash joins](joins.html#hash-joins)
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 - [Window functions](window-functions.html). Note that [support for window functions is limited in the vectorized execution engine](#window-functions).


### PR DESCRIPTION
Removed paragraph pointing to limitation (https://github.com/cockroachdb/cockroach/issues/23620) that was lifted in 19.2 (https://github.com/cockroachdb/cockroach/pull/38014).