### PR TITLE
change Release Support Policy to local URL in include

### DIFF
--- a/_includes/unsupported-version-soon.md
+++ b/_includes/unsupported-version-soon.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-Cockroach Labs will stop providing <strong>Assistance Support</strong> for this version on <strong>May 12, 2021</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, see the <a href="https://www.cockroachlabs.com/docs/releases/release-support-policy.html">Release Support Policy</a>.
+Cockroach Labs will stop providing <strong>Assistance Support</strong> for this version on <strong>May 12, 2021</strong>. Prior to that date, upgrade to a more recent version to continue receiving support. For more details, see the <a href="release-support-policy.html">Release Support Policy</a>.
 {{site.data.alerts.end}}


### PR DESCRIPTION
The Release Support Policy was showing as an external link (it had an "arrow" symbol) in the include on release pages. It is now a local URL.