### PR TITLE
Remove duplicate release note from v20.2.2 notes

### DIFF
--- a/releases/v20.2.2.md
+++ b/releases/v20.2.2.md
@@ -154,7 +154,6 @@ docker pull cockroachdb/cockroach:v20.2.2
 - Fixed a bug where CockroachDB did not respect disabling [protected timestamp settings `kv.protectedts.max_bytes` and `kv.protectedts.max_spans`](../v20.2/cluster-settings.html) by setting them to zero values. [#56453][#56453]
 - Fixed a panic that could occur when running [`SHOW STATISTICS USING JSON`](../v20.2/show-statistics.html) for a table in which at least one of the columns contained all _NULL_ values. [#56516][#56516]
 - Fixed a hypothesized bug that could have allowed a [follower read](../v20.2/follower-reads.html) to miss data on a range in the middle of being [merged](../v20.2/range-merges.html) away into its left-hand neighbor. [#55691][#55691]
-- Fixed a rare bug where when the [Pebble storage engine](../v20.2/architecture/storage-layer.html) is used with [encryption at rest](../v20.2/encryption.html), data corruption could result after a table drop, table truncate, or replica deletion. [#56678][#56678]
 - Fixed a bug introduced in an alpha where [`IMPORT`s](../v20.2/import.html) of tables with [foreign keys](../v20.2/foreign-key.html) can fail in rare circumstances. [#56457][#56457]
 - Fixed a bug which would prevent the dropping of [hash sharded indexes](../v20.2/indexes.html#hash-sharded-indexes) if they were added prior to other columns. [#55822][#55822]
 - Fixed a bug which cause CockroachDB to crash when executing a query with an [`AS OF SYSTEM TIME`](../v20.2/as-of-system-time.html) clause that attempted to use an unspecified placeholder value on a non-prepared statement. [#56780][#56780]
@@ -215,7 +214,6 @@ We would like to thank the following contributors from the CockroachDB community
 [#56638]: https://github.com/cockroachdb/cockroach/pull/56638
 [#56652]: https://github.com/cockroachdb/cockroach/pull/56652
 [#56676]: https://github.com/cockroachdb/cockroach/pull/56676
-[#56678]: https://github.com/cockroachdb/cockroach/pull/56678
 [#56742]: https://github.com/cockroachdb/cockroach/pull/56742
 [#56751]: https://github.com/cockroachdb/cockroach/pull/56751
 [#56774]: https://github.com/cockroachdb/cockroach/pull/56774


### PR DESCRIPTION
Fixes #9011.