### PR TITLE
Make 20.2.0 notes more visible

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -5,6 +5,8 @@
       latest: true
     - date: Nov 20, 2020
       version: v20.2.1
+    - date: Nov 10, 2020
+      version: v20.2.0
     - date: Oct 21, 2020
       version: v20.1.8
     - date: Oct 12, 2020

--- a/releases/v19.2.11.md
+++ b/releases/v19.2.11.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v19.2.11 since version v19
 
 ## October 12, 2020
 
+This page lists additions and changes in v19.2.11 since v19.2.10.
+
+- For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -71,4 +76,3 @@ This release includes 18 merged PRs by 11 authors.
 [#54290]: https://github.com/cockroachdb/cockroach/pull/54290
 [#54592]: https://github.com/cockroachdb/cockroach/pull/54592
 [#54860]: https://github.com/cockroachdb/cockroach/pull/54860
-

--- a/releases/v20.1.4.md
+++ b/releases/v20.1.4.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.4 since version v20.
 
 ## August 3, 2020
 
+This page lists additions and changes in v20.1.4 since v20.1.3.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v20.1.5.md
+++ b/releases/v20.1.5.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.5 since version v20.
 
 ## August 31, 2020
 
+This page lists additions and changes in v20.1.5 since v20.1.4.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -70,4 +75,3 @@ This release includes 31 merged PRs by 15 authors.
 [#52813]: https://github.com/cockroachdb/cockroach/pull/52813
 [#53229]: https://github.com/cockroachdb/cockroach/pull/53229
 [#53318]: https://github.com/cockroachdb/cockroach/pull/53318
-

--- a/releases/v20.1.6.md
+++ b/releases/v20.1.6.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.6 since version v20.
 
 ## September 24, 2020
 
+This page lists additions and changes in v20.1.6 since v20.1.5.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v20.1.7.md
+++ b/releases/v20.1.7.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.7 since version v20.
 
 ## October 12, 2020
 
+This page lists additions and changes in v20.1.7 since v20.1.6.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -52,7 +57,7 @@ $ docker pull cockroachdb/cockroach:v20.1.7
 - Fixed a rare bug which can lead to index backfills failing in the face of [transaction restarts](../v20.1/transactions.html#transaction-retries). [#54859][#54859]
 - Fixed a race condition propagating post-query metadata in the [vectorized execution engine](../v20.1/vectorized-execution.html). [#55168][#55168]
 - Fixed a bug causing nodes running version 20.1 to not be able to serve [follower reads](../v20.1/follower-reads.html) in mixed-version clusters running versions 19.2 and 20.1. [#55089][#55089]
-- The first timing column in the trace.txt file collected as part of a [statement diagnostics bundle](../v20.1/explain-analyze.html#debug-option) has been fixed. 
+- The first timing column in the trace.txt file collected as part of a [statement diagnostics bundle](../v20.1/explain-analyze.html#debug-option) has been fixed.
 
 ### Contributors
 

--- a/releases/v20.1.8.md
+++ b/releases/v20.1.8.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.8 since version v20.
 
 ## October 21, 2020
 
+This page lists additions and changes in v20.1.8 since v20.1.7.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v20.2.1.md
+++ b/releases/v20.2.1.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.2.1 since version v20.
 
 ## November 20, 2020
 
+This page lists additions and changes in v20.2.1 since v20.2.0.
+
+- For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
+- To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">

--- a/releases/v20.2.2.md
+++ b/releases/v20.2.2.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version 20.2.2 since version v20.2
 
 ## November 25, 2020
 
+This page lists additions and changes in v20.2.2 since v20.2.1.
+
+- For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
+- To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">


### PR DESCRIPTION
Also link back to GA release notes from patch releases.

Reverts https://github.com/cockroachdb/docs/pull/8965/files#diff-9c8e76d0395d5fcaeb5d07b307307be91d18e8c2be502e74db81407b2c59a13dL5.