### PR TITLE
Clarified that follower_read_timestamp returns timestamp

### DIFF
--- a/v20.2/as-of-system-time.md
+++ b/v20.2/as-of-system-time.md
@@ -36,7 +36,7 @@ Format | Notes
 [`INT`](int.html) | Nanoseconds since the Unix epoch.
 negative [`INTERVAL`](interval.html) | Added to `statement_timestamp()`, and thus must be negative.
 [`STRING`](string.html) | A [`TIMESTAMP`](timestamp.html), [`INT`](int.html) of nanoseconds, or negative [`INTERVAL`](interval.html).
-`follower_read_timestamp()`| A [function](functions-and-operators.html) that runs your queries at a time as close as possible to the present time known as the [follower read timestamp](follower-reads.html#run-queries-that-use-follower-reads), while remaining safe for [follower reads](follower-reads.html).
+`follower_read_timestamp()`| A [function](functions-and-operators.html) that returns the [`TIMESTAMP`](timestamp.html) `statement_timestamp() - 4.8s` (known as the [follower read timestamp](follower-reads.html#run-queries-that-use-follower-reads)). Using this function will set the time as close as possible to the present time while remaining safe for [follower reads](follower-reads.html).
 
 ## Examples
 

--- a/v20.2/follower-reads.md
+++ b/v20.2/follower-reads.md
@@ -67,7 +67,7 @@ To verify that your cluster is performing follower reads:
 
 Any [`SELECT` statement](select-clause.html) with an [`AS OF SYSTEM TIME`](as-of-system-time.html) value at least 4.8 seconds in the past can be a follower read (i.e., served by any replica).
 
-To simplify this calculation, we've added a convenience function that will always set the [`AS OF SYSTEM TIME`](as-of-system-time.html) value to the minimum required for follower reads, `follower_read_timestamp()`:
+To simplify this calculation, we've added the convenience [function](functions-and-operators.html) `follower_read_timestamp()`. `follower_read_timestamp()` returns the [`TIMESTAMP`](timestamp.html) `statement_timestamp() - 4.8s` (known as the [follower read timestamp](follower-reads.html#run-queries-that-use-follower-reads)). Using this function in an `AS OF SYSTEM TIME` statement will set the time as close as possible to the present time while remaining safe for [follower reads](follower-reads.html):
 
 ``` sql
 SELECT ... FROM ... AS OF SYSTEM TIME follower_read_timestamp();

--- a/v20.2/topology-follower-reads.md
+++ b/v20.2/topology-follower-reads.md
@@ -61,7 +61,7 @@ Insert some data:
 2. Configure your app to use `AS OF SYSTEM TIME follower_read_timestamp()` whenever reading from the table:
 
     {{site.data.alerts.callout_info}}
-    The `follower_read_timestamp()` [function](functions-and-operators.html) will set the [`AS OF SYSTEM TIME`](as-of-system-time.html) value to the minimum required for follower reads.
+    The `follower_read_timestamp()` [function](functions-and-operators.html) returns the [`TIMESTAMP`](timestamp.html) `statement_timestamp() - 4.8s`.
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}

--- a/v21.1/as-of-system-time.md
+++ b/v21.1/as-of-system-time.md
@@ -36,7 +36,7 @@ Format | Notes
 [`INT`](int.html) | Nanoseconds since the Unix epoch.
 negative [`INTERVAL`](interval.html) | Added to `statement_timestamp()`, and thus must be negative.
 [`STRING`](string.html) | A [`TIMESTAMP`](timestamp.html), [`INT`](int.html) of nanoseconds, or negative [`INTERVAL`](interval.html).
-`follower_read_timestamp()`| A [function](functions-and-operators.html) that runs your queries at a time as close as possible to the present time known as the [follower read timestamp](follower-reads.html#run-queries-that-use-follower-reads), while remaining safe for [follower reads](follower-reads.html).
+`follower_read_timestamp()`| A [function](functions-and-operators.html) that returns the [`TIMESTAMP`](timestamp.html) `statement_timestamp() - 4.8s` (known as the [follower read timestamp](follower-reads.html#run-queries-that-use-follower-reads)). Using this function will set the time as close as possible to the present time while remaining safe for [follower reads](follower-reads.html).
 
 ## Examples
 

--- a/v21.1/follower-reads.md
+++ b/v21.1/follower-reads.md
@@ -67,7 +67,7 @@ To verify that your cluster is performing follower reads:
 
 Any [`SELECT` statement](select-clause.html) with an [`AS OF SYSTEM TIME`](as-of-system-time.html) value at least 4.8 seconds in the past can be a follower read (i.e., served by any replica).
 
-To simplify this calculation, we've added a convenience function that will always set the [`AS OF SYSTEM TIME`](as-of-system-time.html) value to the minimum required for follower reads, `follower_read_timestamp()`:
+To simplify this calculation, we've added the convenience [function](functions-and-operators.html) `follower_read_timestamp()`. `follower_read_timestamp()` returns the [`TIMESTAMP`](timestamp.html) `statement_timestamp() - 4.8s` (known as the [follower read timestamp](follower-reads.html#run-queries-that-use-follower-reads)). Using this function in an `AS OF SYSTEM TIME` statement will set the time as close as possible to the present time while remaining safe for [follower reads](follower-reads.html):
 
 ``` sql
 SELECT ... FROM ... AS OF SYSTEM TIME follower_read_timestamp();

--- a/v21.1/topology-follower-reads.md
+++ b/v21.1/topology-follower-reads.md
@@ -61,7 +61,7 @@ Insert some data:
 2. Configure your app to use `AS OF SYSTEM TIME follower_read_timestamp()` whenever reading from the table:
 
     {{site.data.alerts.callout_info}}
-    The `follower_read_timestamp()` [function](functions-and-operators.html) will set the [`AS OF SYSTEM TIME`](as-of-system-time.html) value to the minimum required for follower reads.
+    The `follower_read_timestamp()` [function](functions-and-operators.html) returns the [`TIMESTAMP`](timestamp.html) `statement_timestamp() - 4.8s`.
     {{site.data.alerts.end}}
 
     {% include copy-clipboard.html %}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/9089.
Fixes https://github.com/cockroachdb/docs/issues/5210.

@rmloveland I think this fixes https://github.com/cockroachdb/docs/issues/5210, but please let me know if you disagree.