### PR TITLE
Add a temp unlinked doc for the CC Free closed beta

### DIFF
--- a/cockroachcloud/free-closed-beta.md
+++ b/cockroachcloud/free-closed-beta.md
@@ -1,0 +1,25 @@
+---
+title: CockroachCloud Free (closed beta)
+summary: Learn how to create and use your CockroachCloud cluster.
+toc: true
+---
+
+We have been busy building out and improving the CockroachCloud experience and are excited to invite you to a **closed beta** of a new version that will be permanently free to consume!
+
+We have turned on the ability to create a CockroachCloud Free cluster in your account. Your existing clusters will be unaffected by this additional capability. You will now be able to create up to five free clusters in your organization.
+
+## What is CockroachCloud Free?
+
+CockroachCloud Free delivers free CockroachDB clusters for you and your organization. It is a managed instance of CockroachDB that also removes the friction of initial cluster sizing and auto-scales based on your application traffic. While we have eliminated the concept of nodes for you, there will be an upper limit of usage of up to 1 vCPU and 5GB storage per free cluster. More information to follow.
+
+## Can CockroachCloud Free be used for production apps?
+
+CockroachCloud Free is currently in beta and as such, it is not suitable for production use. Specifically, there are capabilities we are still working on enabling such as the ability to delete clusters, enable backups, and no-downtime upgrades to a paid tier. These capabilities and more are coming soon!
+
+## What’s next?
+
+Free clusters require minimal configuration, and will be instantly available, so all that's left to do is build an app and point it to the free cluster. And while you're at it, we would love some feedback on your experience so we can improve it for all.
+
+## Contact us
+
+If you would like to talk to us directly about this, please [contact Support](https://support.cockroachlabs.com/hc/en-us), and we'd be happy to talk through any questions/concerns with you.

--- a/cockroachcloud/free-closed-beta.md
+++ b/cockroachcloud/free-closed-beta.md
@@ -10,7 +10,7 @@ You are now able to create up to five free clusters in your organization. Creati
 
 ## What is CockroachCloud Free?
 
-CockroachCloud Free delivers free CockroachDB clusters for you and your organization. It is a managed instance of CockroachDB that also removes the friction of initial cluster sizing and auto-scales based on your application traffic. While we have eliminated the concept of nodes for you, there will be an upper limit of usage of up to 1 vCPU and 5GB storage per free cluster. More information to follow.
+CockroachCloud Free delivers free CockroachDB clusters for you and your organization. It is a managed instance of CockroachDB that also removes the friction of initial cluster sizing and auto-scales based on your application traffic. While we have eliminated the concept of nodes for you, there will be an upper limit of usage of up to 1 vCPU and 5GB storage per free cluster.
 
 ## Can CockroachCloud Free be used for production apps?
 

--- a/cockroachcloud/free-closed-beta.md
+++ b/cockroachcloud/free-closed-beta.md
@@ -4,7 +4,7 @@ summary: Learn how to create and use your CockroachCloud cluster.
 toc: true
 ---
 
-We have been busy building out and improving the CockroachCloud experience and are excited to invite you to a **closed beta** of a new version that will be permanently free to consume!
+We have been busy building out and improving the CockroachCloud experience and are excited to invite you to a **closed beta** of a new offering that will be permanently free to consume!
 
 You are now able to create up to five free clusters in your organization. Creating a CockroachCloud Free cluster will not affect your existing clusters in any way.
 
@@ -14,7 +14,7 @@ CockroachCloud Free delivers free CockroachDB clusters for you and your organiza
 
 ## Can CockroachCloud Free be used for production apps?
 
-CockroachCloud Free is currently in beta and as such, it is not suitable for production use. Specifically, there are capabilities we are still working on enabling such as the ability to enable backups, and no-downtime upgrades to a paid tier. These capabilities and more are coming soon!
+CockroachCloud Free is currently in beta and as such, it is not suitable for production use. Specifically, there are capabilities we are still working on enabling, such as the ability to enable backups, to import data, and no-downtime upgrades to a paid tier. These capabilities and more are coming soon!
 
 ## What’s next?
 

--- a/cockroachcloud/free-closed-beta.md
+++ b/cockroachcloud/free-closed-beta.md
@@ -6,7 +6,7 @@ toc: true
 
 We have been busy building out and improving the CockroachCloud experience and are excited to invite you to a **closed beta** of a new version that will be permanently free to consume!
 
-We have turned on the ability to create a CockroachCloud Free cluster in your account. Your existing clusters will be unaffected by this additional capability. You will now be able to create up to five free clusters in your organization.
+You are now able to create up to five free clusters in your organization. Creating a CockroachCloud Free cluster will not affect your existing clusters in any way.
 
 ## What is CockroachCloud Free?
 

--- a/cockroachcloud/free-closed-beta.md
+++ b/cockroachcloud/free-closed-beta.md
@@ -14,7 +14,7 @@ CockroachCloud Free delivers free CockroachDB clusters for you and your organiza
 
 ## Can CockroachCloud Free be used for production apps?
 
-CockroachCloud Free is currently in beta and as such, it is not suitable for production use. Specifically, there are capabilities we are still working on enabling such as the ability to delete clusters, enable backups, and no-downtime upgrades to a paid tier. These capabilities and more are coming soon!
+CockroachCloud Free is currently in beta and as such, it is not suitable for production use. Specifically, there are capabilities we are still working on enabling such as the ability to enable backups, and no-downtime upgrades to a paid tier. These capabilities and more are coming soon!
 
 ## What’s next?
 


### PR DESCRIPTION
Using the [copy from the email](https://docs.google.com/document/d/1OHRaKknfBifj1bMOzlyg7reUZ4rtkwK4iUUZ7UZdhUk/edit#) that goes out to closed beta users, create a temporary, unlinked doc that explains what CC Free (closed beta) is.

This page will be removed once Free (beta) is released at the end of the month.

Closes #9169.