### PR TITLE
add missing release

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -3,6 +3,8 @@
     - date: March 29, 2021
       version: v20.2.7
       latest: true
+    - date: March 15, 2021
+      version: v20.2.6
     - date: Feb 16, 2021
       version: v20.2.5
     - date: Jan 21, 2021


### PR DESCRIPTION
v20.2.6 was mistakenly dropped from the release list, so it's back now.