### PR TITLE
Add note / quickstart for 30-day trial

### DIFF
--- a/_includes/cockroachcloud/use-cockroachcloud-instead.md
+++ b/_includes/cockroachcloud/use-cockroachcloud-instead.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_success}}
-To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the <a href="../cockroachcloud/quickstart.html">Quickstart</a>.
+To deploy a free CockroachCloud cluster instead of running CockroachDB yourself, see the <a href="../cockroachcloud/quickstart.html">Quickstart</a>.
 {{site.data.alerts.end}}

--- a/cockroachcloud/quickstart-trial-cluster.md
+++ b/cockroachcloud/quickstart-trial-cluster.md
@@ -1,0 +1,183 @@
+---
+title: Quickstart with CockroachCloud (30-day trial)
+summary: Learn how to create and use your CockroachCloud cluster.
+toc: true
+---
+
+<div class="filters clearfix">
+    <a href="quickstart.html"><button class="filter-button page-level"><strong>CockroachCloud Free (beta)</strong></button></a>
+    <a href="quickstart-trial-cluster.html"><button class="filter-button page-level current"><strong>CockroachCloud (30-day trial)</strong></button></a>
+</div>
+
+This page shows you how to deploy a CockroachDB cluster on CockroachCloud (free for a 30-day trial for your first cluster), connect to it using a sample workload, and run your first query.
+
+To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/secure-a-cluster.html).
+
+## Before you begin
+
+If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
+
+## Step 1. Create a free cluster
+
+For this tutorial, we will create a 3-node GCP cluster in the `us-west` region.
+
+1. [Log in](https://cockroachlabs.cloud/) to your CockroachCloud account.
+2. On the **Overview** page, click **Create Cluster**.
+3. On the **Create new cluster** page, for **Cloud provider**, select **Google Cloud**.
+4. For **Regions & nodes**, use the default selection of `California (us-west)` region and 3 nodes.
+5. For **Hardware per node**, select `Option 1` (2vCPU, 60 GB disk).
+6. Name the cluster. The cluster name must be 6-20 characters in length, and can include lowercase letters, numbers, and dashes (but no leading or trailing dashes).
+7. Click **Next**.
+8. On the **Summary** page, enter your credit card details.
+
+    {{site.data.alerts.callout_info}}
+    You won't be charged until after your free trial expires in 30 days.
+    {{site.data.alerts.end}}
+
+9. Click **Create cluster**.
+
+Your cluster will be created in approximately 20-30 minutes. Watch this [Getting Started with CockroachCloud](https://youtu.be/3hxSBeE-1tM) video while you wait.
+
+Once your cluster is created, you will be redirected to the **Cluster Overview** page.
+
+## Step 2. Create a SQL user
+
+1. In the left navigation bar, click **SQL Users**.
+2. Click **Add User**. The **Add User** modal displays.
+3. Enter a **Username** and **Password**.
+4. Click **Save**.
+
+## Step 3. Authorize your network
+
+1. In the left navigation bar, click **Networking**.
+2. Click **Add Network**. The **Add Network** modal displays.
+3. From the **Network** dropdown, select **Current Network** to auto-populate your local machine's IP address.
+4. To allow the network to access the cluster's DB Console and to use the CockroachDB client to access the databases, select the **DB Console to monitor the cluster** and **CockroachDB Client to access the databases** checkboxes.
+5. Click **Apply**.
+
+## Step 4. Get the connection string
+
+1. In the top-right corner of the Console, click the **Connect** button. The **Connect** modal displays.
+2. From the **User** dropdown, select the SQL user you created in [Step 2. Create a SQL user](#step-2-create-a-sql-user).
+3. Verify that the `us-west2 GCP` region and `default_db` database are selected.
+4. Click **Continue**. The **Connect** tab is displayed.
+5. Click **Connection string** to get the connection string for your cluster.
+6. Create a `certs` directory on your local workstation.
+7. Click the name of the `ca.crt` file to download the CA certificate to your local machine.
+8. Move the downloaded `ca.crt` file to the `certs` directory.
+
+## Step 5. Run your first query
+
+For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run the first query. On your local machine:
+
+1. [Download the CockroachDB binary](../stable/install-cockroachdb.html):
+
+    <div class="filters clearfix">
+      <button class="filter-button page-level" data-scope="mac">Mac</button>
+      <button class="filter-button page-level" data-scope="linux">Linux</button>
+    </div>
+
+    <section class="filter-content" markdown="1" data-scope="mac">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.darwin-10.9-amd64.tgz \
+    | tar -xJ
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="linux">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
+    ~~~
+    </section>
+
+2. Copy the binary into the `PATH` so it's easy to run the SQL client from any location:
+
+    <div class="filters clearfix">
+      <button class="filter-button page-level" data-scope="mac">Mac</button>
+      <button class="filter-button page-level" data-scope="linux">Linux</button>
+    </div>
+
+    <section class="filter-content" markdown="1" data-scope="mac">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.darwin-10.9-amd64/cockroach /usr/local/bin/
+    ~~~
+    </section>
+
+    <section class="filter-content" markdown="1" data-scope="linux">
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ sudo cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
+    ~~~
+    </section>
+
+3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-4-get-the-connection-string).
+
+    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 2](#step-2-create-a-sql-user). Replace the `<certs_dir>` placeholder with the path to the `certs` directory that you created in [Step 4](#step-4-get-the-connection-string).
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach workload init movr \
+    'postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
+    ~~~
+
+4. Use the built-in SQL client to view the database:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach sql \
+    --url='postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
+    ~~~
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SHOW TABLES FROM movr;
+    ~~~
+
+    ~~~
+                  table_name
+    ------------------------------
+      promo_codes
+      rides
+      user_promo_codes
+      users
+      vehicle_location_histories
+      vehicles
+    (6 rows)
+    ~~~
+
+5. Run your first query:
+
+    {% include copy-clipboard.html %}
+    ~~~ sql
+    > SELECT * FROM movr.users WHERE city='new york';
+    ~~~
+
+    ~~~
+                           id                  |   city   |       name       |           address           | credit_card
+    ---------------------------------------+----------+------------------+-----------------------------+--------------
+      00000000-0000-4000-8000-000000000000 | new york | Robert Murphy    | 99176 Anderson Mills        | 8885705228
+      051eb851-eb85-4ec0-8000-000000000001 | new york | James Hamilton   | 73488 Sydney Ports Suite 57 | 8340905892
+      0a3d70a3-d70a-4d80-8000-000000000002 | new york | Judy White       | 18580 Rosario Ville Apt. 61 | 2597958636
+      0f5c28f5-c28f-4c00-8000-000000000003 | new york | Devin Jordan     | 81127 Angela Ferry Apt. 8   | 5614075234
+      147ae147-ae14-4b00-8000-000000000004 | new york | Catherine Nelson | 1149 Lee Alley              | 0792553487
+      19999999-9999-4a00-8000-000000000005 | new york | Nicole Mcmahon   | 11540 Patton Extensions     | 0303726947
+    (6 rows)
+    ~~~
+
+## What's next?
+
+Learn more:
+
+- Use the [built-in SQL client](connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to connect to your cluster and [learn CockroachDB SQL](learn-cockroachdb-sql.html).
+- Build a ["Hello World" app with the Django framework](build-a-python-app-with-cockroachdb-django.html), or [install another client framework](../stable/install-client-drivers.html) for your preferred language.
+- Use a local cluster to [explore CockroachDB capabilities like fault tolerance and automated repair](../stable/demo-fault-tolerance-and-recovery.html).
+
+Before you move into production:
+
+- [Authorize the network](connect-to-your-cluster.html#step-1-authorize-your-network) from which your app will access the cluster.
+- Download the `ca.crt` file to every machine from which you want to [connect to the cluster](connect-to-your-cluster.html#step-3-select-a-connection-method).
+- Review the [production checklist](production-checklist.html).

--- a/cockroachcloud/quickstart-trial-cluster.md
+++ b/cockroachcloud/quickstart-trial-cluster.md
@@ -19,7 +19,7 @@ If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=d
 
 ## Step 1. Create a free cluster
 
-For this tutorial, we will create a 3-node GCP cluster in the `us-west` region.
+For this tutorial, we will create a 3-node GCP cluster in the `us-west2` region.
 
 1. [Log in](https://cockroachlabs.cloud/) to your CockroachCloud account.
 2. On the **Overview** page, click **Create Cluster**.
@@ -114,9 +114,9 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
     ~~~
     </section>
 
-3. Initialize the `movr` workload using the `cockroach workload` command and the [connection string](#step-4-get-the-connection-string).
+3. Initialize the `movr` [workload](../v20.2/cockroach-workload.html) using the `cockroach workload` command and the [connection string](#step-4-get-the-connection-string).
 
-    In the connection string, the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 2](#step-2-create-a-sql-user). Replace the `<certs_dir>` placeholder with the path to the `certs` directory that you created in [Step 4](#step-4-get-the-connection-string).
+    In the [connection string](../v20.2/connection-parameters.html), the SQL user's username is prepopulated. Replace `<password>` with the SQL user's password that you entered in [Step 2](#step-2-create-a-sql-user). Replace the `<certs_dir>` placeholder with the path to the `certs` directory that you created in [Step 4](#step-4-get-the-connection-string).
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -124,7 +124,7 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
     'postgres://<username>:<password>@<global host>:26257/movr?sslmode=verify-full&sslrootcert=<certs_dir>/<ca.crt>'
     ~~~
 
-4. Use the built-in SQL client to view the database:
+4. Use the [built-in SQL client](connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to view the database:
 
     {% include copy-clipboard.html %}
     ~~~ shell
@@ -173,7 +173,7 @@ For this tutorial, we will use the [`movr` workload](../stable/movr.html) to run
 Learn more:
 
 - Use the [built-in SQL client](connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to connect to your cluster and [learn CockroachDB SQL](learn-cockroachdb-sql.html).
-- Build a ["Hello World" app with the Django framework](build-a-python-app-with-cockroachdb-django.html), or [install another client framework](../stable/install-client-drivers.html) for your preferred language.
+- Build a ["Hello World" app with the Django framework](build-a-python-app-with-cockroachdb-django.html), or [install a client driver](../stable/install-client-drivers.html) for your favorite language.
 - Use a local cluster to [explore CockroachDB capabilities like fault tolerance and automated repair](../stable/demo-fault-tolerance-and-recovery.html).
 
 Before you move into production:

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -1,5 +1,5 @@
 ---
-title: Quickstart with CockroachCloud
+title: Quickstart with CockroachCloud Free (beta)
 summary: Learn how to create and use your free CockroachCloud cluster.
 toc: true
 redirect_from:
@@ -7,7 +7,16 @@ redirect_from:
 - create-your-account.html
 ---
 
+<div class="filters clearfix">
+    <a href="quickstart.html"><button class="filter-button page-level current"><strong>CockroachCloud Free (beta)</strong></button></a>
+    <a href="quickstart-trial-cluster.html"><button class="filter-button page-level"><strong>CockroachCloud (30-day trial)</strong></button></a>
+</div>
+
 This page shows you how to deploy a CockroachDB cluster on CockroachCloud Free (beta), connect to it using the CockroachDB [built-in SQL client](../v20.2/cockroach-sql.html), and run sample SQL statements.
+
+{{site.data.alerts.callout_info}}
+CockroachCloud Free (beta) is in limited availability. If you do not have access yet, you can [start your first cluster using a 30-day free trial](quickstart-trial-cluster.html).
+{{site.data.alerts.end}}
 
 To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/secure-a-cluster.html).
 

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -41,7 +41,6 @@ You can now connect to your cluster using CockroachDB's built-in SQL client:
     <div class="filters clearfix">
       <button class="filter-button page-level" data-scope="mac">Mac</button>
       <button class="filter-button page-level" data-scope="linux">Linux</button>
-      <button class="filter-button page-level" data-scope="homebrew">Homebrew</button>
     </div>
 
     <section class="filter-content" markdown="1" data-scope="mac">
@@ -50,6 +49,10 @@ You can now connect to your cluster using CockroachDB's built-in SQL client:
     $ curl https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.darwin-10.9-amd64.tgz \
     | tar -xJ
     ~~~
+
+    {{site.data.alerts.callout_info}}
+    You can also use Homebrew to install the CockroachDB binary by running `brew install cockroachdb/tap/cockroach`.
+    {{site.data.alerts.end}}
     </section>
 
     <section class="filter-content" markdown="1" data-scope="linux">
@@ -57,13 +60,6 @@ You can now connect to your cluster using CockroachDB's built-in SQL client:
     ~~~ shell
     $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
     | tar  xvz
-    ~~~
-    </section>
-
-    <section class="filter-content" markdown="1" data-scope="homebrew">
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ brew install cockroachdb/tap/cockroach
     ~~~
     </section>
 
@@ -79,6 +75,10 @@ You can now connect to your cluster using CockroachDB's built-in SQL client:
     ~~~ shell
     $ cp -i cockroach-{{ page.release_info.version }}.darwin-10.9-amd64/cockroach /usr/local/bin/
     ~~~
+
+    {{site.data.alerts.callout_info}}
+    If you used Homebrew, Homebrew will automatically add the CockroachDB binary to your path.
+    {{site.data.alerts.end}}
     </section>
 
     <section class="filter-content" markdown="1" data-scope="linux">
@@ -144,5 +144,5 @@ Learn more:
 
 - Use the [built-in SQL client](connect-to-your-cluster.html#use-the-cockroachdb-sql-client) to connect to your cluster and [learn CockroachDB SQL](learn-cockroachdb-sql.html).
 - [Create and manage SQL users](connect-to-your-cluster.html#step-2-create-a-sql-user).
-- Build a ["Hello World" app with the Django framework](build-a-python-app-with-cockroachdb-django.html), or [install another client framework](../stable/install-client-drivers.html) for your preferred language.
+- Build a ["Hello World" app with the Django framework](build-a-python-app-with-cockroachdb-django.html), or [install a client driver](../stable/install-client-drivers.html) for your favorite language.
 - Explore our [sample apps](../stable/hello-world-example-apps.html) for examples on how to build simple "Hello World" applications using CockroachCloud Free (beta).

--- a/v20.2/orchestrate-a-local-cluster-with-kubernetes-insecure.md
+++ b/v20.2/orchestrate-a-local-cluster-with-kubernetes-insecure.md
@@ -14,7 +14,7 @@ On top of CockroachDB's built-in automation, you can use a third-party [orchestr
 This page walks you through a simple demonstration, using the open-source [Kubernetes](http://kubernetes.io/) orchestration system. Using either the CockroachDB [Helm](https://helm.sh/) chart or a few configuration files, you'll quickly create a 3-node local cluster. You'll run some SQL commands against the cluster and then simulate node failure, watching how Kubernetes auto-restarts without the need for any manual intervention. You'll then scale the cluster with a single command before shutting the cluster down, again with a single command.
 
 {{site.data.alerts.callout_info}}
-To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
+To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}

--- a/v20.2/orchestrate-a-local-cluster-with-kubernetes.md
+++ b/v20.2/orchestrate-a-local-cluster-with-kubernetes.md
@@ -16,7 +16,7 @@ On top of CockroachDB's built-in automation, you can use a third-party [orchestr
 This page walks you through a simple demonstration, using the open-source [Kubernetes](http://kubernetes.io/) orchestration system. Using either the CockroachDB [Helm](https://helm.sh/) chart or a few configuration files, you'll quickly create a 3-node local cluster. You'll run some SQL commands against the cluster and then simulate node failure, watching how Kubernetes auto-restarts without the need for any manual intervention. You'll then scale the cluster with a single command before shutting the cluster down, again with a single command.
 
 {{site.data.alerts.callout_info}}
-To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a 30-day free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
+To orchestrate a physically distributed cluster in production, see [Orchestrated Deployments](orchestration.html). To deploy a free CockroachCloud cluster instead of running CockroachDB yourself, see the [Quickstart](../cockroachcloud/quickstart.html).
 {{site.data.alerts.end}}
 
 {% include {{ page.version.version }}/orchestration/local-start-kubernetes.md %}


### PR DESCRIPTION
Some users do not have access to CC Free (beta) yet.

- Added a note to the Quickstart
- Re-added the old instructions on how to start a cluster using the 
30-day free trial
- Updated notes on other pages that point users to use CC

Closes #9358.