### PR TITLE
address typo on #9184

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
 
 PLATFORMS
   ruby
+  universal-darwin-19
 
 DEPENDENCIES
   jekyll!
@@ -117,4 +118,4 @@ DEPENDENCIES
   sassc (~> 2.2)
 
 BUNDLED WITH
-   2.1.4
+   2.2.1

--- a/v20.2/alter-table.md
+++ b/v20.2/alter-table.md
@@ -19,7 +19,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`ADD COLUMN`](add-column.html) | Add columns to tables. | Yes
 [`ADD CONSTRAINT`](add-constraint.html) | Add constraints to columns. | Yes
 [`ALTER COLUMN`](alter-column.html) | Change an existing column. | Yes
-[`ALTER PRIMARY KEY`](alter-primary-key.html) |  Change the [primary key](primary-key.html) of a table. | Yesnes.html) for a table. | No
+[`ALTER PRIMARY KEY`](alter-primary-key.html) |  Change the [primary key](primary-key.html) of a table. | Yes | No
 [`DROP COLUMN`](drop-column.html) | Remove columns from tables. | Yes
 [`DROP CONSTRAINT`](drop-constraint.html) | Remove constraints from columns. | Yes
 [`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Enable per-table audit logs, for security purposes. | Yes

--- a/v21.1/alter-table.md
+++ b/v21.1/alter-table.md
@@ -19,7 +19,7 @@ Subcommand | Description | Can combine with other subcommands?
 [`ADD COLUMN`](add-column.html) | Add columns to tables. | Yes
 [`ADD CONSTRAINT`](add-constraint.html) | Add constraints to columns. | Yes
 [`ALTER COLUMN`](alter-column.html) | Change an existing column. | Yes
-[`ALTER PRIMARY KEY`](alter-primary-key.html) |  Change the [primary key](primary-key.html) of a table. | Yesnes.html) for a table. | No
+[`ALTER PRIMARY KEY`](alter-primary-key.html) |  Change the [primary key](primary-key.html) of a table. | Yes | No
 [`DROP COLUMN`](drop-column.html) | Remove columns from tables. | Yes
 [`DROP CONSTRAINT`](drop-constraint.html) | Remove constraints from columns. | Yes
 [`EXPERIMENTAL_AUDIT`](experimental-audit.html) | Enable per-table audit logs, for security purposes. | Yes


### PR DESCRIPTION
First PR during fixit @lnhsingh for https://github.com/cockroachdb/docs/issues/9184

> Under [Subcommands](https://www.cockroachlabs.com/docs/v20.2/alter-table#subcommands), the third column for ALTER PRIMARY KEY says Yesnes.html) for a table. and seems to have an extra column in the markdown. I think this should just say Yes. 

Changes applied to v20.2 and v21.1

Assigning to you for review 