### PR TITLE
Added databases to list of objects with SELECT privileges

### DIFF
--- a/_includes/v20.2/sql/privileges.md
+++ b/_includes/v20.2/sql/privileges.md
@@ -4,7 +4,7 @@ Privilege | Levels
 `CREATE` | Database, Schema, Table
 `DROP` | Database, Table
 `GRANT` | Database, Schema, Table, Type
-`SELECT` | Table
+`SELECT` | Table, Database
 `INSERT` | Table
 `DELETE` | Table
 `UPDATE` | Table

--- a/_includes/v21.1/sql/privileges.md
+++ b/_includes/v21.1/sql/privileges.md
@@ -4,7 +4,7 @@ Privilege | Levels
 `CREATE` | Database, Schema, Table
 `DROP` | Database, Table
 `GRANT` | Database, Schema, Table, Type
-`SELECT` | Table
+`SELECT` | Table, Database
 `INSERT` | Table
 `DELETE` | Table
 `UPDATE` | Table


### PR DESCRIPTION
`SHOW DATABASES` requires `SELECT` privileges on the databases. (https://www.cockroachlabs.com/docs/stable/show-databases.html#required-privileges)

This PR adds databases to the list of objects that support `SELECT` privileges. 