### PR TITLE
Update confluent start command in CDC examples

### DIFF
--- a/_includes/v21.1/cdc/create-core-changefeed-avro.md
+++ b/_includes/v21.1/cdc/create-core-changefeed-avro.md
@@ -16,10 +16,10 @@ In this example, you'll set up a core changefeed for a single-node cluster that 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./bin/confluent start
+    $ ./bin/confluent local services start
     ~~~
 
-    Only `zookeeper`, `kafka`, and `schema-registry` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives).
+    Only `zookeeper`, `kafka`, and `schema-registry` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives) and the [Quick Start Guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart).
 
 4. As the `root` user, open the [built-in SQL client](cockroach-sql.html):
 

--- a/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -499,10 +499,10 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./bin/confluent start
+    $ ./bin/confluent local services start
     ~~~
 
-    Only `zookeeper`, `kafka`, and `schema-registry` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives).
+    Only `zookeeper`, `kafka`, and `schema-registry` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives) and the [Quick Start Guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart).
 
 5. Create two Kafka topics:
 

--- a/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -302,10 +302,10 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./bin/confluent start
+    $ ./bin/confluent local services start
     ~~~
 
-    Only `zookeeper` and `kafka` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives).
+    Only `zookeeper` and `kafka` are needed. To troubleshoot Confluent, see [their docs](https://docs.confluent.io/current/installation/installing_cp.html#zip-and-tar-archives) and the [Quick Start Guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart).
 
 5. Create two Kafka topics:
 


### PR DESCRIPTION
The command "confluent start" does not work with newer versions of confluent. Updated to the command "confluent local services start" which is the appropriate command for newer versions. Also added a link to the confluent quick start guide where the reader can find more information. 