### PR TITLE
Include auto-gen docs from release-21.1 branch

### DIFF
--- a/v21.1/cluster-settings.md
+++ b/v21.1/cluster-settings.md
@@ -18,7 +18,7 @@ In contrast to cluster-wide settings, node-level settings apply to a single node
 Many cluster settings are intended for tuning CockroachDB internals. Before changing these settings, we strongly encourage you to discuss your goals with Cockroach Labs; otherwise, you use them at your own risk.
 {{site.data.alerts.end}}
 
-{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/generated/settings/settings.html %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/release-21.1/docs/generated/settings/settings.html %}
 
 ## View current cluster settings
 

--- a/v21.1/functions-and-operators.md
+++ b/v21.1/functions-and-operators.md
@@ -36,7 +36,7 @@ functions but have special evaluation rules:
 
 ## Built-in functions
 
-{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/generated/sql/functions.md %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/release-21.1/docs/generated/sql/functions.md %}
 
 ## Aggregate functions
 
@@ -46,11 +46,11 @@ For examples showing how to use aggregate functions, see [the `SELECT` clause do
 Non-commutative aggregate functions are sensitive to the order in which the rows are processed in the surrounding [`SELECT` clause](select-clause.html#aggregate-functions). To specify the order in which input rows are processed, you can add an [`ORDER BY`](order-by.html) clause within the function argument list. For examples, see the [`SELECT` clause](select-clause.html#order-aggregate-function-input-rows-by-column) documentation.
 {{site.data.alerts.end}}
 
-{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/generated/sql/aggregates.md %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/release-21.1/docs/generated/sql/aggregates.md %}
 
 ## Window functions
 
-{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/generated/sql/window_functions.md %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/release-21.1/docs/generated/sql/window_functions.md %}
 
 ## Operators
 
@@ -112,7 +112,7 @@ The following table lists all CockroachDB operators from highest to lowest prece
 
 ### Supported operations
 
-{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/master/docs/generated/sql/operators.md %}
+{% remote_include https://raw.githubusercontent.com/cockroachdb/cockroach/release-21.1/docs/generated/sql/operators.md %}
 
 <!--
 ## `CAST()`


### PR DESCRIPTION
Previously, these docs were including from
master.