### PR TITLE
Fix containers names when cluster stopping

### DIFF
--- a/v20.2/orchestrate-cockroachdb-with-docker-swarm-insecure.md
+++ b/v20.2/orchestrate-cockroachdb-with-docker-swarm-insecure.md
@@ -289,13 +289,13 @@ To stop the CockroachDB cluster, on the instance running your manager node, remo
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ sudo docker service rm cockroachdb-0 cockroachdb-1 cockroachdb-2
+$ sudo docker service rm cockroachdb-1 cockroachdb-2 cockroachdb-3
 ~~~
 
 ~~~
-cockroachdb-0
 cockroachdb-1
 cockroachdb-2
+cockroachdb-3
 ~~~
 
 You may want to remove the persistent volumes used by the services as well. To do this, on each instance:
@@ -307,13 +307,13 @@ $ sudo docker volume ls
 ~~~
 
 ~~~
-cockroachdb-0
+cockroachdb-1
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
 # Remove the local volume:
-$ sudo docker volume rm cockroachdb-0
+$ sudo docker volume rm cockroachdb-1
 ~~~
 
 ## See also


### PR DESCRIPTION
There is no container named cockroachdb-0, but there is a container named cockroachdb-3.