### PR TITLE
Doc for issue 8847

### DIFF
--- a/_includes/v21.1/computed-columns/jsonb.md
+++ b/_includes/v21.1/computed-columns/jsonb.md
@@ -8,6 +8,13 @@ In this example, create a table with a `JSONB` column and a computed column:
 );
 ~~~
 
+Create a compute column after you create a table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE student_profiles ADD COLUMN age INT AS ( (profile->>'age')::INT) STORED;
+~~~
+
 Then, insert a few rows of data:
 
 {% include copy-clipboard.html %}

--- a/_includes/v21.1/computed-columns/jsonb.md
+++ b/_includes/v21.1/computed-columns/jsonb.md
@@ -30,13 +30,13 @@ Then, insert a few rows of data:
 > SELECT * FROM student_profiles;
 ~~~
 ~~~
-+--------+---------------------------------------------------------------------------------------------------------------------+
-|   id   |                                                       profile                                                       |
-+--------+---------------------------------------------------------------------------------------------------------------------+
-| d78236 | {"age": "16", "credits": 120, "id": "d78236", "name": "Arthur Read", "school": "PVPHS", "sports": "none"}           |
-| f98112 | {"age": "15", "clubs": "MUN", "credits": 67, "id": "f98112", "name": "Buster Bunny", "school": "THS"}               |
-| t63512 | {"clubs": "Chess", "id": "t63512", "name": "Ernie Narayan", "school": "Brooklyn Tech", "sports": "Track and Field"} |
-+--------+---------------------------------------------------------------------------------------------------------------------+
++--------+---------------------------------------------------------------------------------------------------------------------+------+
+|   id   |                                                       profile                                                       | age  |
+---------+---------------------------------------------------------------------------------------------------------------------+------+
+| d78236 | {"age": "16", "credits": 120, "id": "d78236", "name": "Arthur Read", "school": "PVPHS", "sports": "none"}           |   16 |
+| f98112 | {"age": "15", "clubs": "MUN", "credits": 67, "id": "f98112", "name": "Buster Bunny", "school": "THS"}               |   15 |
+| t63512 | {"clubs": "Chess", "id": "t63512", "name": "Ernie Narayan", "school": "Brooklyn Tech", "sports": "Track and Field"} | NULL |
++--------+---------------------------------------------------------------------------------------------------------------------+------|
 ~~~
 
-The primary key `id` is computed as a field from the `profile` column.
+The primary key `id` is computed as a field from the `profile` column.  Additionally the `age` column is computed from the profile column data as well.


### PR DESCRIPTION
This is an example of how to do the issue found in #8847

Looking at the computed column doc again, there's a similar example in the "Add a computed column to an existing table" section of the doc.  That probably should suffice.  If you want to reject this, no worries.  The problem with #8847 is that the user needed an extra set of () and STORED in the example.

root@:26257/defaultdb> ALTER TABLE json_data
    ADD COLUMN amount2 DECIMAL
        AS ( (json_info->>'amount')::DECIMAL) STORED;
ALTER TABLE

Time: 1.250s total (execution 0.165s / network 1.085s)