### PR TITLE
draft Helm messaging

### DIFF
--- a/_includes/v20.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+The CockroachDB Helm chart is being maintained to ensure compatibility with newer versions of Kubernetes. No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/_includes/v20.2/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,3 +1,7 @@
+{{site.data.alerts.callout_danger}}
+The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+{{site.data.alerts.end}}
+
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:
 
     {% include copy-clipboard.html %}

--- a/_includes/v20.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-helm-secure.md
@@ -1,3 +1,7 @@
+{{site.data.alerts.callout_danger}}
+The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_info}}
 Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](https://github.com/cockroachdb/cockroach/issues/38847).
 {{site.data.alerts.end}}

--- a/_includes/v20.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-helm-secure.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+The CockroachDB Helm chart is being maintained to ensure compatibility with newer versions of Kubernetes. No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}

--- a/_includes/v21.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+The CockroachDB Helm chart is being maintained to ensure compatibility with newer versions of Kubernetes. No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
 {{site.data.alerts.end}}
 
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:

--- a/_includes/v21.1/orchestration/start-cockroachdb-helm-insecure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-helm-insecure.md
@@ -1,3 +1,7 @@
+{{site.data.alerts.callout_danger}}
+The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+{{site.data.alerts.end}}
+
 1. [Install the Helm client](https://helm.sh/docs/intro/install) (version 3.0 or higher) and add the `cockroachdb` chart repository:
 
     {% include copy-clipboard.html %}

--- a/_includes/v21.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,3 +1,7 @@
+{{site.data.alerts.callout_danger}}
+The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+{{site.data.alerts.end}}
+
 {{site.data.alerts.callout_info}}
 Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](https://github.com/cockroachdb/cockroach/issues/38847).
 {{site.data.alerts.end}}

--- a/_includes/v21.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-helm-secure.md
@@ -1,5 +1,5 @@
 {{site.data.alerts.callout_danger}}
-The CockroachDB Helm chart is undergoing active maintenance. Some features may not be functional. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
+The CockroachDB Helm chart is being maintained to ensure compatibility with newer versions of Kubernetes. No new feature development is currently planned. For new production and local deployments, we currently recommend using a manual configuration (**Configs** option). If you are experiencing issues with a Helm deployment on production, contact our [Support team](https://support.cockroachlabs.com/).
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
Added a callout to our Helm docs that addresses current functionality issues.

This will appear at the following docs in v20.2 and v21.1 (can also backport to previous docs versions if desired):

https://www.cockroachlabs.com/docs/stable/orchestrate-cockroachdb-with-kubernetes.html?filters=helm
https://www.cockroachlabs.com/docs/v20.2/orchestrate-cockroachdb-with-kubernetes-insecure#step-2-start-cockroachdb

https://www.cockroachlabs.com/docs/stable/orchestrate-a-local-cluster-with-kubernetes.html?filters=helm
https://www.cockroachlabs.com/docs/v20.2/orchestrate-a-local-cluster-with-kubernetes-insecure#step-2-start-cockroachdb