### PR TITLE
Simplify dbconsole access from sql playgrounds

### DIFF
--- a/v20.2/sql-playground.md
+++ b/v20.2/sql-playground.md
@@ -4,7 +4,7 @@ summary: Use CockroachDB v20.2 in a sandboxed playground environment
 toc: false
 ---
 
-This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running v20.2. The cluster is pre-loaded with a sample dataset, configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality, and set up with a user to access the DB Console (see the terminal output for login credentials).
+This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running v20.2. The cluster is pre-loaded with a sample dataset, configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality, and set up with a DB Console user (login: max/roach).
 
 For docs on our SQL dialect, see <a href="sql-statements.html" target="_blank">SQL Reference</a>. For a more guided experience, see our [interactive tutorials](#interactive-tutorials).
 

--- a/v21.1/sql-playground.md
+++ b/v21.1/sql-playground.md
@@ -4,7 +4,7 @@ summary: Use CockroachDB v21.1 in a playground environment
 toc: false
 ---
 
-This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running a testing release of v21.1. The cluster is pre-loaded with a sample dataset, configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality, and set up with a user to access the DB Console (see the terminal output for login credentials).
+This playground gives you an interactive SQL shell to a single-node CockroachDB cluster running a testing release of v21.1. The cluster is pre-loaded with a sample dataset, configured for CockroachDB's <a href="spatial-features.html" target="_blank">spatial</a> functionality, and set up with a DB Console user (login: max/roach).
 
 For docs on our SQL dialect, see <a href="sql-statements.html" target="_blank">SQL Reference</a>. For a more guided experience, see our [interactive tutorials](#interactive-tutorials).
 


### PR DESCRIPTION
Previously, we asked users to look in the terminal
output to find the DB Console user credentials. Now,
we just provide that info in the page intro.