### PR TITLE
Restore nightly CI builds

### DIFF
--- a/.htmltest_nightly.yml
+++ b/.htmltest_nightly.yml
@@ -1,0 +1,11 @@
+DirectoryPath: "_site"
+ExternalTimeout: 30
+IgnoreDirs:
+  - ^docs/stable
+  - ^docs/dev
+  - ^docs/v1.2
+IgnoreURLs:
+  - http://localhost:4000
+  - https://github.com
+IgnoreInternalEmptyHash: true
+TestFilesConcurrently: false 

--- a/ci/nightly
+++ b/ci/nightly
@@ -5,5 +5,5 @@ run() {
   "$(dirname "$0")"/builder run "$@"
 }
 
-run bundle exec jekyll build
-run htmltest
+run bundle exec jekyll build --incremental --trace --config _config_base.yml,_config_cockroachdb.yml
+run htmltest -c .htmltest_nightly.yml


### PR DESCRIPTION
Fixes #8094.

See example of successful nightly build run here: https://teamcity.cockroachdb.com/buildConfiguration/Internal_Docs_Nightly/2428145?showLog=2428145_7378__expandAll

"Successful" as in `htmltest` checks return valid results. There is a known issue with 429 errors to GitHub (too many requests): https://github.com/wjdp/htmltest/issues/152. For a quick fix, we could opt out GitHub links from being checked for now to cut down on noise.

Meanwhile, there are a bunch of 404 errors that are valid for fixing. Examples:

    Non-OK status: 404 --- docs/v1.0/deploy-cockroachdb-on-microsoft-azure.html --> https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys
11:17:33
    Non-OK status: 404 --- docs/v1.0/deploy-cockroachdb-on-microsoft-azure.html --> https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-quick-create-portal
11:17:33
  docs/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.html
11:17:33
    Non-OK status: 404 --- docs/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.html --> https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys
11:17:33
    Non-OK status: 404 --- docs/v1.0/deploy-cockroachdb-on-microsoft-azure-insecure.html --> https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-quick-create-portal

Non-OK status: 403 --- docs/v1.0/frequently-asked-questions.html --> http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf
11:17:34
  docs/v1.0/high-availability.html
11:17:34
    Non-OK status: 403 --- docs/v1.0/high-availability.html --> http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf
11:17:34
  docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.9/security/ent/service-auth/custom-service-auth/
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.10/installing/oss/cloud/aws/basic/
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.10/installing/oss/
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.10/installing/ent/
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.10/installing/oss/cloud/aws/basic/#launch-dcos
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.10/cli/install/
11:17:34
    Non-OK status: 404 --- docs/v1.1/orchestrate-cockroachdb-with-mesosphere-insecure.html --> https://docs.mesosphere.com/1.10/deploying-services/install/#installing-a-service-using-the-gui