### PR TITLE
Add column order callout

### DIFF
--- a/_includes/v20.1/misc/csv-import-callout.md
+++ b/_includes/v20.1/misc/csv-import-callout.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+The column order in your schema must match the column order in the file being imported.
+{{site.data.alerts.end}}

--- a/_includes/v20.2/misc/csv-import-callout.md
+++ b/_includes/v20.2/misc/csv-import-callout.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+The column order in your schema must match the column order in the file being imported.
+{{site.data.alerts.end}}

--- a/_includes/v21.1/misc/csv-import-callout.md
+++ b/_includes/v21.1/misc/csv-import-callout.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+The column order in your schema must match the column order in the file being imported.
+{{site.data.alerts.end}}

--- a/v20.1/import-into.md
+++ b/v20.1/import-into.md
@@ -151,6 +151,10 @@ Google Cloud:
     );
 ~~~
 
+{{site.data.alerts.callout_info}}
+The column order in your statement must match the column order in the CSV being imported, regardless of the order in the existing table's schema.
+{{site.data.alerts.end}}
+
 ### Import into an existing table from multiple CSV files
 
 Amazon S3:

--- a/v20.1/import.md
+++ b/v20.1/import.md
@@ -260,6 +260,8 @@ CSV DATA ('gs://acme-co/customers.csv')
 ;
 ~~~
 
+{% include {{ page.version.version }}/misc/csv-import-callout.md %}
+
 ### Import a table from multiple CSV files
 
 #### Using a comma-separated list

--- a/v20.1/migrate-from-csv.md
+++ b/v20.1/migrate-from-csv.md
@@ -65,6 +65,8 @@ Repeat the above for each CSV file you want to import.
 
 {% include {{ page.version.version }}/sql/use-import-into.md %}
 
+{% include {{ page.version.version }}/misc/csv-import-callout.md %}
+
 {{site.data.alerts.callout_info}}
 You will need to run [`ALTER TABLE ... ADD CONSTRAINT`](add-constraint.html) to add any foreign key relationships.
 {{site.data.alerts.end}}

--- a/v20.2/import-into.md
+++ b/v20.2/import-into.md
@@ -163,6 +163,10 @@ Google Cloud:
     );
 ~~~
 
+{{site.data.alerts.callout_info}}
+The column order in your statement must match the column order in the CSV being imported, regardless of the order in the existing table's schema.
+{{site.data.alerts.end}}
+
 ### Import into an existing table from multiple CSV files
 
 Amazon S3:

--- a/v20.2/import.md
+++ b/v20.2/import.md
@@ -249,6 +249,8 @@ CSV DATA ('gs://acme-co/customers.csv')
 ;
 ~~~
 
+{% include {{ page.version.version }}/misc/csv-import-callout.md %}
+
 ### Import a table from multiple CSV files
 
 #### Using a comma-separated list

--- a/v20.2/migrate-from-csv.md
+++ b/v20.2/migrate-from-csv.md
@@ -68,6 +68,8 @@ Repeat the above for each CSV file you want to import.
 
 {% include {{ page.version.version }}/sql/use-import-into.md %}
 
+{% include {{ page.version.version }}/misc/csv-import-callout.md %}
+
 {{site.data.alerts.callout_info}}
 You will need to run [`ALTER TABLE ... ADD CONSTRAINT`](add-constraint.html) to add any foreign key relationships.
 {{site.data.alerts.end}}

--- a/v21.1/import-into.md
+++ b/v21.1/import-into.md
@@ -163,6 +163,10 @@ Google Cloud:
     );
 ~~~
 
+{{site.data.alerts.callout_info}}
+The column order in your statement must match the column order in the CSV being imported, regardless of the order in the existing table's schema.
+{{site.data.alerts.end}}
+
 ### Import into an existing table from multiple CSV files
 
 Amazon S3:

--- a/v21.1/import.md
+++ b/v21.1/import.md
@@ -249,6 +249,8 @@ CSV DATA ('gs://acme-co/customers.csv')
 ;
 ~~~
 
+{% include {{ page.version.version }}/misc/csv-import-callout.md %}
+
 ### Import a table from multiple CSV files
 
 #### Using a comma-separated list

--- a/v21.1/migrate-from-csv.md
+++ b/v21.1/migrate-from-csv.md
@@ -68,6 +68,8 @@ Repeat the above for each CSV file you want to import.
 
 {% include {{ page.version.version }}/sql/use-import-into.md %}
 
+{% include {{ page.version.version }}/misc/csv-import-callout.md %}
+
 {{site.data.alerts.callout_info}}
 You will need to run [`ALTER TABLE ... ADD CONSTRAINT`](add-constraint.html) to add any foreign key relationships.
 {{site.data.alerts.end}}


### PR DESCRIPTION
Resolves issue #4838. Added a note that column order must be the same in user's SQL statement and file being imported to the Migrate from CSV and IMPORT statement docs.