### PR TITLE
Mention Open Shift and IBM Cloud Pak

### DIFF
--- a/_includes/v20.2/orchestration/start-kubernetes.md
+++ b/_includes/v20.2/orchestration/start-kubernetes.md
@@ -5,6 +5,10 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 - [Manual GCE](#manual-gce)
 - [Manual AWS](#manual-aws)
 
+{{site.data.alerts.callout_success}}
+You can also orchestrate CockroachDB on platforms such as [Red Hat OpenShift](https://marketplace.redhat.com/en-us/products/cockroachdb-operator) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
+{{site.data.alerts.end}}
+
 ### Hosted GKE
 
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.
@@ -67,7 +71,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
     {{site.data.alerts.callout_success}}
     To ensure that all 3 nodes can be placed into a different availability zone, you may want to first [confirm that at least 3 zones are available in the region](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe) for your account.
     {{site.data.alerts.end}}
-    
+
     {% include copy-clipboard.html %}
     ~~~ shell
     $ eksctl create cluster \

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -62,7 +62,7 @@ Choose how you want to deploy and maintain the CockroachDB cluster:
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
-The CockroachDB Kubernetes Operator is also available from the [Red Hat Marketplace](https://marketplace.redhat.com/en-us/products/cockroachdb-operator).
+The CockroachDB Kubernetes Operator can also be run on platforms such as [Red Hat OpenShift](https://marketplace.redhat.com/en-us/products/cockroachdb-operator) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
 {{site.data.alerts.end}}
 
 <div class="filters filters-big clearfix">


### PR DESCRIPTION
Repurpose the Kubernetes Operator note about
Red Hat to capture docs searches for Open Shift,
IBM, and Cloud Pak. ibm and cloud pak are two
of the more commonly searched terms that currently
return no results. This small change should
improve that.