### PR TITLE
Modify Gemfile for Ruby 3.0.0 users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ gem "jekyll-redirect-from", "~> 0.15"
 gem "jekyll-sitemap", "~> 1.3.1"
 gem "liquid-c", "~> 4.0.0"
 gem "redcarpet", "~> 3.5"
+gem "rss"
 gem "sassc", "~> 2.2"
+gem "webrick"
 
 group :jekyll_plugins do
     gem "jekyll-include-cache"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     redcarpet (3.5.1)
     rexml (3.2.4)
     rouge (3.26.0)
+    rss (0.2.7)
     safe_yaml (1.0.5)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -98,6 +99,7 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
     verbal_expressions (0.1.5)
+    webrick (1.4.2)
 
 PLATFORMS
   ruby
@@ -113,7 +115,9 @@ DEPENDENCIES
   jekyll-sitemap (~> 1.3.1)
   liquid-c (~> 4.0.0)
   redcarpet (~> 3.5)
+  rss
   sassc (~> 2.2)
+  webrick
 
 BUNDLED WITH
    2.2.14

--- a/ci/builder
+++ b/ci/builder
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/docs-builder
-version=${COCKROACH_DOCS_BUILDER_VERSION:-20210322-155506}
+version=${COCKROACH_DOCS_BUILDER_VERSION:-20210405-130258}
 
 root=$(cd "$(dirname "$0")" && pwd)
 repo_root=$root/..


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

> The following libraries are no longer bundled gems or standard libraries. Install the corresponding gems to use these features.
sdbm
webrick
net-telnet
xmlrpc

As people start to use the latest Ruby for local builds, they might run into issues with our current Gemfile. Per above, Ruby 3 no longer bundles certain gems, including `webrick`, which is needed by Jekyll (https://jekyllrb.com/docs/configuration/webrick/).

Therefore install `webrick` explicitly for now. This will not affect users or CI running older Ruby versions. Our TeamCity Docker image and Netlify are both using older Ruby versions.

We will also explicitly install `rss` for now because @jseldess (who is running Ruby 3) saw dependency issues for that. In Ruby 3 (again per above link), `rss` is now a bundled gem instead of a default gem. We *shouldn't* need to explicitly install a bundled gem, but doing it for now to unblock Jesse while we continue to investigate.