### PR TITLE
(backport) Added tip on disabling row count estimation for SHOW TABLES

### DIFF
--- a/v20.2/show-tables.md
+++ b/v20.2/show-tables.md
@@ -7,6 +7,10 @@ toc: true
 
 The `SHOW TABLES` [statement](sql-statements.html) lists the schema, table name, table type, owner, and estimated row count for the tables or [views](views.html) in a schema or database.
 
+{{site.data.alerts.callout_success}}
+Estimating the number of rows in a table costs resources. To improve the performance of `SHOW TABLES` queries, disable row-count estimation by setting the `sql.show_tables.estimated_row_count.enabled` [cluster setting](cluster-settings.html) to `false` before executing a `SHOW TABLES` statement.
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_info}}
 While a table or view is being [dropped](drop-table.html), `SHOW TABLES` will list the object with a `(dropped)` suffix.
 {{site.data.alerts.end}}


### PR DESCRIPTION
Follow-up on https://github.com/cockroachdb/docs/pull/9944.

Documents https://github.com/cockroachdb/docs/issues/9763.