### PR TITLE
Add required privileges for SHOW DATABASE 

### DIFF
--- a/v20.2/show-databases.md
+++ b/v20.2/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
+The user must be granted the `SELECT` [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v20.2/show-databases.md
+++ b/v20.2/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-No [privileges](authorization.html#assign-privileges) are required to list the databases in the CockroachDB cluster.
+The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v21.1/show-databases.md
+++ b/v21.1/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
+The user must be granted the `SELECT` [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v21.1/show-databases.md
+++ b/v21.1/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-No [privileges](authorization.html#assign-privileges) are required to list the databases in the CockroachDB cluster.
+The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 


### PR DESCRIPTION
This addresses #8852

> The documentation for show databases states currently that no privileges are required
https://www.cockroachlabs.com/docs/stable/show-databases.html#required-privileges

> However this is wrong, for a user to be able list the database with this command they must have been granted `select` privilege on the database

Both v20.2 and v21.1 have been updated.