### PR TITLE
Update benchmarking docs to use built-in workload

### DIFF
--- a/v20.2/performance-benchmarking-with-tpc-c-10-warehouses.md
+++ b/v20.2/performance-benchmarking-with-tpc-c-10-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Learn how to benchmark CockroachDB against TPC-C 13k on a local cluster
-toc: true
-toc_not_nested: true
----

--- a/v20.2/performance-benchmarking-with-tpc-c-100k-warehouses.md
+++ b/v20.2/performance-benchmarking-with-tpc-c-100k-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Learn how to benchmark CockroachDB against TPC-C with 81 nodes on `c5d.9xlarge` machines
-toc: true
-toc_not_nested: true
----

--- a/v20.2/performance-benchmarking-with-tpc-c-10k-warehouses.md
+++ b/v20.2/performance-benchmarking-with-tpc-c-10k-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Benchmark CockroachDB against TPC-C with 15 nodes on `c5d.4xlarge` machines
-toc: true
-toc_not_nested: true
----

--- a/v20.2/performance-benchmarking-with-tpc-c-1k-warehouses.md
+++ b/v20.2/performance-benchmarking-with-tpc-c-1k-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Learn how to benchmark CockroachDB against TPC-C with 3 nodes on `c5d.4xlarge` machines
-toc: true
-toc_not_nested: true
----

--- a/v20.2/performance-benchmarking-with-tpcc-large.md
+++ b/v20.2/performance-benchmarking-with-tpcc-large.md
@@ -3,7 +3,8 @@ title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C with 81 nodes on `c5d.9xlarge` machines
 toc: true
 toc_not_nested: true
-redirect_from: 
+key: performance-benchmarking-with-tpc-c-100k-warehouses.html
+redirect_from:
 - performance-benchmarking-with-tpc-c.html
 - performance-benchmarking-with-tpc-c-100k-warehouses.html
 ---
@@ -191,32 +192,38 @@ You'll be importing a large TPC-C data set. To speed that up, you can temporaril
 
 ## Step 4. Import the TPC-C dataset
 
-CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC-C benchmark. You'll need to put the binary on the VMs for importing the dataset and running TPC-C.
+CockroachDB comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
-1. SSH to one of the VMs where you want to run TPC-C.
+1. SSH to the VM where you want to run TPC-C.
 
-2. Download the `workload` binary for Linux and make it executable:
-
-    {% include copy-clipboard.html %}
-     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST -O workload; chmod 755 workload
-    ~~~
-
-3. Repeat steps 1 and 2 for the other 4 VMs where you'll run TPC-C.
-
-4. On one of the VMs with the `workload` binary, import the TPC-C dataset:
+1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
-    --warehouses 140000 \
-    --partitions 81 \
-    --replicate-static-columns
-    --partition-strategy=leases
-    "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
     ~~~
 
-    This will load the data for 140,000 warehouses. This can take up to 8 hours to complete.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
+    ~~~
+
+    If you get a permissions error, prefix the command with `sudo`.
+
+1. Import the TPC-C dataset:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach workload fixtures import tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --replicate-static-columns \
+    --partition-strategy=leases \
+    'postgres://root@<address of any CockroachDB node>:26257?sslmode=disable'
+    ~~~
+
+    This will load 11.2 TB of data for 140,000 "warehouses". This can take up to 8 hours to complete.
 
     You can monitor progress on the **Jobs** screen of the DB Console. Open the [DB Console](ui-overview.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
 
@@ -273,27 +280,61 @@ Before running the benchmark, it's important to allocate partitions to workload 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 --ramp 30m --duration 1ms --histograms workload1.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload1.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 --ramp 30m --duration 1ms --histograms workload2.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions 81 \
+    --warehouses 140000 \
+    --partition-affinity=17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload2.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 --ramp 30m --duration 1ms --histograms workload3.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload3.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 --ramp 30m --duration 1ms --histograms workload4.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload4.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 --ramp 30m --duration 1ms --histograms workload5.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload5.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
 ## Step 8. Run the benchmark
@@ -306,27 +347,62 @@ It is critical to run the benchmark from the workload nodes in parallel, so star
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 --ramp 4m --duration 30m --histograms workload1.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload1.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 --ramp 4m --duration 30m --histograms workload2.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload2.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 --ramp 4m --duration 30m --histograms workload3.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload3.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 --ramp 4m --duration 30m --histograms workload4.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload4.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 --ramp 4m --duration 30m --histograms workload5.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partition=81 \
+--warehouses=140000 \
+--partition-affinity=65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload5.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 ## Step 9. Interpret the results
@@ -390,7 +466,9 @@ ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --pa
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ./workload debug tpcc-merge-results --warehouses 140000  workload*.histogram.ndjson
+    cockroach workload debug tpcc-merge-results \
+    --warehouses=140000 \
+    workload*.histogram.ndjson
     ~~~
 
     You'll should see results similar to the following, with **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%**:

--- a/v20.2/performance-benchmarking-with-tpcc-local.md
+++ b/v20.2/performance-benchmarking-with-tpcc-local.md
@@ -3,6 +3,7 @@ title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C 13k on 3 nodes on your laptop
 toc: true
 toc_not_nested: true
+key: performance-benchmarking-with-tpc-c-10-warehouses.html
 redirect_from:
 - performance-benchmarking-with-tpc-c-10-warehouses.html
 ---
@@ -79,30 +80,18 @@ This page shows you how to reproduce [CockroachDB's TPC-C performance benchmarki
 
 ## Step 2. Import the TPC-C dataset
 
-CockroachDB comes with built-in load generators for simulating different types of client workloads, printing out per-operation statistics every second and totals after a specific duration or max number of operations. This step features CockroachDB's version of the TPC-C workload.
+CockroachDB comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
 Use [`cockroach workload`](cockroach-workload.html) to load the initial schema and data:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach workload init tpcc \
+$ cockroach workload fixtures import tpcc \
 --warehouses=10 \
 'postgresql://root@localhost:26257?sslmode=disable'
 ~~~
 
-This will take about ten minutes to load, after which you'll see the following output:
-
-~~~
-I191024 03:41:34.308865 1 workload/workloadsql/dataload.go:135  imported warehouse (0s, 10 rows)
-I191024 03:41:34.353839 1 workload/workloadsql/dataload.go:135  imported district (0s, 100 rows)
-I191024 03:42:00.865733 1 workload/workloadsql/dataload.go:135  imported customer (27s, 300000 rows)
-I191024 03:42:13.233536 1 workload/workloadsql/dataload.go:135  imported history (12s, 300000 rows)
-I191024 03:42:20.893806 1 workload/workloadsql/dataload.go:135  imported order (8s, 300000 rows)
-I191024 03:42:21.716409 1 workload/workloadsql/dataload.go:135  imported new_order (1s, 90000 rows)
-I191024 03:42:23.483713 1 workload/workloadsql/dataload.go:135  imported item (2s, 100000 rows)
-I191024 03:43:37.660918 1 workload/workloadsql/dataload.go:135  imported stock (1m14s, 1000000 rows)
-I191024 03:46:51.682670 1 workload/workloadsql/dataload.go:135  imported order_line (3m14s, 3001222 rows)
-~~~
+This will load 2 GB of data for 10 "warehouses".
 
 ## Step 3. Run the benchmark
 

--- a/v20.2/performance-benchmarking-with-tpcc-medium.md
+++ b/v20.2/performance-benchmarking-with-tpcc-medium.md
@@ -3,6 +3,7 @@ title: Performance Benchmarking with TPC-C
 summary: Benchmark CockroachDB against TPC-C with 15 nodes on `c5d.4xlarge` machines
 toc: true
 toc_not_nested: true
+key: performance-benchmarking-with-tpc-c-10k-warehouses.html
 redirect_from:
 - performance-benchmarking-with-tpc-c-10k-warehouses.html
 ---
@@ -182,45 +183,53 @@ You'll be importing a large TPC-C data set. To speed that up, you can tweak some
 
 ## Step 4. Import the TPC-C dataset
 
-CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC-C benchmark. You'll need to put this binary on the VM for importing the dataset and running TPC-C.
+CockroachDB comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
 1. SSH to the VM where you want to run TPC-C.
 
-2. Download the `workload` binary for Linux and make it executable:
+1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST -O workload; chmod 755 workload
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
     ~~~
-
-3. Import the TPC-C dataset:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
-    --partitions 5
-    --warehouses 13000 \
-    "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
     ~~~
 
-    This will load data for 13,000 "warehouses". This can take around 1 hour to complete.
+    If you get a permissions error, prefix the command with `sudo`.
 
-    You can monitor progress on the **Jobs** screen of the DB Console. Open the [DB Console](admin-ui-overview.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
+1. Import the TPC-C dataset:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach workload fixtures import tpcc \
+    --partitions=5 \
+    --warehouses=13000 \
+    'postgres://root@<address of any CockroachDB node>:26257?sslmode=disable'
+    ~~~
+
+    This will load 1.04 TB of data for 13,000 "warehouses". This can take around 1 hour to complete.
+
+    You can monitor progress on the **Jobs** screen of the DB Console. Open the [DB Console](ui-overview.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
 
 ## Step 5. Allow the cluster to rebalance
 
 Next, [partition your database](partitioning.html) to divide all of the TPC-C tables and indexes into 5 partitions, one per rack, and then use [zone configurations](configure-replication-zones.html) to pin those partitions to a particular rack.
 
-1. On the VM with the `workload` binary, briefly run TPC-C to let the cluster balance and the leases settle. Bump the file descriptor limits with `ulimit` to the high value shown below, since the workload generators create a lot of database connections.
+1. Still on the same VM, briefly run TPC-C to let the cluster balance and the leases settle. Bump the file descriptor limits with `ulimit` to the high value shown below, since the workload generators create a lot of database connections.
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ulimit -n 100000 && ./workload run tpcc \
-    --partitions 5 \
-    --warehouses 13000 \
-    --duration 1m \
-    --ramp 1ms \
-    "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"
+    $ ulimit -n 100000 && cockroach workload run tpcc \
+    --partitions=5 \
+    --warehouses=13000 \
+    --duration=1m \
+    --ramp=1ms \
+    'postgres://root@<address of any CockroachDB node>:26257?sslmode=disable'
     ~~~
 
 2. Wait for range rebalancing to finish.
@@ -239,17 +248,17 @@ Next, [partition your database](partitioning.html) to divide all of the TPC-C ta
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ulimit -n 100000 && ./workload run tpcc \
-    --partitions 5 \
-    --warehouses 13000 \
-    --ramp 1m \
-    --duration 30m \
+    $ ulimit -n 100000 && cockroach workload run tpcc \
+    --partitions=5 \
+    --warehouses=13000 \
+    --ramp=1m \
+    --duration=30m \
     $(cat addrs)
     ~~~
 
 ## Step 7. Interpret the results
 
-Once the `workload` has finished running, you will see a final result similar to the following. The efficiency and latency can be combined to determine whether this was a passing run. You should expect to see an efficiency number above 95%, well above the required minimum of 85%, and p95 latencies well below the required maximum of 10 seconds.
+Once the workload has finished running, you will see a final result similar to the following. The efficiency and latency can be combined to determine whether this was a passing run. You should expect to see an efficiency number above 95%, well above the required minimum of 85%, and p95 latencies well below the required maximum of 10 seconds.
 
 ~~~
 _elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)

--- a/v21.1/performance-benchmarking-with-tpc-c-10-warehouses.md
+++ b/v21.1/performance-benchmarking-with-tpc-c-10-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Learn how to benchmark CockroachDB against TPC-C 13k on a local cluster
-toc: true
-toc_not_nested: true
----

--- a/v21.1/performance-benchmarking-with-tpc-c-100k-warehouses.md
+++ b/v21.1/performance-benchmarking-with-tpc-c-100k-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Learn how to benchmark CockroachDB against TPC-C with 81 nodes on `c5d.9xlarge` machines
-toc: true
-toc_not_nested: true
----

--- a/v21.1/performance-benchmarking-with-tpc-c-10k-warehouses.md
+++ b/v21.1/performance-benchmarking-with-tpc-c-10k-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Benchmark CockroachDB against TPC-C with 15 nodes on `c5d.4xlarge` machines
-toc: true
-toc_not_nested: true
----

--- a/v21.1/performance-benchmarking-with-tpc-c-1k-warehouses.md
+++ b/v21.1/performance-benchmarking-with-tpc-c-1k-warehouses.md
@@ -1,6 +1,0 @@
----
-title: Performance Benchmarking with TPC-C
-summary: Learn how to benchmark CockroachDB against TPC-C with 3 nodes on `c5d.4xlarge` machines
-toc: true
-toc_not_nested: true
----

--- a/v21.1/performance-benchmarking-with-tpcc-large.md
+++ b/v21.1/performance-benchmarking-with-tpcc-large.md
@@ -3,7 +3,8 @@ title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C with 81 nodes on `c5d.9xlarge` machines
 toc: true
 toc_not_nested: true
-redirect_from: 
+key: performance-benchmarking-with-tpc-c-100k-warehouses.html
+redirect_from:
 - performance-benchmarking-with-tpc-c.html
 - performance-benchmarking-with-tpc-c-100k-warehouses.html
 ---
@@ -23,10 +24,6 @@ This page shows you how to reproduce [CockroachDB's TPC-C performance benchmarki
 | Small    | 3 nodes on `c5d.4xlarge` machines  | 2500       | 200 GB    |
 | Medium   | 15 nodes on `c5d.4xlarge` machines | 13,000     | 1.04 TB   |
 | Large    | 81 nodes on `c5d.9xlarge` machines | 140,000    | 11.2 TB   |
-
- CockroachDB can achieve a TPC-C run of 140k warehouses on the same cluster size used for 100k in version 19.2, a 40% improvement:
-
-<img src="{{ 'images/v21.1/tpcc140k.png' | relative_url }}" alt="TPC-C 140,000" style="border:1px solid #eee;max-width:100%" />
 
 ## Before you begin
 
@@ -191,32 +188,38 @@ You'll be importing a large TPC-C data set. To speed that up, you can temporaril
 
 ## Step 4. Import the TPC-C dataset
 
-CockroachDB offers a pre-built `workload` binary for Linux that includes the TPC-C benchmark. You'll need to put the binary on the VMs for importing the dataset and running TPC-C.
+CockroachDB comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
-1. SSH to one of the VMs where you want to run TPC-C.
+1. SSH to the VM where you want to run TPC-C.
 
-2. Download the `workload` binary for Linux and make it executable:
-
-    {% include copy-clipboard.html %}
-     ~~~ shell
-    $ wget https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST -O workload; chmod 755 workload
-    ~~~
-
-3. Repeat steps 1 and 2 for the other 4 VMs where you'll run TPC-C.
-
-4. On one of the VMs with the `workload` binary, import the TPC-C dataset:
+1. Download the [CockroachDB archive](https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz) for Linux, extract the binary, and copy it into the `PATH`:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ ./workload fixtures import tpcc \
-    --warehouses 140000 \
-    --partitions 81 \
-    --replicate-static-columns
-    --partition-strategy=leases
-    "postgres://root@<address of any CockroachDB node>:26257?sslmode=disable"
+    $ wget -qO- https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.linux-amd64.tgz \
+    | tar  xvz
     ~~~
 
-    This will load the data for 140,000 warehouses. This can take up to 8 hours to complete.
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cp -i cockroach-{{ page.release_info.version }}.linux-amd64/cockroach /usr/local/bin/
+    ~~~
+
+    If you get a permissions error, prefix the command with `sudo`.
+
+1. Import the TPC-C dataset:
+
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach workload fixtures import tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --replicate-static-columns \
+    --partition-strategy=leases \
+    'postgres://root@<address of any CockroachDB node>:26257?sslmode=disable'
+    ~~~
+
+    This will load 11.2 TB of data for 140,000 "warehouses". This can take up to 8 hours to complete.
 
     You can monitor progress on the **Jobs** screen of the DB Console. Open the [DB Console](ui-overview.html) by pointing a browser to the address in the `admin` field in the standard output of any node on startup.
 
@@ -273,27 +276,61 @@ Before running the benchmark, it's important to allocate partitions to workload 
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 --ramp 30m --duration 1ms --histograms workload1.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload1.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 --ramp 30m --duration 1ms --histograms workload2.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions 81 \
+    --warehouses 140000 \
+    --partition-affinity=17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload2.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 --ramp 30m --duration 1ms --histograms workload3.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload3.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 --ramp 30m --duration 1ms --histograms workload4.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload4.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 --ramp 30m --duration 1ms --histograms workload5.histogram.ndjson $(cat addrs)
+    ulimit -n 500000 && cockroach workload run tpcc \
+    --partitions=81 \
+    --warehouses=140000 \
+    --partition-affinity=65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 \
+    --ramp=30m \
+    --duration=1ms \
+    --histograms=workload5.histogram.ndjson \
+    $(cat addrs)
     ~~~
 
 ## Step 8. Run the benchmark
@@ -306,27 +343,62 @@ It is critical to run the benchmark from the workload nodes in parallel, so star
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 --ramp 4m --duration 30m --histograms workload1.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload1.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 --ramp 4m --duration 30m --histograms workload2.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload2.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 --ramp 4m --duration 30m --histograms workload3.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload3.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 --ramp 4m --duration 30m --histograms workload4.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partitions=81 \
+--warehouses=140000 \
+--partition-affinity=49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload4.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 {% include copy-clipboard.html %}
 ~~~ shell
-ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --partition-affinity 65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 --ramp 4m --duration 30m --histograms workload5.histogram.ndjson $(cat addrs)
+ulimit -n 500000 && cockroach workload run tpcc \
+--partition=81 \
+--warehouses=140000 \
+--partition-affinity=65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80 \
+--ramp=4m \
+--duration=30m \
+--histograms=workload5.histogram.ndjson \
+$(cat addrs)
 ~~~
 
 ## Step 9. Interpret the results
@@ -390,7 +462,9 @@ ulimit -n 500000 && ./workload run tpcc --partitions 81 --warehouses 140000 --pa
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    ./workload debug tpcc-merge-results --warehouses 140000  workload*.histogram.ndjson
+    cockroach workload debug tpcc-merge-results \
+    --warehouses=140000 \
+    workload*.histogram.ndjson
     ~~~
 
     You'll should see results similar to the following, with **1.68M tpmC with 140,000 warehouses, resulting in an efficiency score of 95%**:

--- a/v21.1/performance-benchmarking-with-tpcc-local.md
+++ b/v21.1/performance-benchmarking-with-tpcc-local.md
@@ -3,6 +3,7 @@ title: Performance Benchmarking with TPC-C
 summary: Learn how to benchmark CockroachDB against TPC-C 13k on 3 nodes on your laptop
 toc: true
 toc_not_nested: true
+key: performance-benchmarking-with-tpc-c-10-warehouses.html
 redirect_from:
 - performance-benchmarking-with-tpc-c-10-warehouses.html
 ---
@@ -79,30 +80,18 @@ This page shows you how to reproduce [CockroachDB's TPC-C performance benchmarki
 
 ## Step 2. Import the TPC-C dataset
 
-CockroachDB comes with built-in load generators for simulating different types of client workloads, printing out per-operation statistics every second and totals after a specific duration or max number of operations. This step features CockroachDB's version of the TPC-C workload.
+CockroachDB comes with a number of [built-in workloads](cockroach-workload.html) for simulating client traffic. This step features CockroachDB's version of the [TPC-C](http://www.tpc.org/tpcc/) workload.
 
 Use [`cockroach workload`](cockroach-workload.html) to load the initial schema and data:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach workload init tpcc \
+$ cockroach workload fixtures import tpcc \
 --warehouses=10 \
 'postgresql://root@localhost:26257?sslmode=disable'
 ~~~
 
-This will take about ten minutes to load, after which you'll see the following output:
-
-~~~
-I191024 03:41:34.308865 1 workload/workloadsql/dataload.go:135  imported warehouse (0s, 10 rows)
-I191024 03:41:34.353839 1 workload/workloadsql/dataload.go:135  imported district (0s, 100 rows)
-I191024 03:42:00.865733 1 workload/workloadsql/dataload.go:135  imported customer (27s, 300000 rows)
-I191024 03:42:13.233536 1 workload/workloadsql/dataload.go:135  imported history (12s, 300000 rows)
-I191024 03:42:20.893806 1 workload/workloadsql/dataload.go:135  imported order (8s, 300000 rows)
-I191024 03:42:21.716409 1 workload/workloadsql/dataload.go:135  imported new_order (1s, 90000 rows)
-I191024 03:42:23.483713 1 workload/workloadsql/dataload.go:135  imported item (2s, 100000 rows)
-I191024 03:43:37.660918 1 workload/workloadsql/dataload.go:135  imported stock (1m14s, 1000000 rows)
-I191024 03:46:51.682670 1 workload/workloadsql/dataload.go:135  imported order_line (3m14s, 3001222 rows)
-~~~
+This will load 2 GB of data for 10 "warehouses".
 
 ## Step 3. Run the benchmark
 


### PR DESCRIPTION
Previously, we were using the external `workload` binary.

Unfortunately, `cockroach workload fixtures import`, which
we use to more quickly get tpcc data into a cluster,
is undocumented. We'll handle that separately.

Fixes #5067
Fixes #9774
Fixes #6325