### PR TITLE
Fix busted tornadoes spatial data link

### DIFF
--- a/v20.2/migrate-from-shapefiles.md
+++ b/v20.2/migrate-from-shapefiles.md
@@ -15,7 +15,7 @@ We are using `shp2pgsql` in the example below, but [`ogr2ogr`](https://gdal.org/
 
 {% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
 
-In the example below we will import a [tornadoes data set](https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip) that is [available from the US National Weather Service](https://www.spc.noaa.gov/gis/svrgis/) (NWS).
+In the example below we will import a [tornadoes data set](http://web.archive.org/web/20201018170120/https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip) that is [available from the US National Weather Service](https://www.spc.noaa.gov/gis/svrgis/) (NWS).
 
 {{site.data.alerts.callout_info}}
 Please refer to the documentation of your GIS software for instructions on exporting GIS data to Shapefiles.
@@ -35,7 +35,7 @@ First, download and unzip the tornado data:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-wget https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip
+wget http://web.archive.org/web/20201018170120/https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v21.1/migrate-from-shapefiles.md
+++ b/v21.1/migrate-from-shapefiles.md
@@ -15,7 +15,7 @@ We are using `shp2pgsql` in the example below, but [`ogr2ogr`](https://gdal.org/
 
 {% include {{page.version.version}}/spatial/ogr2ogr-supported-version.md %}
 
-In the example below we will import a [tornadoes data set](https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip) that is [available from the US National Weather Service](https://www.spc.noaa.gov/gis/svrgis/) (NWS).
+In the example below we will import a [tornadoes data set](http://web.archive.org/web/20201018170120/https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip) that is [available from the US National Weather Service](https://www.spc.noaa.gov/gis/svrgis/) (NWS).
 
 {{site.data.alerts.callout_info}}
 Please refer to the documentation of your GIS software for instructions on exporting GIS data to Shapefiles.
@@ -35,7 +35,7 @@ First, download and unzip the tornado data:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-wget https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip
+wget http://web.archive.org/web/20201018170120/https://www.spc.noaa.gov/gis/svrgis/zipped/1950-2018-torn-initpoint.zip
 ~~~
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
Fixes #9320.
Fixes #9812.

Summary of changes:

- Updated old broken link to NWS website with a new link to a copy of
  the same 1950-2018 data set which was saved by the nice people at
  http://archive.org.  This means that the docs can use the same exact
  schema names, etc. as before without breaking anything.

Remember kids: COOL URLs DON'T CHANGE!

https://www.w3.org/Provider/Style/URI.html