### PR TITLE
Adding redirect from 21.1.0 GA URL for links from binary messages

### DIFF
--- a/releases/v21.1.0-alpha.1.md
+++ b/releases/v21.1.0-alpha.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in 21.1.0-alpha.1
 toc: true
 summary: Additions and changes in CockroachDB version 21.1.0-alpha.1.
+redirect_from: v21.1.0.html
 ---
 
 ## December 8, 2020


### PR DESCRIPTION
Follow up on conversation with @arulajmani. 

@jseldess 
FYI, the `cockroach` binary returns links in error and warning messages to the deprecations section of our GA release notes page for major releases. In 20.2, these messages link to https://www.cockroachlabs.com/docs/releases/v20.2.0.html#deprecations. In 21.1, they link to a page that we have yet to create. 

https://github.com/cockroachdb/docs/commit/33ee770b699aead65fc7c1912160236d13f9c281#diff-06124389d47e81e9751a3deb6af80c1c39185669536a72773a5b4064bc9f4b2d was pretty to the v20.2 release date, so I'm guessing we won't make the 21.1 GA page for a while. When we do, we need to remove this redirect.