### PR TITLE
New fragment include file for CRC sql commands.

### DIFF
--- a/_includes/cockroachcloud/connect_to_crc.md
+++ b/_includes/cockroachcloud/connect_to_crc.md
@@ -1,0 +1,17 @@
+<!-- Fragment include sections for connecting to CockroachCloud -->
+
+<!-- BEGIN CRC dedicated sql -->
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql \
+--url='postgres://<username>:<password>@<global host>:26257/<database>?sslmode=verify-full&sslrootcert=<path to the CA certificate>'
+~~~
+<!-- END CRC dedicated sql -->
+
+<!-- BEGIN CRC free sql -->
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql \
+--url='postgres://<username>:<password>@<global host>:26257/<database>?sslmode=verify-full&sslrootcert=<path to the CA certificate>&options=--cluster=<cluster_name>'
+~~~
+<!-- END CRC free sql -->


### PR DESCRIPTION
This is a fragment file with begin/end tokens for referring to the commands to start a SQL shell for the dedicated and free-tier of CRC.