### PR TITLE
port K8s rolling upgrade guidance back to v20.2

### DIFF
--- a/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.1/orchestration/kubernetes-upgrade-cluster.md
@@ -1,6 +1,6 @@
-As new versions of CockroachDB are released, it's strongly recommended to upgrade to newer versions in order to pick up bug fixes, performance improvements, and new features. The [general CockroachDB upgrade documentation](upgrade-cockroach-version.html) provides best practices for how to prepare for and execute upgrades of CockroachDB clusters, but the mechanism of actually stopping and restarting processes in Kubernetes is somewhat special.
+It is strongly recommended that you regularly upgrade your CockroachDB version in order to pick up bug fixes, performance improvements, and new features. The [CockroachDB upgrade documentation](upgrade-cockroach-version.html) describes how to perform a "rolling upgrade" of a CockroachDB cluster by stopping and restarting nodes one at a time. This is to ensure that the cluster remains available during the upgrade.
 
-Kubernetes knows how to carry out a safe rolling upgrade process of the CockroachDB nodes. When you tell it to change the Docker image used in the CockroachDB StatefulSet, Kubernetes will go one-by-one, stopping a node, restarting it with the new image, and waiting for it to be ready to receive client requests before moving on to the next one. For more information, see [the Kubernetes documentation](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets).
+The corresponding process on Kubernetes is a [staged update](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update), in which the Docker image is updated in the CockroachDB StatefulSet and then applied to the pods one at a time.
 
 1. Decide how the upgrade will be finalized.
 
@@ -305,7 +305,7 @@ Kubernetes knows how to carry out a safe rolling upgrade process of the Cockroac
 1. Finish the upgrade.
 
     {{site.data.alerts.callout_info}}
-    This step is relevant only when upgrading from v19.2.x to v20.1. For upgrades within the v19.2.x series, skip this step.
+    This step is relevant only when upgrading from v19.2.x to v20.1. For upgrades within the v20.1.x series, skip this step.
     {{site.data.alerts.end}}
 
     If you disabled auto-finalization in step 1 above, monitor the stability and performance of your cluster for as long as you require to feel comfortable with the upgrade (generally at least a day). If during this time you decide to roll back the upgrade, repeat the rolling restart procedure with the old binary.

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -2,6 +2,7 @@ It is strongly recommended that you regularly upgrade your CockroachDB version i
 
 The corresponding process on Kubernetes is a [staged update](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update), in which the Docker image is updated in the CockroachDB StatefulSet and then applied to the pods one at a time.
 
+<section class="filter-content" markdown="1" data-scope="operator">
 1. Decide how the upgrade will be finalized.
 
     {{site.data.alerts.callout_info}}
@@ -12,69 +13,14 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
 
     We recommend disabling auto-finalization so you can monitor the stability and performance of the upgraded cluster before finalizing the upgrade:
 
-    {% if page.secure == true %}
-
     1. Start the CockroachDB [built-in SQL client](cockroach-sql.html):
 
-        <section class="filter-content" markdown="1" data-scope="operator">
         {% include copy-clipboard.html %}
         ~~~ shell
         $ kubectl exec -it cockroachdb-2 \
         -- ./cockroach sql \
         --certs-dir cockroach-certs
         ~~~
-        </section>
-
-        <section class="filter-content" markdown="1" data-scope="manual">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure \-- ./cockroach sql \
-        --certs-dir=/cockroach-certs \
-        --host=cockroachdb-public
-        ~~~
-        </section>
-
-        <section class="filter-content" markdown="1" data-scope="helm">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure \
-        -- ./cockroach sql \
-        --certs-dir=/cockroach-certs \
-        --host=my-release-cockroachdb-public
-        ~~~
-        </section>
-
-    {% else %}
-
-    1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
-
-        <section class="filter-content" markdown="1" data-scope="manual">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl run cockroachdb -it \
-        --image=cockroachdb/cockroach \
-        --rm \
-        --restart=Never \
-        -- sql \
-        --insecure \
-        --host=cockroachdb-public
-        ~~~
-        </section>
-
-        <section class="filter-content" markdown="1" data-scope="helm">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl run cockroachdb -it \
-        --image=cockroachdb/cockroach \
-        --rm \
-        --restart=Never \
-        -- sql \
-        --insecure \
-        --host=my-release-cockroachdb-public
-        ~~~
-        </section>
-
-    {% endif %}
 
     1. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html) to the version you are upgrading from:
 
@@ -91,8 +37,6 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
         ~~~
 
 1. Change the desired Docker image:
-
-    <section class="filter-content" markdown="1" data-scope="operator">
 
     Open and edit `example.yaml`:
 
@@ -114,9 +58,143 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     ~~~
 
     The Operator will perform the staged update.
-    </section>
 
-    <section class="filter-content" markdown="1" data-scope="manual">
+1. If you then check the status of your cluster's pods, you should see them being restarted:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pods
+    ~~~
+
+    ~~~
+    NAME            READY     STATUS        RESTARTS   AGE
+    cockroachdb-0   1/1       Running       0          2m
+    cockroachdb-1   1/1       Running       0          2m
+    cockroachdb-2   1/1       Running       0          2m
+    cockroachdb-3   0/1       Terminating   0          1m
+    ...
+    ~~~
+    
+1. This will continue until all of the pods have restarted and are running the new image. To check the image of each pod to determine whether they've all be upgraded, run:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
+    ~~~
+
+    ~~~
+    cockroachdb-0   cockroachdb/cockroach:{{page.release_info.version}}
+    cockroachdb-1   cockroachdb/cockroach:{{page.release_info.version}}
+    cockroachdb-2   cockroachdb/cockroach:{{page.release_info.version}}
+    cockroachdb-3   cockroachdb/cockroach:{{page.release_info.version}}
+    ...
+    ~~~
+
+    You can also check the CockroachDB version of each node in the [DB Console](ui-cluster-overview-page.html#node-details).
+
+1. Finish the upgrade.
+
+    {{site.data.alerts.callout_info}}
+    This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.
+    {{site.data.alerts.end}}
+
+    If you disabled auto-finalization in step 1 above, monitor the stability and performance of your cluster for as long as you require to feel comfortable with the upgrade (generally at least a day). If during this time you decide to roll back the upgrade, repeat the rolling restart procedure with the old binary.
+
+    Once you are satisfied with the new version, re-enable auto-finalization.
+    
+    1. Start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl exec -it cockroachdb-2 \
+        -- ./cockroach sql \
+        --certs-dir cockroach-certs
+        ~~~    
+        
+    1. Re-enable auto-finalization:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > RESET CLUSTER SETTING cluster.preserve_downgrade_option;
+        ~~~
+
+    1. Exit the SQL shell and pod:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > \q
+        ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="manual">
+1. Decide how the upgrade will be finalized.
+
+    {{site.data.alerts.callout_info}}
+    This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.
+    {{site.data.alerts.end}}
+
+    By default, after all nodes are running the new version, the upgrade process will be **auto-finalized**. This will enable certain performance improvements and bug fixes introduced in v20.2. After finalization, however, it will no longer be possible to perform a downgrade to v20.1. In the event of a catastrophic failure or corruption, the only option will be to start a new cluster using the old binary and then restore from one of the backups created prior to performing the upgrade.
+
+    We recommend disabling auto-finalization so you can monitor the stability and performance of the upgraded cluster before finalizing the upgrade:
+
+    {% if page.secure == true %}
+
+    1. Get a shell into the pod with the `cockroach` binary created earlier and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl exec -it cockroachdb-client-secure \-- ./cockroach sql \
+        --certs-dir=/cockroach-certs \
+        --host=cockroachdb-public
+        ~~~
+
+    {% else %}
+
+    1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl run cockroachdb -it \
+        --image=cockroachdb/cockroach \
+        --rm \
+        --restart=Never \
+        -- sql \
+        --insecure \
+        --host=cockroachdb-public
+        ~~~
+
+    {% endif %}
+
+    1. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html) to the version you are upgrading from:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '20.1';
+        ~~~
+
+    1. Exit the SQL shell and delete the temporary pod:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > \q
+        ~~~
+
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the update strategy defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch statefulset cockroachdb \
+    -p='{"spec":{"updateStrategy":{"type":"RollingUpdate","rollingUpdate":{"partition":2}}}}'
+    ~~~
+
+    ~~~
+    statefulset.apps/cockroachdb patched
+    ~~~
+
+1. Kick off the upgrade process by changing the Docker image used in the CockroachDB StatefulSet:
+
     {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl patch statefulset cockroachdb \
@@ -127,9 +205,223 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     ~~~
     statefulset.apps/cockroachdb patched
     ~~~
-    </section>
 
-    <section class="filter-content" markdown="1" data-scope="helm">
+1. Check the status of your cluster's pods. You should see one of them being restarted:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pods
+    ~~~
+
+    ~~~
+    NAME            READY     STATUS        RESTARTS   AGE
+    cockroachdb-0   1/1       Running       0          2m
+    cockroachdb-1   1/1       Running       0          2m
+    cockroachdb-2   0/1       Terminating   0          1m
+    ...
+    ~~~
+
+1. After the pod has been restarted with the new image, get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+    {% if page.secure == true %}
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure \-- ./cockroach sql \
+    --certs-dir=/cockroach-certs \
+    --host=cockroachdb-public
+    ~~~
+
+    {% else %}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl run cockroachdb -it \
+    --image=cockroachdb/cockroach \
+    --rm \
+    --restart=Never \
+    -- sql \
+    --insecure \
+    --host=cockroachdb-public
+    ~~~
+
+    {% endif %}
+
+1. Run the following SQL query to verify that the number of underreplicated ranges is zero:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    SELECT sum((metrics->>'ranges.underreplicated')::DECIMAL)::INT AS ranges_underreplicated FROM crdb_internal.kv_store_status;
+    ~~~
+
+    ~~~
+      ranges_underreplicated
+    --------------------------
+                           0
+    (1 row)        
+    ~~~
+
+    This indicates that it is safe to proceed to the next pod.
+
+1. Exit the SQL shell:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > \q
+    ~~~
+
+1. Decrement the partition value by 1 to allow the next pod in the cluster to update:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl patch statefulset cockroachdb \
+    -p='{"spec":{"updateStrategy":{"type":"RollingUpdate","rollingUpdate":{"partition":1}}}}'
+    ~~~
+
+    ~~~
+    statefulset.apps/cockroachdb patched
+    ~~~
+
+1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).
+
+1. Check the image of each pod to confirm that all have been upgraded:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
+    ~~~
+
+    ~~~
+    cockroachdb-0   cockroachdb/cockroach:{{page.release_info.version}}
+    cockroachdb-1   cockroachdb/cockroach:{{page.release_info.version}}
+    cockroachdb-2   cockroachdb/cockroach:{{page.release_info.version}}
+    ...
+    ~~~
+
+    You can also check the CockroachDB version of each node in the [Admin UI](admin-ui-cluster-overview-page.html#node-details).
+
+
+1. Finish the upgrade.
+
+    {{site.data.alerts.callout_info}}
+    This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.
+    {{site.data.alerts.end}}
+
+    If you disabled auto-finalization in step 1 above, monitor the stability and performance of your cluster for as long as you require to feel comfortable with the upgrade (generally at least a day). If during this time you decide to roll back the upgrade, repeat the rolling restart procedure with the old binary.
+
+    Once you are satisfied with the new version, re-enable auto-finalization:
+
+    {% if page.secure == true %}
+
+    1. Get a shell into the pod with the `cockroach` binary created earlier and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl exec -it cockroachdb-client-secure \
+        -- ./cockroach sql \
+        --certs-dir=/cockroach-certs \
+        --host=cockroachdb-public
+        ~~~
+
+    {% else %}
+
+    1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl run cockroachdb -it \
+        --image=cockroachdb/cockroach \
+        --rm \
+        --restart=Never \
+        -- sql \
+        --insecure \
+        --host=cockroachdb-public
+        ~~~
+
+    {% endif %}
+
+    2. Re-enable auto-finalization:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > RESET CLUSTER SETTING cluster.preserve_downgrade_option;
+        ~~~
+
+    3. Exit the SQL shell and delete the temporary pod:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > \q
+        ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="helm">
+1. Decide how the upgrade will be finalized.
+
+    {{site.data.alerts.callout_info}}
+    This step is relevant only when upgrading from v20.1.x to v20.2. For upgrades within the v20.2.x series, skip this step.
+    {{site.data.alerts.end}}
+
+    By default, after all nodes are running the new version, the upgrade process will be **auto-finalized**. This will enable certain performance improvements and bug fixes introduced in v20.2. After finalization, however, it will no longer be possible to perform a downgrade to v20.1. In the event of a catastrophic failure or corruption, the only option will be to start a new cluster using the old binary and then restore from one of the backups created prior to performing the upgrade.
+
+    We recommend disabling auto-finalization so you can monitor the stability and performance of the upgraded cluster before finalizing the upgrade:
+
+    {% if page.secure == true %}
+
+    1. Get a shell into the pod with the `cockroach` binary created earlier and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl exec -it cockroachdb-client-secure \
+        -- ./cockroach sql \
+        --certs-dir=/cockroach-certs \
+        --host=my-release-cockroachdb-public
+        ~~~
+
+    {% else %}
+
+    1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
+
+        {% include copy-clipboard.html %}
+        ~~~ shell
+        $ kubectl run cockroachdb -it \
+        --image=cockroachdb/cockroach \
+        --rm \
+        --restart=Never \
+        -- sql \
+        --insecure \
+        --host=my-release-cockroachdb-public
+        ~~~
+
+    {% endif %}
+
+    1. Set the `cluster.preserve_downgrade_option` [cluster setting](cluster-settings.html) to the version you are upgrading from:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > SET CLUSTER SETTING cluster.preserve_downgrade_option = '20.1';
+        ~~~
+
+    1. Exit the SQL shell and delete the temporary pod:
+
+        {% include copy-clipboard.html %}
+        ~~~ sql
+        > \q
+        ~~~
+
+1. Add a [partition](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#staging-an-update) to the update strategy defined in the StatefulSet. Only the pods numbered greater than or equal to the partition value will be updated. For a cluster with 3 pods (e.g., `cockroachdb-0`, `cockroachdb-1`, `cockroachdb-2`) the partition value should be 2:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm upgrade \
+    my-release \
+    cockroachdb/cockroachdb \
+    --set statefulset.updateStrategy.rollingUpdate.partition=2
+    ~~~
+
+1. Kick off the upgrade process by changing the Docker image used in the CockroachDB StatefulSet:
+
     {{site.data.alerts.callout_info}}
     For Helm, you must remove the cluster initialization job from when the cluster was created before the cluster version can be changed.
     {{site.data.alerts.end}}
@@ -147,37 +439,14 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     --set image.tag={{page.release_info.version}} \
     --reuse-values
     ~~~
-    </section>
 
-1. If you then check the status of your cluster's pods, you should see them being restarted:
+1. Check the status of your cluster's pods. You should see one of them being restarted:
 
     {% include copy-clipboard.html %}
     ~~~ shell
     $ kubectl get pods
     ~~~
 
-    <section class="filter-content" markdown="1" data-scope="operator">
-    ~~~
-    NAME            READY     STATUS        RESTARTS   AGE
-    cockroachdb-0   1/1       Running       0          2m
-    cockroachdb-1   1/1       Running       0          2m
-    cockroachdb-2   1/1       Running       0          2m
-    cockroachdb-3   0/1       Terminating   0          1m
-    ...
-    ~~~
-    </section>
-
-    <section class="filter-content" markdown="1" data-scope="manual">
-    ~~~
-    NAME            READY     STATUS        RESTARTS   AGE
-    cockroachdb-0   1/1       Running       0          2m
-    cockroachdb-1   1/1       Running       0          2m
-    cockroachdb-2   0/1       Terminating   0          1m
-    ...
-    ~~~
-    </section>
-
-    <section class="filter-content" markdown="1" data-scope="helm">
     ~~~
     NAME                                READY     STATUS              RESTARTS   AGE
     my-release-cockroachdb-0            1/1       Running             0          2m
@@ -190,9 +459,69 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     {{site.data.alerts.callout_info}}
     Ignore the pod for cluster initialization. It is re-created as a byproduct of the StatefulSet configuration but does not impact your existing cluster.
     {{site.data.alerts.end}}
-    </section>    
-    
-1. This will continue until all of the pods have restarted and are running the new image. To check the image of each pod to determine whether they've all be upgraded, run:
+
+1. After the pod has been restarted with the new image, get a shell into the pod and start the CockroachDB [built-in SQL client](cockroach-sql.html):
+
+    {% if page.secure == true %}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl exec -it cockroachdb-client-secure \
+    -- ./cockroach sql \
+    --certs-dir=/cockroach-certs \
+    --host=my-release-cockroachdb-public
+    ~~~
+
+    {% else %}
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl run cockroachdb -it \
+    --image=cockroachdb/cockroach \
+    --rm \
+    --restart=Never \
+    -- sql \
+    --insecure \
+    --host=my-release-cockroachdb-public
+    ~~~
+    {% endif %}
+
+1. Run the following SQL query to verify that the number of underreplicated ranges is zero:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    SELECT sum((metrics->>'ranges.underreplicated')::DECIMAL)::INT AS ranges_underreplicated FROM crdb_internal.kv_store_status;
+    ~~~
+
+    ~~~
+      ranges_underreplicated
+    --------------------------
+                           0
+    (1 row)        
+    ~~~
+
+    This indicates that it is safe to proceed to the next pod.
+
+1. Exit the SQL shell:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > \q
+    ~~~
+
+1. Decrement the partition value by 1 to allow the next pod in the cluster to update:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ helm upgrade \
+    my-release \
+    cockroachdb/cockroachdb \
+    --set statefulset.updateStrategy.rollingUpdate.partition=1 \
+    ~~~
+
+1. Repeat steps 4-8 until all pods have been restarted and are running the new image (the final partition value should be `0`).
+
+1. Check the image of each pod to confirm that all have been upgraded:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -200,35 +529,15 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.containers[0].image}{"\n"}'
     ~~~
 
-    <section class="filter-content" markdown="1" data-scope="operator">
-    ~~~
-    cockroachdb-0   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-1   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-2   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-3   cockroachdb/cockroach:{{page.release_info.version}}
-    ...
-    ~~~
-    </section>
-
-    <section class="filter-content" markdown="1" data-scope="manual">
-    ~~~
-    cockroachdb-0   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-1   cockroachdb/cockroach:{{page.release_info.version}}
-    cockroachdb-2   cockroachdb/cockroach:{{page.release_info.version}}
-    ...
-    ~~~
-    </section>
-
-    <section class="filter-content" markdown="1" data-scope="helm">
     ~~~
     my-release-cockroachdb-0    cockroachdb/cockroach:{{page.release_info.version}}
     my-release-cockroachdb-1    cockroachdb/cockroach:{{page.release_info.version}}
     my-release-cockroachdb-2    cockroachdb/cockroach:{{page.release_info.version}}
     ...
     ~~~
-    </section>
 
-    You can also check the CockroachDB version of each node in the [DB Console](ui-cluster-overview-page.html#node-details).
+    You can also check the CockroachDB version of each node in the [Admin UI](admin-ui-cluster-overview-page.html#node-details).
+
 
 1. Finish the upgrade.
 
@@ -238,32 +547,12 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
 
     If you disabled auto-finalization in step 1 above, monitor the stability and performance of your cluster for as long as you require to feel comfortable with the upgrade (generally at least a day). If during this time you decide to roll back the upgrade, repeat the rolling restart procedure with the old binary.
 
-    Once you are satisfied with the new version, re-enable auto-finalization.
+    Once you are satisfied with the new version, re-enable auto-finalization:
 
     {% if page.secure == true %}
-    
-    1. Start the CockroachDB [built-in SQL client](cockroach-sql.html):
 
-        <section class="filter-content" markdown="1" data-scope="operator">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl exec -it cockroachdb-2 \
-        -- ./cockroach sql \
-        --certs-dir cockroach-certs
-        ~~~    
-        </section>
+    1. Get a shell into the pod with the `cockroach` binary created earlier and start the CockroachDB [built-in SQL client](cockroach-sql.html):
 
-        <section class="filter-content" markdown="1" data-scope="manual">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl exec -it cockroachdb-client-secure \
-        -- ./cockroach sql \
-        --certs-dir=/cockroach-certs \
-        --host=cockroachdb-public
-        ~~~
-        </section>
-
-        <section class="filter-content" markdown="1" data-scope="helm">
         {% include copy-clipboard.html %}
         ~~~ shell
         $ kubectl exec -it cockroachdb-client-secure \
@@ -271,26 +560,11 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
         --certs-dir=/cockroach-certs \
         --host=my-release-cockroachdb-public
         ~~~
-        </section>
 
     {% else %}
 
     1. Launch a temporary interactive pod and start the [built-in SQL client](cockroach-sql.html) inside it:
 
-        <section class="filter-content" markdown="1" data-scope="manual">
-        {% include copy-clipboard.html %}
-        ~~~ shell
-        $ kubectl run cockroachdb -it \
-        --image=cockroachdb/cockroach \
-        --rm \
-        --restart=Never \
-        -- sql \
-        --insecure \
-        --host=cockroachdb-public
-        ~~~
-        </section>
-
-        <section class="filter-content" markdown="1" data-scope="helm">
         {% include copy-clipboard.html %}
         ~~~ shell
         $ kubectl run cockroachdb -it \
@@ -301,20 +575,21 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
         --insecure \
         --host=my-release-cockroachdb-public
         ~~~
-        </section>      
 
     {% endif %}
 
-    1. Re-enable auto-finalization:
+    2. Re-enable auto-finalization:
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > RESET CLUSTER SETTING cluster.preserve_downgrade_option;
         ~~~
 
-    1. Exit the SQL shell and pod:
+    3. Exit the SQL shell and delete the temporary pod:
 
         {% include copy-clipboard.html %}
         ~~~ sql
         > \q
         ~~~
+
+</section>

--- a/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-upgrade-cluster.md
@@ -298,7 +298,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     ...
     ~~~
 
-    You can also check the CockroachDB version of each node in the [Admin UI](admin-ui-cluster-overview-page.html#node-details).
+    You can also check the CockroachDB version of each node in the [DB Console](ui-cluster-overview-page.html#node-details).
 
 
 1. Finish the upgrade.
@@ -536,7 +536,7 @@ The corresponding process on Kubernetes is a [staged update](https://kubernetes.
     ...
     ~~~
 
-    You can also check the CockroachDB version of each node in the [Admin UI](admin-ui-cluster-overview-page.html#node-details).
+    You can also check the CockroachDB version of each node in the [DB Console](ui-cluster-overview-page.html#node-details).
 
 
 1. Finish the upgrade.


### PR DESCRIPTION
Updates in #8615 (specifically for partitions) were lost in v20.2 when adding K8s Operator steps. This commit brings them back, but at the slight expense of imposing a less efficient structure on the doc. This was necessary in order to maintain distinct instructions for Operator/Helm/configs without losing enumeration.