### PR TITLE
update default resources

### DIFF
--- a/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_info}}
-The Operator is currently supported for **GKE** only.
+The Operator is currently supported for GKE only.
 {{site.data.alerts.end}}
 
 ### Install the Operator
@@ -66,11 +66,11 @@ On a production cluster, you will need to modify the StatefulSet configuration w
     ~~~
       resources:
         requests:
-          cpu: "4"
-          memory: "16Gi"
+          cpu: "2"
+          memory: "8Gi"
         limits:
-          cpu: "4"
-          memory: "16Gi"
+          cpu: "2"
+          memory: "8Gi"
     ~~~
 
     {{site.data.alerts.callout_info}}


### PR DESCRIPTION
Update documented CPU/memory requests & limits to address https://github.com/cockroachdb/cockroach-operator/issues/234. Verified that these settings work with `n1-standard-4`.