### PR TITLE
Fix incorrect word usage in Architecture Overview

### DIFF
--- a/v1.1/architecture/overview.md
+++ b/v1.1/architecture/overview.md
@@ -74,7 +74,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v19.1/architecture/overview.md
+++ b/v19.1/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v19.2/architecture/overview.md
+++ b/v19.2/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v2.0/architecture/overview.md
+++ b/v2.0/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v2.1/architecture/overview.md
+++ b/v2.1/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v20.1/architecture/overview.md
+++ b/v20.1/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v20.2/architecture/overview.md
+++ b/v20.2/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 

--- a/v21.1/architecture/overview.md
+++ b/v21.1/architecture/overview.md
@@ -67,7 +67,7 @@ Any changes made to the data in a range rely on a consensus algorithm to ensure 
 
 Ultimately, data is written to and read from disk using an efficient storage engine, which is able to keep track of the data's timestamp. This has the benefit of letting us support the SQL standard `AS OF SYSTEM TIME` clause, letting you find historical data for a period of time.
 
-However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these needs will give you much greater understanding of our architecture.
+However, while that high-level overview gives you a notion of what CockroachDB does, looking at how the `cockroach` process operates on each of these nodes will give you much greater understanding of our architecture.
 
 ### Layers
 


### PR DESCRIPTION
s/each of these needs/each of these nodes/

Fixes #9244.