### PR TITLE
Add docs for POINT, LINE, POLYGON, and collections

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -2022,86 +2022,128 @@
     			  "urls": [
     			      "/${VERSION}/spatial-features.html"
     			  ]
-	      },
-	      {
-  			  "title": "Spatial and GIS Glossary of Terms",
-  			  "urls": [
-  			      "/${VERSION}/spatial-glossary.html"
-  			  ]
-	      },
-          {
-              "title": "Spatial Indexes",
-              "urls": [
-                  "/${VERSION}/spatial-indexes.html"
-              ]
-          },
-          { 
-            "title": "ST_Contains",
-            "urls": [
-                "/${VERSION}/st_contains.html"
-            ]
-          },
-          { 
-            "title": "ST_Within",
-            "urls": [
-                "/${VERSION}/st_within.html"
-            ]
-          },
-          { 
-            "title": "ST_Intersects",
-            "urls": [
-                "/${VERSION}/st_intersects.html"
-            ]
-          },
-          { 
-            "title": "ST_CoveredBy",
-            "urls": [
-                "/${VERSION}/st_coveredby.html"
-            ]
-          },
-          { 
-            "title": "ST_Covers",
-            "urls": [
-                "/${VERSION}/st_covers.html"
-            ]
-          },
-          { 
-            "title": "ST_Disjoint",
-            "urls": [
-                "/${VERSION}/st_disjoint.html"
-            ]
-          },
-          { 
-            "title": "ST_Equals",
-            "urls": [
-                "/${VERSION}/st_equals.html"
-            ]
-          },
-          { 
-            "title": "ST_Overlaps",
-            "urls": [
-                "/${VERSION}/st_overlaps.html"
-            ]
-          },
-          { 
-            "title": "ST_Touches",
-            "urls": [
-                "/${VERSION}/st_touches.html"
-            ]
-          },
-          { 
-            "title": "ST_ConvexHull",
-            "urls": [
-                "/${VERSION}/st_convexhull.html"
-            ]
-          },
-          { 
-            "title": "ST_Union",
-            "urls": [
-                "/${VERSION}/st_union.html"
-            ]
-          }
-	]
+              },
+              {
+                  "title": "Spatial and GIS Glossary of Terms",
+                  "urls": [
+                      "/${VERSION}/spatial-glossary.html"
+                  ]
+              },
+              {
+                  "title": "Spatial Indexes",
+                  "urls": [
+                      "/${VERSION}/spatial-indexes.html"
+                  ]
+              },
+              {
+                  "title": "POINT",
+                  "urls": [
+                      "/${VERSION}/point.html"
+                  ]
+              },
+              {
+                  "title": "LINESTRING",
+                  "urls": [
+                      "/${VERSION}/linestring.html"
+                  ]
+              },
+              {
+                  "title": "POLYGON",
+                  "urls": [
+                      "/${VERSION}/polygon.html"
+                  ]
+              },
+              {
+                  "title": "MULTIPOINT",
+                  "urls": [
+                      "/${VERSION}/multipoint.html"
+                  ]
+              },
+              {
+                  "title": "MULTILINESTRING",
+                  "urls": [
+                      "/${VERSION}/multilinestring.html"
+                  ]
+              },
+              {
+                  "title": "MULTIPOLYGON",
+                  "urls": [
+                      "/${VERSION}/multipolygon.html"
+                  ]
+              },
+              {
+                  "title": "GEOMETRYCOLLECTION",
+                  "urls": [
+                      "/${VERSION}/geometrycollection.html"
+                  ]
+              },
+              { 
+                "title": "ST_Contains",
+                "urls": [
+                    "/${VERSION}/st_contains.html"
+                ]
+              },
+              { 
+                "title": "ST_Within",
+                "urls": [
+                    "/${VERSION}/st_within.html"
+                ]
+              },
+              { 
+                "title": "ST_Intersects",
+                "urls": [
+                    "/${VERSION}/st_intersects.html"
+                ]
+              },
+              { 
+                "title": "ST_CoveredBy",
+                "urls": [
+                    "/${VERSION}/st_coveredby.html"
+                ]
+              },
+              { 
+                "title": "ST_Covers",
+                "urls": [
+                    "/${VERSION}/st_covers.html"
+                ]
+              },
+              { 
+                "title": "ST_Disjoint",
+                "urls": [
+                    "/${VERSION}/st_disjoint.html"
+                ]
+              },
+              { 
+                "title": "ST_Equals",
+                "urls": [
+                    "/${VERSION}/st_equals.html"
+                ]
+              },
+              { 
+                "title": "ST_Overlaps",
+                "urls": [
+                    "/${VERSION}/st_overlaps.html"
+                ]
+              },
+              { 
+                "title": "ST_Touches",
+                "urls": [
+                    "/${VERSION}/st_touches.html"
+                ]
+              },
+              { 
+                "title": "ST_ConvexHull",
+                "urls": [
+                    "/${VERSION}/st_convexhull.html"
+                ]
+              },
+              { 
+                "title": "ST_Union",
+                "urls": [
+                    "/${VERSION}/st_union.html"
+                ]
+              }
+	      ]
       },
       {
     		"title": "Performance Optimization",

--- a/v20.2/geometrycollection.md
+++ b/v20.2/geometrycollection.md
@@ -1,0 +1,33 @@
+---
+title: GEOMETRYCOLLECTION
+summary: A GEOMETRYCOLLECTION is used for gathering one or more of the spatial object types into a group.
+toc: true
+---
+
+A `GEOMETRYCOLLECTION` is a collection of heterogeneous [spatial objects](spatial-features.html#spatial-objects), such as [Points](point.html), [LineStrings](linestring.html), [Polygons](polygon.html), or other `GEOMETRYCOLLECTION`s.  It provides a way of referring to a group of spatial objects as one "thing" so that you can operate on it/them more conveniently using various SQL functions.
+
+## Examples
+
+A GeometryCollection can be created from SQL by calling the `st_geomfromtext` function on a GeometryCollection definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format as shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1440 900), POLYGON((0 0, 0 1024, 1024 1024, 1024 0, 0 0)))');
+~~~
+
+~~~
+                                                                                                                                                              st_geomfromtext
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  0107000000030000000101000000000000000000000000000000000000000102000000020000000000000000000000000000000000000000000000008096400000000000208C40010300000001000000050000000000000000000000000000000000000000000000000000000000000000009040000000000000904000000000000090400000000000009040000000000000000000000000000000000000000000000000
+(1 row)
+~~~
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)

--- a/v20.2/linestring.md
+++ b/v20.2/linestring.md
@@ -1,0 +1,37 @@
+---
+title: LINESTRING
+summary: A LINESTRING is a collection of POINTs joined into a line.
+toc: true
+---
+
+A `LINESTRING` is a collection of [Points](point.html) that are "strung together" into one geometric object. A LineString can be used to represent an arbitrary curve, such as a [Bézier curve](https://en.wikipedia.org/wiki/Bézier_curve).  In practice, this means that LineStrings are useful for representing real-world objects such as roads and rivers.
+
+The coordinates of each Point that makes up the LineString are translated according to the current [spatial reference system](spatial-glossary.html#spatial-reference-system) (denoted by an [SRID](spatial-glossary.html#srid)) to determine what the Point "is", or what it "means" relative to the [other spatial objects](spatial-features.html#spatial-objects) (if any) in the data set.
+
+## Examples
+
+A LineString can be created from SQL by calling the `st_geomfromtext` function on a LineString definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format as shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('LINESTRING(0 0, 1440 900)');
+~~~
+
+~~~
+                                   st_geomfromtext
+--------------------------------------------------------------------------------------
+  0102000000020000000000000000000000000000000000000000000000008096400000000000208C40
+(1 row)
+~~~
+
+You can also make a LineString using the [aggregate function form](functions-and-operators.html#aggregate-functions) of `st_makeline`.
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [POINT](point.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)

--- a/v20.2/multilinestring.md
+++ b/v20.2/multilinestring.md
@@ -1,0 +1,73 @@
+---
+title: MULTILINESTRING
+summary: A MULTILINESTRING is a collection of LINESTRINGs.
+toc: true
+---
+
+A `MULTILINESTRING` is a collection of [LineStrings](linestring.html).  MultiLineStrings are useful for gathering a group of LineStrings into one geometry. For example, you may want to gather the LineStrings denoting all of the roads in a particular municipality.
+
+## Examples
+
+### Well known text
+
+A MultiLineString can be created from SQL by calling the `st_geomfromtext` function on a MultiLineString definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('MULTILINESTRING((0 0, 1440 900), (800 600, 200 400))');
+~~~
+
+~~~
+                                                                                     st_geomfromtext
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  0105000000020000000102000000020000000000000000000000000000000000000000000000008096400000000000208C4001020000000200000000000000000089400000000000C0824000000000000069400000000000007940
+(1 row)
+~~~
+
+### SQL
+
+A MultiLineString can be created from SQL by calling an aggregate function such as `ST_Collect` or [`ST_Union`](st_union.html) on a column that contains [LineString](linestring.html) geometries.  In the example below, we will build a MultiLineString from several LineStrings.
+
+First, insert the LineStrings:
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE TABLE tmp_linestrings (id INT8 default unique_rowid(), geom GEOMETRY);
+
+INSERT INTO tmp_linestrings (geom)
+VALUES
+(st_geomfromtext('SRID=4326;LINESTRING(-88.243385 40.116421, -87.906471 43.038902, -95.992775 36.153980)')),
+(st_geomfromtext('SRID=4326;LINESTRING(-75.704722 36.076944, -95.992775 36.153980, -87.906471 43.038902)')),
+(st_geomfromtext('SRID=4326;LINESTRING(-76.8261 42.1727,  -75.6608 41.4102,-73.5422 41.052, -73.929 41.707,  -76.8261 42.1727)'));
+~~~
+
+Next, build a MultiLineString from the individual [LineStrings](linestring.html) using `ST_Collect`, and check the output with `ST_GeometryType` to verify that it is indeed a MultiLineString:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeometryType(st_collect(geom)) AS output FROM tmp_linestrings;
+~~~
+
+~~~
+        output
+----------------------
+  ST_MultiLineString
+(1 row)
+~~~
+
+Finally, drop the temporary table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+DROP TABLE tmp_linestrings;
+~~~
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)

--- a/v20.2/multipoint.md
+++ b/v20.2/multipoint.md
@@ -1,0 +1,75 @@
+---
+title: MULTIPOINT
+summary: A MULTIPOINT is a collection of POINTs.
+toc: true
+---
+
+A `MULTIPOINT` is a collection of [Points](point.html).  MultiPoints are useful for gathering a group of Points into one geometry. For example, you may want to gather the points denoting all of the State Capitols in the U.S. into a single geometry.
+
+## Examples
+
+### SQL
+
+A MultiPoint can be created from SQL by calling an aggregate function such as `ST_Collect` or [`ST_Union`](st_union.html) on a column that contains [Point](point.html) geometries.  In the example below, we will build a MultiPoint from several Points.
+
+First, insert the Points:
+
+{% include copy-clipboard.html %}
+~~~ sql
+CREATE TABLE tmp_points (id INT8 default unique_rowid(), geom GEOMETRY);
+
+INSERT INTO tmp_points (geom)
+VALUES
+(st_geomfromtext('POINT (-88.243357000000003 40.117404000000001)')),
+(st_geomfromtext('POINT (-94.598371 39.050068000000003)')),
+(st_geomfromtext('POINT (-73.962090000000003 40.609226)'));
+~~~
+
+Next, build a MultiPoint from the individual [Points](point.html) using `ST_Collect`, and check the output with `ST_GeometryType` to verify that it is indeed a MultiPoint:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeometryType(st_collect(geom)) AS output FROM tmp_points;
+~~~
+
+~~~
+     output
+-----------------
+  ST_MultiPoint
+(1 row)
+~~~
+
+Finally, drop the temporary table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+DROP TABLE tmp_points;
+~~~
+
+### Well known text
+
+A MultiPoint can be created from SQL by calling the `st_geomfromtext` function on a MultiPoint definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format.
+
+For example, the MultiPoint in the example below includes the locations of [independent bookstores in Chicago, Illinois USA](https://www.bookweb.org/member_directory/search/ABAmember/results/0/Chicago/IL/0):
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('MULTIPOINT (-87.738258999999999 42.010930999999999, -87.716257999999996 41.981231000000001, -87.708889999999997 41.975000000000001, -87.707705000000004 41.929195999999997, -87.707192000000006 41.926580000000001, -87.704300000000003 41.928013999999997, -87.698012000000006 41.939076, -87.682384999999996 41.943232000000002, -87.681599000000006 41.705936999999999, -87.677763999999996 41.916998, -87.674808999999996 41.9086, -87.668653000000006 41.977356999999998, -87.668611999999996 41.904580000000003, -87.664944000000006 41.921931999999998, -87.655131999999995 41.881686000000002, -87.654752999999999 41.881632000000003, -87.654584 41.944774000000002, -87.653409999999994 41.857928000000001, -87.650779999999997 41.926853000000001, -87.644745999999998 41.941915999999999, -87.644356999999999 41.899109000000003, -87.634562000000003 41.897446000000002, -87.630498000000003 41.899751000000002, -87.629164000000003 41.873215999999999, -87.627983999999998 41.883583999999999, -87.627189999999999 41.890832000000003, -87.624488999999997 41.885147000000003, -87.624283000000005 41.876899000000002, -87.624251999999998 41.874115000000003, -87.622851999999995 41.894931999999997, -87.619151000000002 41.864832999999997, -87.597796000000002 41.789636000000002, -87.596547999999999 41.790515999999997, -87.594948000000002 41.791434000000002, -87.591048999999998 41.808132999999998, -87.590436999999994 41.783611000000001, -87.590277 41.800938000000002)');
+~~~
+
+~~~
+                                                                               st_geomfromtext
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  0104000000250000000101000000923EADA23FEF55C09CC1DF2F660145400101000000E55FCB2BD7ED55C0236937FA98FD44400101000000889D29745EED55C0CDCCCCCCCCFC44400101000000CE8DE9094BED55C079C9FFE4EFF6444001010000008BFF3BA242ED55C05890662C9AF644400101000000A9A44E4013ED55C0751DAA29C9F644400101000000CC0D863AACEC55C0B03A72A433F844400101000000FB912232ACEB55C0354580D3BBF844400101000000207F69519FEB55C0A704C4245CDA44400101000000FE99417C60EB55C0AB3FC23060F544400101000000F982161230EB55C0A3923A014DF444400101000000D4D7F335CBEA55C022C2BF081AFD44400101000000A46DFC89CAEA55C0CF4E0647C9F344400101000000F96A47718EEA55C0649126DE01F64440010100000009A4C4AEEDE955C0A8AB3B16DBF0444001010000004E7D2079E7E955C0B58D3F51D9F044400101000000081F4AB4E4E955C0390EBC5AEEF84440010100000047382D78D1E955C04E29AF95D0ED4440010100000004392861A6E955C089997D1EA3F644400101000000840EBA8443E955C021CA17B490F844400101000000B77C24253DE955C00745F30016F3444001010000003352EFA99CE855C088F6B182DFF244400101000000618C48145AE855C08BC56F0A2BF34440010100000084F4143944E855C0062CB98AC5EF44400101000000529ACDE330E855C06AA2CF4719F144400101000000359886E123E855C07A1D71C806F2444001010000008DEDB5A0F7E755C08693347F4CF144400101000000B91CAF40F4E755C09372F7393EF0444001010000009B1DA9BEF3E755C0B6F81400E3EF44400101000000E28FA2CEDCE755C06A12BC218DF2444001010000004912842BA0E755C033C005D9B2EE444001010000007F6B274A42E655C044DFDDCA12E544400101000000A19FA9D72DE655C07C7BD7A02FE54440010100000085B4C6A013E655C0A37895B54DE54440010100000058552FBFD3E555C0C0E8F2E670E7444001010000004B5645B8C9E555C097E4805D4DE4444001010000002FA52E19C7E555C0D40FEA2285E64440
+(1 row)
+~~~
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)

--- a/v20.2/multipolygon.md
+++ b/v20.2/multipolygon.md
@@ -1,0 +1,33 @@
+---
+title: MULTIPOLYGON
+summary: A MULTIPOLYGON is a collection of POLYGONs.
+toc: true
+---
+
+A `MULTIPOLYGON` is a collection of [Polygons](polygon.html).  MultiPolygons are useful for gathering a group of Polygons into one geometry. For example, you may want to gather the Polygons denoting a group of properties in a particular municipality.  Another use of MultiPolygons is to represent states or countries that include islands, or that are otherwise made up of non-overlapping shapes.
+
+## Examples
+
+A MultiPolygon can be created from SQL by calling the `st_geomfromtext` function on a MultiPolygon definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('SRID=4326;MULTIPOLYGON(((-87.906471 43.038902, -95.992775 36.153980, -75.704722 36.076944, -87.906471 43.038902), (-87.623177 41.881832, -90.199402 38.627003, -82.446732 38.413651, -87.623177 41.881832), (-84.191605 39.758949, -75.165222 39.952583, -78.878738 42.880230, -84.191605 39.758949)))');
+~~~
+
+~~~
+                                                                                                                                                                                                                            st_geomfromtext
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  0106000020E610000001000000010300000003000000040000006FF1F09E03FA55C0DFDFA0BDFA844540545227A089FF57C0791EDC9DB513424064B14D2A1AED52C0CCCF0D4DD90942406FF1F09E03FA55C0DFDFA0BDFA84454004000000A4A7C821E2E755C07C48F8DEDFF0444073309B00C38C56C038BF61A241504340E884D041979C54C0967A1684F2344340A4A7C821E2E755C07C48F8DEDFF044400400000001309E41430C55C07C2AA73D25E143401AA54BFF92CA52C0DFDC5F3DEEF9434028F04E3E3DB853C0A27A6B60AB70454001309E41430C55C07C2AA73D25E14340
+(1 row)
+~~~
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)

--- a/v20.2/point.md
+++ b/v20.2/point.md
@@ -1,0 +1,53 @@
+---
+title: POINT
+summary: A POINT is a geometry object; a sizeless location identified by its X and Y coordinates.
+toc: true
+---
+
+A `POINT` is a sizeless location identified by its X and Y coordinates. These coordinates are then translated according to the current [spatial reference system](spatial-glossary.html#spatial-reference-system) (denoted by an [SRID](spatial-glossary.html#srid)) to determine what the Point "is", or what it "means" relative to the [other spatial objects](spatial-features.html#spatial-objects) (if any) in the data set. 
+
+## Examples
+
+### SQL
+
+A Point can be created in SQL by the `st_point` function.
+
+The statement below creates a Point (using the common [SRID 4326](spatial-glossary.html#srid)).
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_SetSRID(ST_Makepoint(0,0), 4326);
+~~~
+
+~~~
+                      st_setsrid
+------------------------------------------------------
+  0101000020E610000000000000000000000000000000000000
+(1 row)
+~~~
+
+### Well known text
+
+A Point can be created from SQL by calling the `st_geomfromtext` function on a Point definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format as shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('POINT(0 0)');
+~~~
+
+~~~
+               st_geomfromtext
+----------------------------------------------
+  010100000000000000000000000000000000000000
+(1 row)
+~~~
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)

--- a/v20.2/polygon.md
+++ b/v20.2/polygon.md
@@ -1,0 +1,68 @@
+---
+title: POLYGON
+summary: A POLYGON
+toc: true
+---
+
+A `POLYGON` is a shape with a closed exterior that is made up of lines. Polygons can also contain holes.  Polygons are often used to represent areas such as countries, states, or municipalities.
+
+The coordinates of each Point and line that make up the Polygon are translated according to the current [spatial reference system](spatial-glossary.html#spatial-reference-system) (denoted by an [SRID](spatial-glossary.html#srid)) to determine what the point "is", or what it "means" relative to the [other spatial objects](spatial-features.html#spatial-objects) (if any) in the data set.
+
+## Examples
+
+### Well known text
+
+A Polygon can be created from SQL by calling the `st_geomfromtext` function on a LineString definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format as shown below.
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('POLYGON((0 0, 0 1024, 1024 1024, 1024 0, 0 0))');
+~~~
+
+~~~
+                                                                                       st_geomfromtext
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  010300000001000000050000000000000000000000000000000000000000000000000000000000000000009040000000000000904000000000000090400000000000009040000000000000000000000000000000000000000000000000
+(1 row)
+~~~
+
+### Polygons with holes
+
+To represent a polygon with holes in [WKT](spatial-glossary.html#wkt), add one or more additional lists of coordinates that define the boundaries of the holes as shown below:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_GeomFromText('POLYGON((-87.906471 43.038902, -95.992775 36.153980, -75.704722 36.076944, -87.906471 43.038902), (-87.623177 41.881832, -90.199402 38.627003, -82.446732 38.413651, -87.623177 41.881832))');
+~~~
+
+~~~
+                                                                                                                                           st_geomfromtext
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  010300000002000000040000006FF1F09E03FA55C0DFDFA0BDFA844540545227A089FF57C0791EDC9DB513424064B14D2A1AED52C0CCCF0D4DD90942406FF1F09E03FA55C0DFDFA0BDFA84454004000000A4A7C821E2E755C07C48F8DEDFF0444073309B00C38C56C038BF61A241504340E884D041979C54C0967A1684F2344340A4A7C821E2E755C07C48F8DEDFF04440
+(1 row)
+~~~
+
+### Using a SQL function
+
+You can also use the `st_makepolygon` function on a LineString that defines the outer boundary of the Polygon, e.g.:
+
+{% include copy-clipboard.html %}
+~~~ sql
+SELECT ST_MakePolygon('LINESTRING(0 0, 0 1024, 1024 1024, 1024 0, 0 0)');
+~~~
+
+~~~
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  010300000001000000050000000000000000000000000000000000000000000000000000000000000000009040000000000000904000000000000090400000000000009040000000000000000000000000000000000000000000000000
+(1 row)
+~~~
+
+## See also
+
+- [Spatial objects](spatial-features.html#spatial-objects)
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)

--- a/v20.2/spatial-features.md
+++ b/v20.2/spatial-features.md
@@ -24,6 +24,21 @@ See the links below for more information about how to use CockroachDB for spatia
 
 - [Spatial indexes](spatial-indexes.html)
 - [Spatial and GIS Glossary of Terms](spatial-glossary.html)
+- [Spatial functions](functions-and-operators.html#spatial-functions)
+
+<a name="spatial-objects"></a>
+
+Spatial objects:
+
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)
+
+<a name="spatial-functions"></a>
 
 In addition to the [generated reference documentation for spatial functions](functions-and-operators.html#spatial-functions), we have written additional documentation for the following functions, including examples:
 

--- a/v20.2/spatial-indexes.md
+++ b/v20.2/spatial-indexes.md
@@ -137,7 +137,7 @@ VALUES (1, st_geomfromtext('LINESTRING(-76.8261 42.1727,  -75.6608 41.4102,-73.5
 
 INSERT INTO tmp_viz (id, geom) VALUES (2, st_s2covering(st_geomfromtext('LINESTRING(-76.8261 42.1727,  -75.6608 41.4102,-73.5422 41.052, -73.929 41.707,  -76.8261 42.1727)'), 's2_max_cells=20,s2_max_level=12,s2_level_mod=3,geometry_min_x=-180,geometry_max_x=180,geometry_min_y=-180,geometry_max_y=180'));
 
-SELECT st_asgeojson(st_collect(geom)) FROM tmp_viz;
+SELECT ST_AsGeoJSON(st_collect(geom)) FROM tmp_viz;
 ~~~
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
Specifically, this change adds basic reference docs for the following
spatial objects:

- POINT
- LINESTRING
- POLYGON
- MULTIPOINT
- MULTILINESTRING
- MULTIPOLYGON
- GEOMETRYCOLLECTION

Fixes #8567, #8568, #8569, #8570.