### PR TITLE
Changed minimum Kubernetes version in K8s tutorial from 1.8 to 1.15

### DIFF
--- a/_includes/v19.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v19.1/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+Kubernetes 1.15 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
 
 #### Storage
 

--- a/_includes/v19.2/orchestration/kubernetes-limitations.md
+++ b/_includes/v19.2/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+Kubernetes 1.15 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
 
 #### Helm version
 

--- a/_includes/v20.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v20.1/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+Kubernetes 1.15 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
 
 #### Helm version
 

--- a/_includes/v20.2/orchestration/kubernetes-limitations.md
+++ b/_includes/v20.2/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+Kubernetes 1.15 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
 
 #### Helm version
 

--- a/_includes/v21.1/orchestration/kubernetes-limitations.md
+++ b/_includes/v21.1/orchestration/kubernetes-limitations.md
@@ -1,6 +1,6 @@
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
+Kubernetes 1.15 or higher is required in order to use our most up-to-date configuration files. Earlier Kubernetes releases do not support some of the options used in our configuration files. If you need to run on an older version of Kubernetes, we have kept around configuration files that work on older Kubernetes releases in the versioned subdirectories of [https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes) (e.g., [v1.7](https://github.com/cockroachdb/cockroach/tree/master/cloud/kubernetes/v1.7)).
 
 #### Helm version
 

--- a/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.1/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -43,7 +43,7 @@ Finally, if you haven't worked with multiple Kubernetes clusters often before, y
 
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required.
+Kubernetes 1.15 or higher is required.
 
 #### Exposing DNS servers
 

--- a/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
+++ b/v19.2/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md
@@ -43,7 +43,7 @@ Finally, if you haven't worked with multiple Kubernetes clusters often before, y
 
 #### Kubernetes version
 
-Kubernetes 1.8 or higher is required.
+Kubernetes 1.15 or higher is required.
 
 #### Exposing DNS servers
 


### PR DESCRIPTION
Fixes: #9072 