### PR TITLE
CC GitHub Auth

### DIFF
--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -149,10 +149,6 @@ If you want to change your login method, you can do so at any time:
 {{site.data.alerts.callout_info}}
 As a best security practice, you can also [remove CockroachCloud's access to your GitHub account details](https://docs.github.com/en/developers/apps/deleting-an-oauth-app).
 {{site.data.alerts.end}}
-        
-{{site.data.alerts.callout_info}}
-Creating an account password will _not_ change your [SQL user](user-authorization.html#create-a-sql-user) password.
-{{site.data.alerts.end}}
 
 ### Switch from an email login to GitHub
 

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -19,9 +19,11 @@ To register a new account, navigate to the [CockroachCloud registration page](ht
 <section class="filter-content" markdown="1" data-scope="github">
 
 1. Click **Sign up with GitHub**.
-1. Enter your GitHub **Username or email address** associated with your account.
-1. Enter your GitHub **Password**
-1. Click **Sign in**
+1. Select the checkbox to accept the [terms of service](https://www.cockroachlabs.com/cloud-terms-and-conditions) and [privacy policy](https://www.cockroachlabs.com/privacy).
+1. Log in to GitHub if you haven't already.
+1. Click **Authorize CockroachCloud by Cockroach Labs**.
+
+    A confirmation email will be sent.
 
 {{site.data.alerts.callout_info}}
 GitHub will verify your identity using [GitHub 2FA](https://docs.github.com/en/github/authenticating-to-github/about-two-factor-authentication), if you have it enabled.
@@ -142,8 +144,12 @@ If you want to change your login method, you can do so at any time:
 1. Enter a **Password**.
 1. Click **Save**.
 
-    A confirmation email will be sent to your email address.
-    
+    A confirmation email will be sent.
+  
+{{site.data.alerts.callout_info}}
+As a best security practice, you can also [remove CockroachCloud's access to your GitHub account details](https://docs.github.com/en/developers/apps/deleting-an-oauth-app).
+{{site.data.alerts.end}}
+        
 {{site.data.alerts.callout_info}}
 Creating an account password will _not_ change your [SQL user](user-authorization.html#create-a-sql-user) password.
 {{site.data.alerts.end}}
@@ -155,6 +161,7 @@ Creating an account password will _not_ change your [SQL user](user-authorizatio
 1. Click **Switch to GitHub login**.
 1. In the **Log in with GitHub** dialog, enter your **Password**.
 1. Click **Continue**.
-1. You will be prompted to log in to GitHub if you haven't already.
+1. Log in to GitHub if you haven't already.
+1. Click **Authorize CockroachCloud by Cockroach Labs**.
 
-    A confirmation email will be sent to your email address.
+    A confirmation email will be sent.

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -130,26 +130,30 @@ If you are a [Console Admin](console-access-management.html#console-admin), you 
 
 If you want to change your login method, you can do so at any time:
 
-- [Switch from a GitHub login to email](#switch-from-github-login-to-email)
-- [Switch from an email login to GitHub](#switch-from-email-login-to-github)
+- [Switch from a GitHub login to email](#switch-from-a-github-login-to-email)
+- [Switch from an email login to GitHub](#switch-from-an-email-login-to-github)
 
 ### Switch from a GitHub login to email
 
 1. Click the account icon in the top right corner.
 1. From the dropdown, select **My Account**.
 1. Click **Switch to email login**.
-1. Click **Continue** in the **Log in with email and password** dialog.
+1. In the **Log in with email and password** dialog, click **Continue**.
 1. Enter a **Password**.
 1. Click **Save**.
 
     A confirmation email will be sent to your email address.
+    
+{{site.data.alerts.callout_info}}
+Creating an account password will _not_ change your [SQL user](user-authorization.html#create-a-sql-user) password.
+{{site.data.alerts.end}}
 
 ### Switch from an email login to GitHub
 
 1. Click the account icon in the top right corner.
 1. From the dropdown, select **My Account**.
 1. Click **Switch to GitHub login**.
-1. In the **Log in with GitHub** dialog, enter your password.
+1. In the **Log in with GitHub** dialog, enter your **Password**.
 1. Click **Continue**.
 1. You will be prompted to log in to GitHub if you haven't already.
 

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -125,3 +125,32 @@ If you are a [Console Admin](console-access-management.html#console-admin), you 
 1. Click the pencil icon in the **Organization name** row.
 1. In the **Edit organization name** dialog, enter the new **Organization name**.
 1. Click **Save**.
+
+## Change your login method
+
+If you want to change your login method, you can do so at any time:
+
+- [Switch from a GitHub login to email](#switch-from-github-login-to-email)
+- [Switch from an email login to GitHub](#switch-from-email-login-to-github)
+
+### Switch from a GitHub login to email
+
+1. Click the account icon in the top right corner.
+1. From the dropdown, select **My Account**.
+1. Click **Switch to email login**.
+1. Click **Continue** in the **Log in with email and password** dialog.
+1. Enter a **Password**.
+1. Click **Save**.
+
+    A confirmation email will be sent to your email address.
+
+### Switch from an email login to GitHub
+
+1. Click the account icon in the top right corner.
+1. From the dropdown, select **My Account**.
+1. Click **Switch to GitHub login**.
+1. In the **Log in with GitHub** dialog, enter your password.
+1. Click **Continue**.
+1. You will be prompted to log in to GitHub if you haven't already.
+
+    A confirmation email will be sent to your email address.

--- a/cockroachcloud/create-an-account.md
+++ b/cockroachcloud/create-an-account.md
@@ -18,10 +18,6 @@ To register a new account, navigate to the [CockroachCloud registration page](ht
 
 <section class="filter-content" markdown="1" data-scope="github">
 
-{{site.data.alerts.callout_info}}
-This feature is only available to select users at this time. If you do not have access yet, you can register a new account with an email.
-{{site.data.alerts.end}}
-
 1. Click **Sign up with GitHub**.
 1. Enter your GitHub **Username or email address** associated with your account.
 1. Enter your GitHub **Password**


### PR DESCRIPTION
Hold until Console changes are live.

Add instructions to switch between GitHub and email login methods.
Closes https://cockroachlabs.atlassian.net/browse/CC-3651