### PR TITLE
GitHub Actions to trigger nightly htmltest run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,14 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: '0 22 * * *'
+    
+jobs:
+  curl:
+    runs-on: ubuntu-latest
+    steps:
+    - name: hook
+      uses: wei/curl@v1
+      with:
+        args: -X POST -d {} https://api.netlify.com/build_hooks/60623d6d4f10e018bbca9b7d


### PR DESCRIPTION
Trigger nightly htmltest checks for external links on Netlify, every day at 10 pm UTC.