### PR TITLE
Doc edit for Show Ranges with null start and end keys #7800

### DIFF
--- a/_includes/v21.1/computed-columns/jsonb.md
+++ b/_includes/v21.1/computed-columns/jsonb.md
@@ -8,6 +8,13 @@ In this example, create a table with a `JSONB` column and a computed column:
 );
 ~~~
 
+Create a compute column after you create a table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> ALTER TABLE student_profiles ADD COLUMN age INT AS ( (profile->>'age')::INT) STORED;
+~~~
+
 Then, insert a few rows of data:
 
 {% include copy-clipboard.html %}

--- a/_includes/v21.1/computed-columns/jsonb.md
+++ b/_includes/v21.1/computed-columns/jsonb.md
@@ -30,13 +30,13 @@ Then, insert a few rows of data:
 > SELECT * FROM student_profiles;
 ~~~
 ~~~
-+--------+---------------------------------------------------------------------------------------------------------------------+
-|   id   |                                                       profile                                                       |
-+--------+---------------------------------------------------------------------------------------------------------------------+
-| d78236 | {"age": "16", "credits": 120, "id": "d78236", "name": "Arthur Read", "school": "PVPHS", "sports": "none"}           |
-| f98112 | {"age": "15", "clubs": "MUN", "credits": 67, "id": "f98112", "name": "Buster Bunny", "school": "THS"}               |
-| t63512 | {"clubs": "Chess", "id": "t63512", "name": "Ernie Narayan", "school": "Brooklyn Tech", "sports": "Track and Field"} |
-+--------+---------------------------------------------------------------------------------------------------------------------+
++--------+---------------------------------------------------------------------------------------------------------------------+------+
+|   id   |                                                       profile                                                       | age  |
+---------+---------------------------------------------------------------------------------------------------------------------+------+
+| d78236 | {"age": "16", "credits": 120, "id": "d78236", "name": "Arthur Read", "school": "PVPHS", "sports": "none"}           |   16 |
+| f98112 | {"age": "15", "clubs": "MUN", "credits": 67, "id": "f98112", "name": "Buster Bunny", "school": "THS"}               |   15 |
+| t63512 | {"clubs": "Chess", "id": "t63512", "name": "Ernie Narayan", "school": "Brooklyn Tech", "sports": "Track and Field"} | NULL |
++--------+---------------------------------------------------------------------------------------------------------------------+------|
 ~~~
 
-The primary key `id` is computed as a field from the `profile` column.
+The primary key `id` is computed as a field from the `profile` column.  Additionally the `age` column is computed from the profile column data as well.

--- a/v21.1/show-ranges.md
+++ b/v21.1/show-ranges.md
@@ -5,7 +5,7 @@ toc: true
 redirect_from: [show-testing-ranges.html, show-experimental-ranges.html]
 ---
 
-The `SHOW RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that comprise the data for a table, index, or entire database. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for ranges are located.  If `SHOW RANGES` displays `NULL` for both the start and end keys, that typically indicates the range is empty a has no splits.
+The `SHOW RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that comprise the data for a table, index, or entire database. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for ranges are located.  If `SHOW RANGES` displays `NULL` for both the start and end keys, that typically indicates the range is empty and has no splits.
 
 {{site.data.alerts.callout_info}}
 To show range information for a specific row in a table or index, use the [`SHOW RANGE ... FOR ROW`](show-range-for-row.html) statement.

--- a/v21.1/show-ranges.md
+++ b/v21.1/show-ranges.md
@@ -5,7 +5,7 @@ toc: true
 redirect_from: [show-testing-ranges.html, show-experimental-ranges.html]
 ---
 
-The `SHOW RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that comprise the data for a table, index, or entire database. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for ranges are located.
+The `SHOW RANGES` [statement](sql-statements.html) shows information about the [ranges](architecture/overview.html#glossary) that comprise the data for a table, index, or entire database. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for ranges are located.  If `SHOW RANGES` displays `NULL` for both the start and end keys, that typically indicates the range is empty a has no splits.
 
 {{site.data.alerts.callout_info}}
 To show range information for a specific row in a table or index, use the [`SHOW RANGE ... FOR ROW`](show-range-for-row.html) statement.


### PR DESCRIPTION
This is a small fix to update an explanation for SHOW RANGES when null start and end keys return.  The jsonb.md change here can be discarded as it's part of another pull request.  I tried rebasing and couldn't get it out of my branch.

Closes https://github.com/cockroachdb/docs/issues/7800