### PR TITLE
Update delimiter for migrate from oracle example

### DIFF
--- a/v20.1/migrate-from-oracle.md
+++ b/v20.1/migrate-from-oracle.md
@@ -284,7 +284,7 @@ For example, to import the data from `CUSTOMERS.csv.gz` into a new `CUSTOMERS` t
    CSV DATA (
         'https://your-bucket-name.s3.us-east-2.amazonaws.com/CUSTOMERS.csv.gz'
        )
-  WITH delimiter = '|',
+  WITH delimiter = e'\t',
        "nullif" = '',
        decompress = 'gzip';
 ~~~

--- a/v20.2/migrate-from-oracle.md
+++ b/v20.2/migrate-from-oracle.md
@@ -287,7 +287,7 @@ For example, to import the data from `CUSTOMERS.csv.gz` into a new `CUSTOMERS` t
    CSV DATA (
         'https://your-bucket-name.s3.us-east-2.amazonaws.com/CUSTOMERS.csv.gz'
        )
-  WITH delimiter = '|',
+  WITH delimiter = e'\t',
        "nullif" = '',
        decompress = 'gzip';
 ~~~

--- a/v21.1/migrate-from-oracle.md
+++ b/v21.1/migrate-from-oracle.md
@@ -288,7 +288,7 @@ For example, to import the data from `CUSTOMERS.csv.gz` into a new `CUSTOMERS` t
    CSV DATA (
         'https://your-bucket-name.s3.us-east-2.amazonaws.com/CUSTOMERS.csv.gz'
        )
-  WITH delimiter = '|',
+  WITH delimiter = e'\t',
        "nullif" = '',
        decompress = 'gzip';
 ~~~


### PR DESCRIPTION
Change to `WITH delimiter = e'\t'`
Closes #9293 