### PR TITLE
Technical Advisory 58932

### DIFF
--- a/_data/advisories.yml
+++ b/_data/advisories.yml
@@ -1,7 +1,7 @@
 - advisory: 58932
-  summary: HTTP requests can cause full cluster DoS
+  summary: HTTP requests can cause full-cluster denial of service (DoS)
   versions: 19.2.0-19.2.11,20.1.0-20.1.10,20.2.0-20.2.3
-  date: February 1, 2020
+  date: February 2, 2021
 - advisory: 56116
   summary: Incorrect timezone calculations with "slim" zoneinfo format
   versions: All

--- a/_data/advisories.yml
+++ b/_data/advisories.yml
@@ -1,3 +1,7 @@
+- advisory: 58932
+  summary: HTTP requests can cause full cluster DoS
+  versions: 19.2.0-19.2.11,20.1.0-20.1.10,20.2.0-20.2.3
+  date: February 1, 2020
 - advisory: 56116
   summary: Incorrect timezone calculations with "slim" zoneinfo format
   versions: All

--- a/advisories/a58932.md
+++ b/advisories/a58932.md
@@ -1,10 +1,10 @@
 ---
 title: Technical Advisory 58932
-summary: HTTP requests can cause full cluster DoS
+summary: HTTP requests can cause full-cluster denial of service (DoS)
 toc: true
 ---
 
-Publication date: February 1, 2021
+Publication date: February 2, 2021
 
 ## Description
 A bug in the [protobuf](https://github.com/gogo/protobuf) binary decode functions makes it possible to crash a CockroachDB node by sending a specially crafted HTTP request. This bug can be triggered even without an authenticated session to the DB console. 
@@ -21,11 +21,11 @@ Users of CockroachDB v19.2, v20.1, or v20.2 are invited to upgrade to v19.2.12, 
 When upgrading is not an option, users should audit their network configuration to verify that the CockroachDB HTTP port is not available to untrusted clients. We recommend blocking the HTTP port behind a firewall. 
 
 ## Impact
-This bug constitutes a security vulnerability, as an attacker can use it to cause full cluster unavailability. 
+This bug constitutes a security vulnerability, as an attacker can use it to cause full-cluster unavailability. 
 This vulnerability in protobuf is known as [CVE-2021-3121](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121).
 All versions of CockroachDB up to and including v19.2.11, v20.1.10, and v20.2.3 are affected.
 
-Questions about any technical alert can be directed to our [support team](https://support.cockroachlabs.com/).
+Questions about any technical alert can be directed to our [Support team](https://support.cockroachlabs.com/).
 
 [#58716]: https://github.com/cockroachdb/cockroach/pull/58716
 [#58932]: https://github.com/cockroachdb/cockroach/issues/58932

--- a/advisories/a58932.md
+++ b/advisories/a58932.md
@@ -1,0 +1,31 @@
+---
+title: Technical Advisory 58932
+summary: HTTP requests can cause full cluster DoS
+toc: true
+---
+
+Publication date: February 1, 2021
+
+## Description
+A bug in the [protobuf](https://github.com/gogo/protobuf) binary decode functions makes it possible to crash a CockroachDB node by sending a specially crafted HTTP request. This bug can be triggered even without an authenticated session to the DB console. 
+
+## Statement
+This is resolved in CockroachDB by PR [#58716] which fixes the decoding routine of protobuf payloads. 
+
+The fix has been applied to maintenance releases of CockroachDB v19.2, v20.1, and v21.1.
+
+This public issue is tracked as [#58932].
+
+## Mitigation
+Users of CockroachDB v19.2, v20.1, or v20.2 are invited to upgrade to v19.2.12, v20.1.11, v20.2.4, or a later version.
+When upgrading is not an option, users should audit their network configuration to verify that the CockroachDB HTTP port is not available to untrusted clients. We recommend blocking the HTTP port behind a firewall. 
+
+## Impact
+This bug constitutes a security vulnerability, as an attacker can use it to cause full cluster unavailability. 
+This vulnerability in protobuf is known as [CVE-2021-3121](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3121).
+All versions of CockroachDB up to and including v19.2.11, v20.1.10, and v20.2.3 are affected.
+
+Questions about any technical alert can be directed to our [support team](https://support.cockroachlabs.com/).
+
+[#58716]: https://github.com/cockroachdb/cockroach/pull/58716
+[#58932]: https://github.com/cockroachdb/cockroach/issues/58932


### PR DESCRIPTION
Adding Technical Advisory 58932: "HTTP requests can cause full-cluster denial of service (DoS)".

Minor edits of an original [draft](https://docs.google.com/document/d/1piMHNdZ9pPBleI2avPcNmC827dN5hM04ffJAmDH0YFY/) by @knz.

Further comms plans to be discussed [here](https://cockroachlabs.slack.com/archives/CSPK16V51/p1612222917012500?thread_ts=1612216017.010400&cid=CSPK16V51).