### PR TITLE
Fixing command to prepare tpc-c benchmark

### DIFF
--- a/v20.2/performance-benchmarking-with-tpcc-large.md
+++ b/v20.2/performance-benchmarking-with-tpcc-large.md
@@ -208,7 +208,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
+    $ ./workload init tpcc \
     --warehouses 140000 \
     --partitions 81 \
     --replicate-static-columns

--- a/v20.2/performance-benchmarking-with-tpcc-medium.md
+++ b/v20.2/performance-benchmarking-with-tpcc-medium.md
@@ -197,7 +197,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
+    $ ./workload init tpcc \
     --partitions 5
     --warehouses 13000 \
     "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"

--- a/v20.2/performance-benchmarking-with-tpcc-small.md
+++ b/v20.2/performance-benchmarking-with-tpcc-small.md
@@ -133,7 +133,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
+    $ ./workload init tpcc \
     --warehouses 2500 \
     "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"
     ~~~

--- a/v21.1/performance-benchmarking-with-tpcc-large.md
+++ b/v21.1/performance-benchmarking-with-tpcc-large.md
@@ -208,7 +208,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
+    $ ./workload init tpcc \
     --warehouses 140000 \
     --partitions 81 \
     --replicate-static-columns

--- a/v21.1/performance-benchmarking-with-tpcc-medium.md
+++ b/v21.1/performance-benchmarking-with-tpcc-medium.md
@@ -197,7 +197,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
+    $ ./workload init tpcc \
     --partitions 5
     --warehouses 13000 \
     "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"

--- a/v21.1/performance-benchmarking-with-tpcc-small.md
+++ b/v21.1/performance-benchmarking-with-tpcc-small.md
@@ -133,7 +133,7 @@ CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
+    $ ./workload init tpcc \
     --warehouses 2500 \
     "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"
     ~~~


### PR DESCRIPTION
Proposing a fix for issue https://github.com/cockroachdb/docs/issues/9774.

According to the [docs for the workload tool](https://www.cockroachlabs.com/docs/dev/cockroach-workload.html), there is no `workload fixtures import` command, so I am proposing to use `workload init ` instead. 
This is also used in the [docs for local testing](https://github.com/cockroachdb/docs/blame/master/v20.2/performance-benchmarking-with-tpcc-local.md).

 