### PR TITLE
Correct python file location for download

### DIFF
--- a/tutorials/katacoda/build-python-app/step3.md
+++ b/tutorials/katacoda/build-python-app/step3.md
@@ -1,6 +1,6 @@
 In a new terminal, download the Python code:
 
-`curl -O https://raw.githubusercontent.com/cockroachdb/docs/master/_includes/v20.2/app/python/psycopg2/example.py`{{execute T2}}
+`curl -O https://raw.githubusercontent.com/cockroachlabs/hello-world-python-psycopg2/master/example.py`{{execute T2}}
 
 Open the file: `example.py`{{open}}
 


### PR DESCRIPTION
We recently remove our psycopg2 code sample in favor of using a plugin to include the sample from an external repository. The katacoda tutorial needs to download from that external repository. 