### PR TITLE
Run vale and htmltest on Netlify

### DIFF
--- a/netlify/build
+++ b/netlify/build
@@ -10,10 +10,22 @@ build _config_cockroachdb.yml
 
 cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
-cat _site/docs/cockroachcloud/_redirects >> _site/_redirects
 
 # Run Algolia if building master
 if [[ "$CONTEXT" = "production" ]]; then
 	echo "Building Algolia index..."
 	ALGOLIA_API_KEY=$PROD_ALGOLIA_API_KEY bundle exec jekyll algolia --config _config_base.yml --builds-config _config_cockroachdb.yml
 fi;
+
+# Set up Vale, a text linter
+wget -O- https://github.com/errata-ai/vale/releases/download/v1.2.7/vale_1.2.7_Linux_64-bit.tar.gz | tar -xz vale
+
+# Set up htmltest
+go get -u github.com/cockroachdb/htmltest
+pushd $GOPATH/src/github.com/cockroachdb/htmltest && ./build.sh && popd
+
+# Run Vale, but don't fail the build if it reports errors
+./vale --no-wrap v20.2 || true
+
+# Run htmltest, but skip checking external links to speed things up
+$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest --skip-external


### PR DESCRIPTION
Fixes #7050.

This enables migration of PR builds away from TeamCity and onto Netlify. Note that this does not yet disable TeamCity PR builds. That should happen in a separate PR once/if people are happy with Netlify build output. This means we might be briefly running vale and htmltest on both TeamCity and Netlify.

New Netlify output: https://app.netlify.com/teams/cockroach-labs/builds/605b333c041fe700089c1f99

Observation from one push:
Netlify: Build time: 3m 45s. Total deploy time: 4m 14s
TeamCity: 4m:18s