### PR TITLE
Add release notes for v20.2.3

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -50,11 +50,11 @@ release_info:
     build_time: 2020/10/21 11:00:26 (go1.13.4)
     start_time: 2020-10-21 11:01:26.34274101 +0000 UTC
   v20.2:
-    name: v20.2.2
-    version: v20.2.2
+    name: v20.2.3
+    version: v20.2.3
     docker_image: cockroachdb/cockroach
-    build_time: 2020/11/25 11:00:26 (go1.13.4)
-    start_time: 2020-11-25 11:01:26.34274101 +0000 UTC
+    build_time: 2020/11/25 11:02:26 (go1.13.4)
+    start_time: 2020-11-25 11:05:26.34274101 +0000 UTC
 
 include: ["_redirects"]
 exclude:

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,8 +1,10 @@
 - title: Production releases
   releases:
     - date: Nov 25, 2020
-      version: v20.2.2
+      version: v20.2.3
       latest: true
+    - date: Nov 25, 2020
+      version: v20.2.2
     - date: Nov 20, 2020
       version: v20.2.1
     - date: Oct 21, 2020

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -7,7 +7,7 @@
         {
           "title": "Latest v20.2",
           "urls": [
-            "/releases/v20.2.2.html"
+            "/releases/v20.2.3.html"
           ]
         },
         {

--- a/releases/v20.2.3.md
+++ b/releases/v20.2.3.md
@@ -1,7 +1,7 @@
 ---
-title: What&#39;s New in v20.2.2
+title: What&#39;s New in v20.2.3
 toc: true
-summary: Additions and changes in CockroachDB version 20.2.2 since version v20.2.1
+summary: Additions and changes in CockroachDB version 20.2.3 since version v20.2.1
 ---
 
 ## November 25, 2020
@@ -21,10 +21,10 @@ Get future release notes emailed to you:
     </script>
 </div>
 
-{{site.data.alerts.callout_danger}}
-CockroachDB v20.2.2 has been replaced by [v20.2.3](v20.2.3.html), which contains an improved bugfix for a spurious foreign key validation error that could occur for clusters that were initiated at versions of CockroachDB v19.1 or prior.
+{{site.data.alerts.callout_info}}
+CockroachDB v20.2.2 has been replaced by v20.2.3, which contains an improved bugfix for a spurious foreign key validation error that could occur for clusters that were initiated at versions of CockroachDB v19.1 or prior.
 
-If you never upgraded to v20.2.2, please upgrade directly to [v20.2.3](v20.2.3.html).
+If you never upgraded to v20.2.2, please upgrade directly to v20.2.3.
 
 If your cluster was initiated at v19.2 or later, there is no need to upgrade to v20.2.3 from v20.2.2.
 {{site.data.alerts.end}}
@@ -32,17 +32,17 @@ If your cluster was initiated at v19.2 or later, there is no need to upgrade to 
 ### Downloads
 
 <div id="os-tabs" class="clearfix">
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.2.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.2.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.2.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.2.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.3.darwin-10.9-amd64.tgz"><button id="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.3.linux-amd64.tgz"><button id="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.3.windows-6.2-amd64.zip"><button id="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.3.src.tgz"><button id="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 
 ### Docker image
 
 {% include copy-clipboard.html %}
 ~~~shell
-docker pull cockroachdb/cockroach:v20.2.2
+docker pull cockroachdb/cockroach:v20.2.3
 ~~~
 
 ### Security updates


### PR DESCRIPTION
Fixes #8921.

This is a hotfix release that adds a patch on top of a patch that was
squeezed into v20.2.2.  However the release note text does not change,
since the textual description of the above patch was correct about its
intention.

Therefore this change adds:

- A new v20.2.3 page
- A note to the v20.2.2 and v20.2.3 pages, describing the situation