### PR TITLE
Embed an in-browser SQL playground

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -2595,5 +2595,12 @@
       },
       {% include sidebar-releases.json %}
     ]
+  },
+  {
+    "title": "SQL Playground",
+    "is_top_level": true,
+    "urls": [
+      "/${VERSION}/sql-playground.html"
+    ]
   }
 ]

--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -2595,5 +2595,12 @@
       },
       {% include sidebar-releases.json %}
     ]
+  },
+  {
+    "title": "SQL Playground",
+    "is_top_level": true,
+    "urls": [
+      "/${VERSION}/sql-playground.html"
+    ]
   }
 ]

--- a/tutorials/katacoda/playground-20.2/index.json
+++ b/tutorials/katacoda/playground-20.2/index.json
@@ -1,7 +1,7 @@
 {
   "noindex": true,
   "title": "CockroachDB v20.2 Playground",
-  "description": "Use CockroachDB v20.2 in a sandboxed playground environment",
+  "description": "Use CockroachDB v20.2 in a playground environment",
   "details": {
     "steps": [
       {

--- a/tutorials/katacoda/playground-20.2/step1.md
+++ b/tutorials/katacoda/playground-20.2/step1.md
@@ -1,4 +1,4 @@
-This playground gives you an interactive SQL shell connected to a temporary, single-node CockroachDB cluster. It is pre-loaded with a database called `movr`. Run `SHOW TABLES;`{{execute}} for more details.
+This playground gives you an interactive SQL shell to a temporary, single-node CockroachDB cluster running v20.2. The cluster is pre-loaded with a sample dataset and configured for CockroachDB's [spatial](https://www.cockroachlabs.com/docs/v20.2/spatial-features.html) functionality.
 
 For the basics of CockroachDB SQL, see [Learn Cockroach SQL](https://www.cockroachlabs.com/docs/stable/learn-cockroachdb-sql.html).
 

--- a/tutorials/katacoda/playground-21.1/foreground.sh
+++ b/tutorials/katacoda/playground-21.1/foreground.sh
@@ -1,10 +1,10 @@
-echo 'Installing CockroachDB v20.2 and supporting spatial libraries...'
+echo 'Installing a testing release of CockroachDB v21.1 and supporting spatial libraries...'
 
-wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.4.linux-amd64.tgz | tar  xvz
-cp -i cockroach-v20.2.4.linux-amd64/cockroach /usr/local/bin/
+wget -qO- https://binaries.cockroachdb.com/cockroach-v21.1.0-alpha.1.linux-amd64.tgz | tar  xvz
+cp -i cockroach-v21.1.0-alpha.1.linux-amd64/cockroach /usr/local/bin/
 mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v20.2.4.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v20.2.4.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.0-alpha.1.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
+cp -i cockroach-v21.1.0-alpha.1.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
 
 echo 'Starting a secure single-node cluster...'
 

--- a/tutorials/katacoda/playground-21.1/index.json
+++ b/tutorials/katacoda/playground-21.1/index.json
@@ -1,12 +1,12 @@
 {
   "noindex": true,
   "title": "CockroachDB Playground",
-  "description": "Use CockroachDB in a sandboxed playground environment",
+  "description": "Use a testing release of CockroachDB v21.1 in a playground environment",
   "details": {
     "steps": [
       {
         "text": "step1.md",
-        "code": "foreground.sh"
+        "foreground": "foreground.sh"
       }
     ]
   },

--- a/tutorials/katacoda/playground-21.1/step1.md
+++ b/tutorials/katacoda/playground-21.1/step1.md
@@ -1,4 +1,4 @@
-This playground gives you an interactive SQL shell connected to a temporary, single-node CockroachDB cluster. It is pre-loaded with a database called `movr`. Run `SHOW TABLES;`{{execute}} for more details.
+This playground gives you an interactive SQL shell to a temporary, single-node CockroachDB cluster running a testing release of v21.1. The cluster is pre-loaded with a sample dataset and configured for CockroachDB's [spatial](https://www.cockroachlabs.com/docs/v20.2/spatial-features.html) functionality.
 
 For the basics of CockroachDB SQL, see [Learn Cockroach SQL](https://www.cockroachlabs.com/docs/stable/learn-cockroachdb-sql.html).
 

--- a/tutorials/katacoda/playground/foreground.sh
+++ b/tutorials/katacoda/playground/foreground.sh
@@ -1,6 +1,0 @@
-wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.4.linux-amd64.tgz | tar  xvz
-cp -i cockroach-v20.2.4.linux-amd64/cockroach /usr/local/bin/
-mkdir -p /usr/local/lib/cockroach
-cp -i cockroach-v20.2.4.linux-amd64/lib/libgeos.so /usr/local/lib/cockroach/
-cp -i cockroach-v20.2.4.linux-amd64/lib/libgeos_c.so /usr/local/lib/cockroach/
-cockroach demo

--- a/v20.2/sql-playground.md
+++ b/v20.2/sql-playground.md
@@ -1,0 +1,18 @@
+---
+title: SQL Playground
+summary: Use CockroachDB v20.2 in a sandboxed playground environment
+toc: false
+---
+
+This playground gives you an interactive SQL shell to a temporary, single-node CockroachDB cluster running v20.2. The cluster is pre-loaded with a sample dataset and configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality. For docs on our SQL dialect, see <a href="sql-statements.html" target="_blank">SQL Reference</a>.
+
+<div
+  data-katacoda-hidetitle="true"
+  data-katacoda-hidesidebar="true"
+  data-katacoda-id="cockroachlabs/playground-20-2"
+  data-katacoda-color="#222"
+  data-katacoda-secondary="#37A806"  
+  style="height: 500px; width: 100%;">
+</div>
+
+<script src="//katacoda.com/embed.js"></script>

--- a/v21.1/sql-playground.md
+++ b/v21.1/sql-playground.md
@@ -1,0 +1,11 @@
+---
+title: SQL Playground
+summary: Use CockroachDB v21.1 in a sandboxed playground environment
+toc: false
+---
+
+This playground gives you an interactive SQL shell to a temporary, single-node CockroachDB cluster running a testing release of v21.1. The cluster is pre-loaded with a sample dataset and configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality. For docs on our SQL dialect, see <a href="sql-statements.html" target="_blank">SQL Reference</a>.
+
+<iframe height="600px" width="100%" src="https://repl.it/@jseldess/cockroachdb-playground-v211?lite=true&outputonly=1"></iframe>
+
+<!-- <iframe height="600px" width="100%" src="https://cockroachdb-playground-v211.jseldess.repl.co"></iframe> -->


### PR DESCRIPTION
- For 20.2 docs, the playground is running in Katacoda,
  using cockroach-single-node, with movr loaded via
  cockroach workload, and the SQL shell via cockroach sql.
- For 21.1 docs, the playground is running in repl.it,
  using cockroach demo.

In both cases, spatial is configured.