### PR TITLE
update minikube start defaults

### DIFF
--- a/_includes/v20.2/orchestration/local-start-kubernetes.md
+++ b/_includes/v20.2/orchestration/local-start-kubernetes.md
@@ -16,7 +16,7 @@ Feature | Description
 
     {{site.data.alerts.callout_info}}Make sure you install <code>minikube</code> version 0.21.0 or later. Earlier versions do not include a Kubernetes server that supports the <code>maxUnavailability</code> field and <code>PodDisruptionBudget</code> resource type used in the CockroachDB StatefulSet configuration.{{site.data.alerts.end}}
 
-1. Depending on the CPU and memory resources you allocate to CockroachDB in the [next section](#configure-the-cluster), you may need to change the `minikube` settings. The following values will work with the default 2 CPUs and 8Gi of memory that are specified in our [example manifest](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml).
+1. Depending on the CPU and memory resources you allocate to CockroachDB in the next section, you may need to change the `minikube` settings before starting. When using the Operator, the following values will work with the default 2 CPUs and 8Gi of memory that are specified in our [example manifest](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml).
 
     {% include copy-clipboard.html %}
 	~~~ shell

--- a/_includes/v20.2/orchestration/local-start-kubernetes.md
+++ b/_includes/v20.2/orchestration/local-start-kubernetes.md
@@ -16,7 +16,19 @@ Feature | Description
 
     {{site.data.alerts.callout_info}}Make sure you install <code>minikube</code> version 0.21.0 or later. Earlier versions do not include a Kubernetes server that supports the <code>maxUnavailability</code> field and <code>PodDisruptionBudget</code> resource type used in the CockroachDB StatefulSet configuration.{{site.data.alerts.end}}
 
-2. Start a local Kubernetes cluster:
+1. Depending on the CPU and memory resources you allocate to CockroachDB in the [next section](#configure-the-cluster), you may need to change the `minikube` settings. The following values will work with the default 2 CPUs and 8Gi of memory that are specified in our [example manifest](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml).
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ minikube config set cpus 7
+	~~~
+
+	{% include copy-clipboard.html %}
+	~~~ shell
+	$ minikube config set memory 26000
+	~~~
+
+1. Start a local Kubernetes cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell

--- a/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
@@ -115,7 +115,7 @@ By default, the Operator uses the built-in Kubernetes CA to generate and approve
 	NAME                                  READY   STATUS    RESTARTS   AGE
 	cockroach-operator-6f7b86ffc4-9t9zb   1/1     Running   0          3m22s
 	cockroachdb-0                         1/1     Running   0          2m31s
-	cockroachdb-1                         1/1     Running   1          102s
+	cockroachdb-1                         1/1     Running   0          102s
 	cockroachdb-2                         1/1     Running   0          46s
 	~~~
 

--- a/_includes/v21.1/orchestration/local-start-kubernetes.md
+++ b/_includes/v21.1/orchestration/local-start-kubernetes.md
@@ -16,7 +16,7 @@ Feature | Description
 
     {{site.data.alerts.callout_info}}Make sure you install <code>minikube</code> version 0.21.0 or later. Earlier versions do not include a Kubernetes server that supports the <code>maxUnavailability</code> field and <code>PodDisruptionBudget</code> resource type used in the CockroachDB StatefulSet configuration.{{site.data.alerts.end}}
 
-1. Depending on the CPU and memory resources you allocate to CockroachDB in the [next section](#configure-the-cluster), you may need to change the `minikube` settings. The following values will work with the default 2 CPUs and 8Gi of memory that are specified in our [example manifest](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml).
+1. Depending on the CPU and memory resources you allocate to CockroachDB in the next section, you may need to change the `minikube` settings before starting. When using the Operator, the following values will work with the default 2 CPUs and 8Gi of memory that are specified in our [example manifest](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml).
 
     {% include copy-clipboard.html %}
 	~~~ shell

--- a/_includes/v21.1/orchestration/local-start-kubernetes.md
+++ b/_includes/v21.1/orchestration/local-start-kubernetes.md
@@ -16,7 +16,19 @@ Feature | Description
 
     {{site.data.alerts.callout_info}}Make sure you install <code>minikube</code> version 0.21.0 or later. Earlier versions do not include a Kubernetes server that supports the <code>maxUnavailability</code> field and <code>PodDisruptionBudget</code> resource type used in the CockroachDB StatefulSet configuration.{{site.data.alerts.end}}
 
-2. Start a local Kubernetes cluster:
+1. Depending on the CPU and memory resources you allocate to CockroachDB in the [next section](#configure-the-cluster), you may need to change the `minikube` settings. The following values will work with the default 2 CPUs and 8Gi of memory that are specified in our [example manifest](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml).
+
+    {% include copy-clipboard.html %}
+	~~~ shell
+	$ minikube config set cpus 7
+	~~~
+
+	{% include copy-clipboard.html %}
+	~~~ shell
+	$ minikube config set memory 26000
+	~~~
+
+1. Start a local Kubernetes cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell

--- a/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
@@ -115,7 +115,7 @@ By default, the Operator uses the built-in Kubernetes CA to generate and approve
 	NAME                                  READY   STATUS    RESTARTS   AGE
 	cockroach-operator-6f7b86ffc4-9t9zb   1/1     Running   0          3m22s
 	cockroachdb-0                         1/1     Running   0          2m31s
-	cockroachdb-1                         1/1     Running   1          102s
+	cockroachdb-1                         1/1     Running   0          102s
 	cockroachdb-2                         1/1     Running   0          46s
 	~~~
 


### PR DESCRIPTION
Adjusted the minikube CPU and memory defaults (7 CPU and 26 GB) to work with the resource requests (2 CPU and 8 GB) we prepopulate in the [example.yaml](https://github.com/cockroachdb/cockroach-operator/blob/master/examples/example.yaml) for the Operator. This updates the [local Kubernetes deployment guide](https://www.cockroachlabs.com/docs/v20.2/orchestrate-a-local-cluster-with-kubernetes.html) for 20.2 and 21.1.

(Also removed the restart count for a cockroach pod in the example deploy output)