### PR TITLE
Fix error on CockroachDB in Comparison page

### DIFF
--- a/v19.1/cockroachdb-in-comparison.md
+++ b/v19.1/cockroachdb-in-comparison.md
@@ -19,7 +19,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB" selected>MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th class="comparison-chart__column-two">
@@ -30,7 +30,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB">MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th>CockroachDB</th>

--- a/v19.2/cockroachdb-in-comparison.md
+++ b/v19.2/cockroachdb-in-comparison.md
@@ -19,7 +19,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB" selected>MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th class="comparison-chart__column-two">
@@ -30,7 +30,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB">MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th>CockroachDB</th>

--- a/v20.1/cockroachdb-in-comparison.md
+++ b/v20.1/cockroachdb-in-comparison.md
@@ -19,7 +19,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB" selected>MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th class="comparison-chart__column-two">
@@ -30,7 +30,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB">MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th>CockroachDB</th>

--- a/v20.2/cockroachdb-in-comparison.md
+++ b/v20.2/cockroachdb-in-comparison.md
@@ -19,7 +19,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB" selected>MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th class="comparison-chart__column-two">
@@ -30,7 +30,7 @@ This page shows you how the key features of CockroachDB stack up against other d
         <option value="Cassandra">Cassandra</option>
         <option value="MongoDB">MongoDB</option>
         <option value="Spanner">Spanner</option>
-        <option value="Spanner">Yugabyte</option>
+        <option value="Yugabyte">Yugabyte</option>
       </select>
     </th>
     <th>CockroachDB</th>


### PR DESCRIPTION
On [this page](https://www.cockroachlabs.com/docs/dev/cockroachdb-in-comparison.html), Spanner values are mistakenly shown for Yugabyte. 

Not sure who should review, but GitHub recommended Rich =)