### PR TITLE
Schema best practice and examples update

### DIFF
--- a/v21.1/connect-to-the-database.md
+++ b/v21.1/connect-to-the-database.md
@@ -183,27 +183,26 @@ conn = psycopg2.connect(
 
 </section>
 
-## See also
-
-Reference information related to this task:
-
-- [Connection parameters][connection_params]
-- [Manual deployments][manual]
-- [Orchestrated deployments][orchestrated]
-- [Start a local cluster (secure)][local_secure]
+## What's next?
 
 <a name="tasks"></a>
 
-Other common tasks:
-
+- [Design a Database Schema](schema-design-overview.html)
 - [Insert Data](insert-data.html)
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
+
+You might also be interested in the following pages:
+
+- [Connection Pooling](connection-pooling.html)
+- [Connection Parameters][connection_params]
+- [Manual Deployments][manual]
+- [Orchestrated Deployments][orchestrated]
+- [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Make Queries Fast](make-queries-fast.html)
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.1/developer-guide-overview.md
+++ b/v21.1/developer-guide-overview.md
@@ -49,19 +49,20 @@ CockroachDB supports the PostgreSQL wire protocol, and CockroachDB supports [mos
 
 A growing number of popular third-party database tools offer full support for CockroachDB, but, CockroachDB uses the PostgreSQL wire protocol and supports PostgreSQL syntax, most PostgreSQL-compatible third-party tools are also compatible with CockroachDB. For a list of libraries and tools that we have tested against CockroachDB, see [Third-party Database Tools](third-party-database-tools.html).
 
-## Sample Apps and Tutorials
+## What's next?
 
-For simple but complete sample apps and tutorials, see [Hello World](hello-world-example-apps.html).
+- [Start a Local Cluster](secure-a-cluster.html)
+- [Install a Driver or ORM Framework](install-client-drivers.html)
+- [Connect to CockroachDB](connect-to-the-database.html)
 
-For more advanced sample apps and tutorials, see [Build a Spring App with CockroachDB](build-a-spring-app-with-cockroachdb-jdbc.html) and [Develop and Deploy a Multi-Region Web Application](multi-region-overview.html).
+You might also be interested in the following pages:
 
-{% include cockroach_u_pydev.md %}
-
-## See also
-
-- [Start a local cluster](secure-a-cluster.html)
-- [Install a client library](install-client-drivers.html)
-- [Migrate to CockroachDB](migration-overview.html)
-- [PostgreSQL compatibility](postgresql-compatibility.html)
 - [Architecture Overview](architecture/overview.html)
 - [Transactions](transactions.html)
+- [CockroachDB Migration](migration-overview.html)
+- [PostgreSQL Compatibility](postgresql-compatibility.html)
+- [Hello World Example Apps](hello-world-example-apps.html)
+- [Build a Spring App with CockroachDB](build-a-spring-app-with-cockroachdb-jdbc.html)
+- [Develop and Deploy a Multi-Region Web Application](multi-region-overview.html)
+
+{% include cockroach_u_pydev.md %}

--- a/v21.1/install-client-drivers.md
+++ b/v21.1/install-client-drivers.md
@@ -439,7 +439,12 @@ Install TypeORM as described in the [official documentation](https://typeorm.io/
 
 </section>
 
-## See also
+## What's next?
+
+- [Connect to CockroachDB](connect-to-the-database.html)
+- [Design a Database Schema](schema-design-overview.html)
+
+You might also be interested in the following pages:
 
 - [Third party database tools](third-party-database-tools.html)
 - [Connection parameters](connection-parameters.html)

--- a/v21.1/schema-design-database.md
+++ b/v21.1/schema-design-database.md
@@ -4,7 +4,7 @@ summary: Create a database for your CockroachDB cluster
 toc: true
 ---
 
-This page provides best-practice guidance on creating databases, with a simple example.
+This page provides best-practice guidance on creating databases, with a couple examples based on Cockroach Labs' fictional vehicle-sharing company, [MovR](movr.html).
 
 {{site.data.alerts.callout_success}}
 For reference documentation on the `CREATE DATABASE` statement, including additional examples, see the [`CREATE DATABASE` syntax page](create-database.html).
@@ -36,15 +36,18 @@ Before reading this page, do the following:
 
 Database objects make up the first level of the [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy).
 
-To create a database, use a [`CREATE DATABASE` statement](create-database.html), following [the database best practices](#database-best-practices). After reviewing the best practices, see the example we provide [below](#example).
+To create a database, use a [`CREATE DATABASE` statement](create-database.html), following [the database best practices](#database-best-practices). After reviewing the best practices, see the examples we provide [below](#examples).
 
 ### Database best practices
 
 Here are some best practices to follow when creating and using databases:
 
 - Do not use the preloaded `defaultdb` database. Instead, create your own database with a `CREATE DATABASE` statement, and change it to the SQL session's [current database](sql-name-resolution.html#current-database) by executing a `USE [databasename];` statement, by passing the `--database=[databasename]` flag to the [`cockroach sql` command](cockroach-sql.html#general), or by specifying the `database` parameter in the [connection string](connection-parameters.html#connect-using-a-url) passed to your database schema migration tool.
-- Create databases as the `root` user, and create all other lower-level objects with a [different user](schema-design-overview.html#controlling-access-to-objects), with more limited privileges, following [authorization best practices](authorization.html#authorization-best-practices).
-- Limit the number of databases you create. If you need to create multiple tables with the same name in your cluster, do so in different [user-defined schemas](#create-a-user-defined-schema) in the same database.
+
+- Create databases as the `root` user, and create all other lower-level objects with a [different user](schema-design-overview.html#controlling-access-to-objects), with fewer privileges, following [authorization best practices](authorization.html#authorization-best-practices).
+
+- Limit the number of databases you create. If you need to create multiple tables with the same name in your cluster, do so in different [user-defined schemas](#create-a-user-defined-schema), in the same database.
+
 - {% include {{page.version.version}}/sql/dev-schema-changes.md %}
 
 ### Example
@@ -73,10 +76,10 @@ To create a database as `root`, issue a `CREATE DATABASE` statement in the SQL s
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> CREATE DATABASE cockroachlabs;
+> CREATE DATABASE movr;
 ~~~
 
-This statement creates a database object with the name `cockroachlabs`.
+This statement creates a database object with the name `movr`. This database will store all of the data for the MovR application.
 
 To view the database in the cluster, use a [`SHOW DATABASES`](show-databases.html) statement:
 
@@ -88,47 +91,69 @@ To view the database in the cluster, use a [`SHOW DATABASES`](show-databases.htm
 ~~~
   database_name
 -----------------
-  cockroachlabs
   defaultdb
+  movr
   postgres
   system
 (4 rows)
 ~~~
 
-To follow [authorization best practices](authorization.html#authorization-best-practices), after you create a new database, you should also create a new SQL user to manage the lower-level objects in the new database.
+To follow [authorization best practices](authorization.html#authorization-best-practices), after you create a new database, you should also create some new SQL users to manage the lower-level objects in the new database.
 
 In the open SQL shell, execute the following `CREATE USER` statement:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> CREATE USER maxroach;
+> CREATE USER max;
 ~~~
 
-This creates a SQL user named `maxroach`, with no privileges.
+This creates a SQL user named `max`, with no privileges.
 
-Use a `GRANT` statements to grant the user `CREATE` privileges on the `cockroachlabs` database.
+Use a `GRANT` statements to grant the user `CREATE` privileges on the `movr` database.
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> GRANT CREATE ON DATABASE cockroachlabs TO maxroach;
+> GRANT CREATE ON DATABASE movr TO max;
 ~~~
 
-This privilege allows `maxroach` to create objects (i.e., user-defined schemas) in the `cockroachlabs` database.
+This privilege allows `max` to create objects (i.e., user-defined schemas) in the `movr` database.
 
-To connect to a secure cluster, the user needs a user certificate. To create a user certificate for `maxroach`, open a new terminal, and run the following [`cockroach cert`](cockroach-cert.html) command:
+In the same SQL shell, create a second user named `abbey`, and grant them the same privileges.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE USER abbey;
+> GRANT CREATE ON DATABASE movr TO abbey;
+~~~
+
+This creates a second SQL user named `abbey`, with `CREATE` privileges on the database.
+
+To connect to a secure cluster and execute SQL statements, users need [user certificates](authentication.html#client-authentication). To create a user certificate for `max`, open a new terminal, and run the following [`cockroach cert`](cockroach-cert.html) command:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach cert create-client maxroach --certs-dir=[certs-directory] --ca-key=[my-safe-directory]/ca.key
+$ cockroach cert create-client max --certs-dir=[certs-directory] --ca-key=[my-safe-directory]/ca.key
 ~~~
 
-You're now ready to start adding user-defined schemas to the `cockroachlabs` database, as the `maxroach` user.
+Create a user certificate for `abbey` as well:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach cert create-client abbey --certs-dir=[certs-directory] --ca-key=[my-safe-directory]/ca.key
+~~~
+
+You're now ready to start adding user-defined schemas to the `movr` database for the `max` and `abbey` users.
 
 For guidance on creating user-defined schemas, see at [Create a User-defined Schema](schema-design-schema.html).
 
-## See also
+## What's next?
 
 - [Create a User-defined Schema](schema-design-schema.html)
-- [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)
-- [Schema Design Overview](schema-design-overview.html)
+- [Create a Table](schema-design-table.html)
+
+You might also be interested in the following pages:
+
 - [`CREATE DATABASE`](create-database.html)
+- [Cockroach Commands](cockroach-commands.html)
+- [Schema Design Overview](schema-design-overview.html)
+- [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)

--- a/v21.1/schema-design-overview.md
+++ b/v21.1/schema-design-overview.md
@@ -28,7 +28,7 @@ For guidance on creating databases, see [Create a Database](schema-design-databa
 
 Schemas make up the second level of the naming hierarchy. Each schema belongs to a single database. Schemas contain [tables](#tables), [indexes](#indexes), and other objects, like [views](#views) and [sequences](#sequences).
 
-All CockroachDB clusters include a preloaded schema named `public`. Rather than using the `public` schema, we recommend creating your own *user-defined schema*.
+All CockroachDB clusters include a preloaded schema named `public`. CockroachDB also supports creating your own *user-defined schema*.
 
 For guidance on creating user-defined schemas, see [Create a User-defined Schema](schema-design-schema.html).
 
@@ -104,9 +104,13 @@ We do not recommend using client drivers or ORM frameworks to execute database s
     The CockroachDB SQL client allows you to execute commands from the command line, or through the [CockroachDB SQL shell](cockroach-sql.html#sql-shell) interface. From the command line, you can pass a string to the client for execution, or you can pass a `.sql` file populated with SQL commands. From the SQL shell, you can execute SQL commands directly. Throughout the guide, we pass a `.sql` file to the SQL client to perform most database schema changes.
 
 
-## See also
+## What's next?
 
 - [Create a Database](schema-design-database.html)
+- [Create a User-defined Schema](schema-design-database.html)
+
+You might also be interested in the following pages:
+
 - [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)
 - [Authorization](authorization.html)
 - [Liquibase](liquibase.html)

--- a/v21.1/schema-design-schema.md
+++ b/v21.1/schema-design-schema.md
@@ -45,60 +45,93 @@ To create a user-defined schema, use a [`CREATE SCHEMA` statement](create-schema
 
 Here are some best practices to follow when creating and using user-defined schemas:
 
-- Do not use the preloaded `public` schema. Instead, create a user-defined schema with `CREATE SCHEMA`, and then refer to lower-level objects with fully-qualified names (e.g., `schema_name.table_name`).
-- Do not create user-defined schemas as the `root` user. Instead, create all lower-level objects with a [different user](schema-design-overview.html#controlling-access-to-objects), with more limited privileges, following [authorization best practices](authorization.html#authorization-best-practices).
-- Do not create user-defined schemas in the preloaded `defaultdb` database. Instead, use a database [you have created](schema-design-database.html). Schemas can only be created in your SQL session's [current database](sql-name-resolution.html#current-database), so be sure to [change the session's database](schema-design-database.html#database-best-practices) before creating a user-defined schema.
-- When you create a user-defined schema, take note of the [object's *owner*](authorization.html#object-ownership). You can specify the owner in a `CREATE SCHEMA` statement with the `AUTHORIZATION` keyword. If `AUTHORIZATION` is not specified, the owner will be the user creating the user-defined schema. We recommend creating user-defined schemas as the user that will create and use the lower-level objects of the database schema (e.g., tables and indexes).
+- If you want to create multiple objects (e.g., tables or views) with the same name in your cluster, do so in different user-defined schemas in the same database.
+
+- If you want to separate lower-level objects (e.g., a set of [tables](create-a-table.html) or [views](views.html)) for access or organizational purposes, do not create those objects in the preloaded [`public` schema](sql-name-resolution.html#naming-hierarchy). Instead, create user-defined schemas, and then create the objects in the user-defined schemas.
+
+- Do not create user-defined schemas as the `root` user. Instead, create them as a [different user](schema-design-overview.html#controlling-access-to-objects), with fewer privileges on the database, following [authorization best practices](authorization.html#authorization-best-practices).
+
+- When you create a user-defined schema, take note of the [object's owner](authorization.html#object-ownership). You can specify the owner in a `CREATE SCHEMA` statement with the `AUTHORIZATION` keyword. If `AUTHORIZATION` is not specified, the owner will be the user creating the user-defined schema. We recommend creating user-defined schemas as the user that will create and use the lower-level objects of the database schema (e.g., tables and indexes).
+
+- Do not create user-defined schemas in the preloaded `defaultdb` database. Instead, use a database [you have created](schema-design-database.html). User-defined schemas can only be created in your SQL session's [current database](sql-name-resolution.html#current-database), so be sure to [change the session's database](schema-design-database.html#database-best-practices) to a database that you have created before creating a user-defined schema.
+
+- When referring to a lower-level object in a database (e.g., a table), include the object's schema name (e.g., `schema_name.table_name`). Specifying the schema name in a lower-level object reference can prevent users from attempting to access the wrong object, if there are multiple objects with the same name in a database.
+
 - {% include {{page.version.version}}/sql/dev-schema-changes.md %}
 
 ### Example
 
-{{site.data.alerts.callout_info}}
-For the examples in the rest of the [**Design a Database Schema** sections](schema-design-table.html), we'll add all database schema change statements to a `.sql` file, and then pass the file to the [SQL client](cockroach-sql.html) for execution as the `maxroach` user.
-{{site.data.alerts.end}}
+For the examples in the rest of the **Design a Database Schema** sections, you'll add database schema change statements to `.sql` files, and then pass the files to the [SQL client](cockroach-sql.html) to be executed as a specific user.
 
-Create an empty file with the `.sql` file extension at the end of the filename. For example:
+For each user that you created in the `movr` database in [Create a Database](schema-design-database.html) (i.e., `max` and `abbey`), create an empty file with the `.sql` file extension at the end of the filename. For example:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ touch dbinit.sql
+$ touch max_dbinit.sql
 ~~~
 
-Now, open `dbinit.sql` in a text editor of your choice, and add a `CREATE SCHEMA` statement to the top of the file:
+{% include copy-clipboard.html %}
+~~~ shell
+$ touch abbey_dbinit.sql
+~~~
+
+These files will initialize the objects in the `movr` database, for each user.
+
+Open `max_dbinit.sql` in a text editor of your choice, and add a `CREATE SCHEMA` statement to the top of the file:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE SCHEMA IF NOT EXISTS movr;
+CREATE SCHEMA IF NOT EXISTS max_schema;
 ~~~
 
-This statement will create a user-defined schema named `movr` in the [current database](sql-name-resolution.html#current-database), if one does not already exist.
+This statement will create a user-defined schema named `max_schema` in the [current database](sql-name-resolution.html#current-database), if one does not already exist. This schema will hold all of the objects in the database schema [owned by](authorization.html#object-ownership) `max`.
 
-To execute the statements in the `dbinit.sql` file, run the following command:
+Now, open `abbey_dbinit.sql` in a text editor of your choice, and add a `CREATE SCHEMA` statement to the top of the file:
+
+{% include copy-clipboard.html %}
+~~~
+CREATE SCHEMA IF NOT EXISTS abbey_schema;
+~~~
+
+This statement will create a user-defined schema named `abbey_schema` in the current database, if one does not already exist. This schema will hold all of the objects in the database schema accessible to `abbey`.
+
+To execute the statements in the `max_dbinit.sql` file as `max`, run the following command:
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql \
 --certs-dir=[certs-directory] \
---user=maxroach \
---database=cockroachlabs
-< dbinit.sql
+--user=max \
+--database=movr
+< max_dbinit.sql
 ~~~
 
-The SQL client will execute any statements in `dbinit.sql`, with `cockroachlabs` as the database and `maxroach` as the user.
+The SQL client will execute any statements in `max_dbinit.sql`, with `movr` as the database and `max` as the user. `max` will be the [owner](authorization.html#object-ownership) of any objects created by the statements in the file.
 
-After you have executed the statements, you can see the `cockroachlabs` database and the `movr` user-defined schema in the [CockroachDB SQL shell](cockroach-sql.html#sql-shell).
-
-To open the SQL shell with `cockroachlabs` as the database, run the following command:
+To execute the statements in the `abbey_dbinit.sql` file as `abbey`, run the following command:
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql \
 --certs-dir=[certs-directory] \
---user=maxroach \
---database=cockroachlabs
+--user=abbey \
+--database=movr
+< abbey_dbinit.sql
 ~~~
 
-To view the user-defined schemas in `cockroachlabs`, issue a [`SHOW SCHEMAS`](show-schemas.html) statement:
+`abbey` will be the owner of any objects created by the statements in the file.
+
+After you have executed the statements in both files, you can see the user-defined schemas in the [CockroachDB SQL shell](cockroach-sql.html#sql-shell), as either user:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql \
+--certs-dir=[certs-directory] \
+--user=max \
+--database=movr
+~~~
+
+To view the user-defined schemas in the current database, issue a [`SHOW SCHEMAS`](show-schemas.html) statement:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -108,21 +141,29 @@ To view the user-defined schemas in `cockroachlabs`, issue a [`SHOW SCHEMAS`](sh
 ~~~
      schema_name
 ----------------------
+  abbey_schema
   crdb_internal
   information_schema
-  movr
+  max_schema
   pg_catalog
   pg_extension
   public
-(6 rows)
+(7 rows)
 ~~~
 
-You're now ready to start adding tables to the `movr` user-defined schema as the `maxroach` user. For guidance on creating tables, see at [Create a Table](schema-design-table.html).
+You're now ready to start adding tables to the `max_schema` user-defined schema as the `max` user, and to the `abbey_schema` user-defined schema as the `abbey` user.
 
-## See also
+For guidance on creating tables, see at [Create a Table](schema-design-table.html).
 
-- [Create a Database](schema-design-database.html)
+## What's next?
+
 - [Create a Table](schema-design-table.html)
-- [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)
-- [Schema Design Overview](schema-design-overview.html)
+- [Add Secondary Indexes](schema-design-indexes.html)
+
+You might also be interested in the following pages:
+
 - [`CREATE SCHEMA`](create-schema.html)
+- [Cockroach Commands](cockroach-commands.html)
+- [Create a Database](schema-design-database.html)
+- [Schema Design Overview](schema-design-overview.html)
+- [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)

--- a/v21.1/schema-design-table.md
+++ b/v21.1/schema-design-table.md
@@ -52,7 +52,9 @@ To create a table, use a [`CREATE TABLE` statement](create-table.html), followin
 
 ### Name a table
 
-Naming a table is the first step in table creation. `CREATE TABLE` statements generally take the form:
+Naming a table is the first step in table creation.
+
+`CREATE TABLE` statements generally take the form:
 
 ~~~
 CREATE TABLE [schema_name].[table_name] (
@@ -66,22 +68,23 @@ Where `schema_name` is the name of the user-defined schema, `table_name` is the 
 
 Here are some best practices to follow when naming tables:
 
-- Use a fully-qualified name (i.e., `CREATE TABLE schema_name.table_name`). If you do not specify the user-defined schema in the table name, CockroachDB will create the table in the preloaded `public` schema.
+- Use a [fully-qualified name](sql-name-resolution.html#how-name-resolution-works) (i.e., `CREATE TABLE database_name.schema_name.table_name`). If you do not specify the database name, CockroachDB will use the SQL session's [current database](sql-name-resolution.html#current-database) (`defaultdb`, by default). If you do not specify the user-defined schema in the table name, CockroachDB will create the table in the preloaded `public` schema.
+
 - Use a table name that reflects the contents of the table. For example, for a table containing information about orders, you could use the name `orders` (as opposed to naming the table something like `table1`).
 
 #### Table naming example
 
 Suppose you want to create a table to store information about users of the [MovR](movr.html) platform.
 
-In a text editor, open the `dbinit.sql` file that you used to create the `movr` user-defined schema in [Create a User-defined Schema](schema-design-schema.html). Under the `CREATE SCHEMA` statement, add an empty `CREATE TABLE` statement for the `users` table.
+In a text editor, open the `max_dbinit.sql` file that you used to create the `max_schema` user-defined schema in [Create a User-defined Schema](schema-design-schema.html). Under the `CREATE SCHEMA` statement, add an empty `CREATE TABLE` statement for the `users` table.
 
 The file should now look something like this:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE SCHEMA IF NOT EXISTS cockroachlabs;
+CREATE SCHEMA IF NOT EXISTS movr;
 
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.users (
+CREATE TABLE IF NOT EXISTS movr.max_schema.users (
 );
 ~~~
 
@@ -91,30 +94,35 @@ Don't execute the file yet. You need to first [define the columns](#define-colum
 
 ### Define columns
 
-Column definitions give structure to a table by separating the values in each row into columns of a single data type. Column definitions generally take the following form:
+Column definitions give structure to a table by separating the values in each row into columns of a single data type.
+
+Column definitions generally take the following form:
 
 ~~~
 [column_name] [DATA_TYPE] [column_qualification]
 ~~~
 
-Where `column_name` is the column name, `DATA_TYPE` is the [data type](data-types.html) of the row values in the column, and `column_qualification` is some column qualification, such as a [constraint](#add-additional-constraints).
+Where `column_name` is the column name, `DATA_TYPE` is the [data type](data-types.html) of the row values in the column, and `column_qualification` is some column qualification, such as a [column-level constraint](#add-additional-constraints).
 
 #### Column definition best practices
 
 Here are some best practices to follow when defining table columns:
 
 - Review the supported column [data types](data-types.html), and select the appropriate type for the data you plan to store in a column, following the best practices listed on the data type's reference page.
+
 - Use column data types with a fixed size limit, or set a maximum size limit on column data types of variable size (e.g., [`VARBIT(n)`](bit.html#size)). Values exceeding 1MB can lead to [write amplification](https://en.wikipedia.org/wiki/Write_amplification) and cause significant performance degradation.
-- Review the [primary key best practices](#select-the-primary-key-columns), decide if you need to define any dedicated primary key columns.
-- Review the best practices for [adding additional constraints](#add-additional-constraints), and decide if you need to add any additional constraints to your columns.
+
+- Review the [primary key best practices](#select-the-primary-key-columns) and [examples](#primary-key-examples), decide if you need to define any dedicated primary key columns.
+
+- Review the best practices and examples for [adding additional constraints](#add-additional-constraints), and decide if you need to add any additional constraints to your columns.
 
 #### Column definition examples
 
-In the `dbinit.sql` file, add a few column definitions to the `users` table's `CREATE TABLE` statement, for user names and email addresses:
+In the `max_dbinit.sql` file, add a few column definitions to the `users` table's `CREATE TABLE` statement, for user names and email addresses:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.users (
+CREATE TABLE IF NOT EXISTS movr.max_schema.users (
     first_name STRING,
     last_name STRING,
     email STRING
@@ -125,14 +133,13 @@ All of the columns shown above use the [`STRING`](string.html) data type, meanin
 
 CockroachDB supports a number of other column data types, including [`DECIMAL`](decimal.html), [`INT`](integer.html), [`TIMESTAMP`](timestamp.html), [`UUID`](uuid.html), and [enumerated data types](#user-defined-types) and [spatial data types](#spatial-data-types). We recommend that you review the [supported types](data-types.html), and create columns with data types that correspond to the types of data that you intend to persist to the cluster from your application.
 
-Let's add another example table to our `movr` schema, with more column data types.
+Let's add another example table to our `max_schema` schema, with more column data types.
 
-As a vehicle-sharing platform, MovR needs to store data about its vehicles. In `dbinit.sql`, add a `CREATE TABLE` statement for a `vehicles` table, under the `CREATE TABLE` statement for `users`. This table should probably include information about the type of vehicle, when it was created, what its availability is, and where it is located:
-:
+As a vehicle-sharing platform, MovR needs to store data about its vehicles. In `max_dbinit.sql`, add a `CREATE TABLE` statement for a `vehicles` table, under the `CREATE TABLE` statement for `users`. This table should probably include information about the type of vehicle, when it was created, what its availability is, and where it is located:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
+CREATE TABLE IF NOT EXISTS movr.max_schema.vehicles (
       id UUID,
       type STRING,
       creation_time TIMESTAMPTZ,
@@ -143,19 +150,19 @@ CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
 
 This table includes a few more data types than the `users` table:
 
-- `UUID`, which we recommend for columns with [values that uniquely identify rows](https://en.wikipedia.org/wiki/Unique_key) (like an "id" column).
-- `TIMESTAMPTZ`, which we recommend for [timestamp values](https://en.wikipedia.org/wiki/Timestamp)
-- `BOOL`, which we recommend for columns that will only take one of two possible values.
+- [`UUID`](uuid.html), which we recommend for columns with [values that uniquely identify rows](https://en.wikipedia.org/wiki/Unique_key) (like an "id" column).
+- [`TIMESTAMPTZ`](timestamp.html), which we recommend for [timestamp values](https://en.wikipedia.org/wiki/Timestamp).
+- [`BOOL`](bool.html), which we recommend for columns that will only take one of two possible values.
 
 The rest of the columns are `STRING`-typed.
 
-Note that values in the `STRING`-typed `type` column will likely only be values from a fixed list of possible values, as the `type` of a vehicle can only be one of the vehicles supported by the MovR platform (e.g., a `bike`, a `scooter`, or a `skateboard`). For values like this, we recommend using a [user-defined, enumerated type](enum.html).
+Note that values in the `type` column will likely only be `STRING` values from a fixed list of values. Specifically, the vehicle type can only be one of the vehicle types supported by the MovR platform (e.g., a `bike`, a `scooter`, or a `skateboard`). For values like this, we recommend using a [user-defined, enumerated type](enum.html).
 
 To create a user-defined type, use a `CREATE TYPE` statement. For example, above the `CREATE TABLE` statement for the `vehicles` table, add the following statements:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TYPE vtype AS ENUM ('bike', 'scooter', 'skateboard');
+CREATE TYPE movr.max_schema.vtype AS ENUM ('bike', 'scooter', 'skateboard');
 ~~~
 
 {{site.data.alerts.callout_success}}
@@ -166,7 +173,7 @@ You can then use `vtype` as the `type` column's data type:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
+CREATE TABLE IF NOT EXISTS movr.max_schema.vehicles (
       id UUID,
       type vtype,
       creation_time TIMESTAMPTZ,
@@ -177,7 +184,7 @@ CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
 
 Only values in the set of `vtype` values will be allowed in the `type` column.
 
-The `users` and `vehicles` tables now have syntactically valid column definitions. As a best practice, you should explicitly [select primary key columns](#select-primary-key-columns) for the tables before executing the `CREATE TABLE` statements.
+The `users` and `vehicles` tables now have syntactically valid `CREATE TABLE` statements. As a best practice, the `CREATE TABLE` statements should explicitly [select primary key columns](#select-primary-key-columns).
 
 ### Select primary key columns
 
@@ -197,41 +204,33 @@ For detailed reference documentation on the `PRIMARY KEY` constraint, including 
 
 Here are some best practices to follow when selecting primary key columns:
 
-- Understand how the data in the primary key column(s) is [distributed across a cluster](architecture/distribution-layer.html).
+- Avoid defining primary keys over a single column of sequential data.
 
-    Non-uniform data distributions can lead to hotspots on a single range, or cause [transaction contention](transactions.html#transaction-contention).
+    Querying a table with a primary key on a single sequential column (e.g., an auto-incrementing [`INT`](int.html) column, or a [`TIMESTAMP`](timestamp.html) value) can result in single-range hotspots that negatively affect performance, or cause [transaction contention](transactions.html#transaction-contention).
 
-- Consider the [data types](data-types.html) of the primary key column(s).
-
-    A primary key column's data type can determine where its row data is stored on a cluster. For example, some data types are sequential in nature (e.g., [`TIMESTAMP`](timestamp.html)). Defining primary keys on columns of sequential data can result in data being concentrated in a smaller number of ranges, which can negatively affect performance.
+    If you are working with a table that *must* be indexed on sequential keys, use [hash-sharded indexes](hash-sharded-indexes.html). For details about the mechanics and performance improvements of hash-sharded indexes in CockroachDB, see our [Hash Sharded Indexes Unlock Linear Scaling for Sequential Workloads](https://www.cockroachlabs.com/blog/hash-sharded-indexes-unlock-linear-scaling-for-sequential-workloads/) blog post.
 
 - Define a primary key for every table.
 
     If you create a table without defining a primary key, CockroachDB will automatically create a primary key over a hidden, [`INT`](int.html)-typed column named `rowid`. By default, sequential, unique identifiers are generated for each row in the `rowid` column with the [`unique_rowid()` function](functions-and-operators.html#built-in-functions). The sequential nature of the `rowid` values can lead to a poor distribution of the data across a cluster, which can negatively affect performance. Furthermore, because you cannot meaningfully use the `rowid` column to filter table data, the primary key index on `rowid` does not offer any performance optimization. This means you will always have improved performance by defining a primary key for a table.
 
-- Define primary key constraints over multiple columns (i.e., use [composite primary keys](https://en.wikipedia.org/wiki/Composite_key)).
+- When possible, define primary key constraints over multiple columns (i.e., use [composite primary keys](https://en.wikipedia.org/wiki/Composite_key)).
 
-    When defining composite primary keys, make sure the data in the first column of the primary key prefix is well-distributed across the nodes in the cluster. To improve the performance of [ordered queries](query-order.html), you can add monotonically increasing primary key columns after the first column of the primary key prefix. For an example, see [Use multi-column primary keys](performance-best-practices-overview.html#use-multi-column-primary-keys) on the [SQL Performance Best Practices](performance-best-practices-overview.html) page.
+    When defining composite primary keys, make sure the data in the first column of the primary key prefix is well-distributed across the nodes in the cluster. To improve the performance of [ordered queries](query-order.html), you can add monotonically increasing primary key columns after the first column of the primary key prefix. For an example, see [below](#primary-key-examples).
 
-- For single-column primary keys, use [`UUID`](uuid.html)-typed columns with [randomly-generated default values](performance-best-practices-overview.html#use-uuid-to-generate-unique-ids), using the `gen_random_uuid()` [SQL function](functions-and-operators.html#id-generation-functions).
+- For single-column primary keys, use [`UUID`](uuid.html)-typed columns with default values randomly-generated, using the `gen_random_uuid()` [SQL function](functions-and-operators.html#id-generation-functions).
 
-    Randomly generating `UUID` values ensures that the primary key values will be unique and well-distributed across a cluster.
-
-- Avoid defining primary keys over a single column of sequential data.
-
-    Querying a table with a primary key on a single sequential column (e.g., an auto-incrementing [`INT`](int.html) column) can result in single-range hotspots that negatively affect performance. Instead, use a composite key with a non-sequential prefix, or use a `UUID`-typed column.
-
-    If you are working with a table that *must* be indexed on sequential keys, use [hash-sharded indexes](hash-sharded-indexes.html). For details about the mechanics and performance improvements of hash-sharded indexes in CockroachDB, see our [Hash Sharded Indexes Unlock Linear Scaling for Sequential Workloads](https://www.cockroachlabs.com/blog/hash-sharded-indexes-unlock-linear-scaling-for-sequential-workloads/) blog post.
+    Randomly generating `UUID` values ensures that the primary key values will be unique and well-distributed across a cluster. For an example, see [below](#primary-key-examples).
 
 #### Primary key examples
 
-To follow a [primary key best practice](#primary-key-best-practices), the `CREATE TABLE` statements in `dbinit.sql` for the `users` and `vehicles` tables need to explicitly define a primary key.
+To follow a [primary key best practice](#primary-key-best-practices), the `CREATE TABLE` statements in `max_dbinit.sql` for the `users` and `vehicles` tables need to explicitly define a primary key.
 
-In the `dbinit.sql` file, add a composite primary key on the `first_name` and `last_name` columns of the `users` table:
+In the `max_dbinit.sql` file, add a composite primary key on the `first_name` and `last_name` columns of the `users` table:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.users (
+CREATE TABLE IF NOT EXISTS movr.max_schema.users (
     first_name STRING,
     last_name STRING,
     email STRING,
@@ -249,7 +248,7 @@ In the `vehicles` table definition, add a `PRIMARY KEY` constraint on the `id` c
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
+CREATE TABLE IF NOT EXISTS movr.max_schema.vehicles (
       id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
       type vtype,
       creation_time TIMESTAMPTZ,
@@ -262,9 +261,9 @@ Note that, in addition to the `PRIMARY KEY` constraint, the `id` column has a `D
 
 ### Add additional constraints
 
-In addition to the `PRIMARY KEY` constraint, CockroachDB supports a number of other [column-level constraints](constraints.html), including [`CHECK`](check.html), [`DEFAULT`](#populate-with-default-values), [`FOREIGN KEY`](#reference-other-tables), [`UNIQUE`](#prevent-duplicates), [`NOT NULL`](#prevent-null-values). Using constraints can simplify table queries, improve query performance, and ensure that data remains semantically valid.
+In addition to the `PRIMARY KEY` constraint, CockroachDB supports a number of other [column-level constraints](constraints.html), including [`CHECK`](check.html), [`DEFAULT`](#populate-with-default-values), [`FOREIGN KEY`](#reference-other-tables), [`UNIQUE`](#prevent-duplicates), and [`NOT NULL`](#prevent-null-values). Using constraints can simplify table queries, improve query performance, and ensure that data remains semantically valid.
 
-To constrain a column, you can add the constraint's clause to the column's definition, as shown in the [`PRIMARY KEY` example above](#primary-key-examples). To constrain more than one column, add the entire constraint's definition after the list of columns in the `CREATE TABLE` statement, also shown in the [`PRIMARY KEY` example above](#primary-key-examples).
+To constrain a single column, add a constraint keyword to the column's definition, as shown in the [single-column `PRIMARY KEY` example above](#primary-key-examples). To constrain more than one column, add the entire constraint's definition after the list of columns in the `CREATE TABLE` statement, also shown in the [composite `PRIMARY KEY` example above](#primary-key-examples).
 
 For guidance and examples for each constraint, see the sections below.
 
@@ -278,11 +277,11 @@ To set default values on columns, use the `DEFAULT` constraint. Default values e
 
 When combined with [supported SQL functions](functions-and-operators.html), default values can save resources in your application's persistence layer by offloading computation onto CockroachDB. For example, rather than using an application library to generate unique `UUID` values, you can set a default value to be an automatically-generated `UUID` value with the `gen_random_uuid()` SQL function. Similarly, you could use a default value to populate a `TIMESTAMP` column with the current time of day, using the `now()` function.
 
-For example, in the `vehicles` table definition in `dbinit.sql`, you added a `DEFAULT gen_random_uuid()` clause to the `id` column definition. Now, add a default value to the `creation_time` column:
+For example, in the `vehicles` table definition in `max_dbinit.sql`, you added a `DEFAULT gen_random_uuid()` clause to the `id` column definition. Now, add a default value to the `creation_time` column:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
+CREATE TABLE IF NOT EXISTS movr.max_schema.vehicles (
       id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
       type vtype,
       creation_time TIMESTAMPTZ DEFAULT now(),
@@ -291,7 +290,7 @@ CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
   );
 ~~~
 
-When a row is inserted into the `vehicles` table, CockroachDB generates a random default value for the vehicle `id`, and uses the current timestamp for the vehicle's `creation_time`. Rows inserted into the `vehicles` table do not need to include a value for `id` or `creation_time`.
+When a row is inserted into the `vehicles` table, CockroachDB generates a random default value for the vehicle `id`, and uses the current timestamp for the vehicle's `creation_time`. Rows inserted into the `vehicles` table do not need to include an explicit value for `id` or `creation_time`.
 
 {{site.data.alerts.callout_success}}
 For detailed reference documentation on the `DEFAULT` constraint, including additional examples, see [the `DEFAULT` syntax page](default-value.html).
@@ -303,13 +302,13 @@ To reference values in another table, use a `FOREIGN KEY` constraint. `FOREIGN K
 
 For example, suppose you want to add a new table that contains data about the rides that MovR users are taking on vehicles. This table should probably include information about the location and duration of the ride, as well as information about the vehicle used for the ride.
 
-In `dbinit.sql`, under the `CREATE TABLE` statement for `vehicles`, add a definition for a `rides` table, with a foreign key dependency on the `vehicles` table. To define a foreign key constraint, use the `REFERENCES` keyword:
+In `max_dbinit.sql`, under the `CREATE TABLE` statement for `vehicles`, add a definition for a `rides` table, with a foreign key dependency on the `vehicles` table. To define a foreign key constraint, use the `REFERENCES` keyword:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.rides (
+CREATE TABLE IF NOT EXISTS movr.max_schema.rides (
       id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-      vehicle_id UUID REFERENCES cockroachlabs.movr.vehicles(id),
+      vehicle_id UUID REFERENCES movr.max_schema.vehicles(id),
       start_address STRING,
       end_address STRING,
       start_time TIMESTAMPTZ DEFAULT now(),
@@ -318,6 +317,24 @@ CREATE TABLE IF NOT EXISTS cockroachlabs.movr.rides (
 ~~~
 
 The `vehicle_id` column will be identical to the `id` column in the `vehicles` table. Any queries that insert a `vehicle_id` that does not exist in the `id` column of the `vehicles` table will return an error.
+
+Foreign keys cannot reference tables in a different database. They can, however reference tables in a different schema.
+
+Suppose that you want to introduce promotional codes for users on the MovR platform, but you want to limit access to the user promo code data to the `abbey` user that you created in [Create a Database](schema-design-database.html).
+
+Open the `abbey_dbinit.sql` file that you used to create the `abbey_schema` user-defined schema in [Create a User-defined Schema](schema-design-schema.html), and add a `CREATE TABLE` statement for a table called `user_promo_codes`:
+
+{% include copy-clipboard.html %}
+~~~
+CREATE TABLE movr.abbey_schema.user_promo_codes (
+    code STRING,
+    user_email STRING REFERENCES movr.max_schema.users(email),
+    valid BOOL,
+    CONSTRAINT "primary" PRIMARY KEY (code, user_email)
+  );
+~~~
+
+This new table references the `email` column of the `users` table in `max_schema`. Note that, because the `user_promo_codes` table depends on the `users` table, you'll need to execute `max_dbinit.sql` before `abbey_dbinit.sql`.
 
 {{site.data.alerts.callout_info}}
 Foreign key dependencies can significantly impact query performance, as queries involving tables with foreign keys, or tables referenced by foreign keys, require CockroachDB to check two separate tables. We recommend using them sparingly.
@@ -335,7 +352,7 @@ For example, suppose that you want to ensure that the email addresses of all use
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.users (
+CREATE TABLE IF NOT EXISTS movr.max_schema.users (
     first_name STRING,
     last_name STRING,
     email STRING UNIQUE,
@@ -363,7 +380,7 @@ For example, if you require all users of the MovR platform to have an email on f
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.users (
+CREATE TABLE IF NOT EXISTS movr.max_schema.users (
     first_name STRING,
     last_name STRING,
     email STRING UNIQUE NOT NULL,
@@ -388,39 +405,41 @@ After you have defined `CREATE TABLE` statements for your tables, you can execut
 Here are some general best practices to follow when executing `CREATE TABLE` statements:
 
 - Do not create tables as the `root` user. Instead, create tables as a [different user](schema-design-overview.html#controlling-access-to-objects), with fewer privileges, following [authorization best practices](authorization.html#authorization-best-practices). This can be the same user that created the user-defined schema to which the tables belong.
+
 - {% include {{page.version.version}}/sql/dev-schema-changes.md %}
+
 - Review the [limitations of online schema changes in CockroachDB](online-schema-changes.html#limitations). In specific, note that CockroachDB has [limited support for schema changes within the same explicit transaction](online-schema-changes#limited-support-for-schema-changes-within-transactions).
 
   We recommend doing schema changes (including `CREATE TABLE` statements) outside explicit transactions, where possible. When a database schema management tool manages transactions on your behalf, we recommend only including one schema change operation per transaction.
 
 #### Execute the example `CREATE TABLE` statements
 
-After following the examples provided in the sections above, the `dbinit.sql` file should look similar to the following:
+After following the examples provided in the sections above, the `max_dbinit.sql` file should look similar to the following:
 
 {% include copy-clipboard.html %}
 ~~~
-CREATE SCHEMA IF NOT EXISTS movr;
+CREATE SCHEMA IF NOT EXISTS max_schema;
 
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.users (
+CREATE TABLE IF NOT EXISTS movr.max_schema.users (
     first_name STRING,
     last_name STRING,
     email STRING UNIQUE NOT NULL,
     CONSTRAINT "primary" PRIMARY KEY (first_name, last_name)
 );
 
-CREATE TYPE vtype AS ENUM ('bike', 'scooter', 'skateboard');
+CREATE TYPE movr.max_schema.vtype AS ENUM ('bike', 'scooter', 'skateboard');
 
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.vehicles (
+CREATE TABLE IF NOT EXISTS movr.max_schema.vehicles (
       id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-      type vtype,
+      type movr.max_schema.vtype,
       creation_time TIMESTAMPTZ DEFAULT now(),
       available BOOL,
       last_location STRING
   );
 
-CREATE TABLE IF NOT EXISTS cockroachlabs.movr.rides (
+CREATE TABLE IF NOT EXISTS movr.max_schema.rides (
       id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-      vehicle_id UUID REFERENCES cockroachlabs.movr.vehicles(id),
+      vehicle_id UUID REFERENCES movr.max_schema.vehicles(id),
       start_address STRING,
       end_address STRING,
       start_time TIMESTAMPTZ DEFAULT now(),
@@ -428,44 +447,44 @@ CREATE TABLE IF NOT EXISTS cockroachlabs.movr.rides (
   );
 ~~~
 
-To execute the statements in the `dbinit.sql` file, run the following command:
+To execute the statements in the `max_dbinit.sql` file, run the following command:
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql \
 --certs-dir=[certs-directory] \
---user=maxroach \
---database=cockroachlabs
-< dbinit.sql
+--user=max \
+--database=movr
+< dbinit_max.sql
 ~~~
 
-The SQL client will execute any statements in `dbinit.sql`, with `cockroachlabs` as the database and `maxroach` as the user.
+The SQL client will execute any statements in `max_dbinit.sql`, with `movr` as the database and `max` as the user. `max` is now the owner of all objects created by the statements in the `max_dbinit.sql` file.
 
 After the statements have been executed, you can see the tables in the [CockroachDB SQL shell](cockroach-sql.html#sql-shell).
 
-Open the SQL shell to your cluster, with `cockroachlabs` as the database:
+Open the SQL shell to your cluster, with `movr` as the database as `max` as the user:
 
 {% include copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql \
 --certs-dir=[certs-directory] \
---user=maxroach \
---database=cockroachlabs
+--user=max \
+--database=movr
 ~~~
 
-To view the tables in the `movr` user-defined schema, issue a [`SHOW TABLES`](show-tables.html) statement:
+To view the tables in the `max_schema` user-defined schema, issue a [`SHOW TABLES`](show-tables.html) statement:
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW TABLES FROM movr;
+> SHOW TABLES FROM max_schema;
 ~~~
 
 ~~~
-  schema_name | table_name | type  | estimated_row_count
---------------+------------+-------+----------------------
-  movr        | rides      | table |                   0
-  movr        | users      | table |                   0
-  movr        | vehicles   | table |                   0
+  schema_name | table_name | type  | owner | estimated_row_count
+--------------+------------+-------+-------+----------------------
+  max_schema  | rides      | table | max   |                   0
+  max_schema  | users      | table | max   |                   0
+  max_schema  | vehicles   | table | max   |                   0
 (3 rows)
 ~~~
 
@@ -473,30 +492,111 @@ To see the individual `CREATE TABLE` statements for each table, use a [`SHOW CRE
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> SHOW CREATE TABLE movr.vehicles;
+> SHOW CREATE TABLE movr.max_schema.vehicles;
 ~~~
 
 ~~~
-   table_name   |                           create_statement
-----------------+------------------------------------------------------------------------
-  movr.vehicles | CREATE TABLE movr.vehicles (
-                |     id UUID NOT NULL DEFAULT gen_random_uuid(),
-                |     type public.vtype NULL,
-                |     creation_time TIMESTAMPTZ NULL DEFAULT now():::TIMESTAMPTZ,
-                |     available BOOL NULL,
-                |     last_location STRING NULL,
-                |     CONSTRAINT "primary" PRIMARY KEY (id ASC),
-                |     FAMILY "primary" (id, type, creation_time, available, last_location)
-                | )
+         table_name        |                             create_statement
+---------------------------+---------------------------------------------------------------------------
+  movr.max_schema.vehicles | CREATE TABLE max_schema.vehicles (
+                           |     id UUID NOT NULL DEFAULT gen_random_uuid(),
+                           |     type max_schema.vtype NULL,
+                           |     creation_time TIMESTAMPTZ NULL DEFAULT now():::TIMESTAMPTZ,
+                           |     available BOOL NULL,
+                           |     last_location STRING NULL,
+                           |     CONSTRAINT "primary" PRIMARY KEY (id ASC),
+                           |     FAMILY "primary" (id, type, creation_time, available, last_location)
+                           | )
 (1 row)
 ~~~
 
-Note that these tables only have `primary` indexes. For guidance on adding secondary indexes, see at [Add Secondary Indexes](schema-design-indexes.html).
+After following the examples provided in the sections above, the `abbey_dbinit.sql` file should look similar to the following:
 
-## See also
+{% include copy-clipboard.html %}
+~~~
+CREATE SCHEMA IF NOT EXISTS abbey_schema;
 
-- [Create a User-defined Schema](schema-design-schema.html)
+CREATE TABLE movr.abbey_schema.user_promo_codes (
+    code STRING,
+    user_email STRING REFERENCES movr.max_schema.users(email),
+    valid BOOL,
+    CONSTRAINT "primary" PRIMARY KEY (code, user_email)
+  );
+~~~
+
+To execute the statements in the `abbey_dbinit.sql` file, run the following command:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql \
+--certs-dir=[certs-directory] \
+--user=abbey \
+--database=movr
+< dbinit_abbey.sql
+~~~
+
+After the statements have been executed, you can see the table in the [CockroachDB SQL shell](cockroach-sql.html#sql-shell).
+
+Open the SQL shell to your cluster, with `movr` as the database as `abbey` as the user:
+
+{% include copy-clipboard.html %}
+~~~ shell
+$ cockroach sql \
+--certs-dir=[certs-directory] \
+--user=abbey \
+--database=movr
+~~~
+
+To view the table in the `abbey_schema` user-defined schema, issue a [`SHOW TABLES`](show-tables.html) statement:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW TABLES FROM abbey_schema;
+~~~
+
+~~~
+  schema_name  |    table_name    | type  | owner | estimated_row_count
+---------------+------------------+-------+-------+----------------------
+  abbey_schema | user_promo_codes | table | abbey |                   0
+(1 row
+~~~
+
+Show the `CREATE TABLE` statement for `user_promo_codes`:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW CREATE TABLE movr.abbey_schema.user_promo_codes;
+~~~
+
+~~~
+              table_name             |                                          create_statement
+-------------------------------------+------------------------------------------------------------------------------------------------------
+  movr.abbey_schema.user_promo_codes | CREATE TABLE abbey_schema.user_promo_codes (
+                                     |     code STRING NOT NULL,
+                                     |     user_email STRING NOT NULL,
+                                     |     valid BOOL NULL,
+                                     |     CONSTRAINT "primary" PRIMARY KEY (code ASC, user_email ASC),
+                                     |     CONSTRAINT fk_user_email_ref_users FOREIGN KEY (user_email) REFERENCES max_schema.users(email),
+                                     |     FAMILY "primary" (code, user_email, usage_count)
+                                     | )
+(1 row)
+~~~
+
+Note that none of the tables that you have created thus far have secondary indexes. For guidance on adding secondary indexes, see at [Add Secondary Indexes](schema-design-indexes.html).
+
+## What's next?
+
 - [Add Secondary Indexes](schema-design-indexes.html)
-- [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)
-- [Schema Design Overview](schema-design-overview.html)
+- [Online Schema Changes](online-schema-changes.html)
+
+You might also be interested in the following pages:
+
 - [`CREATE TABLE`](create-table.html)
+- [Data Types](data-types.html)
+- [`PRIMARY KEY`](primary-key.html)
+- [Constraints](constraints.html)
+- [Cockroach Commands](cockroach-commands.html)
+- [Create a User-defined Schema](schema-design-schema.html)
+- [Create a Database](schema-design-database.html)
+- [Schema Design Overview](schema-design-overview.html)
+- [CockroachDB naming hierarchy](sql-name-resolution.html#naming-hierarchy)

--- a/v21.1/secure-a-cluster.md
+++ b/v21.1/secure-a-cluster.md
@@ -444,7 +444,11 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 
 ## What's next?
 
-- Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
-- [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
+- [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
 - Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)
+
+You might also be interested in the following pages:
+
+- [CockroachDB SQL client](cockroach-sql.html)
+- [Hello World Example Apps](hello-world-example-apps.html)

--- a/v21.1/start-a-local-cluster.md
+++ b/v21.1/start-a-local-cluster.md
@@ -373,7 +373,7 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 
 ## What's next?
 
-- Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
+- Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Build an app with CockroachDB](build-an-app-with-cockroachdb.html)
 - Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [geo-partitioning](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)


### PR DESCRIPTION
Opening this PR in response to the need for updated best-practice guidance around user-defined schemas.

See https://github.com/cockroachdb/docs/pull/9487/files/0dc7f87c6dd97fa04017c2e0687d08f0dc22d099#r565570489.

Changes include:

- Updated best-practice guidance for databases, user-defined schemas, and tables.
- A new user, schema, and table in the examples in the "Create a Database", "Create a User-defined Schema" and "Create a Table" pages.

The PR also includes:

- Minor updates to the end of pages (`See also`-> `What's next?`).
- Minor updates to formatting and wording on a few pages.