### PR TITLE
ALTER PRIMARY KEY doc updates

### DIFF
--- a/v20.1/alter-primary-key.md
+++ b/v20.1/alter-primary-key.md
@@ -22,6 +22,8 @@ toc: true
 
 - The secondary index created by `ALTER PRIMARY KEY` will not be partitioned, even if a partition is defined on [a column in the original primary key](partitioning.html#partition-using-primary-key). To ensure that the table is partitioned correctly, you must create a partition on the secondary index, or drop the secondary index.
 
+- Any new primary key column set by `ALTER PRIMARY KEY` must have an existing [`NOT NULL` constraint](not-null.html). To add a `NOT NULL` constraint to an existing column, use [`ALTER TABLE ... ALTER COLUMN ... SET NOT NULL`](alter-column.html#set-not-null-constraint).
+
 {{site.data.alerts.callout_success}}
 To change an existing primary key without creating a secondary index from that primary key, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key). For examples, see the [`ADD CONSTRAINT`](add-constraint.html#examples) and [`DROP CONSTRAINT`](drop-constraint.html#examples) pages.
 {{site.data.alerts.end}}

--- a/v20.1/partition-by.md
+++ b/v20.1/partition-by.md
@@ -16,7 +16,7 @@ toc: true
 
 The [primary key required for partitioning](partitioning.html#partition-using-primary-key) is different from the conventional primary key: The unique identifier in the primary key must be prefixed with all columns you want to partition and subpartition the table on, in the order in which you want to nest your subpartitions.
 
-You cannot alter the primary key after it has been defined while [creating the table](create-table.html#create-a-table-with-partitions). If the primary key in your existing table does not meet the requirements, you will not be able to use the `ALTER TABLE` or `ALTER INDEX` statement to define partitions or subpartitions on the existing table or index.
+<span class="version-tag">New in v20.1:</span> If the primary key in your existing table does not meet the requirements, you can change the primary key with an [`ALTER TABLE ... PRIMARY KEY` statement](alter-primary-key.html).
 
 ## Synopsis
 

--- a/v20.2/alter-primary-key.md
+++ b/v20.2/alter-primary-key.md
@@ -22,6 +22,8 @@ toc: true
 
 - The secondary index created by `ALTER PRIMARY KEY` will not be partitioned, even if a partition is defined on [a column in the original primary key](partitioning.html#partition-using-primary-key). To ensure that the table is partitioned correctly, you must create a partition on the secondary index, or drop the secondary index.
 
+- Any new primary key column set by `ALTER PRIMARY KEY` must have an existing [`NOT NULL` constraint](not-null.html). To add a `NOT NULL` constraint to an existing column, use [`ALTER TABLE ... ALTER COLUMN ... SET NOT NULL`](alter-column.html#set-not-null-constraint).
+
 {{site.data.alerts.callout_success}}
 To change an existing primary key without creating a secondary index from that primary key, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key). For examples, see the [`ADD CONSTRAINT`](add-constraint.html#examples) and [`DROP CONSTRAINT`](drop-constraint.html#examples) pages.
 {{site.data.alerts.end}}

--- a/v20.2/partition-by.md
+++ b/v20.2/partition-by.md
@@ -16,7 +16,7 @@ toc: true
 
 The [primary key required for partitioning](partitioning.html#partition-using-primary-key) is different from the conventional primary key: The unique identifier in the primary key must be prefixed with all columns you want to partition and subpartition the table on, in the order in which you want to nest your subpartitions.
 
-You cannot alter the primary key after it has been defined while [creating the table](create-table.html#create-a-table-with-partitions). If the primary key in your existing table does not meet the requirements, you will not be able to use the `ALTER TABLE` or `ALTER INDEX` statement to define partitions or subpartitions on the existing table or index.
+If the primary key in your existing table does not meet the requirements, you can change the primary key with an [`ALTER TABLE ... PRIMARY KEY` statement](alter-primary-key.html).
 
 ## Synopsis
 

--- a/v21.1/alter-primary-key.md
+++ b/v21.1/alter-primary-key.md
@@ -22,6 +22,8 @@ toc: true
 
 - The secondary index created by `ALTER PRIMARY KEY` will not be partitioned, even if a partition is defined on [a column in the original primary key](partitioning.html#partition-using-primary-key). To ensure that the table is partitioned correctly, you must create a partition on the secondary index, or drop the secondary index.
 
+- Any new primary key column set by `ALTER PRIMARY KEY` must have an existing [`NOT NULL` constraint](not-null.html). To add a `NOT NULL` constraint to an existing column, use [`ALTER TABLE ... ALTER COLUMN ... SET NOT NULL`](alter-column.html#set-not-null-constraint).
+
 {{site.data.alerts.callout_success}}
 To change an existing primary key without creating a secondary index from that primary key, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key). For examples, see the [`ADD CONSTRAINT`](add-constraint.html#examples) and [`DROP CONSTRAINT`](drop-constraint.html#examples) pages.
 {{site.data.alerts.end}}

--- a/v21.1/partition-by.md
+++ b/v21.1/partition-by.md
@@ -16,7 +16,7 @@ toc: true
 
 The [primary key required for partitioning](partitioning.html#partition-using-primary-key) is different from the conventional primary key: The unique identifier in the primary key must be prefixed with all columns you want to partition and subpartition the table on, in the order in which you want to nest your subpartitions.
 
-You cannot alter the primary key after it has been defined while [creating the table](create-table.html#create-a-table-with-partitions). If the primary key in your existing table does not meet the requirements, you will not be able to use the `ALTER TABLE` or `ALTER INDEX` statement to define partitions or subpartitions on the existing table or index.
+If the primary key in your existing table does not meet the requirements, you can change the primary key with an [`ALTER TABLE ... PRIMARY KEY` statement](alter-primary-key.html).
 
 ## Synopsis
 


### PR DESCRIPTION
This PR includes the following changes:

-  Added note on `NOT NULL` requirement for new PK columns to `ALTER PRIMARY KEY` page. 
    
    Without this constraint, the statement will return the following error:
    ```
    ERROR: cannot use nullable column "valid" in primary key
    SQLSTATE: 42P15
    ```

- Removed outdated requirement note in PARTITION BY docs. 

    This fixes https://github.com/cockroachdb/docs/issues/9507.