### PR TITLE
Update tar invocation on 20.2 Linux install

### DIFF
--- a/v20.2/install-cockroachdb-linux.html
+++ b/v20.2/install-cockroachdb-linux.html
@@ -28,7 +28,7 @@ key: install-cockroachdb.html
         <svg id="copy-check" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"><style>.st1{fill:#54B30E;}</style><path id="path-1_2_" class="st1" d="M3.8 9.1c-.3 0-.5-.1-.6-.2L.3 6C0 5.7-.1 5.2.2 4.8c.3-.4.9-.4 1.3-.1L3.8 7 10.6.2c.3-.3.9-.4 1.2 0 .3.3.3.9 0 1.2L4.4 8.9c-.2.1-.4.2-.6.2z"/></svg>
       </div>
 
-      <div class="highlight"><pre><code data-eventcategory="linux-binary-step1" data-lang="shell"><span class="nv language-shell linux-binary-step1" id="linux-binary-step1-{{ page.version.version }}" data-eventcategory="linux-binary-step1">$ </span>curl https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz | tar -xJ</code></pre></div>
+      <div class="highlight"><pre><code data-eventcategory="linux-binary-step1" data-lang="shell"><span class="nv language-shell linux-binary-step1" id="linux-binary-step1-{{ page.version.version }}" data-eventcategory="linux-binary-step1">$ </span>curl https://binaries.cockroachdb.com/cockroach-{{page.release_info.version}}.linux-amd64.tgz | tar -xzv</code></pre></div>
     </li>
     <li>
       <p>Copy the binary into your <code>PATH</code> so you can execute <a href="cockroach-commands.html">cockroach commands</a> from any shell:</p>


### PR DESCRIPTION
Fixes #8988.

Summary of changes:

- Change the `tar` invocation to `tar -xzv`, which works on Linux.

- Note: `tar -xJ` only seems to work on Mac.  It does not work on Linux
  for either Fedora (tested by me) or Debian (as reported by the user in
  #8988).