### PR TITLE
Clarify description for SHOW GRANTS

### DIFF
--- a/v20.1/show-grants.md
+++ b/v20.1/show-grants.md
@@ -30,7 +30,7 @@ Parameter | Description
 
 ### Show all grants
 
-To list all grants for all users and roles on all databases and tables:
+To list all grants for all users and roles on the current database and its tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v20.2/show-databases.md
+++ b/v20.2/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
+The user must be granted the `SELECT` [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v20.2/show-databases.md
+++ b/v20.2/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-No [privileges](authorization.html#assign-privileges) are required to list the databases in the CockroachDB cluster.
+The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v20.2/show-grants.md
+++ b/v20.2/show-grants.md
@@ -71,7 +71,7 @@ Field        |  Description
 
 ### Show all grants
 
-To list all grants for all users and roles on all database objects:
+To list all grants for all users and roles on the current database and its tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v21.1/show-databases.md
+++ b/v21.1/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
+The user must be granted the `SELECT` [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v21.1/show-databases.md
+++ b/v21.1/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-No [privileges](authorization.html#assign-privileges) are required to list the databases in the CockroachDB cluster.
+The user must be granted the SELECT [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v21.1/show-grants.md
+++ b/v21.1/show-grants.md
@@ -71,7 +71,7 @@ Field        |  Description
 
 ### Show all grants
 
-To list all grants for all users and roles on all database objects:
+To list all grants for all users and roles on the current database and its tables:
 
 {% include copy-clipboard.html %}
 ~~~ sql


### PR DESCRIPTION
Address feedback noted in #8452 to clarify that `SHOW GRANTS` will list grants for all users and roles on the _current_ database and its tables, _not_ all databases and tables as was previously documented.

Updated for v21.1, v20.2, and v20.1