### PR TITLE
Added diagrams for CREATE SCHEMA, ALTER SCHEMA, DROP SCHEMA; updated parameters

### DIFF
--- a/_includes/v20.2/sql/diagrams/alter_schema.html
+++ b/_includes/v20.2/sql/diagrams/alter_schema.html
@@ -1,0 +1,30 @@
+<div><svg width="675" height="81">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="76" height="32" rx="10"></rect>
+<rect x="111" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">SCHEMA</text><a xlink:href="sql-grammar.html#schema_name" xlink:title="schema_name">
+<rect x="209" y="3" width="112" height="32"></rect>
+<rect x="207" y="1" width="112" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="217" y="21">schema_name</text></a><rect x="361" y="3" width="76" height="32" rx="10"></rect>
+<rect x="359" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="369" y="21">RENAME</text>
+<rect x="457" y="3" width="38" height="32" rx="10"></rect>
+<rect x="455" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="465" y="21">TO</text><a xlink:href="sql-grammar.html#schema_name" xlink:title="schema_name">
+<rect x="515" y="3" width="112" height="32"></rect>
+<rect x="513" y="1" width="112" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="523" y="21">schema_name</text></a><rect x="361" y="47" width="72" height="32" rx="10"></rect>
+<rect x="359" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="369" y="65">OWNER</text>
+<rect x="453" y="47" width="38" height="32" rx="10"></rect>
+<rect x="451" y="45" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="461" y="65">TO</text><a xlink:href="sql-grammar.html#role_spec" xlink:title="role_spec">
+<rect x="511" y="47" width="82" height="32"></rect>
+<rect x="509" y="45" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="519" y="65">role_spec</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m112 0 h10 m20 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m112 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m82 0 h10 m0 0 h34 m23 -44 h-3"></path>
+<polygon points="665 17 673 13 673 21"></polygon>
+<polygon points="665 17 657 13 657 21"></polygon></svg></div>

--- a/_includes/v20.2/sql/diagrams/create_schema.html
+++ b/_includes/v20.2/sql/diagrams/create_schema.html
@@ -1,0 +1,31 @@
+<div><svg width="473" height="211">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="72" height="32" rx="10"></rect>
+<rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">CREATE</text>
+<rect x="123" y="3" width="76" height="32" rx="10"></rect>
+<rect x="121" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="131" y="21">SCHEMA</text>
+<rect x="239" y="35" width="34" height="32" rx="10"></rect>
+<rect x="237" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="247" y="53">IF</text>
+<rect x="293" y="35" width="48" height="32" rx="10"></rect>
+<rect x="291" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="301" y="53">NOT</text>
+<rect x="361" y="35" width="70" height="32" rx="10"></rect>
+<rect x="359" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="369" y="53">EXISTS</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="69" y="101" width="56" height="32"></rect>
+<rect x="67" y="99" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="77" y="119">name</text></a><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="89" y="177" width="56" height="32"></rect>
+<rect x="87" y="175" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="97" y="195">name</text></a><rect x="185" y="145" width="138" height="32" rx="10"></rect>
+<rect x="183" y="143" width="138" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="193" y="163">AUTHORIZATION</text><a xlink:href="sql-grammar.html#role_spec" xlink:title="role_spec">
+<rect x="343" y="145" width="82" height="32"></rect>
+<rect x="341" y="143" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="351" y="163">role_spec</text></a><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-446 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h300 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v24 m396 0 v-24 m-396 24 q0 10 10 10 m376 0 q10 0 10 -10 m-366 10 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m138 0 h10 m0 0 h10 m82 0 h10 m23 -44 h-3"></path>
+<polygon points="463 115 471 111 471 119"></polygon>
+<polygon points="463 115 455 111 455 119"></polygon></svg></div>

--- a/_includes/v20.2/sql/diagrams/drop_schema.html
+++ b/_includes/v20.2/sql/diagrams/drop_schema.html
@@ -1,0 +1,26 @@
+<div><svg width="647" height="113">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="58" height="32" rx="10"></rect>
+<rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">DROP</text>
+<rect x="109" y="3" width="76" height="32" rx="10"></rect>
+<rect x="107" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="117" y="21">SCHEMA</text>
+<rect x="225" y="35" width="34" height="32" rx="10"></rect>
+<rect x="223" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="233" y="53">IF</text>
+<rect x="279" y="35" width="70" height="32" rx="10"></rect>
+<rect x="277" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="287" y="53">EXISTS</text><a xlink:href="sql-grammar.html#name_list" xlink:title="name_list">
+<rect x="389" y="3" width="82" height="32"></rect>
+<rect x="387" y="1" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="397" y="21">name_list</text></a><rect x="511" y="35" width="84" height="32" rx="10"></rect>
+<rect x="509" y="33" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="519" y="53">CASCADE</text>
+<rect x="511" y="79" width="88" height="32" rx="10"></rect>
+<rect x="509" y="77" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="519" y="97">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m82 0 h10 m20 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="637 17 645 13 645 21"></polygon>
+<polygon points="637 17 629 13 629 21"></polygon></svg></div>

--- a/_includes/v21.1/sql/generated/diagrams/alter_schema.html
+++ b/_includes/v21.1/sql/generated/diagrams/alter_schema.html
@@ -1,0 +1,35 @@
+<div><svg width="447" height="179">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="62" height="32" rx="10"></rect>
+<rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">ALTER</text>
+<rect x="113" y="3" width="76" height="32" rx="10"></rect>
+<rect x="111" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="121" y="21">SCHEMA</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="209" y="3" width="56" height="32"></rect>
+<rect x="207" y="1" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="217" y="21">name</text></a><rect x="305" y="35" width="24" height="32" rx="10"></rect>
+<rect x="303" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="313" y="53">.</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="349" y="35" width="56" height="32"></rect>
+<rect x="347" y="33" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="357" y="53">name</text></a><rect x="133" y="101" width="76" height="32" rx="10"></rect>
+<rect x="131" y="99" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="141" y="119">RENAME</text>
+<rect x="229" y="101" width="38" height="32" rx="10"></rect>
+<rect x="227" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="237" y="119">TO</text><a xlink:href="sql-grammar.html#schema_name" xlink:title="schema_name">
+<rect x="287" y="101" width="112" height="32"></rect>
+<rect x="285" y="99" width="112" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="295" y="119">schema_name</text></a><rect x="133" y="145" width="72" height="32" rx="10"></rect>
+<rect x="131" y="143" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="141" y="163">OWNER</text>
+<rect x="225" y="145" width="38" height="32" rx="10"></rect>
+<rect x="223" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="233" y="163">TO</text><a xlink:href="sql-grammar.html#role_spec" xlink:title="role_spec">
+<rect x="283" y="145" width="82" height="32"></rect>
+<rect x="281" y="143" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="291" y="163">role_spec</text></a><path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m24 0 h10 m0 0 h10 m56 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-356 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m112 0 h10 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v24 m306 0 v-24 m-306 24 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m82 0 h10 m0 0 h34 m23 -44 h-3"></path>
+<polygon points="437 115 445 111 445 119"></polygon>
+<polygon points="437 115 429 111 429 119"></polygon></svg></div>

--- a/_includes/v21.1/sql/generated/diagrams/create_schema.html
+++ b/_includes/v21.1/sql/generated/diagrams/create_schema.html
@@ -1,0 +1,41 @@
+<div><svg width="609" height="275">
+<polygon points="11 17 3 13 3 21"></polygon>
+<polygon points="19 17 11 13 11 21"></polygon>
+<rect x="33" y="3" width="72" height="32" rx="10"></rect>
+<rect x="31" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="41" y="21">CREATE</text>
+<rect x="125" y="3" width="76" height="32" rx="10"></rect>
+<rect x="123" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="133" y="21">SCHEMA</text>
+<rect x="241" y="35" width="34" height="32" rx="10"></rect>
+<rect x="239" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="249" y="53">IF</text>
+<rect x="295" y="35" width="48" height="32" rx="10"></rect>
+<rect x="293" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="303" y="53">NOT</text>
+<rect x="363" y="35" width="70" height="32" rx="10"></rect>
+<rect x="361" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="371" y="53">EXISTS</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="45" y="101" width="56" height="32"></rect>
+<rect x="43" y="99" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="53" y="119">name</text></a><rect x="141" y="133" width="24" height="32" rx="10"></rect>
+<rect x="139" y="131" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="149" y="151">.</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="185" y="133" width="56" height="32"></rect>
+<rect x="183" y="131" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="193" y="151">name</text></a><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="65" y="209" width="56" height="32"></rect>
+<rect x="63" y="207" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="73" y="227">name</text></a><rect x="161" y="241" width="24" height="32" rx="10"></rect>
+<rect x="159" y="239" width="24" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="169" y="259">.</text><a xlink:href="sql-grammar.html#name" xlink:title="name">
+<rect x="205" y="241" width="56" height="32"></rect>
+<rect x="203" y="239" width="56" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="213" y="259">name</text></a><rect x="321" y="177" width="138" height="32" rx="10"></rect>
+<rect x="319" y="175" width="138" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="329" y="195">AUTHORIZATION</text><a xlink:href="sql-grammar.html#role_spec" xlink:title="role_spec">
+<rect x="479" y="177" width="82" height="32"></rect>
+<rect x="477" y="175" width="82" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="487" y="195">role_spec</text></a><path class="line" d="m19 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h202 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v12 m232 0 v-12 m-232 12 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m70 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-472 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m24 0 h10 m0 0 h10 m56 0 h10 m20 -32 h300 m-556 0 h20 m536 0 h20 m-576 0 q10 0 10 10 m556 0 q0 -10 10 -10 m-566 10 v56 m556 0 v-56 m-556 56 q0 10 10 10 m536 0 q10 0 10 -10 m-526 10 h10 m0 0 h226 m-256 0 h20 m236 0 h20 m-276 0 q10 0 10 10 m256 0 q0 -10 10 -10 m-266 10 v12 m256 0 v-12 m-256 12 q0 10 10 10 m236 0 q10 0 10 -10 m-246 10 h10 m56 0 h10 m20 0 h10 m0 0 h110 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v12 m140 0 v-12 m-140 12 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m24 0 h10 m0 0 h10 m56 0 h10 m40 -64 h10 m138 0 h10 m0 0 h10 m82 0 h10 m23 -76 h-3"></path>
+<polygon points="599 115 607 111 607 119"></polygon>
+<polygon points="599 115 591 111 591 119"></polygon></svg></div>

--- a/_includes/v21.1/sql/generated/diagrams/drop_schema.html
+++ b/_includes/v21.1/sql/generated/diagrams/drop_schema.html
@@ -1,0 +1,26 @@
+<div><svg width="703" height="113">
+<polygon points="9 17 1 13 1 21"></polygon>
+<polygon points="17 17 9 13 9 21"></polygon>
+<rect x="31" y="3" width="58" height="32" rx="10"></rect>
+<rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="39" y="21">DROP</text>
+<rect x="109" y="3" width="76" height="32" rx="10"></rect>
+<rect x="107" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="117" y="21">SCHEMA</text>
+<rect x="225" y="35" width="34" height="32" rx="10"></rect>
+<rect x="223" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="233" y="53">IF</text>
+<rect x="279" y="35" width="70" height="32" rx="10"></rect>
+<rect x="277" y="33" width="70" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="287" y="53">EXISTS</text><a xlink:href="sql-grammar.html#schema_name_list" xlink:title="schema_name_list">
+<rect x="389" y="3" width="138" height="32"></rect>
+<rect x="387" y="1" width="138" height="32" class="nonterminal"></rect>
+<text class="nonterminal" x="397" y="21">schema_name_list</text></a><rect x="567" y="35" width="84" height="32" rx="10"></rect>
+<rect x="565" y="33" width="84" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="575" y="53">CASCADE</text>
+<rect x="567" y="79" width="88" height="32" rx="10"></rect>
+<rect x="565" y="77" width="88" height="32" class="terminal" rx="10"></rect>
+<text class="terminal" x="575" y="97">RESTRICT</text>
+<path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m34 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m138 0 h10 m20 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m84 0 h10 m0 0 h4 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -76 h-3"></path>
+<polygon points="693 17 701 13 701 21"></polygon>
+<polygon points="693 17 685 13 685 21"></polygon></svg></div>

--- a/v20.2/alter-schema.md
+++ b/v20.2/alter-schema.md
@@ -8,17 +8,17 @@ toc: true
 
 ## Syntax
 
-~~~
-ALTER SCHEMA ... RENAME TO <newschemaname>
-ALTER SCHEMA ... OWNER TO <newowner>
-~~~
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/alter_schema.html %}
+</div>
 
 ### Parameters
 
 Parameter | Description
 ----------|------------
-`RENAME TO ...` | Rename the schema. The new schema name must be unique within the current database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
-`OWNER TO ...` | Change the owner of the schema.
+`schema_name` | The name of the schema to alter.
+`RENAME TO schema_name` | Rename the schema to `schema_name`. The new schema name must be unique within the database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
+`OWNER TO role_spec` | Change the owner of the schema to `role_spec`.
 
 ## Required privileges
 

--- a/v20.2/create-schema.md
+++ b/v20.2/create-schema.md
@@ -18,17 +18,17 @@ You can also create a user-defined schema by converting an existing database to 
 
 ## Syntax
 
-~~~
-CREATE SCHEMA [IF NOT EXISTS] { <schemaname> | [<schemaname>] AUTHORIZATION <user_name> }
-~~~
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/create_schema.html %}
+</div>
 
 ### Parameters
 
 Parameter | Description
 ----------|------------
-`IF NOT EXISTS` | Create a new schema only if a schema of the same name does not already exist within the current database. If one does exist, do not return an error.
-`schemaname` | The name of the schema to create, which must be unique within the current database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
-`AUTHORIZATION ...` | Optionally identify a user to be the owner of the schema.<br><br>If a `CREATE SCHEMA` statement has an `AUTHORIZATION` clause, but no `schemaname`, the schema will be named after the specified owner of the schema. If a `CREATE SCHEMA` statement does not have an `AUTHORIZATION` clause, the user executing the statement will be named the owner.
+`IF NOT EXISTS` | Create a new schema only if a schema of the same name does not already exist within the database. If one does exist, do not return an error.
+`name` | The name of the schema to create. The schema name must be unique within its database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
+`AUTHORIZATION role_spec` | Optionally identify a user (`role_spec`) to be the owner of the schema.<br><br>If a `CREATE SCHEMA` statement has an `AUTHORIZATION` clause, but no schema name is specified, the schema will be named after the specified owner of the schema. If a `CREATE SCHEMA` statement does not have an `AUTHORIZATION` clause, the user executing the statement will be named the owner.
 
 ## Example
 

--- a/v20.2/drop-schema.md
+++ b/v20.2/drop-schema.md
@@ -12,16 +12,16 @@ The user must have the `DROP` [privilege](authorization.html#assign-privileges) 
 
 ## Syntax
 
-~~~
-DROP SCHEMA [IF EXISTS] <schema_name> [, ...] [CASCADE | RESTRICT]
-~~~
+<div>
+  {% include {{ page.version.version }}/sql/diagrams/drop_schema.html %}
+</div>
 
 ### Parameters
 
 Parameter | Description
 ----------|------------
 `IF EXISTS`   | Drop the schema if it exists. If it does not exist, do not return an error.
-`schema_name`  | The name of the schema you want to drop from the current database.
+`name_list`  | The schema, or a list of schemas, that you want to drop.
 `CASCADE` | Drop all tables and views in the schema as well as all objects (such as [constraints](constraints.html) and [views](views.html)) that depend on those tables.<br><br>`CASCADE` does not list objects it drops, so should be used cautiously.
 `RESTRICT` | _(Default)_ Do not drop the schema if it contains any [tables](create-table.html) or [views](create-view.html).
 

--- a/v21.1/alter-schema.md
+++ b/v21.1/alter-schema.md
@@ -4,21 +4,21 @@ summary: The ALTER SCHEMA statement modifies a user-defined schema in a database
 toc: true
 ---
 
- The `ALTER SCHEMA` [statement](sql-statements.html) modifies a user-defined [schema](sql-name-resolution.html#naming-hierarchy) in the current database. CockroachDB currently supports changing the name of the schema and the owner of the schema.
+ The `ALTER SCHEMA` [statement](sql-statements.html) modifies a user-defined [schema](sql-name-resolution.html#naming-hierarchy). CockroachDB currently supports changing the name of the schema and the owner of the schema.
 
 ## Syntax
 
-~~~
-ALTER SCHEMA ... RENAME TO <newschemaname>
-ALTER SCHEMA ... OWNER TO <newowner>
-~~~
+<div>
+  {% include {{ page.version.version }}/sql/generated/diagrams/alter_schema.html %}
+</div>
 
 ### Parameters
 
 Parameter | Description
 ----------|------------
-`RENAME TO ...` | Rename the schema. The new schema name must be unique within the current database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
-`OWNER TO ...` | Change the owner of the schema.
+`name`<br>`name.name` | The name of the schema to alter, or the name of the database containing the schema and the schema name, separated by a "`.`".
+`RENAME TO schema_name` | Rename the schema to `schema_name`. The new schema name must be unique within the database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
+`OWNER TO role_spec` | Change the owner of the schema to `role_spec`.
 
 ## Required privileges
 

--- a/v21.1/create-schema.md
+++ b/v21.1/create-schema.md
@@ -4,7 +4,7 @@ summary: The CREATE SCHEMA statement creates a new user-defined schema.
 toc: true
 ---
 
- The `CREATE SCHEMA` [statement](sql-statements.html) creates a user-defined [schema](sql-name-resolution.html#naming-hierarchy) in the current database.
+ The `CREATE SCHEMA` [statement](sql-statements.html) creates a user-defined [schema](sql-name-resolution.html#naming-hierarchy).
 
 {{site.data.alerts.callout_info}}
 You can also create a user-defined schema by converting an existing database to a schema using [`ALTER DATABASE ... CONVERT TO SCHEMA`](convert-to-schema.html).
@@ -18,17 +18,17 @@ You can also create a user-defined schema by converting an existing database to 
 
 ## Syntax
 
-~~~
-CREATE SCHEMA [IF NOT EXISTS] { <schemaname> | [<schemaname>] AUTHORIZATION <user_name> }
-~~~
+<div>
+  {% include {{ page.version.version }}/sql/generated/diagrams/create_schema.html %}
+</div>
 
 ### Parameters
 
 Parameter | Description
 ----------|------------
-`IF NOT EXISTS` | Create a new schema only if a schema of the same name does not already exist within the current database. If one does exist, do not return an error.
-`schemaname` | The name of the schema to create, which must be unique within the current database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
-`AUTHORIZATION ...` | Optionally identify a user to be the owner of the schema.<br><br>If a `CREATE SCHEMA` statement has an `AUTHORIZATION` clause, but no `schemaname`, the schema will be named after the specified owner of the schema. If a `CREATE SCHEMA` statement does not have an `AUTHORIZATION` clause, the user executing the statement will be named the owner.
+`IF NOT EXISTS` | Create a new schema only if a schema of the same name does not already exist within the database. If one does exist, do not return an error.
+`name`<br>`name.name` | The name of the schema to create, or the name of the database in which to create the schema and the schema name, separated by a "`.`". The schema name must be unique within its database and follow these [identifier rules](keywords-and-identifiers.html#identifiers).
+`AUTHORIZATION role_spec` | Optionally identify a user (`role_spec`) to be the owner of the schema.<br><br>If a `CREATE SCHEMA` statement has an `AUTHORIZATION` clause, but no schema name is specified, the schema will be named after the specified owner of the schema. If a `CREATE SCHEMA` statement does not have an `AUTHORIZATION` clause, the user executing the statement will be named the owner.
 
 ## Example
 

--- a/v21.1/drop-schema.md
+++ b/v21.1/drop-schema.md
@@ -4,7 +4,7 @@ summary: The DROP SCHEMA statement removes a schema and all its objects from a C
 toc: true
 ---
 
- The `DROP SCHEMA` [statement](sql-statements.html) removes a user-defined [schema](sql-name-resolution.html#naming-hierarchy) from the current database.
+ The `DROP SCHEMA` [statement](sql-statements.html) removes a user-defined [schema](sql-name-resolution.html#naming-hierarchy).
 
 ## Required privileges
 
@@ -12,16 +12,16 @@ The user must have the `DROP` [privilege](authorization.html#assign-privileges) 
 
 ## Syntax
 
-~~~
-DROP SCHEMA [IF EXISTS] <schema_name> [, ...] [CASCADE | RESTRICT]
-~~~
+<div>
+  {% include {{ page.version.version }}/sql/generated/diagrams/drop_schema.html %}
+</div>
 
 ### Parameters
 
 Parameter | Description
 ----------|------------
 `IF EXISTS`   | Drop the schema if it exists. If it does not exist, do not return an error.
-`schema_name`  | The name of the schema you want to drop from the current database.
+`schema_name_list`  | The schema, or a list of schemas, that you want to drop.<br>To drop a schema in a database other than the current database, specify the name of the database and the name of the schema, separated by a "`.`" (e.g., `DROP SCHEMA IF EXISTS database.schema;`).
 `CASCADE` | Drop all tables and views in the schema as well as all objects (such as [constraints](constraints.html) and [views](views.html)) that depend on those tables.<br><br>`CASCADE` does not list objects it drops, so should be used cautiously.
 `RESTRICT` | _(Default)_ Do not drop the schema if it contains any [tables](create-table.html) or [views](create-view.html).
 

--- a/v21.1/schema-design-schema.md
+++ b/v21.1/schema-design-schema.md
@@ -37,7 +37,7 @@ Here are some best practices to follow when creating and using user-defined sche
 
 - When you create a user-defined schema, take note of the [object's owner](authorization.html#object-ownership). You can specify the owner in a `CREATE SCHEMA` statement with the [`AUTHORIZATION` keyword](create-schema.html#parameters). If `AUTHORIZATION` is not specified, the owner will be the user creating the user-defined schema.
 
-- Do not create user-defined schemas in the preloaded `defaultdb` database. Instead, use a database [you have created](schema-design-database.html). User-defined schemas can only be created in your SQL session's [current database](sql-name-resolution.html#current-database), so be sure to [change the session's database](schema-design-database.html#database-best-practices) to a database that you have created before creating a user-defined schema.
+- Do not create user-defined schemas in the preloaded `defaultdb` database. Instead, use a database [you have created](schema-design-database.html). If you do not specify a database in the `CREATE SCHEMA` statement, the user-defined schema will be created in your SQL session's [current database](sql-name-resolution.html#current-database).
 
 - When referring to a lower-level object in a database (e.g., a table), include the object's schema name (e.g., `schema_name.table_name`). Specifying the schema name in a lower-level object reference can prevent users from attempting to access the wrong object, if there are multiple objects with the same name in a database.
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/9100.
Related to https://github.com/cockroachdb/cockroach/pull/63168.

This PR adds syntax diagrams for the following statements to 21.1 and 20.2 docs:

- `CREATE SCHEMA`
- `ALTER SCHEMA`
- `DROP SCHEMA`

Each version's docs are based on the version-specific branch of `sql.y`.

The PR also updates the schema name qualification.