### PR TITLE
Highlight sidenav for more release note pages

### DIFF
--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -240,7 +240,16 @@
         {
           "title": "All Release Notes",
           "urls": [
-            "/releases/index-cockroachcloud.html"
+            "/releases/index-cockroachcloud.html",
+            "/releases/cockroachcloud-02092021.html",
+            "/releases/cockroachcloud-01222021.html",
+            "/releases/cockroachcloud-12112020.html",
+            "/releases/cockroachcloud-11192020.html",
+            "/releases/cockroachcloud-07062020.html",
+            "/releases/cockroachcloud-06112020.html",
+            "/releases/cockroachcloud-05042020.html",
+            "/releases/cockroachcloud-04062020.html",
+            "/releases/cockroachcloud-03022020.html"
           ]
         }
       ]

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -25,7 +25,36 @@
         {
           "title": "All Production Releases",
           "urls": [
-            "/releases/#production-releases"
+            "/releases/index.html#production-releases",
+            "/releases/v20.2.4.html",
+            "/releases/v20.2.3.html",
+            "/releases/v20.2.2.html",
+            "/releases/v20.2.1.html",
+            "/releases/v20.2.0.html",
+            "/releases/v20.1.11.html",
+            "/releases/v20.1.10.html",
+            "/releases/v20.1.9.html",
+            "/releases/v20.1.8.html",
+            "/releases/v20.1.7.html",
+            "/releases/v20.1.6.html",
+            "/releases/v20.1.5.html",
+            "/releases/v20.1.4.html",
+            "/releases/v20.1.3.html",
+            "/releases/v20.1.2.html",
+            "/releases/v20.1.1.html",
+            "/releases/v20.1.0.html",
+            "/releases/v19.2.11.html",
+            "/releases/v19.2.10.html",
+            "/releases/v19.2.9.html",
+            "/releases/v19.2.8.html",
+            "/releases/v19.2.7.html",
+            "/releases/v19.2.6.html",
+            "/releases/v19.2.5.html",
+            "/releases/v19.2.4.html",
+            "/releases/v19.2.3.html",
+            "/releases/v19.2.2.html",
+            "/releases/v19.2.1.html",
+            "/releases/v19.2.0.html"
           ]
         }
       ]
@@ -33,7 +62,10 @@
     {
       "title": "Testing Releases",
       "urls": [
-        "/releases/#testing-releases"
+        "/releases/index.html#testing-releases",
+        "/releases/v21.1.0-alpha.1.html",
+        "/releases/v21.1.0-alpha.2.html",
+        "/releases/v21.1.0-alpha.3.html"
       ]
     },
     {


### PR DESCRIPTION
Previously, when looking at many of our  specific release note pages,
the sidenav would collapse. Now:

- When looking at any supported production release of CRDB,
the sidenav stays open to:
CockroachDB > Releases > Production Releases > All Production Releases
- When looking at any testing release for the upcoming version,
the sidenav stays open to:
CockroachDB > Releases > Testing Releases
- When looking at any but the latest CockroachCloud release,
the sidenav stays open to:
CockroachCloud > Release Notes > All Release Notes

For CRDB, pages for earlier production releases continue and pages
for earlier testing releases are not reflected in the sidenav.
We could cover those, too, but I'm not sure it's worth the effort.

Fixes #9957
Fixes #8454

One open issue: The "All Production Releases" and "Testing Releases" links
in the sidenav open /releases/index.html at specific anchor points. These
links work, but our sidenav doesn't seem to able keep the right entry
highlighted in the sidenav due to the anchors. I've opened an issue
for that: https://github.com/cockroachdb/docs/issues/9982.