### PR TITLE
Add warning about IMPORT INTO statement

### DIFF
--- a/v20.1/foreign-key.md
+++ b/v20.1/foreign-key.md
@@ -137,6 +137,10 @@ Because the foreign key constraint requires per-row checks on two tables, statem
 
 You can improve the performance of some statements that use foreign keys by also using [`INTERLEAVE IN PARENT`](interleave-in-parent.html), but there are tradeoffs. For more information about the performance implications of interleaved tables (as well as the limitations), see the **Interleave tables** section of [Performance best practices](performance-best-practices-overview.html#interleave-tables).
 
+{{site.data.alerts.callout_danger}}
+Using `IMPORT INTO` will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+{{site.data.alerts.end}}
+
 ## Syntax
 
 Foreign key constraints can be defined at the [table level](#table-level). However, if you only want the constraint to apply to a single column, it can be applied at the [column level](#column-level).

--- a/v20.1/foreign-key.md
+++ b/v20.1/foreign-key.md
@@ -138,7 +138,7 @@ Because the foreign key constraint requires per-row checks on two tables, statem
 You can improve the performance of some statements that use foreign keys by also using [`INTERLEAVE IN PARENT`](interleave-in-parent.html), but there are tradeoffs. For more information about the performance implications of interleaved tables (as well as the limitations), see the **Interleave tables** section of [Performance best practices](performance-best-practices-overview.html#interleave-tables).
 
 {{site.data.alerts.callout_danger}}
-Using `IMPORT INTO` will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+Using [`IMPORT INTO`](import-into.html) will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 {{site.data.alerts.end}}
 
 ## Syntax

--- a/v20.2/foreign-key.md
+++ b/v20.2/foreign-key.md
@@ -126,7 +126,7 @@ Because the foreign key constraint requires per-row checks on two tables, statem
 You can improve the performance of some statements that use foreign keys by also using [`INTERLEAVE IN PARENT`](interleave-in-parent.html), but there are tradeoffs. For more information about the performance implications of interleaved tables (as well as the limitations), see the **Interleave tables** section of [Performance best practices](performance-best-practices-overview.html#interleave-tables).
 
 {{site.data.alerts.callout_danger}}
-Using `IMPORT INTO` will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+Using [`IMPORT INTO`](import-into.html) will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 {{site.data.alerts.end}}
 
 ## Syntax

--- a/v20.2/foreign-key.md
+++ b/v20.2/foreign-key.md
@@ -125,6 +125,10 @@ Because the foreign key constraint requires per-row checks on two tables, statem
 
 You can improve the performance of some statements that use foreign keys by also using [`INTERLEAVE IN PARENT`](interleave-in-parent.html), but there are tradeoffs. For more information about the performance implications of interleaved tables (as well as the limitations), see the **Interleave tables** section of [Performance best practices](performance-best-practices-overview.html#interleave-tables).
 
+{{site.data.alerts.callout_danger}}
+Using `IMPORT INTO` will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+{{site.data.alerts.end}}
+
 ## Syntax
 
 Foreign key constraints can be defined at the [table level](#table-level). However, if you only want the constraint to apply to a single column, it can be applied at the [column level](#column-level).

--- a/v21.1/foreign-key.md
+++ b/v21.1/foreign-key.md
@@ -126,7 +126,7 @@ Because the foreign key constraint requires per-row checks on two tables, statem
 You can improve the performance of some statements that use foreign keys by also using [`INTERLEAVE IN PARENT`](interleave-in-parent.html), but there are tradeoffs. For more information about the performance implications of interleaved tables (as well as the limitations), see the **Interleave tables** section of [Performance best practices](performance-best-practices-overview.html#interleave-tables).
 
 {{site.data.alerts.callout_danger}}
-Using `IMPORT INTO` will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+Using [`IMPORT INTO`](import-into.html) will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 {{site.data.alerts.end}}
 
 

--- a/v21.1/foreign-key.md
+++ b/v21.1/foreign-key.md
@@ -125,6 +125,11 @@ Because the foreign key constraint requires per-row checks on two tables, statem
 
 You can improve the performance of some statements that use foreign keys by also using [`INTERLEAVE IN PARENT`](interleave-in-parent.html), but there are tradeoffs. For more information about the performance implications of interleaved tables (as well as the limitations), see the **Interleave tables** section of [Performance best practices](performance-best-practices-overview.html#interleave-tables).
 
+{{site.data.alerts.callout_danger}}
+Using `IMPORT INTO` will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
+{{site.data.alerts.end}}
+
+
 ## Syntax
 
 Foreign key constraints can be defined at the [table level](#table-level). However, if you only want the constraint to apply to a single column, it can be applied at the [column level](#column-level).

--- a/v21.1/foreign-key.md
+++ b/v21.1/foreign-key.md
@@ -129,7 +129,6 @@ You can improve the performance of some statements that use foreign keys by also
 Using [`IMPORT INTO`](import-into.html) will invalidate foreign keys without a [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 {{site.data.alerts.end}}
 
-
 ## Syntax
 
 Foreign key constraints can be defined at the [table level](#table-level). However, if you only want the constraint to apply to a single column, it can be applied at the [column level](#column-level).


### PR DESCRIPTION
Add a warning that `import into` will invalidate foreign keys without a `validate constraint` statement. Resolves issue #8651.