### PR TITLE
Comment out CRC content in Python tutorials as part of #7816

### DIFF
--- a/_includes/v20.1/app/create-a-database.md
+++ b/_includes/v20.1/app/create-a-database.md
@@ -25,6 +25,7 @@
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 1. If you haven't already, [download the CockroachDB binary](install-cockroachdb.html).
@@ -55,3 +56,4 @@
     ~~~
 
 </section>
+{% endcomment %}

--- a/_includes/v20.1/app/python/psycopg2/example.py
+++ b/_includes/v20.1/app/python/psycopg2/example.py
@@ -156,10 +156,7 @@ def parse_cmdline():
         help="database connection string\n\n"
              "For cockroach demo, use postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require,\n"
              "with the username and password created in the demo cluster, and the hostname and port listed in the\n"
-             "(sql/tcp) connection parameters of the demo cluster welcome message.\n\n"
-             "For CockroachCloud, use postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>,\n"
-             "with the username and password created in the CockroachCloud console, the hostname and port provided\n"
-             "in the console, and the certificates downloaded from the console."
+             "(sql/tcp) connection parameters of the demo cluster welcome message."
     )
 
     parser.add_argument("-v", "--verbose",

--- a/_includes/v20.1/app/python/sqlalchemy/example.py
+++ b/_includes/v20.1/app/python/sqlalchemy/example.py
@@ -32,8 +32,6 @@ class Account(Base):
 engine = create_engine(
     # For cockroach demo:
     'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
-    # For CockroachCloud:
-    # 'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>',
     echo=True                   # Log SQL queries to stdout
 )
 

--- a/_includes/v20.1/app/python/sqlalchemy/sqlalchemy-large-txns.py
+++ b/_includes/v20.1/app/python/sqlalchemy/sqlalchemy-large-txns.py
@@ -22,8 +22,6 @@ Base = declarative_base()
 engine = create_engine(
     # For cockroach demo:
     'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
-    # For CockroachCloud:
-    # 'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>',
     echo=True                   # Log SQL queries to stdout
 )
 

--- a/_includes/v20.1/app/start-cockroachdb.md
+++ b/_includes/v20.1/app/start-cockroachdb.md
@@ -1,3 +1,4 @@
+{% comment %}
 Choose whether to run a temporary local cluster or a free CockroachDB cluster on CockroachCloud. The instructions below will adjust accordingly.
 
 <div class="filters clearfix">
@@ -5,6 +6,7 @@ Choose whether to run a temporary local cluster or a free CockroachDB cluster on
   <button class="filter-button page-level" data-scope="cockroachcloud">Use CockroachCloud</button>
 </div>
 <p></p>
+{% endcomment %}
 
 <section class="filter-content" markdown="1" data-scope="local">
 
@@ -31,6 +33,7 @@ Choose whether to run a temporary local cluster or a free CockroachDB cluster on
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 ### Create a free cluster
@@ -83,3 +86,4 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 1. Move the downloaded `ca.crt` file to the `certs` directory.
 
 </section>
+{% endcomment %}

--- a/_includes/v20.2/app/create-a-database.md
+++ b/_includes/v20.2/app/create-a-database.md
@@ -25,6 +25,7 @@
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 1. If you haven't already, [download the CockroachDB binary](install-cockroachdb.html).
@@ -55,3 +56,4 @@
     ~~~
 
 </section>
+{% endcomment %}

--- a/_includes/v20.2/app/python/psycopg2/example.py
+++ b/_includes/v20.2/app/python/psycopg2/example.py
@@ -156,10 +156,7 @@ def parse_cmdline():
         help="database connection string\n\n"
              "For cockroach demo, use postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require,\n"
              "with the username and password created in the demo cluster, and the hostname and port listed in the\n"
-             "(sql/tcp) connection parameters of the demo cluster welcome message.\n\n"
-             "For CockroachCloud, use postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>,\n"
-             "with the username and password created in the CockroachCloud console, the hostname and port provided\n"
-             "in the console, and the certificates downloaded from the console."
+             "(sql/tcp) connection parameters of the demo cluster welcome message."
     )
 
     parser.add_argument("-v", "--verbose",

--- a/_includes/v20.2/app/python/sqlalchemy/example.py
+++ b/_includes/v20.2/app/python/sqlalchemy/example.py
@@ -32,8 +32,6 @@ class Account(Base):
 engine = create_engine(
     # For cockroach demo:
     'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
-    # For CockroachCloud:
-    # 'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>',
     echo=True                   # Log SQL queries to stdout
 )
 

--- a/_includes/v20.2/app/python/sqlalchemy/sqlalchemy-large-txns.py
+++ b/_includes/v20.2/app/python/sqlalchemy/sqlalchemy-large-txns.py
@@ -22,8 +22,6 @@ Base = declarative_base()
 engine = create_engine(
     # For cockroach demo:
     'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=require',
-    # For CockroachCloud:
-    # 'cockroachdb://<username>:<password>@<hostname>:<port>/bank?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>',
     echo=True                   # Log SQL queries to stdout
 )
 

--- a/_includes/v20.2/app/start-cockroachdb.md
+++ b/_includes/v20.2/app/start-cockroachdb.md
@@ -1,3 +1,4 @@
+{% comment %}
 Choose whether to run a temporary local cluster or a free CockroachDB cluster on CockroachCloud. The instructions below will adjust accordingly.
 
 <div class="filters clearfix">
@@ -5,6 +6,7 @@ Choose whether to run a temporary local cluster or a free CockroachDB cluster on
   <button class="filter-button page-level" data-scope="cockroachcloud">Use CockroachCloud</button>
 </div>
 <p></p>
+{% endcomment %}
 
 <section class="filter-content" markdown="1" data-scope="local">
 
@@ -31,6 +33,7 @@ Choose whether to run a temporary local cluster or a free CockroachDB cluster on
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 ### Create a free cluster
@@ -83,3 +86,4 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
 1. Move the downloaded `ca.crt` file to the `certs` directory.
 
 </section>
+{% endcomment %}

--- a/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -13,7 +13,7 @@ twitter: false
     <a href="http://docs.peewee-orm.com/en/latest/peewee/playhouse.html#cockroach-database"><button style="width: 22%" class="filter-button">Use <strong>peewee</strong></button></a>
 </div>
 
-This tutorial shows you how build a simple Python application with CockroachDB and the [SQLAlchemy](https://docs.sqlalchemy.org/en/latest/) ORM. For the CockroachDB back-end, you'll use either a temporary local cluster or a free cluster on CockroachCloud.
+This tutorial shows you how build a simple Python application with CockroachDB and the [SQLAlchemy](https://docs.sqlalchemy.org/en/latest/) ORM. For the CockroachDB back-end, you'll use a temporary local cluster.
 
 {{site.data.alerts.callout_info}}
 The example code on this page uses Python 3.
@@ -92,6 +92,7 @@ In the `create_engine()` function, update the connection string as follows:
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 - Comment out the connection string for `cockroach demo`, and uncomment the connection string for CockroachCloud.
@@ -100,6 +101,7 @@ In the `create_engine()` function, update the connection string as follows:
 - Replace `<certs_dir>/<ca.crt>` with the path to the CA certificate that you downloaded from the CockroachCloud Console.
 
 </section>
+{% endcomment %}
 
 ### Run the code
 

--- a/v20.1/build-a-python-app-with-cockroachdb.md
+++ b/v20.1/build-a-python-app-with-cockroachdb.md
@@ -13,7 +13,7 @@ twitter: false
     <a href="http://docs.peewee-orm.com/en/latest/peewee/playhouse.html#cockroach-database"><button style="width: 22%" class="filter-button">Use <strong>peewee</strong></button></a>
 </div>
 
-This tutorial shows you how build a simple Python application with CockroachDB and the psycopg2 driver. For the CockroachDB back-end, you'll use either a temporary local cluster or a free cluster on CockroachCloud.
+This tutorial shows you how build a simple Python application with CockroachDB and the psycopg2 driver. For the CockroachDB back-end, you'll use a temporary local cluster.
 
 ## Step 1. Install the psycopg2 driver
 
@@ -77,6 +77,7 @@ $ python3 example.py \
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 - Replace `<username>` and `<password>` with the SQL username and password that you created in the CockroachCloud Console.
@@ -90,6 +91,7 @@ $ python3 example.py \
 ~~~
 
 </section>
+{% endcomment %}
 
 The output should show the account balances before and after the funds transfer:
 

--- a/v20.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v20.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -13,7 +13,7 @@ twitter: false
     <a href="http://docs.peewee-orm.com/en/latest/peewee/playhouse.html#cockroach-database"><button class="filter-button page-level"><strong>peewee</strong></button></a>
 </div></br>
 
-This tutorial shows you how build a simple Python application with CockroachDB and the [SQLAlchemy](https://docs.sqlalchemy.org/en/latest/) ORM. For the CockroachDB back-end, you'll use either a temporary local cluster or a free cluster on CockroachCloud.
+This tutorial shows you how build a simple Python application with CockroachDB and the [SQLAlchemy](https://docs.sqlalchemy.org/en/latest/) ORM. For the CockroachDB back-end, you'll use a temporary local cluster.
 
 {{site.data.alerts.callout_info}}
 The example code on this page uses Python 3.
@@ -92,6 +92,7 @@ In the `create_engine()` function, update the connection string as follows:
 
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 - Comment out the connection string for `cockroach demo`, and uncomment the connection string for CockroachCloud.
@@ -100,6 +101,7 @@ In the `create_engine()` function, update the connection string as follows:
 - Replace `<certs_dir>/<ca.crt>` with the path to the CA certificate that you downloaded from the CockroachCloud Console.
 
 </section>
+{% endcomment %}
 
 ### Run the code
 

--- a/v20.2/build-a-python-app-with-cockroachdb.md
+++ b/v20.2/build-a-python-app-with-cockroachdb.md
@@ -13,7 +13,7 @@ twitter: false
     <a href="http://docs.peewee-orm.com/en/latest/peewee/playhouse.html#cockroach-database"><button class="filter-button page-level"><strong>peewee</strong></button></a>
 </div></br>
 
-This tutorial shows you how build a simple Python application with CockroachDB and the psycopg2 driver. For the CockroachDB back-end, you'll use either a temporary local cluster or a free cluster on CockroachCloud.
+This tutorial shows you how build a simple Python application with CockroachDB and the psycopg2 driver. For the CockroachDB back-end, you'll use a temporary local cluster.
 
 <div class="filters clearfix">
   <a href="../tutorials/build-a-python-app-with-cockroachdb-interactive.html" target="_blank"><button class="filter-button current">Run this in your browser &rarr;</button></a>
@@ -79,6 +79,7 @@ $ python3 example.py \
 'postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require'
 ~~~
 
+{% comment %}
 </section>
 
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
@@ -94,6 +95,7 @@ $ python3 example.py \
 ~~~
 
 </section>
+{% endcomment %}
 
 The output should show the account balances before and after the funds transfer:
 

--- a/v20.2/build-a-python-app-with-cockroachdb.md
+++ b/v20.2/build-a-python-app-with-cockroachdb.md
@@ -79,9 +79,9 @@ $ python3 example.py \
 'postgresql://<username>:<password>@<hostname>:<port>/bank?sslmode=require'
 ~~~
 
-{% comment %}
 </section>
 
+{% comment %}
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
 - Replace `<username>` and `<password>` with the SQL username and password that you created in the CockroachCloud Console.


### PR DESCRIPTION
Per discussion with Andy, Vy, and Eric, we are removing CRC instructions until CRC Free Tier is available and just going with secure demo clusters. I'm leaving the updates Jesse made to the Python tutorials in, but commenting them out so we can revise it later.