### PR TITLE
Add exec to cockroach demo in learn sql tutorial

### DIFF
--- a/tutorials/katacoda/learn-cockroachdb-sql/foreground.sh
+++ b/tutorials/katacoda/learn-cockroachdb-sql/foreground.sh
@@ -1,3 +1,3 @@
 wget -qO- https://binaries.cockroachdb.com/cockroach-v20.2.4.linux-amd64.tgz | tar  xvz
 cp -i cockroach-v20.2.4.linux-amd64/cockroach /usr/local/bin/
-cockroach demo
+exec cockroach demo


### PR DESCRIPTION
To prevent users from getting to the shell prompt by
exiting the sql shell. Testing this in one tutorial
before applying it to others.