### PR TITLE
Fix typo in FAQ

### DIFF
--- a/v20.2/frequently-asked-questions.md
+++ b/v20.2/frequently-asked-questions.md
@@ -28,7 +28,7 @@ CockroachDB is well suited for applications that require reliable, available, an
 - Multi-datacenter deployments
 - Multi-region deployments
 - Cloud migrations
-- Iinfrastructure initiatives built for the cloud
+- Infrastructure initiatives built for the cloud
 
 CockroachDB returns single-row reads in 2ms or less and single-row writes in 4ms or less, and supports a variety of [SQL and operational tuning practices](performance-tuning.html) for optimizing query performance. However, CockroachDB is not yet suitable for heavy analytics / OLAP.
 


### PR DESCRIPTION
Typo added in [`e01e614`](https://github.com/cockroachdb/docs/commit/e01e614d4002eaf4ab750194e8bc8a523844532a#diff-888ecd01f5d9e28c61a8aed0ac5e8196bccfb73795f2ebe7319d459b924536adR31)