### PR TITLE
Use updated 404 page on v20.2

### DIFF
--- a/v20.2/404.md
+++ b/v20.2/404.md
@@ -1,19 +1,15 @@
 ---
-title: Page Not Found
 description: "Page not found."
 sitemap: false
 search: exclude
 related_pages: none
 toc: false
+contribute: false
+feedback: false
 ---  
 
+<div class="page-not-found">
+  <p id="page-not-found-heading">Whoops!</p>
 
-{%comment%}
-<script type="text/javascript">
-  var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = '{{ site.url }}'
-</script>
-<script type="text/javascript"
-  src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
-</script>
-{%endcomment%}
+  <p id="page-not-found-body">We can't find the page you are looking for. You may have typed the wrong address or found a broken link.</p>
+</div>


### PR DESCRIPTION
We were using the updated 404 page on v20.1. We now need to use it in v20.2 since Netlify always redirects 404s to "stable" version.

Related to #8082