### PR TITLE
Add docs for exporting spatial data

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -821,6 +821,12 @@
             ]
           },
           {
+            "title": "Export Spatial Data",
+            "urls": [
+              "/${VERSION}/export-spatial-data.html"
+            ]
+          },
+          {
             "title": "Import Performance Best Practices",
             "urls": [
               "/${VERSION}/import-performance-best-practices.html"

--- a/_includes/v20.2/spatial/ogr2ogr-supported-version.md
+++ b/_includes/v20.2/spatial/ogr2ogr-supported-version.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+An `ogr2ogr` version of 3.1.0 or higher is required to generate data that can be imported into CockroachDB.
+{{site.data.alerts.end}}

--- a/v20.2/export-spatial-data.md
+++ b/v20.2/export-spatial-data.md
@@ -1,0 +1,128 @@
+---
+title: Export Spatial Data
+summary: Learn how to export spatial data from CockroachDB into various formats.
+toc: true
+---
+
+<span class="version-tag">New in v20.2</span>: CockroachDB supports efficiently storing and querying spatial data.
+
+This page has instructions for exporting spatial data from CockroachDB and converting it to other spatial formats using the [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) command.
+
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
+
+## Step 1. Export data to CSV
+
+First, use the [`EXPORT`](export.html) statement to export your data to a CSV file.
+
+In the example statement below, we export the tornadoes database used in [Working with spatial data](spatial-data.html).
+
+The statement will place the CSV file in the node's [store directory](cockroach-start.html#store), in a subdirectory named `extern/tornadoes`. The file's name is automatically generated, and will be displayed as output in the [SQL shell](cockroach-sql.html).
+
+{% include copy-clipboard.html %}
+~~~ sql
+EXPORT INTO CSV 'nodelocal://self/tornadoes' WITH nullas = '' FROM SELECT * from "1950-2018-torn-initpoint";
+~~~
+
+~~~
+                     filename                     | rows  |  bytes
+--------------------------------------------------+-------+-----------
+  export16467a35d30d25700000000000000001-n1.0.csv | 63645 | 16557064
+(1 row)
+~~~
+
+{{site.data.alerts.callout_info}}
+This example uses local file storage.  For more information about other locations where you can export your data (such as cloud storage), see [`EXPORT`](export.html).
+{{site.data.alerts.end}}
+
+## Step 2. Combine multiple CSV files into one, as needed
+
+You should now have one or more CSV files in the `extern/tornadoes` subdirectory of your node's [store directory](cockroach-start.html#store).  Depending on the size of the data set, there may be more than one CSV file.
+
+To combine multiple CSVs into one file:
+
+1. Open the CSV file where you will be storing the combined output in a text editor.  You will need to manually add the CSV header columns to that file so that the `ogr2ogr` output we generate below will have the proper column names.  Start by running the statement below on the table you are exporting to get the necessary column names:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    SELECT string_agg(column_name, ',') FROM [SHOW COLUMNS FROM "1950-2018-torn-initpoint"];
+    ~~~
+
+    ~~~
+                                                  string_agg
+    ------------------------------------------------------------------------------------------------------
+      gid,om,yr,mo,dy,date,time,tz,st,stf,stn,mag,inj,fat,loss,closs,slat,slon,elat,elon,len,wid,fc,geom
+    ~~~
+
+2. Add the column names output above to your target output CSV file (e.g., `tornadoes.csv`) as header columns.  For the tornadoes database, they should look like the following:
+
+    ~~~
+    gid, om, yr, mo, dy, date, time, tz, st, stf, stn, mag, inj, fat, loss, closs, slat, slon, elat, elon, len, wid, fc, geom
+    ~~~
+
+2. Concatenate the non-header data from all of the exported CSV files, and append the output to the target CSV file as shown below.  The node's store directory on this machine is `/tmp/node0`.
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    cat /tmp/node0/extern/tornadoes/*.csv >> tornadoes.csv
+    ~~~
+
+## Step 3. Convert CSV to other formats using `ogr2ogr`
+
+Now that you have your data in CSV format, you can convert it to other spatial formats using [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html).
+
+For example, to convert the data to SQL, run the following command:
+
+{% include copy-clipboard.html %}
+~~~ shell
+ogr2ogr -f PGDUMP tornadoes.sql -lco LAUNDER=NO -lco DROP_TABLE=OFF -oo GEOM_POSSIBLE_NAMES=geom -oo KEEP_GEOM_COLUMNS=off tornadoes.csv
+~~~
+
+Note that the options `-oo GEOM_POSSIBLE_NAMES=<geom_column_name> -oo KEEP_GEOM_COLUMNS=off` are required no matter what output format you are converting into.
+
+For more information about the formats supported by `ogr2ogr`, see the [`ogr2ogr` documentation](https://gdal.org/programs/ogr2ogr.html).
+
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
+
+Finally, note that SQL type information is lost in the conversion to CSV, such that the `tornadoes.sql` file output by the `ogr2ogr` command above lists every non-geometry field as a [`VARCHAR`](string.html).
+
+This can be addressed in one of the following ways:
+
+- Modify the data definitions in the SQL output file to use the correct types.
+
+- Run [`ALTER TYPE`](alter-type.html) statements to restore the data's SQL types after loading this data into another database (including another CockroachDB instance).
+
+## See also
+
+- [`EXPORT`](export.html)
+- [Migrate from Shapefiles](migrate-from-shapefiles.html)
+- [Migrate from GeoJSON](migrate-from-geojson.html)
+- [Migrate from GeoPackage](migrate-from-geopackage.html)
+- [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Spatial features](spatial-features.html)
+- [Spatial indexes](spatial-indexes.html)
+- [Working with Spatial Data](spatial-data.html)
+- [Spatial and GIS Glossary of Terms](spatial-glossary.html)
+- [Known Limitations](known-limitations.html#spatial-support-limitations)
+- [Spatial functions](functions-and-operators.html#spatial-functions)
+- [POINT](point.html)
+- [LINESTRING](linestring.html)
+- [POLYGON](polygon.html)
+- [MULTIPOINT](multipoint.html)
+- [MULTILINESTRING](multilinestring.html)
+- [MULTIPOLYGON](multipolygon.html)
+- [GEOMETRYCOLLECTION](geometrycollection.html)
+- [Well known text](well-known-text.html)
+- [Well known binary](well-known-binary.html)
+- [GeoJSON](geojson.html)
+- [SRID 4326 - longitude and latitude](srid-4326.html)
+- [`ST_Contains`](st_contains.html)
+- [`ST_ConvexHull`](st_convexhull.html)
+- [`ST_CoveredBy`](st_coveredby.html)
+- [`ST_Covers`](st_covers.html)
+- [`ST_Disjoint`](st_disjoint.html)
+- [`ST_Equals`](st_equals.html)
+- [`ST_Intersects`](st_intersects.html)
+- [`ST_Overlaps`](st_overlaps.html)
+- [`ST_Touches`](st_touches.html)
+- [`ST_Union`](st_union.html)
+- [`ST_Within`](st_within.html)

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -63,7 +63,7 @@ CockroachDB supports efficiently storing and querying [spatial data](spatial-dat
 
     [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/55903)
 
-- CockroachDB does not yet support `DECLARE CURSOR`, which prevents the `ogr2ogr` conversion tool from exporting from CockroachDB to certain formats and prevents [QGIS](https://qgis.org/en/site/) from working with CockroachDB. To work around this limitation, export data first to CSV or GeoJSON format.
+- CockroachDB does not yet support `DECLARE CURSOR`, which prevents the `ogr2ogr` conversion tool from exporting from CockroachDB to certain formats and prevents [QGIS](https://qgis.org/en/site/) from working with CockroachDB. To work around this limitation, [export data first to CSV](export-spatial-data.html) or GeoJSON format.
 
     [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/41412)
 

--- a/v20.2/migrate-from-geojson.md
+++ b/v20.2/migrate-from-geojson.md
@@ -18,6 +18,8 @@ To follow along with the example below, you will need the following prerequisite
 - [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html)
 - [Python 3](https://www.python.org)
 
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
+
 ## Step 1. Download the GeoJSON data
 
 First, download the storage tank GeoJSON data:
@@ -35,6 +37,8 @@ Next, convert the GeoJSON data to SQL using the following `ogr2ogr` command:
 ~~~ shell
 ogr2ogr -f PGDUMP tanks.sql -lco LAUNDER=NO -lco DROP_TABLE=OFF tanks.geojson
 ~~~
+
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
 
 ## Step 3. Host the files where the cluster can access them
 
@@ -81,6 +85,7 @@ IMPORT PGDUMP ('http://localhost:3000/tanks.sql');
 ## See also
 
 - [`IMPORT`][import]
+- [Export Spatial Data](export-spatial-data.html)
 - [Working with Spatial Data](spatial-data.html)
 - [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
 - [Migrate from Shapefiles](migrate-from-shapefiles.html)

--- a/v20.2/migrate-from-geopackage.md
+++ b/v20.2/migrate-from-geopackage.md
@@ -18,6 +18,8 @@ To follow along with the example below, you will need the following prerequisite
 - [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html)
 - [Python 3](https://www.python.org)
 
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
+
 ## Step 1. Download the GeoPackage data
 
 First, download the zip file containing the spring location data:
@@ -48,6 +50,8 @@ This particular data set emits a warning  due to some date formatting.
 ~~~
 Warning 1: Non-conformant content for record 1 in column field_ch_1, 2017/05/04, successfully parsed
 ~~~
+
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
 
 ## Step 3. Host the files where the cluster can access them
 
@@ -94,6 +98,7 @@ IMPORT PGDUMP ('http://localhost:3000/springs.sql');
 ## See also
 
 - [`IMPORT`][import]
+- [Export Spatial Data](export-spatial-data.html)
 - [Working with Spatial Data](spatial-data.html)
 - [Spatial indexes](spatial-indexes.html)
 - [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)

--- a/v20.2/migrate-from-openstreetmap.md
+++ b/v20.2/migrate-from-openstreetmap.md
@@ -122,6 +122,7 @@ Osm2pgsql took 2879s overall
 ## See also
 
 - [`IMPORT`][import]
+- [Export Spatial Data](export-spatial-data.html)
 - [Working with Spatial Data](spatial-data.html)
 - [Spatial indexes](spatial-indexes.html)
 - [Migrate from GeoPackages](migrate-from-geopackage.html)

--- a/v20.2/migrate-from-shapefiles.md
+++ b/v20.2/migrate-from-shapefiles.md
@@ -13,6 +13,8 @@ We are using `shp2pgsql` in the example below, but [`ogr2ogr`](https://gdal.org/
 `ogr2ogr -f PGDUMP file.sql -lco LAUNDER=NO -lco DROP_TABLE=OFF file.shp`
 {{site.data.alerts.end}}
 
+{% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
+
 In the example below we will import a [tornadoes data set](https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip) that is [available from the US National Weather Service](https://www.spc.noaa.gov/gis/svrgis/) (NWS).
 
 {{site.data.alerts.callout_info}}
@@ -100,6 +102,7 @@ IMPORT PGDUMP ('http://localhost:3000/tornado-points.sql');
 ## See also
 
 - [`IMPORT`][import]
+- [Export Spatial Data](export-spatial-data.html)
 - [Working with Spatial Data](spatial-data.html)
 - [Spatial indexes](spatial-indexes.html)
 - [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)

--- a/v20.2/spatial-features.md
+++ b/v20.2/spatial-features.md
@@ -13,12 +13,13 @@ See the links below for more information about how to use CockroachDB for spatia
 - [Install CockroachDB](install-cockroachdb.html)
 - [Working with Spatial Data](spatial-data.html)
 
-## Migrating spatial data into CockroachDB
+## Migrating spatial data into and out of CockroachDB
 
 - [Migrate from Shapefiles](migrate-from-shapefiles.html)
 - [Migrate from GeoJSON](migrate-from-geojson.html)
 - [Migrate from GeoPackage](migrate-from-geopackage.html)
 - [Migrate from OpenStreetMap](migrate-from-openstreetmap.html)
+- [Export Spatial Data](export-spatial-data.html)
 
 ## Reference
 


### PR DESCRIPTION
Fixes #8682, #8822.

Summary of changes:

- Add an 'Export Spatial Data' page that shows how to get spatial data
  out of CRDB.

- Also, note that CRDB requires `ogr2ogr` to be version 3.1.0 or greater
  to work properly.