### PR TITLE
Fix latest 20.1 and 20.2 release notes

### DIFF
--- a/releases/v20.1.9.md
+++ b/releases/v20.1.9.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.1.9 since version v20.
 
 ## December 1, 2020
 
+This page lists additions and changes in v20.1.8 since v20.1.7.
+
+- For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
+- To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -34,9 +39,8 @@ Get future release notes emailed to you:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-unstable:v20.1.9
+$ docker pull cockroachdb/cockroach:v20.1.9
 ~~~
-
 
 ### Enterprise edition changes
 
@@ -89,4 +93,3 @@ We would like to thank the following contributors from the CockroachDB community
 [#56396]: https://github.com/cockroachdb/cockroach/pull/56396
 [#56454]: https://github.com/cockroachdb/cockroach/pull/56454
 [59b2bc218]: https://github.com/cockroachdb/cockroach/commit/59b2bc218
-

--- a/releases/v20.2.3.md
+++ b/releases/v20.2.3.md
@@ -6,6 +6,11 @@ summary: Additions and changes in CockroachDB version v20.2.3 since version v20.
 
 ## December 14, 2020
 
+This page lists additions and changes in v20.2.2 since v20.2.1.
+
+- For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
+- To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html)
+
 Get future release notes emailed to you:
 
 <div class="hubspot-install-form install-form-1 clearfix">
@@ -34,7 +39,7 @@ Get future release notes emailed to you:
 
 {% include copy-clipboard.html %}
 ~~~shell
-$ docker pull cockroachdb/cockroach-unstable:v20.2.3
+$ docker pull cockroachdb/cockroach:v20.2.3
 ~~~
 
 ### SQL language changes
@@ -117,4 +122,3 @@ We would like to thank the following contributors from the CockroachDB community
 [#57599]: https://github.com/cockroachdb/cockroach/pull/57599
 [#57651]: https://github.com/cockroachdb/cockroach/pull/57651
 [#57667]: https://github.com/cockroachdb/cockroach/pull/57667
-


### PR DESCRIPTION
- Add intro linking back to GA release notes.
- Remove "unstable" from docker image.