### PR TITLE
COPY FROM docs

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -1124,6 +1124,12 @@
                     ]
                   },
                   {
+                    "title": "<code>COPY FROM</code>",
+                    "urls": [
+                      "/${VERSION}/copy-from.html"
+                    ]
+                  },
+                  {
                     "title": "<code>CREATE CHANGEFEED</code> (Enterprise)",
                     "urls": [
                       "/${VERSION}/create-changefeed.html"

--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -1124,6 +1124,12 @@
                     ]
                   },
                   {
+                    "title": "<code>COPY FROM</code>",
+                    "urls": [
+                      "/${VERSION}/copy-from.html"
+                    ]
+                  },
+                  {
                     "title": "<code>CREATE CHANGEFEED</code> (Enterprise)",
                     "urls": [
                       "/${VERSION}/create-changefeed.html"

--- a/_includes/v20.2/known-limitations/copy-from-clients.md
+++ b/_includes/v20.2/known-limitations/copy-from-clients.md
@@ -1,0 +1,5 @@
+The built-in SQL shell provided with CockroachDB ([`cockroach sql`](cockroach-sql.html) / [`cockroach demo`](cockroach-demo.html)) does not currently support importing data with the `COPY` statement.
+
+To load data into CockroachDB, we recommend that you use an [`IMPORT`](import.html). If you must use a `COPY` statement, you can issue the statement from the [`psql` client](https://www.postgresql.org/docs/current/app-psql.html) command provided with PostgreSQL, or from another third-party client.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16392)

--- a/_includes/v20.2/known-limitations/copy-syntax.md
+++ b/_includes/v20.2/known-limitations/copy-syntax.md
@@ -1,0 +1,17 @@
+CockroachDB does not yet support the following `COPY` syntax:
+
+- `COPY ... TO`. To copy data from a CockroachDB cluster to a file, use an [`EXPORT`](export.html) statement.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/41608)
+
+- `COPY ... FROM CSV`
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/51891)
+
+- `COPY ... FROM STDIN` with a delimiter other than the default tab delimiter.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16407)
+
+- `COPY ... FROM ... WHERE <expr>`
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/54580)

--- a/_includes/v21.1/known-limitations/copy-from-clients.md
+++ b/_includes/v21.1/known-limitations/copy-from-clients.md
@@ -1,0 +1,5 @@
+The built-in SQL shell provided with CockroachDB ([`cockroach sql`](cockroach-sql.html) / [`cockroach demo`](cockroach-demo.html)) does not currently support importing data with the `COPY` statement.
+
+To load data into CockroachDB, we recommend that you use an [`IMPORT`](import.html). If you must use a `COPY` statement, you can issue the statement from the [`psql` client](https://www.postgresql.org/docs/current/app-psql.html) command provided with PostgreSQL, or from another third-party client.
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16392)

--- a/_includes/v21.1/known-limitations/copy-syntax.md
+++ b/_includes/v21.1/known-limitations/copy-syntax.md
@@ -1,0 +1,17 @@
+CockroachDB does not yet support the following `COPY` syntax:
+
+- `COPY ... TO`. To copy data from a CockroachDB cluster to a file, use an [`EXPORT`](export.html) statement.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/41608)
+
+- `COPY ... FROM CSV`
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/51891)
+
+- `COPY ... FROM STDIN` with a delimiter other than the default tab delimiter.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16407)
+
+- `COPY ... FROM ... WHERE <expr>`
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/54580)

--- a/v20.2/copy-from.md
+++ b/v20.2/copy-from.md
@@ -1,0 +1,122 @@
+---
+title: COPY FROM
+summary: Copy data from a third-party client to CockroachDB.
+toc: true
+---
+
+The `COPY FROM` statement copies data from third-party clients to tables in your cluster.
+
+{{site.data.alerts.callout_info}}
+CockroachDB currently only supports `COPY FROM` statements issued from third-party clients, for compatibility with PostgreSQL drivers and ORMs. `COPY FROM` statements cannot be issued from the [`cockroach` SQL shell](cockroach-sql.html). To copy data from a file to your cluster, we recommend using an [`IMPORT`](import.html) statement instead.
+{{site.data.alerts.end}}
+
+## Syntax
+
+~~~
+COPY table_name [( <colnames...> )] FROM STDIN [WITH <option> = <value>]
+~~~
+
+### Parameters
+
+Parameter | Description
+-----------|-------------
+`table_name` | The name of the table to which to copy data.
+`<colnames>` | The name(s) of the column(s) to which to copy data.
+`WITH <option> = value` | Specify one or more [copy options](#options).
+
+### Options
+
+Option | Description
+-----------|-------------
+`BINARY` | Copy data from binary format.<br>If not specified, CockroachDB copies in plaintext format. Note that CSV format is not yet supported.
+
+## Required privileges
+
+Only members of the `admin` role can run `COPY` statements. By default, the `root` user belongs to the `admin` role.
+
+## Known limitations
+
+### `COPY FROM` statements are not supported in the CockroachDB SQL shell
+
+{% include {{ page.version.version }}/known-limitations/copy-from-clients.md %}
+
+### `COPY` syntax not supported by CockroachDB
+
+{% include {{ page.version.version }}/known-limitations/copy-syntax.md %}
+
+## Example
+
+The following example copies data from the PostgreSQL [`psql` client](https://www.postgresql.org/docs/current/app-psql.html) into a demo CockroachDB cluster. To follow along, make sure that you have [PostgreSQL](https://www.postgresql.org/download/) installed.
+
+Run [`cockroach demo`](cockroach-demo.html) to start a temporary, in-memory cluster with the [`movr` database](movr.html) preloaded:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach demo
+~~~
+
+Take note of the `(sql/tcp)` connection string listed under `Connection parameters` in the welcome message of the demo cluster's SQL shell:
+
+~~~
+# Connection parameters:
+...
+#   (sql/tcp) postgres://root:admin@127.0.0.1:65207?sslmode=require
+~~~
+
+Open a new terminal window, and connect to your demo cluster with `psql`, using the connection string provided for the demo cluster, with the `movr` database specified:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ psql postgres://root:admin@127.0.0.1:65207/movr?sslmode=require
+~~~
+
+In the `psql` shell, run the following command to start copying data from `psql` to the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> movr=# COPY users FROM STDIN;
+~~~
+
+The following prompt should appear:
+
+~~~
+Enter data to be copied followed by a newline.
+End with a backslash and a period on a line by itself, or an EOF signal.
+~~~
+
+Enter some tab-delimited data that you want copied to the `users` table:
+
+{% include copy-clipboard.html %}
+~~~
+>> 8a3d70a3-d70a-4000-8000-00000000001d seattle	Hannah	400 Broad St	0987654321
+>> 9eb851eb-851e-4800-8000-00000000001e	new york	Carl	53 W 23rd St	5678901234
+>> \.
+~~~
+
+~~~
+COPY 2
+~~~
+
+In the demo cluster's shell, query the `users` table for the rows that you just inserted:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851eb-851e-4800-8000-00000000001e');
+~~~
+
+~~~
+                   id                  |   city   |  name  |   address    | credit_card
+---------------------------------------+----------+--------+--------------+--------------
+  8a3d70a3-d70a-4000-8000-00000000001d | seattle  | Hannah | 400 Broad St | 0987654321
+  9eb851eb-851e-4800-8000-00000000001e | new york | Carl   | 53 W 23rd St | 5678901234
+(2 rows)
+~~~
+
+## See also
+
+- [`IMPORT`](import.html)
+- [`IMPORT INTO`](import-into.html)
+- [`EXPORT`](export.html)
+- [Migrate from Postgres](migrate-from-postgres.html)
+- [Migration Overview](migration-overview.html)
+

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -12,9 +12,9 @@ This page describes newly identified limitations in the CockroachDB {{page.relea
 
 Clusters with 100 or more jobs in a non-terminal state (i.e., any state other than `succeeded`, `failed`, or `canceled`) are unable to upgrade to v20.2. The v20.2 node will hang and never successfully start, and the [logs](debug-and-error-logs.html) will show `checked 100 jobs for existence of deprecated schema change jobs` in a tight loop.
 
-To avoid this limitation: 
+To avoid this limitation:
 
-1. Before starting the upgrade to v20.2, check the [Jobs page](ui-jobs-page.html#jobs-list) in the DB Console or run `SELECT count(*) FROM crdb_internal.jobs WHERE status NOT IN ('succeeded', 'canceled', 'failed')` to ensure that fewer than 100 jobs are in a non-terminal state. 
+1. Before starting the upgrade to v20.2, check the [Jobs page](ui-jobs-page.html#jobs-list) in the DB Console or run `SELECT count(*) FROM crdb_internal.jobs WHERE status NOT IN ('succeeded', 'canceled', 'failed')` to ensure that fewer than 100 jobs are in a non-terminal state.
 
 1. You can then [start the rolling upgrade](upgrade-cockroach-version.html#step-4-perform-the-rolling-upgrade) and wait for the log message `done ensuring all necessary migrations have run` to appear on the first upgraded node, at which point there are no further restrictions on jobs.
 
@@ -299,11 +299,13 @@ As a workaround, set `default_int_size` via your database driver, or ensure that
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/32846)
 
-### Importing data using the PostgreSQL COPY protocol
+### `COPY FROM` statements are not supported in the CockroachDB SQL shell
 
-Currently, the built-in SQL shell provided with CockroachDB (`cockroach sql` / `cockroach demo`) does not support importing data using the `COPY` statement. Users can use the `psql` client command provided with PostgreSQL to load this data into CockroachDB instead. For details, see [Import from generic SQL dump](https://www.cockroachlabs.com/docs/stable/import-data.html#import-from-generic-sql-dump).
+{% include {{ page.version.version }}/known-limitations/copy-from-clients.md %}
 
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16392)
+### `COPY` syntax not supported by CockroachDB
+
+{% include {{ page.version.version }}/known-limitations/copy-syntax.md %}
 
 ### Import with a high amount of disk contention
 

--- a/v20.2/sql-statements.md
+++ b/v20.2/sql-statements.md
@@ -15,6 +15,7 @@ In the [built-in SQL shell](cockroach-sql.html#help), use `\h [statement]` to ge
 Statement | Usage
 ----------|------------
 [`CREATE TABLE AS`](create-table-as.html) | Create a new table in a database using the results from a [selection query](selection-queries.html).
+[`COPY FROM`](copy-from.html) | Copy data from a third-party client to a CockroachDB cluster.<br>Note that CockroachDB currently only supports `COPY FROM` statements issued from third-party clients, for compatibility with PostgreSQL drivers and ORMs. `COPY FROM` statements cannot be issued from the [`cockroach` SQL shell](cockroach-sql.html). To import data from files, we use an [`IMPORT`](import.html) statement instead.
 [`DELETE`](delete.html) | Delete specific rows from a table.
 [`EXPORT`](export.html) | Export an entire table's data, or the results of a `SELECT` statement, to CSV files. Note that this statement requires an [enterprise license](enterprise-licensing.html).
 [`IMPORT`](import.html) | Bulk-insert CSV data into a new table.
@@ -90,7 +91,7 @@ Statement | Usage
 [`SHOW TABLES`](show-tables.html) | List tables or views in a database or virtual schema.
 [`SHOW TYPES`](show-types.html) |  <span class="version-tag">New in v20.2:</span> List user-defined [data types](data-types.html) in a database.
 [`SHOW RANGES`](show-ranges.html) | Show range information for all data in a table or index.
-[`SHOW RANGE FOR ROW`](show-range-for-row.html) | Show range information for a single row in a table or index. 
+[`SHOW RANGE FOR ROW`](show-range-for-row.html) | Show range information for a single row in a table or index.
 [`SHOW ZONE CONFIGURATIONS`](show-zone-configurations.html) | List details about existing [replication zones](configure-replication-zones.html).
 [`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table or index.
 [`UNSPLIT AT`](unsplit-at.html) | Remove a range split enforcement at a specified row in the table or index.

--- a/v21.1/copy-from.md
+++ b/v21.1/copy-from.md
@@ -1,0 +1,122 @@
+---
+title: COPY FROM
+summary: Copy data from a third-party client to CockroachDB.
+toc: true
+---
+
+The `COPY FROM` statement copies data from third-party clients to tables in your cluster.
+
+{{site.data.alerts.callout_info}}
+CockroachDB currently only supports `COPY FROM` statements issued from third-party clients, for compatibility with PostgreSQL drivers and ORMs. `COPY FROM` statements cannot be issued from the [`cockroach` SQL shell](cockroach-sql.html). To copy data from a file to your cluster, we recommend using an [`IMPORT`](import.html) statement instead.
+{{site.data.alerts.end}}
+
+## Syntax
+
+~~~
+COPY table_name [( <colnames...> )] FROM STDIN [WITH <option> = <value>]
+~~~
+
+### Parameters
+
+Parameter | Description
+-----------|-------------
+`table_name` | The name of the table to which to copy data.
+`<colnames>` | The name(s) of the column(s) to which to copy data.
+`WITH <option> = value` | Specify one or more [copy options](#options).
+
+### Options
+
+Option | Description
+-----------|-------------
+`BINARY` | Copy data from binary format.<br>If not specified, CockroachDB copies in plaintext format. Note that CSV format is not yet supported.
+
+## Required privileges
+
+Only members of the `admin` role can run `COPY` statements. By default, the `root` user belongs to the `admin` role.
+
+## Known limitations
+
+### `COPY FROM` statements are not supported in the CockroachDB SQL shell
+
+{% include {{ page.version.version }}/known-limitations/copy-from-clients.md %}
+
+### `COPY` syntax not supported by CockroachDB
+
+{% include {{ page.version.version }}/known-limitations/copy-syntax.md %}
+
+## Example
+
+The following example copies data from the PostgreSQL [`psql` client](https://www.postgresql.org/docs/current/app-psql.html) into a demo CockroachDB cluster. To follow along, make sure that you have [PostgreSQL](https://www.postgresql.org/download/) installed.
+
+Run [`cockroach demo`](cockroach-demo.html) to start a temporary, in-memory cluster with the [`movr` database](movr.html) preloaded:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach demo
+~~~
+
+Take note of the `(sql/tcp)` connection string listed under `Connection parameters` in the welcome message of the demo cluster's SQL shell:
+
+~~~
+# Connection parameters:
+...
+#   (sql/tcp) postgres://root:admin@127.0.0.1:65207?sslmode=require
+~~~
+
+Open a new terminal window, and connect to your demo cluster with `psql`, using the connection string provided for the demo cluster, with the `movr` database specified:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ psql postgres://root:admin@127.0.0.1:65207/movr?sslmode=require
+~~~
+
+In the `psql` shell, run the following command to start copying data from `psql` to the `users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> movr=# COPY users FROM STDIN;
+~~~
+
+The following prompt should appear:
+
+~~~
+Enter data to be copied followed by a newline.
+End with a backslash and a period on a line by itself, or an EOF signal.
+~~~
+
+Enter some tab-delimited data that you want copied to the `users` table:
+
+{% include copy-clipboard.html %}
+~~~
+>> 8a3d70a3-d70a-4000-8000-00000000001d seattle	Hannah	400 Broad St	0987654321
+>> 9eb851eb-851e-4800-8000-00000000001e	new york	Carl	53 W 23rd St	5678901234
+>> \.
+~~~
+
+~~~
+COPY 2
+~~~
+
+In the demo cluster's shell, query the `users` table for the rows that you just inserted:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM users WHERE id IN ('8a3d70a3-d70a-4000-8000-00000000001d', '9eb851eb-851e-4800-8000-00000000001e');
+~~~
+
+~~~
+                   id                  |   city   |  name  |   address    | credit_card
+---------------------------------------+----------+--------+--------------+--------------
+  8a3d70a3-d70a-4000-8000-00000000001d | seattle  | Hannah | 400 Broad St | 0987654321
+  9eb851eb-851e-4800-8000-00000000001e | new york | Carl   | 53 W 23rd St | 5678901234
+(2 rows)
+~~~
+
+## See also
+
+- [`IMPORT`](import.html)
+- [`IMPORT INTO`](import-into.html)
+- [`EXPORT`](export.html)
+- [Migrate from Postgres](migrate-from-postgres.html)
+- [Migration Overview](migration-overview.html)
+

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -297,11 +297,14 @@ As a workaround, set `default_int_size` via your database driver, or ensure that
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/32846)
 
-### Importing data using the PostgreSQL COPY protocol
+### `COPY FROM` statements are not supported in the CockroachDB SQL shell
 
-Currently, the built-in SQL shell provided with CockroachDB (`cockroach sql` / `cockroach demo`) does not support importing data using the `COPY` statement. Users can use the `psql` client command provided with PostgreSQL to load this data into CockroachDB instead. For details, see [Import from generic SQL dump](https://www.cockroachlabs.com/docs/stable/import-data.html#import-from-generic-sql-dump).
+{% include {{ page.version.version }}/known-limitations/copy-from-clients.md %}
 
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/16392)
+### `COPY` syntax not supported by CockroachDB
+
+{% include {{ page.version.version }}/known-limitations/copy-syntax.md %}
+
 
 ### Import with a high amount of disk contention
 

--- a/v21.1/sql-statements.md
+++ b/v21.1/sql-statements.md
@@ -15,6 +15,7 @@ In the [built-in SQL shell](cockroach-sql.html#help), use `\h [statement]` to ge
 Statement | Usage
 ----------|------------
 [`CREATE TABLE AS`](create-table-as.html) | Create a new table in a database using the results from a [selection query](selection-queries.html).
+[`COPY FROM`](copy-from.html) | Copy data from a third-party client to a CockroachDB cluster.<br>Note that CockroachDB currently only supports `COPY FROM` statements issued from third-party clients, for compatibility with PostgreSQL drivers and ORMs. `COPY FROM` statements cannot be issued from the [`cockroach` SQL shell](cockroach-sql.html). To import data from files, we use an [`IMPORT`](import.html) statement instead.
 [`DELETE`](delete.html) | Delete specific rows from a table.
 [`EXPORT`](export.html) | Export an entire table's data, or the results of a `SELECT` statement, to CSV files. Note that this statement requires an [enterprise license](enterprise-licensing.html).
 [`IMPORT`](import.html) | Bulk-insert CSV data into a new table.
@@ -90,7 +91,7 @@ Statement | Usage
 [`SHOW TABLES`](show-tables.html) | List tables or views in a database or virtual schema.
 [`SHOW TYPES`](show-types.html) |   List user-defined [data types](data-types.html) in a database.
 [`SHOW RANGES`](show-ranges.html) | Show range information for all data in a table or index.
-[`SHOW RANGE FOR ROW`](show-range-for-row.html) | Show range information for a single row in a table or index. 
+[`SHOW RANGE FOR ROW`](show-range-for-row.html) | Show range information for a single row in a table or index.
 [`SHOW ZONE CONFIGURATIONS`](show-zone-configurations.html) | List details about existing [replication zones](configure-replication-zones.html).
 [`SPLIT AT`](split-at.html) | Force a range split at the specified row in the table or index.
 [`UNSPLIT AT`](unsplit-at.html) | Remove a range split enforcement at a specified row in the table or index.


### PR DESCRIPTION
Fixes #9022.

Please review this PR carefully for accuracy.

This statement was fairly difficult to document, for the following reasons:

- We don't support `COPY FROM` in the CockroachDB SQL shell. As a result, I had to use a different client (`psql`) to create a simple example. And I'm not sure how useful this example is...
- We don't support most of the PostgreSQL [`COPY FROM` syntax](https://www.postgresql.org/docs/current/sql-copy.html) (e.g., `WHERE`, `PROGRAM`, etc.). We have several different issues tracking some of the individual, unsupported options and clauses (e.g., https://github.com/cockroachdb/cockroach/issues/54580), but we don't have all of them, so it's a little hard to point to tracking issues or to create "known limitations" for syntax that we might not intend to support. There is a catch-all issue (https://github.com/cockroachdb/cockroach/issues/41608), but it only lists some of the unsupported syntax.
- We recommend *not* using `COPY FROM` to import data into CockroachDB, which makes these docs a little superfluous.
- Some of the `COPY FROM` syntax that we allow doesn't really make sense in the context of copying data *into* CockroachDB. For example, for `COPY FROM ... DESTINATION = filename`, I'm not sure what `DESTINATION = filename` refers to, and it's not documented in the Postgres docs, so I omitted the option.
- I wasn't able to copy data from a file using `COPY FROM` in the `psql` client. Do we support copying from files?
- There is no help text, and I couldn't really find any examples, so my example and the syntax documented here is based on https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/parser/sql.y#L2861.