### PR TITLE
Add referral link to creating a CC Free cluster to Sample Apps

### DIFF
--- a/_includes/cockroachcloud/quickstart/create-a-free-cluster.md
+++ b/_includes/cockroachcloud/quickstart/create-a-free-cluster.md
@@ -1,3 +1,4 @@
+1. If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
 1. [Log in](https://cockroachlabs.cloud/) to your CockroachCloud account.
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select the **Free Plan**.

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -17,15 +17,12 @@ This page walks you through the process of creating a CockroachCloud cluster. No
 To create and connect to a 30-day free CockroachCloud cluster and run your first query, see the [Quickstart](quickstart.html).
 {{site.data.alerts.end}}
 
-## Before you begin
-
-If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
-
 ## Step 1. Start the cluster creation process
 
+1. If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
 1. [Log in](https://cockroachlabs.cloud/) to your CockroachCloud account.
-2. If there are multiple [organizations](console-access-management.html#organization) in your account, select the correct organization in the top right corner.
-3. On the **Overview** page, click **Create Cluster**.
+1. If there are multiple [organizations](console-access-management.html#organization) in your account, select the correct organization in the top right corner.
+1. On the **Overview** page, click **Create Cluster**.
 
 ## Step 2. Select the cloud provider
 
@@ -91,7 +88,7 @@ Self-service VPC peering is a limited-availability feature for GCP clusters. For
 You can use [VPC peering](network-authorization.html#vpc-peering) to connect your application to the CockroachCloud cluster. To enable VPC peering:
 
 1. Under **Additional Settings**, toggle the VPC Peering switch to **Yes**.
-2. Configure the IP address range and size (in CIDR format) for the CockroachCloud network based on the following considerations:
+1. Configure the IP address range and size (in CIDR format) for the CockroachCloud network based on the following considerations:
       -  As per [GCP's overlapping subnets restriction](https://cloud.google.com/vpc/docs/vpc-peering#restrictions), configure an IP range that doesn't overlap with the IP ranges in your application network.
       - The IP range and size cannot be changed after the cluster is created. Configuring a smaller IP range size may limit your ability to expand into multiple regions in the future. We recommend configuring an IP range size of `/16` or lower.
 
@@ -99,22 +96,22 @@ You can use [VPC peering](network-authorization.html#vpc-peering) to connect you
 
         To use the default IP range, select **Use the default IP range**. To configure your own IP range, select **Configure the IP range** and enter the IP range and size in CIDR format.
 
-3. Click **Next**.
+1. Click **Next**.
 
 ## Step 8. Enter billing details
 
 1. On the **Summary** page, verify your selections for the cloud provider, region, number of nodes, and the hardware configuration per node.
-2. Verify the hourly estimated cost for the cluster.
+1. Verify the hourly estimated cost for the cluster.
     {{site.data.alerts.callout_info}}
     The cost displayed does not include taxes.
     {{site.data.alerts.end}}
     You will be billed on the 1st and 15th of every month.
-3. Add your preferred [payment method](console-access-management.html#manage-billing-for-the-organization).
-4. [If applicable](frequently-asked-questions.html#how-do-cockroachcloud-free-trials-work), the 30-day trial code is pre-applied to your cluster.
+1. Add your preferred [payment method](console-access-management.html#manage-billing-for-the-organization).
+1. [If applicable](frequently-asked-questions.html#how-do-cockroachcloud-free-trials-work), the 30-day trial code is pre-applied to your cluster.
       {{site.data.alerts.callout_info}}
       Make sure that you [delete your trial cluster](cluster-management.html#delete-cluster) before the trial expires. Your credit card will be charged after the trial ends. You can check the validity of the code on the [Billing](console-access-management.html#manage-billing-for-the-organization) page.
       {{site.data.alerts.end}}
-5. Click **Create cluster**.
+1. Click **Create cluster**.
 
 Your cluster will be created in approximately 20-30 minutes.
 

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -18,10 +18,6 @@ This page shows you how to deploy a CockroachDB cluster on CockroachCloud Free (
 
 To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/secure-a-cluster.html).
 
-## Before you begin
-
-If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
-
 ## Step 1. Create a free cluster
 
 {% include cockroachcloud/quickstart/create-a-free-cluster.md %}


### PR DESCRIPTION
- Removed the Before You Begin section on the Quickstart
- Added the sign up referral link for CC Free to step 1 of the Create a 
Free Cluster section

Closes #9651