### PR TITLE
Expose dbconsole in 20.2 and 21.1 sql playgrounds

### DIFF
--- a/tutorials/katacoda/playground-20.2/foreground.sh
+++ b/tutorials/katacoda/playground-20.2/foreground.sh
@@ -12,11 +12,15 @@ mkdir certs my-safe-directory
 cockroach cert create-ca --certs-dir=certs --ca-key=my-safe-directory/ca.key
 cockroach cert create-node localhost $(hostname) --certs-dir=certs --ca-key=my-safe-directory/ca.key
 cockroach cert create-client root --certs-dir=certs --ca-key=my-safe-directory/ca.key
-cockroach start-single-node --certs-dir=certs --listen-addr=localhost:26257 --http-addr=localhost:8080 --background
+cockroach start-single-node --certs-dir=certs --background
 
 echo 'Loading a sample database...'
 
 cockroach workload init movr 'postgres://root@localhost:26257?sslmode=verify-full&sslrootcert=certs/ca.crt&sslcert=certs/client.root.crt&sslkey=certs/client.root.key'
+
+echo 'Creating a user for accessing the DB Console...'
+
+cockroach sql --certs-dir=certs --execute="CREATE USER max WITH PASSWORD 'roach'; GRANT admin TO max;"
 
 echo 'Opening an interactive SQL shell and listing tables in the sample database...'
 

--- a/tutorials/katacoda/playground-20.2/index.json
+++ b/tutorials/katacoda/playground-20.2/index.json
@@ -13,6 +13,13 @@
   "environment": {
     "hideintro": true,
     "hidefinish": true,
+    "showdashboard": true,
+    "dashboards": [
+      {
+        "name": "DB Console",
+        "port": 8080
+      }
+    ],
     "uilayout": "terminal"
   },
   "backend": {

--- a/tutorials/katacoda/playground-21.1/foreground.sh
+++ b/tutorials/katacoda/playground-21.1/foreground.sh
@@ -12,11 +12,15 @@ mkdir certs my-safe-directory
 cockroach cert create-ca --certs-dir=certs --ca-key=my-safe-directory/ca.key
 cockroach cert create-node localhost $(hostname) --certs-dir=certs --ca-key=my-safe-directory/ca.key
 cockroach cert create-client root --certs-dir=certs --ca-key=my-safe-directory/ca.key
-cockroach start-single-node --certs-dir=certs --listen-addr=localhost:26257 --http-addr=localhost:8080 --background
+cockroach start-single-node --certs-dir=certs --background
 
 echo 'Loading a sample database...'
 
 cockroach workload init movr 'postgres://root@localhost:26257?sslmode=verify-full&sslrootcert=certs/ca.crt&sslcert=certs/client.root.crt&sslkey=certs/client.root.key'
+
+echo 'Creating a user for accessing the DB Console...'
+
+cockroach sql --certs-dir=certs --execute="CREATE USER max WITH PASSWORD 'roach'; GRANT admin TO max;"
 
 echo 'Opening an interactive SQL shell and listing tables in the sample database...'
 

--- a/tutorials/katacoda/playground-21.1/index.json
+++ b/tutorials/katacoda/playground-21.1/index.json
@@ -13,6 +13,13 @@
   "environment": {
     "hideintro": true,
     "hidefinish": true,
+    "showdashboard": true,
+    "dashboards": [
+      {
+        "name": "DB Console",
+        "port": 8080
+      }
+    ],
     "uilayout": "terminal"
   },
   "backend": {

--- a/v20.2/sql-playground.md
+++ b/v20.2/sql-playground.md
@@ -4,7 +4,7 @@ summary: Use CockroachDB v20.2 in a sandboxed playground environment
 toc: false
 ---
 
-This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running v20.2. The cluster is pre-loaded with a sample dataset and configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality.
+This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running v20.2. The cluster is pre-loaded with a sample dataset, configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality, and set up with a user to access the DB Console (see the terminal output for login credentials).
 
 For docs on our SQL dialect, see <a href="sql-statements.html" target="_blank">SQL Reference</a>. For a more guided experience, see our [interactive tutorials](#interactive-tutorials).
 

--- a/v21.1/sql-playground.md
+++ b/v21.1/sql-playground.md
@@ -4,7 +4,7 @@ summary: Use CockroachDB v21.1 in a playground environment
 toc: false
 ---
 
-This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running a testing release of v21.1. The cluster is pre-loaded with a sample dataset and configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality.
+This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running a testing release of v21.1. The cluster is pre-loaded with a sample dataset, configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality, and set up with a user to access the DB Console (see the terminal output for login credentials).
 
 For docs on our SQL dialect, see <a href="sql-statements.html" target="_blank">SQL Reference</a>. For a more guided experience, see our [interactive tutorials](#interactive-tutorials).
 


### PR DESCRIPTION
Start cockroach to listen on all IPs. Katacoda requires this
to be able to access the UI.

Also create user for dbconsole access as part of startup
script.