### PR TITLE
Updates to 21.1 session variables

### DIFF
--- a/_includes/v20.1/misc/session-vars.html
+++ b/_includes/v20.1/misc/session-vars.html
@@ -178,6 +178,16 @@
 
   <tr>
    <td>
+    <code>locality</code>
+   </td>
+   <td>The location of the node. For more information, see <a href="cockroach-start.html#locality">Locality</a>.</td>
+   <td>Node-dependent</td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>node_id</code>
    </td>
    <td>The ID of the node currently connected to.<br />

--- a/_includes/v20.2/misc/session-vars.html
+++ b/_includes/v20.2/misc/session-vars.html
@@ -234,6 +234,16 @@
 
   <tr>
    <td>
+    <code>locality</code>
+   </td>
+   <td>The location of the node. For more information, see <a href="cockroach-start.html#locality">Locality</a>.</td>
+   <td>Node-dependent</td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>node_id</code>
    </td>
    <td>The ID of the node currently connected to.<br />

--- a/_includes/v21.1/misc/session-vars.html
+++ b/_includes/v21.1/misc/session-vars.html
@@ -119,6 +119,18 @@
 
   <tr>
    <td>
+    <code>default_transaction_use_follower_reads</code>
+   </td>
+   <td><span class="version-tag">New in v21.1</span>: If set to <code>on</code>, all read-only transactions use <a href="as-of-system-time.html"><code>AS OF SYSTEM TIME follower_read_timestamp()</code></a>, to allow the transaction to use <a href="follower-reads.html">follower reads</a>.<br>If set to <code>off</code>, read-only transactions will only use follower reads if an <code>AS OF SYSTEM TIME</code> clause is specified in the statement, with an interval of at least 4.8 seconds.</td>
+   <td>
+    <code>off</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>disallow_full_table_scans</code>
    </td>
    <td> If set to <code>on</code>, all queries that have planned a full table or full secondary index scan will return an error message. This setting does not apply to internal queries, which may plan full table or index scans without checking the session variable.</td>
@@ -136,6 +148,18 @@
    <td>The query distribution mode for the session. By default, CockroachDB determines which queries are faster to execute if distributed across multiple nodes, and all other queries are run through the gateway node.</td>
    <td>
     <code>auto</code>
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>enable_drop_enum_value</code>
+   </td>
+   <td>Indicates whether <code>DROP VALUE</code> clauses are enabled for <a href="alter-type.html"><code>ALTER TYPE</code></a> statements.</td>
+   <td>
+    <code>off</code>
    </td>
    <td>Yes</td>
    <td>Yes</td>
@@ -229,6 +253,16 @@
     <code>0</code>
    </td>
    <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
+    <code>locality</code>
+   </td>
+   <td>The location of the node. For more information, see <a href="cockroach-start.html#locality">Locality</a>.</td>
+   <td>Node-dependent</td>
+   <td>No</td>
    <td>Yes</td>
   </tr>
 


### PR DESCRIPTION
This PR adds the following session variables:

- `locality` (added to 21.1, 20.2, and 20.1; not sure why this was left out in previous releases)
- `default_transaction_use_follower_reads` (related to https://github.com/cockroachdb/docs/issues/9584; will introduce follow-up PR)
- `enable_drop_enum_value` (related to https://github.com/cockroachdb/docs/issues/10137)

Note the following session variables, which exist in v21.1.0-beta.2, but remain undocumented:

- `disable_partially_distributed_plans` (for internal testing - no docs need; https://github.com/cockroachdb/cockroach/pull/50903)
- `override_multi_region_zone_config` (not sure if we need docs for this @rmloveland; https://github.com/cockroachdb/cockroach/pull/62119, https://github.com/cockroachdb/docs/issues/10131)
- `testing_vectorize_inject_panics` (for internal testing - no docs need; https://github.com/cockroachdb/cockroach/pull/55516)
- `enable_experimental_stream_replication` (not sure if we need docs for this @jseldess ; https://github.com/cockroachdb/docs/issues/10110; https://github.com/cockroachdb/cockroach/pull/60826)
- `experimental_distsql_planning` (we never documented this for 20.2, but I'm not sure if we need docs @yuzefovich)
- `experimental_enable_implicit_column_partitioning` (not sure if we need docs for this @rmloveland; https://github.com/cockroachdb/cockroach/pull/58521, https://github.com/cockroachdb/cockroach/pull/60465)
- `experimental_enable_unique_without_index_constraints` (this needs docs @ianjevans; https://github.com/cockroachdb/cockroach/pull/57666)
- `experimental_use_new_schema_changer` (I don't think this needs docs; https://github.com/cockroachdb/cockroach/commit/c0bb7c0fff35fe9b16efd83def55c5df8dadafb2#diff-cac22f70970154948cf8958f45e3fb5946f5dfb71a96aac384e99ccf310119b1)

Just mentioning people in this description for visibility. No response required. :)