### PR TITLE
CDC batch of changes

### DIFF
--- a/v20.1/changefeed-for.md
+++ b/v20.1/changefeed-for.md
@@ -8,7 +8,7 @@ toc: true
 `EXPERIMENTAL CHANGEFEED FOR` is the core implementation of changefeeds. For the [enterprise-only](enterprise-licensing.html) version, see [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
-The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. Multiple tables can be watched by one core changefeed.
+The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
 For more information, see [Change Data Capture](change-data-capture.html).
 

--- a/v20.1/changefeed-for.md
+++ b/v20.1/changefeed-for.md
@@ -8,7 +8,7 @@ toc: true
 `EXPERIMENTAL CHANGEFEED FOR` is the core implementation of changefeeds. For the [enterprise-only](enterprise-licensing.html) version, see [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
-The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. Multiple tables can be watched by one core changefeed.
 
 For more information, see [Change Data Capture](change-data-capture.html).
 

--- a/v20.2/changefeed-for.md
+++ b/v20.2/changefeed-for.md
@@ -8,7 +8,7 @@ toc: true
 `EXPERIMENTAL CHANGEFEED FOR` is the core implementation of changefeeds. For the [enterprise-only](enterprise-licensing.html) version, see [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
-The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. Multiple tables can be watched by one core changefeed.
+The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
 {% include {{ page.version.version }}/cdc/core-url.md %}
 

--- a/v20.2/changefeed-for.md
+++ b/v20.2/changefeed-for.md
@@ -8,7 +8,7 @@ toc: true
 `EXPERIMENTAL CHANGEFEED FOR` is the core implementation of changefeeds. For the [enterprise-only](enterprise-licensing.html) version, see [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
-The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. Multiple tables can be watched by one core changefeed.
 
 {% include {{ page.version.version }}/cdc/core-url.md %}
 

--- a/v20.2/create-changefeed.md
+++ b/v20.2/create-changefeed.md
@@ -64,7 +64,13 @@ Use a cloud storage sink to deliver changefeed data to OLAP or big data systems 
 Currently, cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 
-For more information on the sink URL structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+Example of a cloud storage sink URI:
+
+~~~
+`experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`
+~~~
+
+Cloud storage sink URIs must be prepended with `experimental-` when working with core changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
 
 #### Query parameters
 

--- a/v20.2/create-changefeed.md
+++ b/v20.2/create-changefeed.md
@@ -70,7 +70,7 @@ Example of a cloud storage sink URI:
 `experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`
 ~~~
 
-Cloud storage sink URIs must be prepended with `experimental-` when working with core changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+Cloud storage sink URIs must be prepended with `experimental-` when working with changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
 
 #### Query parameters
 

--- a/v20.2/create-changefeed.md
+++ b/v20.2/create-changefeed.md
@@ -64,7 +64,7 @@ Use a cloud storage sink to deliver changefeed data to OLAP or big data systems 
 Currently, cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 
-For more information on the sink URL structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
+For more information on the sink URL structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
 
 #### Query parameters
 

--- a/v20.2/use-cloud-storage-for-bulk-operations.md
+++ b/v20.2/use-cloud-storage-for-bulk-operations.md
@@ -64,6 +64,10 @@ HTTP         | `http://localhost:8080/employees`
 NFS/Local    | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>5</sup>](#considerations)
 
 {{site.data.alerts.callout_info}}
+URLs for [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) should be prepended with `experimental-`.
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_info}}
 Currently, cloud storage sinks (for changefeeds) only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 

--- a/v21.1/changefeed-for.md
+++ b/v21.1/changefeed-for.md
@@ -8,7 +8,7 @@ toc: true
 `EXPERIMENTAL CHANGEFEED FOR` is the core implementation of changefeeds. For the [enterprise-only](enterprise-licensing.html) version, see [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
-The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. Multiple tables can be watched by one core changefeed.
+The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. A core changefeed can watch one table or multiple tables in a comma-separated list.
 
 {% include {{ page.version.version }}/cdc/core-url.md %}
 

--- a/v21.1/changefeed-for.md
+++ b/v21.1/changefeed-for.md
@@ -8,7 +8,7 @@ toc: true
 `EXPERIMENTAL CHANGEFEED FOR` is the core implementation of changefeeds. For the [enterprise-only](enterprise-licensing.html) version, see [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
-The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.
+The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new core changefeed, which streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled. Multiple tables can be watched by one core changefeed.
 
 {% include {{ page.version.version }}/cdc/core-url.md %}
 

--- a/v21.1/create-changefeed.md
+++ b/v21.1/create-changefeed.md
@@ -70,7 +70,7 @@ Example of a cloud storage sink URI:
 `experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`
 ~~~
 
-Cloud storage sink URIs must be pre-pended with `experimental-` when working with core changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+Cloud storage sink URIs must be pre-pended with `experimental-` when working with changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
 
 #### Query parameters
 

--- a/v21.1/create-changefeed.md
+++ b/v21.1/create-changefeed.md
@@ -64,7 +64,7 @@ Use a cloud storage sink to deliver changefeed data to OLAP or big data systems 
 Currently, cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 
-For more information on the sink URL structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
+For more information on the sink URL structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
 
 #### Query parameters
 
@@ -109,7 +109,9 @@ Option | Value | Description
 
 #### Avro limitations
 
-Currently, support for Avro is limited and experimental. Below is a list of unsupported SQL types and values for Avro changefeeds:
+Currently, support for Avro is limited and experimental. You can only emit an Avro record if you are using a changefeed [connected to Kafka](#create-a-changefeed-connected-to-kafka-using-avro).
+
+Below is a list of unsupported SQL types and values for Avro changefeeds:
 
 - [Decimals](decimal.html) must have precision specified.
 - [Decimals](decimal.html) with `NaN` or infinite values cannot be written in Avro.

--- a/v21.1/create-changefeed.md
+++ b/v21.1/create-changefeed.md
@@ -64,7 +64,13 @@ Use a cloud storage sink to deliver changefeed data to OLAP or big data systems 
 Currently, cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 
-For more information on the sink URL structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+Example of a cloud storage sink URI:
+
+~~~
+`experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`
+~~~
+
+Cloud storage sink URIs must be pre-pended with `experimental-` when working with core changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
 
 #### Query parameters
 

--- a/v21.1/use-cloud-storage-for-bulk-operations.md
+++ b/v21.1/use-cloud-storage-for-bulk-operations.md
@@ -53,7 +53,7 @@ If your environment requires an HTTP or HTTPS proxy server for outgoing connecti
 
 ## Example file URLs
 
-Example URLs for [`BACKUP`](backup.html), [`EXPORT`](export.html), or [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html):
+Example URLs for [`BACKUP`](backup.html), [`EXPORT`](export.html):
 
 Location     | Example                                                                          
 -------------+----------------------------------------------------------------------------------
@@ -62,6 +62,16 @@ Azure        | `azure://employees?AZURE_ACCOUNT_KEY=123&AZURE_ACCOUNT_NAME=acme-
 Google Cloud | `gs://acme-co`                                                     
 HTTP         | `http://localhost:8080/employees`
 NFS/Local    | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>5</sup>](#considerations)
+
+Example URLs for [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html):
+
+Location     | Example                                                                          
+-------------+----------------------------------------------------------------------------------
+Amazon S3    | `experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`     
+Azure        | `experimental-azure://employees?AZURE_ACCOUNT_KEY=123&AZURE_ACCOUNT_NAME=acme-co`         
+Google Cloud | `experimental-gs://acme-co`                                                     
+HTTP         | `experimental-http://localhost:8080/employees`
+NFS/Local    | `experimental-nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>5</sup>](#considerations)
 
 {{site.data.alerts.callout_info}}
 Currently, cloud storage sinks (for changefeeds) only work with `JSON` and emits newline-delimited `JSON` files.

--- a/v21.1/use-cloud-storage-for-bulk-operations.md
+++ b/v21.1/use-cloud-storage-for-bulk-operations.md
@@ -53,7 +53,7 @@ If your environment requires an HTTP or HTTPS proxy server for outgoing connecti
 
 ## Example file URLs
 
-Example URLs for [`BACKUP`](backup.html), [`EXPORT`](export.html):
+Example URLs for [`BACKUP`](backup.html), [`EXPORT`](export.html), or [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html):
 
 Location     | Example                                                                          
 -------------+----------------------------------------------------------------------------------
@@ -63,15 +63,9 @@ Google Cloud | `gs://acme-co`
 HTTP         | `http://localhost:8080/employees`
 NFS/Local    | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>5</sup>](#considerations)
 
-Example URLs for [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html):
-
-Location     | Example                                                                          
--------------+----------------------------------------------------------------------------------
-Amazon S3    | `experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456`     
-Azure        | `experimental-azure://employees?AZURE_ACCOUNT_KEY=123&AZURE_ACCOUNT_NAME=acme-co`         
-Google Cloud | `experimental-gs://acme-co`                                                     
-HTTP         | `experimental-http://localhost:8080/employees`
-NFS/Local    | `experimental-nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>5</sup>](#considerations)
+{{site.data.alerts.callout_info}}
+URLs for [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) should be prepended with `experimental-`.
+{{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
 Currently, cloud storage sinks (for changefeeds) only work with `JSON` and emits newline-delimited `JSON` files.


### PR DESCRIPTION
Closes #6151, #9718, #5806

-add limitation that Avro is only available with Kafka
-add callout that cloud storage sink urls must be prepended with `experimental-` for changefeeds
-mention that core changefeeds can watch multiple tables