### PR TITLE
Add database object sizing considerations and limits info

### DIFF
--- a/v20.2/recommended-production-settings.md
+++ b/v20.2/recommended-production-settings.md
@@ -54,7 +54,7 @@ Each node should have **at least 2 vCPUs**. For best performance, we recommend a
 
 - To optimize for resiliency, use many smaller nodes instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
-- To optimize for the support of large numbers of tables, increase the amount of RAM. For more information, see [Quantity of tables and other schema objects](schema-design-overview.html#quantity-of-tables-and-other-schema-objects). Supporting a large number of rows is a matter of [Storage](storage).
+- To optimize for the support of large numbers of tables, increase the amount of RAM. For more information, see [Quantity of tables and other schema objects](schema-design-overview.html#quantity-of-tables-and-other-schema-objects). Supporting a large number of rows is a matter of [Storage](#storage).
 
 - Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
 

--- a/v20.2/recommended-production-settings.md
+++ b/v20.2/recommended-production-settings.md
@@ -54,6 +54,8 @@ Each node should have **at least 2 vCPUs**. For best performance, we recommend a
 
 - To optimize for resiliency, use many smaller nodes instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
+- To optimize for the support of large numbers of tables, increase the amount of RAM. For more information, see [Quantity of tables and other schema objects](schema-design-overview.html#quantity-of-tables-and-other-schema-objects). Supporting a large number of rows is a matter of [Storage](storage).
+
 - Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
 
 - To ensure consistent SQL performance, make sure all nodes have a uniform configuration.

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -130,7 +130,7 @@ While practical limitations may exist, CockroachDB does not impose hard limits o
   - a maximum of 128 bytes is recommended for identifiers and may be enforced in future versions of CockroachDB. For compatibility with other databases, CockroachDB has a `max_identifier_length` variable set to 128. This is a reported value that is not currently enforced.
   - this does not apply to role or user names, which have a limit of 63 bytes, among other [restrictions](create-role.html#role-name-limitations).
 
-By default, a [range](architecture/overview.html#terms) automatically [splits](architecture/distribution-layer#range-splits) into two ranges when it reaches 512MiB in size. You can also choose to [manually split ranges](https://www.cockroachlabs.com/docs/stable/split-at.html) at a specified row in a table or index. The size of each range will continue to be within the 512MiB limit, in this case.
+By default, a [range](architecture/overview.html#terms) automatically [splits](architecture/distribution-layer.html#range-splits) into two ranges when it reaches 512MiB in size. You can also choose to [manually split ranges](https://www.cockroachlabs.com/docs/stable/split-at.html) at a specified row in a table or index. The size of each range will continue to be within the 512MiB limit, in this case.
 
 ## What's next?
 

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -103,17 +103,17 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
 ## Object size and scaling considerations
 
-CockroachDB does not place hard limits on most database objects, however, there are scenarios where exteremely large attributes may not be supported or may cause performance to degrade.
+CockroachDB does not place hard limits on most database objects, however, there are scenarios where extremely large attributes may not be supported or may cause performance to degrade.
 
 ### Hard limits
 
 The following table lists specific limits imposed by CockroachDB.
 
 | Object | Limit | Comments |
-| --- | --- | --- |
+| ------ | ----- | -------- |
 | Role names | 63 bytes | Other [restrictions](create-role.html#role-name-limitations) apply. |
 | User names | 63 bytes | These are [equivalent](create-user.html) to role names. |
-| Identifier length | 128 bytes | This limit is specified in the `max_identifier_length` variable for compatibility with other databases, but is not currently enforced. It may be enforced in future versions of CockroachDB. | 
+| Identifier length | 128 bytes | This limit is specified in the `max_identifier_length` variable for compatibility with other databases, but is not currently enforced. It may be enforced in future versions of CockroachDB, so we recommended remaining within this limit. | 
 
 ### Quantity of tables and other schema objects
 
@@ -121,7 +121,7 @@ CockroachDB has been shown to perform well with clusters containing 2,500 tables
 
 As you scale to a large number of tables, note that:
 
-- The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support: columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact, while increasing the number of nodes will not have a substantial effect.
+- The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support. This includes columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact, while increasing the number of nodes will not have a substantial effect.
 - The number of databases or schemas has minimal impact as compared to the total number of tables and their complexity.
 
 ### Quantity of rows

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -121,7 +121,7 @@ CockroachDB has been shown to perform well with clusters containing 2,500 tables
 
 As you scale to a large number of tables, note that:
 
-- The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support. This includes columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact, while increasing the number of nodes will not have a substantial effect.
+- The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support. This includes columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact on the number of these objects that a cluster can support, while increasing the number of nodes will not have a substantial effect.
 - The number of databases or schemas on the cluster has minimal impact on the total number of tables that it can support.
 
 See the [Hardware](recommended-production-settings.html#hardware) section for additional recommendations based on your expected workloads.

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -103,7 +103,7 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
 ## Object size and scaling considerations
 
-CockroachDB does not place hard limits on most database objects, however, extremely large attributes are not supported in certain scenarios.
+CockroachDB does not place hard limits on most database objects. Extremely large attributes are not supported in certain scenarios as described in this section.
 
 ### Hard limits
 
@@ -128,7 +128,7 @@ See the [Hardware](recommended-production-settings.html#hardware) section for ad
 
 ### Quantity of rows
 
-CockroachDB can support any number of rows by adding additional nodes and storage.
+CockroachDB can support any number of rows by adding additional nodes and [storage](recommended-production-settings.html#storage).
 
 ## What's next?
 

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -103,7 +103,7 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
 ## Object size and scaling considerations
 
-CockroachDB does not place hard limits on most database objects, however, there are scenarios where extremely large attributes may not be supported.
+CockroachDB does not place hard limits on most database objects, however, extremely large attributes are not supported in certain scenarios.
 
 ### Hard limits
 
@@ -117,12 +117,14 @@ The following table lists specific limits imposed by CockroachDB.
 
 ### Quantity of tables and other schema objects
 
-CockroachDB has been shown to perform well with clusters containing 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes) and system specifications.
+CockroachDB has been shown to perform well with clusters containing 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes) and hardware specifications.
 
 As you scale to a large number of tables, note that:
 
 - The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support. This includes columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact, while increasing the number of nodes will not have a substantial effect.
-- The number of databases or schemas has minimal impact as compared to the total number of tables and their complexity.
+- The number of databases or schemas on the cluster has minimal impact on the total number of tables that it can support.
+
+See the [Hardware](recommended-production-settings.html#hardware) section for additional recommendations based on your expected workloads.
 
 ### Quantity of rows
 

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -105,7 +105,7 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
 CockroachDB does not place hard limits on most database objects, however, there are scenarios where exteremely large attributes may cause performance to degrade.
 
-CockroachDB has been shown to perform well with clusters of 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes).
+CockroachDB has been shown to perform well with clusters containing 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes) and system specifications.
 
 As you scale to a large number of tables, note that:
 
@@ -126,6 +126,11 @@ While practical limitations may exist, CockroachDB does not impose hard limits o
   - inverted indexes
   - constraints
   - partitions
+- the length of identifiers. Note:
+  - a maximum of 128 bytes is recommended for identifiers and may be enforced in future versions of CockroachDB. For compatibility with other databases, CockroachDB has a `max_identifier_length` variable set to 128. This is a reported value that is not currently enforced.
+  - this does not apply to role or user names, which have a limit of 63 bytes, among other [restrictions](create-role.html#role-name-limitations).
+
+By default, a [range](architecture/overview.html#terms) automatically [splits](architecture/distribution-layer#range-splits) into two ranges when it reaches 512MiB in size. You can also choose to [manually split ranges](https://www.cockroachlabs.com/docs/stable/split-at.html) at a specified row in a table or index. The size of each range will continue to be within the 512MiB limit, in this case.
 
 ## What's next?
 

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -103,7 +103,7 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
 ## Object size and scaling considerations
 
-CockroachDB does not place hard limits on most database objects, however, there are scenarios where extremely large attributes may not be supported or may cause performance to degrade.
+CockroachDB does not place hard limits on most database objects, however, there are scenarios where extremely large attributes may not be supported.
 
 ### Hard limits
 

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -101,6 +101,31 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
     The CockroachDB SQL client allows you to execute commands from the command line, or through the [CockroachDB SQL shell](cockroach-sql.html#sql-shell) interface. From the command line, you can pass a string to the client for execution, or you can pass a `.sql` file populated with SQL commands. From the SQL shell, you can execute SQL commands directly. Throughout the guide, we pass a `.sql` file to the SQL client to perform most database schema changes.
 
+## Object size and scaling considerations
+
+CockroachDB does not place hard limits on most database objects, however, there are scenarios where exteremely large attributes may cause performance to degrade.
+
+CockroachDB has been shown to perform well with clusters of 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes).
+
+As you scale to a large number of tables, note that:
+
+- The number of databases or schemas has minimal impact as compared to the total number of tables and their complexity.
+- Increasing RAM may have the greatest impact on performance. Increasing the number of nodes will not have a substantial effect.
+
+### Limits
+
+While practical limitations may exist, CockroachDB does not impose hard limits on:
+
+- database size.
+- the number of databases in a cluster.
+- the number of tables in a database or cluster.
+- the number of the following objects per table, database, or cluster:
+  - rows
+  - columns
+  - indexes
+  - inverted indexes
+  - constraints
+  - partitions
 
 ## What's next?
 

--- a/v20.2/schema-design-overview.md
+++ b/v20.2/schema-design-overview.md
@@ -103,34 +103,30 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
 ## Object size and scaling considerations
 
-CockroachDB does not place hard limits on most database objects, however, there are scenarios where exteremely large attributes may cause performance to degrade.
+CockroachDB does not place hard limits on most database objects, however, there are scenarios where exteremely large attributes may not be supported or may cause performance to degrade.
+
+### Hard limits
+
+The following table lists specific limits imposed by CockroachDB.
+
+| Object | Limit | Comments |
+| --- | --- | --- |
+| Role names | 63 bytes | Other [restrictions](create-role.html#role-name-limitations) apply. |
+| User names | 63 bytes | These are [equivalent](create-user.html) to role names. |
+| Identifier length | 128 bytes | This limit is specified in the `max_identifier_length` variable for compatibility with other databases, but is not currently enforced. It may be enforced in future versions of CockroachDB. | 
+
+### Quantity of tables and other schema objects
 
 CockroachDB has been shown to perform well with clusters containing 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes) and system specifications.
 
 As you scale to a large number of tables, note that:
 
+- The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support: columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact, while increasing the number of nodes will not have a substantial effect.
 - The number of databases or schemas has minimal impact as compared to the total number of tables and their complexity.
-- Increasing RAM may have the greatest impact on performance. Increasing the number of nodes will not have a substantial effect.
 
-### Limits
+### Quantity of rows
 
-While practical limitations may exist, CockroachDB does not impose hard limits on:
-
-- database size.
-- the number of databases in a cluster.
-- the number of tables in a database or cluster.
-- the number of the following objects per table, database, or cluster:
-  - rows
-  - columns
-  - indexes
-  - inverted indexes
-  - constraints
-  - partitions
-- the length of identifiers. Note:
-  - a maximum of 128 bytes is recommended for identifiers and may be enforced in future versions of CockroachDB. For compatibility with other databases, CockroachDB has a `max_identifier_length` variable set to 128. This is a reported value that is not currently enforced.
-  - this does not apply to role or user names, which have a limit of 63 bytes, among other [restrictions](create-role.html#role-name-limitations).
-
-By default, a [range](architecture/overview.html#terms) automatically [splits](architecture/distribution-layer.html#range-splits) into two ranges when it reaches 512MiB in size. You can also choose to [manually split ranges](https://www.cockroachlabs.com/docs/stable/split-at.html) at a specified row in a table or index. The size of each range will continue to be within the 512MiB limit, in this case.
+CockroachDB can support any number of rows by adding additional nodes and storage.
 
 ## What's next?
 

--- a/v21.1/recommended-production-settings.md
+++ b/v21.1/recommended-production-settings.md
@@ -54,6 +54,8 @@ Each node should have **at least 2 vCPUs**. For best performance, we recommend a
 
 - To optimize for resiliency, use many smaller nodes instead of fewer larger nodes. Recovery from a failed node is faster when data is spread across more nodes.
 
+- To optimize for the support of large numbers of tables, increase the amount of RAM. For more information, see [Quantity of tables and other schema objects](schema-design-overview.html#quantity-of-tables-and-other-schema-objects). Supporting a large number of rows is a matter of [Storage](#storage).
+
 - Avoid "burstable" or "shared-core" virtual machines that limit the load on CPU resources.
 
 - To ensure consistent SQL performance, make sure all nodes have a uniform configuration.

--- a/v21.1/schema-design-overview.md
+++ b/v21.1/schema-design-overview.md
@@ -83,7 +83,7 @@ For guidance on using temporary objects, see [Temporary Tables](temporary-tables
 
 ## Controlling access to objects
 
-CockroachDB supports both user-based and role-based access control. With roles, or with direct assignment, you can grant a [SQL user](authorization.html#sql-users) the [privileges](authorization.html#privileges) required to view, modify, and delete database schema objects.
+CockroachDB supports both user-based and role-based access control. With roles, or with direct assignment, you can grant a [SQL user](authorization.html#users) the [privileges](authorization.html#privileges) required to view, modify, and delete database schema objects.
 
 By default, the user that creates an object is that object's *owner*. [Object owners](authorization.html#object-ownership) have all privileges required to view, modify, or delete that object and the data stored within it.
 
@@ -101,6 +101,34 @@ We do not recommend using client drivers or ORM frameworks to execute database s
 
     The CockroachDB SQL client allows you to execute commands from the command line, or through the [CockroachDB SQL shell](cockroach-sql.html#sql-shell) interface. From the command line, you can pass a string to the client for execution, or you can pass a `.sql` file populated with SQL commands. From the SQL shell, you can execute SQL commands directly. Throughout the guide, we pass a `.sql` file to the SQL client to perform most database schema changes.
 
+## Object size and scaling considerations
+
+CockroachDB does not place hard limits on most database objects. Extremely large attributes are not supported in certain scenarios as described in this section.
+
+### Hard limits
+
+The following table lists specific limits imposed by CockroachDB.
+
+| Object | Limit | Comments |
+| ------ | ----- | -------- |
+| Role names | 63 bytes | Other [restrictions](create-role.html#role-name-limitations) apply. |
+| User names | 63 bytes | These are [equivalent](create-user.html) to role names. |
+| Identifier length | 128 bytes | This limit is specified in the `max_identifier_length` variable for compatibility with other databases, but is not currently enforced. It may be enforced in future versions of CockroachDB, so we recommended remaining within this limit. | 
+
+### Quantity of tables and other schema objects
+
+CockroachDB has been shown to perform well with clusters containing 2,500 tables. Greater numbers are possible, depending on the complexity of the tables (number of columns and indexes) and hardware specifications.
+
+As you scale to a large number of tables, note that:
+
+- The amount of RAM per node is the limiting factor for the number of tables and other schema objects the cluster can support. This includes columns, indexes, inverted indexes, constraints, and partitions. Increasing RAM is likely to have the greatest impact on the number of these objects that a cluster can support, while increasing the number of nodes will not have a substantial effect.
+- The number of databases or schemas on the cluster has minimal impact on the total number of tables that it can support.
+
+See the [Hardware](recommended-production-settings.html#hardware) section for additional recommendations based on your expected workloads.
+
+### Quantity of rows
+
+CockroachDB can support any number of rows by adding additional nodes and [storage](recommended-production-settings.html#storage).
 
 ## What's next?
 


### PR DESCRIPTION
Initial PR to publish this information per https://github.com/cockroachdb/docs/issues/1830, https://github.com/cockroachdb/docs/issues/10031, and the internal SSOT sheet https://docs.google.com/spreadsheets/d/1JWqggZ1tZ_wDI_lrvWdEBtge4hQFvXEZYczQtMhkRjI/.

Going forward, efforts to gather further information for discovering limits or sizing best practices can be addressed separately in the respective issues (or otherwise as separate topics).