### PR TITLE
Fix typo on DR docs

### DIFF
--- a/v20.1/disaster-recovery.md
+++ b/v20.1/disaster-recovery.md
@@ -83,7 +83,7 @@ To be able to survive 2+ availability zones failing, scale to a [multi-region](#
 
 For hardware failures in a single-region cluster, the recovery actions vary and depend on the type of infrastructure used.
 
-For example, consider a cloud-deployed CockroachBD cluster with the following setup:
+For example, consider a cloud-deployed CockroachDB cluster with the following setup:
 
 - Single-region
 - 3 nodes
@@ -225,7 +225,7 @@ The chart below describes the CockroachDB default behavior when locality flags a
 
 For hardware failures in a multi-region cluster, the actions taken to recover vary and depend on the type of infrastructure used.
 
-For example, consider a cloud-deployed CockroachBD cluster with the following setup:
+For example, consider a cloud-deployed CockroachDB cluster with the following setup:
 
 - 3 regions
 - 3 AZs per region

--- a/v20.2/disaster-recovery.md
+++ b/v20.2/disaster-recovery.md
@@ -83,7 +83,7 @@ To be able to survive 2+ availability zones failing, scale to a [multi-region](#
 
 For hardware failures in a single-region cluster, the recovery actions vary and depend on the type of infrastructure used.
 
-For example, consider a cloud-deployed CockroachBD cluster with the following setup:
+For example, consider a cloud-deployed CockroachDB cluster with the following setup:
 
 - Single-region
 - 3 nodes
@@ -225,7 +225,7 @@ The chart below describes the CockroachDB default behavior when locality flags a
 
 For hardware failures in a multi-region cluster, the actions taken to recover vary and depend on the type of infrastructure used.
 
-For example, consider a cloud-deployed CockroachBD cluster with the following setup:
+For example, consider a cloud-deployed CockroachDB cluster with the following setup:
 
 - 3 regions
 - 3 AZs per region

--- a/v21.1/disaster-recovery.md
+++ b/v21.1/disaster-recovery.md
@@ -83,7 +83,7 @@ To be able to survive 2+ availability zones failing, scale to a [multi-region](#
 
 For hardware failures in a single-region cluster, the recovery actions vary and depend on the type of infrastructure used.
 
-For example, consider a cloud-deployed CockroachBD cluster with the following setup:
+For example, consider a cloud-deployed CockroachDB cluster with the following setup:
 
 - Single-region
 - 3 nodes
@@ -225,7 +225,7 @@ The chart below describes the CockroachDB default behavior when locality flags a
 
 For hardware failures in a multi-region cluster, the actions taken to recover vary and depend on the type of infrastructure used.
 
-For example, consider a cloud-deployed CockroachBD cluster with the following setup:
+For example, consider a cloud-deployed CockroachDB cluster with the following setup:
 
 - 3 regions
 - 3 AZs per region


### PR DESCRIPTION
Simple typo on the docs that I figured I could just go in and fix in a jiffy.

CockroachBD->CockroachDB