### PR TITLE
Fix Contribute > Report Doc Issue

### DIFF
--- a/_includes/contribute-options.html
+++ b/_includes/contribute-options.html
@@ -6,7 +6,7 @@
     </button>
     <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
       <li><a href="https://github.com/cockroachdb/docs/edit/master/{{ page.path }}" target="blank" id="edit-this-page" data-proofer-ignore>Edit This Page</a></li>
-      <li><a href="https://github.com/cockroachdb/docs/issues/new?title={{page.title}}%20Doc%20Update%20&amp;body=Re%3A%20%5B{{page.title}}%5D(https%3A%2F%2Fcockroachlabs.com/docs/{{page.url}})%0A%0A%23%23%20Issue%20Description%0A%0A%23%23%20Suggested%20Resolution%20%0A&amp;labels=community" target="blank" id="report-doc-issue" data-proofer-ignore>Report Doc Issue</a></li>
+      <li><a href="https://github.com/cockroachdb/docs/issues/new?title={{page.title}}%20Doc%20Update%20&amp;body=Re%3A%20%5B{{page.title}}%5D(https%3A%2F%2Fcockroachlabs.com/docs{{page.url}})%0A%0A%23%23%20Issue%20Description%0A%0A%23%23%20Suggested%20Resolution%20%0A&amp;labels=community" target="blank" id="report-doc-issue" data-proofer-ignore>Report Doc Issue</a></li>
       <li><a href="https://github.com/cockroachdb/docs/issues/new?title=New%20Doc%20Proposal%20&amp;body=%23%23%20Title%0A%0A%0A%23%23%20Description%0A%0A%0A%23%23%20Outline%0A%0A%0A%23%23%20Expected%20Audience%0A&amp;labels=community" target="blank" id="suggest-new-content" data-proofer-ignore>Suggest New Content</a></li>
     </ul>
   </div>


### PR DESCRIPTION
Previously, selecting this option on a doc page would
create a docs issue starting with an incorrectly formatted
link to the relevant doc page. Specifically, the page url
would include 2 forward slashes, e.g., docs//v20.2/secure...
Now, the generated link is correct.

Finishes up #8454.