### PR TITLE
Add alerts for advisory 63162 to affected versions

### DIFF
--- a/_includes/v19.1/alerts/warning-a63162.md
+++ b/_includes/v19.1/alerts/warning-a63162.md
@@ -1,0 +1,3 @@
+Cockroach Labs has discovered a bug relating to incremental backups, for CockroachDB v19.1.0 - v19.1.11. If a backup coincides with an in-progress index creation (backfill), `RESTORE`, or `IMPORT`, it is possible that a subsequent incremental backup will not include all of the indexed, restored or imported data.
+
+For more information, including other affected versions, see [Technical Advisory 63162](../advisories/a63162.html).

--- a/_includes/v19.2/alerts/warning-a63162.md
+++ b/_includes/v19.2/alerts/warning-a63162.md
@@ -1,0 +1,3 @@
+Cockroach Labs has discovered a bug relating to incremental backups, for CockroachDB v19.2.0 - v19.2.12. If a backup coincides with an in-progress index creation (backfill), `RESTORE`, or `IMPORT`, it is possible that a subsequent incremental backup will not include all of the indexed, restored or imported data.
+
+For more information, including other affected versions, see [Technical Advisory 63162](../advisories/a63162.html).

--- a/_includes/v20.1/alerts/warning-a63162.md
+++ b/_includes/v20.1/alerts/warning-a63162.md
@@ -1,0 +1,3 @@
+Cockroach Labs has discovered a bug relating to incremental backups, for CockroachDB v20.1.0 - v20.1.13. If a backup coincides with an in-progress index creation (backfill), `RESTORE`, or `IMPORT`, it is possible that a subsequent incremental backup will not include all of the indexed, restored or imported data.
+
+For more information, including other affected versions, see [Technical Advisory 63162](../advisories/a63162.html).

--- a/_includes/v20.2/alerts/warning-a63162.md
+++ b/_includes/v20.2/alerts/warning-a63162.md
@@ -1,0 +1,3 @@
+Cockroach Labs has discovered a bug relating to incremental backups, for CockroachDB v20.2.0 - v20.2.7. If a backup coincides with an in-progress index creation (backfill), `RESTORE`, or `IMPORT`, it is possible that a subsequent incremental backup will not include all of the indexed, restored or imported data.
+
+For more information, including other affected versions, see [Technical Advisory 63162](../advisories/a63162.html).

--- a/releases/v19.1.0.md
+++ b/releases/v19.1.0.md
@@ -16,6 +16,10 @@ With the release of CockroachDB v19.1, we’ve made a variety of security, perfo
 
 Check out a comprehensive [summary of the most significant user-facing changes](#summary) and then [upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html). You can also read more about these changes in the [v19.1 blog post](https://www.cockroachlabs.com/blog/cockroachdb-19dot1-release) or sign up for our [live webinar on May 9th](https://www.cockroachlabs.com/webinars/19.1-release) where we'll dive into the details of the new capabilities.
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.1.md
+++ b/releases/v19.1.1.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.1 since v19.1.0.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.10.md
+++ b/releases/v19.1.10.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.10 since v19.1.9.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.11.md
+++ b/releases/v19.1.11.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.11 since v19.1.10.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.2.md
+++ b/releases/v19.1.2.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.2 since v19.1.1.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.3.md
+++ b/releases/v19.1.3.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.3 since v19.1.2.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.4.md
+++ b/releases/v19.1.4.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.4 since v19.1.3.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.5.md
+++ b/releases/v19.1.5.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.5 since v19.1.4.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.6.md
+++ b/releases/v19.1.6.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.6 since v19.1.5.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.7.md
+++ b/releases/v19.1.7.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.7 since v19.1.6.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.8.md
+++ b/releases/v19.1.8.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.8 since v19.1.7.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.1.9.md
+++ b/releases/v19.1.9.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.1.9 since v19.1.8.
 - For a comprehensive summary of features in v19.1, see the [v19.1 GA release notes](v19.1.0.html).
 - To upgrade to v19.1, see [Upgrade to CockroachDB v19.1](../v19.1/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.0.md
+++ b/releases/v19.2.0.md
@@ -12,6 +12,10 @@ With the release of CockroachDB v19.2, we’ve made a variety of performance, re
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.1.md
+++ b/releases/v19.2.1.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.1 since v19.2.0.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.10.md
+++ b/releases/v19.2.10.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.10 since v19.2.9.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.11.md
+++ b/releases/v19.2.11.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.11 since v19.2.10.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.12.md
+++ b/releases/v19.2.12.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v19.2.12 since v19.2.11.
 - For a comprehensive summary of features in v19.2, see the [v19.2 GA release notes](v19.2.0.html).
 - To upgrade to the latest production release of CockroachDB, see this [article](../stable/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.2.md
+++ b/releases/v19.2.2.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.2 since v19.2.1.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.3.md
+++ b/releases/v19.2.3.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.3 since v19.2.2.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.4.md
+++ b/releases/v19.2.4.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.4 since v19.2.3.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.5.md
+++ b/releases/v19.2.5.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.5 since v19.2.4.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.6.md
+++ b/releases/v19.2.6.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.6 since v19.2.5.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.7.md
+++ b/releases/v19.2.7.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.7 since v19.2.6.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.8.md
+++ b/releases/v19.2.8.md
@@ -14,7 +14,11 @@ This page lists additions and changes in v19.2.8 since v19.2.7.
 {{site.data.alerts.callout_danger}}
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
-s
+
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v19.2.9.md
+++ b/releases/v19.2.9.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v19.2.9 since v19.2.8.
 {% include /v19.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v19.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.0.md
+++ b/releases/v20.1.0.md
@@ -12,6 +12,10 @@ With the release of CockroachDB v20.1, we've made a variety of productivity, per
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.1.md
+++ b/releases/v20.1.1.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.1 since v20.1.0.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.10.md
+++ b/releases/v20.1.10.md
@@ -13,6 +13,10 @@ summary: Additions and changes in CockroachDB version v20.1.10 since version v20
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.11.md
+++ b/releases/v20.1.11.md
@@ -9,6 +9,10 @@ summary: Additions and changes in CockroachDB version v20.1.11 since version v20
 - For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
 - To upgrade to v20.1, see [Upgrade to CockroachDB v20.1](../v20.1/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.12.md
+++ b/releases/v20.1.12.md
@@ -9,6 +9,10 @@ summary: Additions and changes in CockroachDB version v20.1.12 since version v20
 - For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
 - To upgrade to v20.1, see [Upgrade to CockroachDB v20.1](../v20.1/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.13.md
+++ b/releases/v20.1.13.md
@@ -9,6 +9,10 @@ summary: Additions and changes in CockroachDB version v20.1.13 since version v20
 - For a comprehensive summary of features in v20.1, see the [v20.1 GA release notes](v20.1.0.html).
 - To upgrade to v20.1, see [Upgrade to CockroachDB v20.1](../v20.1/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.2.md
+++ b/releases/v20.1.2.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.2 since v20.1.1.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.3.md
+++ b/releases/v20.1.3.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.3 since v20.1.2.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.4.md
+++ b/releases/v20.1.4.md
@@ -21,6 +21,10 @@ CockroachDB introduced a critical bug in the v20.1.4 release that affects [`UPSE
 For more information, see [Technical Advisory 54418](../advisories/a54418.html).
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.5.md
+++ b/releases/v20.1.5.md
@@ -18,6 +18,10 @@ This page lists additions and changes in v20.1.5 since v20.1.4.
 {{site.data.alerts.callout_danger}}
 CockroachDB introduced a critical bug in the [v20.1.4 release](../releases/v20.1.4.html) that affects [`UPSERT`](../v20.1/upsert.html) and [`INSERT … ON CONFLICT DO UPDATE SET x = excluded.x`](../v20.1/insert.html#on-conflict-clause) statements involving more than 10,000 rows. All deployments running CockroachDB v20.1.4 and v20.1.5 are affected. A fix is included in [v20.1.6](../releases/v20.1.6.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 For more information, see [Technical Advisory 54418](../advisories/a54418.html).
 {{site.data.alerts.end}}
 

--- a/releases/v20.1.6.md
+++ b/releases/v20.1.6.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.6 since v20.1.5.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.7.md
+++ b/releases/v20.1.7.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.7 since v20.1.6.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.8.md
+++ b/releases/v20.1.8.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.8 since v20.1.7.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.1.9.md
+++ b/releases/v20.1.9.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.1.8 since v20.1.7.
 {% include /v20.1/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.1/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.0.md
+++ b/releases/v20.2.0.md
@@ -19,6 +19,10 @@ To learn more:
 {% include /v20.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 ## Downloads
 
 <div id="os-tabs" class="clearfix">

--- a/releases/v20.2.1.md
+++ b/releases/v20.2.1.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.2.1 since v20.2.0.
 {% include /v20.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.2.md
+++ b/releases/v20.2.2.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.2.2 since v20.2.1.
 {% include /v20.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.3.md
+++ b/releases/v20.2.3.md
@@ -15,6 +15,10 @@ This page lists additions and changes in v20.2.3 since v20.2.2.
 {% include /v20.2/alerts/warning-a58932.md %}
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.4.md
+++ b/releases/v20.2.4.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v20.2.4 since v20.2.3.
 - For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
 - To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.5.md
+++ b/releases/v20.2.5.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v20.2.5 since v20.2.4.
 - For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
 - To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html)
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.6.md
+++ b/releases/v20.2.6.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v20.2.6 since v20.2.5.
 - For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
 - To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}

--- a/releases/v20.2.7.md
+++ b/releases/v20.2.7.md
@@ -11,6 +11,10 @@ This page lists additions and changes in v20.2.7 since version v20.2.6.
 - For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
 - To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html).
 
+{{site.data.alerts.callout_danger}}
+{% include /v20.2/alerts/warning-a63162.md %}
+{{site.data.alerts.end}}
+
 Get future release notes emailed to you:
 
 {% include marketo.html %}


### PR DESCRIPTION
Title should be self-explanatory, this adds a warning flag to affected release pages. Please give it a once-over to make sure I that I got all the versions right.