### PR TITLE
CLI Import privileges fix

### DIFF
--- a/v21.1/cockroach-import.md
+++ b/v21.1/cockroach-import.md
@@ -12,7 +12,7 @@ We recommend using `cockroach import` for quick imports from your client (about 
 
 ## Required privileges
 
-Only members of the `admin` role can run `cockroach import`. By default, the `root` user belongs to the `admin` role.
+The user must have `CREATE` [privileges](authorization.html#assign-privileges) on the default database.
 
 ## Synopsis
 

--- a/v21.1/cockroach-import.md
+++ b/v21.1/cockroach-import.md
@@ -12,7 +12,7 @@ We recommend using `cockroach import` for quick imports from your client (about 
 
 ## Required privileges
 
-The user must have `CREATE` [privileges](authorization.html#assign-privileges) on the default database.
+The user must have `CREATE` [privileges](authorization.html#assign-privileges) on `defaultdb`.
 
 ## Synopsis
 


### PR DESCRIPTION
Missed @adityamaru's last comment before merging https://github.com/cockroachdb/docs/pull/9788. 

Change privileges from `admin` to `CREATE` on default database.