### PR TITLE
Add back homebrew install instructions for 20.2

### DIFF
--- a/v20.2/install-cockroachdb-mac.html
+++ b/v20.2/install-cockroachdb-mac.html
@@ -16,14 +16,6 @@ key: install-cockroachdb.html
 
 {% include cockroachcloud/use-cockroachcloud-instead.md %}
 
-<!--
-
-Commented out by Rich Loveland on Monday, November 9, 2020
-
-We will add this back once the issues around the 20.2.0 brew installation for spatial libraries are resolved.
-
-For details, see https://github.com/cockroachdb/docs/issues/8858
-
 <div id="use-homebrew" class="install-option">
   <h2>Use Homebrew</h2>
   <ol>
@@ -57,11 +49,9 @@ For details, see https://github.com/cockroachdb/docs/issues/8858
     </li>
   </ol>
 {{site.data.alerts.callout_info}}
-If you previously installed CockroachDB via Homebrew before version v19.2, run <code>brew uninstall cockroach</code> before installing the new version. If you installed using a different method, you may need to remove the binary before installing via Homebrew.
+If you previously installed CockroachDB via Homebrew before version v20.2, run <code>brew uninstall cockroach</code> before installing the new version. If you installed using a different method, you may need to remove the binary before installing via Homebrew.
 {{site.data.alerts.end}}
 </div>
-
--->
 
 <div id="download-the-binary" class="install-option">
   <h2>Download the binary</h2>


### PR DESCRIPTION
Fixes #8858.

Summary of changes:

- Uncomment homebrew install instructions

- Update instructions to mention that this is now v20.2 (not 19.2)

- Note that I manually tested the `brew install`-ed CockroachDB and
  verified that spatial features work.