### PR TITLE
Add new TPC-C pages to 20.2 sidebar

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -594,10 +594,10 @@
               {
                 "title": "Benchmarking Instructions",
                 "urls": [
-                  "/${VERSION}/performance-benchmarking-with-tpc-c-10-warehouses.html",
-                  "/${VERSION}/performance-benchmarking-with-tpc-c-1k-warehouses.html",
-                  "/${VERSION}/performance-benchmarking-with-tpc-c-10k-warehouses.html",
-                  "/${VERSION}/performance-benchmarking-with-tpc-c-100k-warehouses.html"
+                  "/${VERSION}/performance-benchmarking-with-tpcc-local.html",
+                  "/${VERSION}/performance-benchmarking-with-tpcc-small.html",
+                  "/${VERSION}/performance-benchmarking-with-tpcc-medium.html",
+                  "/${VERSION}/performance-benchmarking-with-tpcc-large.html"
                 ]
               },
               {


### PR DESCRIPTION
Follow-up to #8212.

When I added redirects from the old pages to the new, I forgot to add
the new pages to the TOC sidebar.