### PR TITLE
Updated stmt_block for 21.1

### DIFF
--- a/_includes/v21.1/sql/generated/diagrams/stmt_block.html
+++ b/_includes/v21.1/sql/generated/diagrams/stmt_block.html
@@ -16,7 +16,7 @@
          <polygon points="97 17 89 13 89 21"></polygon>
       </svg>
       <p>no references</p><br/><p style="font-size: 14px; font-weight:bold"><a name="stmt" href="#stmt">stmt:</a></p>
-      <svg width="274" height="804">
+      <svg width="282" height="848">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
@@ -78,39 +78,44 @@
             <rect x="49" y="505" width="118" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="525">savepoint_stmt</text>
          </a>
-         <a xlink:href="#reassign_owned_stmt" xlink:title="reassign_owned_stmt">
-            <rect x="51" y="551" width="160" height="32"></rect>
-            <rect x="49" y="549" width="160" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="569">reassign_owned_stmt</text>
+         <a xlink:href="#reassign_owned_by_stmt" xlink:title="reassign_owned_by_stmt">
+            <rect x="51" y="551" width="184" height="32"></rect>
+            <rect x="49" y="549" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="569">reassign_owned_by_stmt</text>
+         </a>
+         <a xlink:href="#drop_owned_by_stmt" xlink:title="drop_owned_by_stmt">
+            <rect x="51" y="595" width="158" height="32"></rect>
+            <rect x="49" y="593" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="613">drop_owned_by_stmt</text>
          </a>
          <a xlink:href="#release_stmt" xlink:title="release_stmt">
-            <rect x="51" y="595" width="102" height="32"></rect>
-            <rect x="49" y="593" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="613">release_stmt</text>
+            <rect x="51" y="639" width="102" height="32"></rect>
+            <rect x="49" y="637" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="657">release_stmt</text>
          </a>
          <a xlink:href="#refresh_stmt" xlink:title="refresh_stmt">
-            <rect x="51" y="639" width="100" height="32"></rect>
-            <rect x="49" y="637" width="100" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="657">refresh_stmt</text>
+            <rect x="51" y="683" width="100" height="32"></rect>
+            <rect x="49" y="681" width="100" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="701">refresh_stmt</text>
          </a>
          <a xlink:href="#nonpreparable_set_stmt" xlink:title="nonpreparable_set_stmt">
-            <rect x="51" y="683" width="176" height="32"></rect>
-            <rect x="49" y="681" width="176" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="701">nonpreparable_set_stmt</text>
+            <rect x="51" y="727" width="176" height="32"></rect>
+            <rect x="49" y="725" width="176" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="745">nonpreparable_set_stmt</text>
          </a>
          <a xlink:href="#transaction_stmt" xlink:title="transaction_stmt">
-            <rect x="51" y="727" width="126" height="32"></rect>
-            <rect x="49" y="725" width="126" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="745">transaction_stmt</text>
+            <rect x="51" y="771" width="126" height="32"></rect>
+            <rect x="49" y="769" width="126" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="789">transaction_stmt</text>
          </a>
          <a xlink:href="#close_cursor_stmt" xlink:title="close_cursor_stmt">
-            <rect x="51" y="771" width="134" height="32"></rect>
-            <rect x="49" y="769" width="134" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="789">close_cursor_stmt</text>
+            <rect x="51" y="815" width="134" height="32"></rect>
+            <rect x="49" y="813" width="134" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="833">close_cursor_stmt</text>
          </a>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m124 0 h10 m0 0 h52 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m104 0 h10 m0 0 h72 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m112 0 h10 m0 0 h64 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m120 0 h10 m0 0 h56 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m90 0 h10 m0 0 h86 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m106 0 h10 m0 0 h70 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m98 0 h10 m0 0 h78 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m118 0 h10 m0 0 h58 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m160 0 h10 m0 0 h16 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m102 0 h10 m0 0 h74 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m100 0 h10 m0 0 h76 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m176 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m126 0 h10 m0 0 h50 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m134 0 h10 m0 0 h42 m23 -780 h-3"></path>
-         <polygon points="265 5 273 1 273 9"></polygon>
-         <polygon points="265 5 257 1 257 9"></polygon>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m100 0 h10 m0 0 h84 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m124 0 h10 m0 0 h60 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m104 0 h10 m0 0 h80 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m120 0 h10 m0 0 h64 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m112 0 h10 m0 0 h72 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m106 0 h10 m0 0 h78 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m120 0 h10 m0 0 h64 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m100 0 h10 m0 0 h84 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m90 0 h10 m0 0 h94 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m106 0 h10 m0 0 h78 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m98 0 h10 m0 0 h86 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m118 0 h10 m0 0 h66 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m184 0 h10 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m158 0 h10 m0 0 h26 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m102 0 h10 m0 0 h82 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m100 0 h10 m0 0 h84 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m176 0 h10 m0 0 h8 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m126 0 h10 m0 0 h58 m-214 -10 v20 m224 0 v-20 m-224 20 v24 m224 0 v-24 m-224 24 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m134 0 h10 m0 0 h50 m23 -824 h-3"></path>
+         <polygon points="273 5 281 1 281 9"></polygon>
+         <polygon points="273 5 265 1 265 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -435,75 +440,75 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="grant_stmt" href="#grant_stmt">grant_stmt:</a></p>
-      <svg width="738" height="200">
+      <svg width="682" height="266">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="66" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">GRANT</text>
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="66" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">GRANT</text>
          <a xlink:href="#privileges" xlink:title="privileges">
-            <rect x="137" y="3" width="80" height="32"></rect>
-            <rect x="135" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="145" y="21">privileges</text>
+            <rect x="45" y="69" width="80" height="32"></rect>
+            <rect x="43" y="67" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="87">privileges</text>
          </a>
-         <rect x="237" y="3" width="40" height="32" rx="10"></rect>
-         <rect x="235" y="1" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="245" y="21">ON</text>
+         <rect x="145" y="69" width="40" height="32" rx="10"></rect>
+         <rect x="143" y="67" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="153" y="87">ON</text>
          <a xlink:href="#targets" xlink:title="targets">
-            <rect x="317" y="3" width="66" height="32"></rect>
-            <rect x="315" y="1" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="325" y="21">targets</text>
+            <rect x="225" y="69" width="66" height="32"></rect>
+            <rect x="223" y="67" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="87">targets</text>
          </a>
-         <rect x="317" y="47" width="54" height="32" rx="10"></rect>
-         <rect x="315" y="45" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="325" y="65">TYPE</text>
+         <rect x="225" y="113" width="54" height="32" rx="10"></rect>
+         <rect x="223" y="111" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="131">TYPE</text>
          <a xlink:href="#target_types" xlink:title="target_types">
-            <rect x="391" y="47" width="102" height="32"></rect>
-            <rect x="389" y="45" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="399" y="65">target_types</text>
+            <rect x="299" y="113" width="102" height="32"></rect>
+            <rect x="297" y="111" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="131">target_types</text>
          </a>
-         <rect x="317" y="91" width="76" height="32" rx="10"></rect>
-         <rect x="315" y="89" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="325" y="109">SCHEMA</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="413" y="91" width="80" height="32"></rect>
-            <rect x="411" y="89" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="421" y="109">name_list</text>
+         <rect x="225" y="157" width="76" height="32" rx="10"></rect>
+         <rect x="223" y="155" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="175">SCHEMA</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="321" y="157" width="136" height="32"></rect>
+            <rect x="319" y="155" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="329" y="175">schema_name_list</text>
          </a>
-         <rect x="533" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="531" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="541" y="21">TO</text>
+         <rect x="497" y="69" width="38" height="32" rx="10"></rect>
+         <rect x="495" y="67" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="505" y="87">TO</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="591" y="3" width="80" height="32"></rect>
-            <rect x="589" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="599" y="21">name_list</text>
+            <rect x="555" y="69" width="80" height="32"></rect>
+            <rect x="553" y="67" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="563" y="87">name_list</text>
          </a>
          <a xlink:href="#privilege_list" xlink:title="privilege_list">
-            <rect x="137" y="135" width="98" height="32"></rect>
-            <rect x="135" y="133" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="145" y="153">privilege_list</text>
+            <rect x="45" y="201" width="98" height="32"></rect>
+            <rect x="43" y="199" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="219">privilege_list</text>
          </a>
-         <rect x="255" y="135" width="38" height="32" rx="10"></rect>
-         <rect x="253" y="133" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="263" y="153">TO</text>
+         <rect x="163" y="201" width="38" height="32" rx="10"></rect>
+         <rect x="161" y="199" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="171" y="219">TO</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="313" y="135" width="80" height="32"></rect>
-            <rect x="311" y="133" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="321" y="153">name_list</text>
+            <rect x="221" y="201" width="80" height="32"></rect>
+            <rect x="219" y="199" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="229" y="219">name_list</text>
          </a>
-         <rect x="433" y="167" width="58" height="32" rx="10"></rect>
-         <rect x="431" y="165" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="441" y="185">WITH</text>
-         <rect x="511" y="167" width="66" height="32" rx="10"></rect>
-         <rect x="509" y="165" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="519" y="185">ADMIN</text>
-         <rect x="597" y="167" width="74" height="32" rx="10"></rect>
-         <rect x="595" y="165" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="605" y="185">OPTION</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m66 0 h10 m0 0 h110 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m54 0 h10 m0 0 h10 m102 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m76 0 h10 m0 0 h10 m80 0 h10 m20 -88 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h20 m-594 0 h20 m574 0 h20 m-614 0 q10 0 10 10 m594 0 q0 -10 10 -10 m-604 10 v112 m594 0 v-112 m-594 112 q0 10 10 10 m574 0 q10 0 10 -10 m-584 10 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m74 0 h10 m43 -164 h-3"></path>
-         <polygon points="729 17 737 13 737 21"></polygon>
-         <polygon points="729 17 721 13 721 21"></polygon>
+         <rect x="341" y="233" width="58" height="32" rx="10"></rect>
+         <rect x="339" y="231" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="349" y="251">WITH</text>
+         <rect x="419" y="233" width="66" height="32" rx="10"></rect>
+         <rect x="417" y="231" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="427" y="251">ADMIN</text>
+         <rect x="505" y="233" width="74" height="32" rx="10"></rect>
+         <rect x="503" y="231" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="513" y="251">OPTION</text>
+         <path class="line" d="m19 17 h2 m0 0 h10 m66 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-118 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m66 0 h10 m0 0 h166 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m54 0 h10 m0 0 h10 m102 0 h10 m0 0 h56 m-262 -10 v20 m272 0 v-20 m-272 20 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m76 0 h10 m0 0 h10 m136 0 h10 m20 -88 h10 m38 0 h10 m0 0 h10 m80 0 h10 m-630 0 h20 m610 0 h20 m-650 0 q10 0 10 10 m630 0 q0 -10 10 -10 m-640 10 v112 m630 0 v-112 m-630 112 q0 10 10 10 m610 0 q10 0 10 -10 m-620 10 h10 m98 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m58 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m74 0 h10 m20 -32 h36 m23 -132 h-3"></path>
+         <polygon points="673 83 681 79 681 87"></polygon>
+         <polygon points="673 83 665 79 665 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -544,7 +549,7 @@
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="revoke_stmt" href="#revoke_stmt">revoke_stmt:</a></p>
-      <svg width="650" height="266">
+      <svg width="696" height="266">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -575,10 +580,10 @@
          <rect x="325" y="91" width="76" height="32" rx="10"></rect>
          <rect x="323" y="89" width="76" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="333" y="109">SCHEMA</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="421" y="91" width="80" height="32"></rect>
-            <rect x="419" y="89" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="429" y="109">name_list</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="421" y="91" width="136" height="32"></rect>
+            <rect x="419" y="89" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="429" y="109">schema_name_list</text>
          </a>
          <rect x="165" y="167" width="66" height="32" rx="10"></rect>
          <rect x="163" y="165" width="66" height="32" class="terminal" rx="10"></rect>
@@ -594,17 +599,17 @@
             <rect x="431" y="133" width="98" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="441" y="153">privilege_list</text>
          </a>
-         <rect x="571" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="569" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="579" y="21">FROM</text>
+         <rect x="617" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="615" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="625" y="21">FROM</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="543" y="233" width="80" height="32"></rect>
-            <rect x="541" y="231" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="551" y="251">name_list</text>
+            <rect x="589" y="233" width="80" height="32"></rect>
+            <rect x="587" y="231" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="597" y="251">name_list</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m66 0 h10 m0 0 h110 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m54 0 h10 m0 0 h10 m102 0 h10 m-206 -10 v20 m216 0 v-20 m-216 20 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m76 0 h10 m0 0 h10 m80 0 h10 m20 -88 h10 m-426 0 h20 m406 0 h20 m-446 0 q10 0 10 10 m426 0 q0 -10 10 -10 m-436 10 v112 m426 0 v-112 m-426 112 q0 10 10 10 m406 0 q10 0 10 -10 m-396 10 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m66 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m48 0 h10 m20 -32 h10 m98 0 h10 m20 -132 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-130 230 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m3 0 h-3"></path>
-         <polygon points="641 247 649 243 649 251"></polygon>
-         <polygon points="641 247 633 243 633 251"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m80 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m66 0 h10 m0 0 h166 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m54 0 h10 m0 0 h10 m102 0 h10 m0 0 h56 m-262 -10 v20 m272 0 v-20 m-272 20 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m76 0 h10 m0 0 h10 m136 0 h10 m-452 -88 h20 m452 0 h20 m-492 0 q10 0 10 10 m472 0 q0 -10 10 -10 m-482 10 v112 m472 0 v-112 m-472 112 q0 10 10 10 m452 0 q10 0 10 -10 m-442 10 h10 m0 0 h238 m-268 0 h20 m248 0 h20 m-288 0 q10 0 10 10 m268 0 q0 -10 10 -10 m-278 10 v12 m268 0 v-12 m-268 12 q0 10 10 10 m248 0 q10 0 10 -10 m-258 10 h10 m66 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m48 0 h10 m20 -32 h10 m98 0 h10 m0 0 h46 m20 -132 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-130 230 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="687 247 695 243 695 251"></polygon>
+         <polygon points="687 247 679 243 679 251"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -631,7 +636,7 @@
          </p><ul>
             <li><a href="#stmt" title="stmt">stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="reassign_owned_stmt" href="#reassign_owned_stmt">reassign_owned_stmt:</a></p>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="reassign_owned_by_stmt" href="#reassign_owned_by_stmt">reassign_owned_by_stmt:</a></p>
       <svg width="582" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
@@ -661,6 +666,38 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m90 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m3 0 h-3"></path>
          <polygon points="573 17 581 13 581 21"></polygon>
          <polygon points="573 17 565 13 565 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#stmt" title="stmt">stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_owned_by_stmt" href="#drop_owned_by_stmt">drop_owned_by_stmt:</a></p>
+      <svg width="552" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">DROP</text>
+         <rect x="109" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="107" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="117" y="21">OWNED</text>
+         <rect x="201" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="199" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="209" y="21">BY</text>
+         <a xlink:href="#role_spec_list" xlink:title="role_spec_list">
+            <rect x="259" y="3" width="106" height="32"></rect>
+            <rect x="257" y="1" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="267" y="21">role_spec_list</text>
+         </a>
+         <a xlink:href="#opt_drop_behavior" xlink:title="opt_drop_behavior">
+            <rect x="385" y="3" width="140" height="32"></rect>
+            <rect x="383" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="393" y="21">opt_drop_behavior</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m140 0 h10 m3 0 h-3"></path>
+         <polygon points="543 17 551 13 551 21"></polygon>
+         <polygon points="543 17 535 13 535 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -914,7 +951,7 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_stmt" href="#create_stmt">create_stmt:</a></p>
-      <svg width="336" height="212">
+      <svg width="336" height="300">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -938,12 +975,22 @@
             <rect x="49" y="133" width="238" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="153">create_schedule_for_backup_stmt</text>
          </a>
-         <a xlink:href="#create_extension_stmt" xlink:title="create_extension_stmt">
-            <rect x="51" y="179" width="166" height="32"></rect>
-            <rect x="49" y="177" width="166" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">create_extension_stmt</text>
+         <a xlink:href="#create_changefeed_stmt" xlink:title="create_changefeed_stmt">
+            <rect x="51" y="179" width="178" height="32"></rect>
+            <rect x="49" y="177" width="178" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">create_changefeed_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m128 0 h10 m0 0 h110 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m122 0 h10 m0 0 h116 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m136 0 h10 m0 0 h102 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m238 0 h10 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m166 0 h10 m0 0 h72 m23 -176 h-3"></path>
+         <a xlink:href="#create_replication_stream_stmt" xlink:title="create_replication_stream_stmt">
+            <rect x="51" y="223" width="220" height="32"></rect>
+            <rect x="49" y="221" width="220" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">create_replication_stream_stmt</text>
+         </a>
+         <a xlink:href="#create_extension_stmt" xlink:title="create_extension_stmt">
+            <rect x="51" y="267" width="166" height="32"></rect>
+            <rect x="49" y="265" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">create_extension_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m128 0 h10 m0 0 h110 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m122 0 h10 m0 0 h116 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m136 0 h10 m0 0 h102 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m238 0 h10 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m178 0 h10 m0 0 h60 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m220 0 h10 m0 0 h18 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m166 0 h10 m0 0 h72 m23 -264 h-3"></path>
          <polygon points="327 17 335 13 335 21"></polygon>
          <polygon points="327 17 319 13 319 21"></polygon>
       </svg>
@@ -1291,50 +1338,92 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="restore_stmt" href="#restore_stmt">restore_stmt:</a></p>
-      <svg width="666" height="178">
+      <svg width="1184" height="254">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
          <rect x="33" y="3" width="82" height="32" rx="10"></rect>
          <rect x="31" y="1" width="82" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="41" y="21">RESTORE</text>
-         <rect x="155" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="153" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="163" y="21">FROM</text>
-         <a xlink:href="#targets" xlink:title="targets">
-            <rect x="155" y="47" width="66" height="32"></rect>
-            <rect x="153" y="45" width="66" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="163" y="65">targets</text>
-         </a>
-         <rect x="241" y="47" width="58" height="32" rx="10"></rect>
-         <rect x="239" y="45" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="249" y="65">FROM</text>
+         <rect x="45" y="69" width="58" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">FROM</text>
          <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="339" y="79" width="158" height="32"></rect>
-            <rect x="337" y="77" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="347" y="97">string_or_placeholder</text>
+            <rect x="143" y="101" width="158" height="32"></rect>
+            <rect x="141" y="99" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="151" y="119">string_or_placeholder</text>
          </a>
-         <rect x="517" y="79" width="36" height="32" rx="10"></rect>
-         <rect x="515" y="77" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="525" y="97">IN</text>
+         <rect x="321" y="101" width="36" height="32" rx="10"></rect>
+         <rect x="319" y="99" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="329" y="119">IN</text>
          <a xlink:href="#list_of_string_or_placeholder_opt_list" xlink:title="list_of_string_or_placeholder_opt_list">
-            <rect x="25" y="145" width="258" height="32"></rect>
-            <rect x="23" y="143" width="258" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="33" y="163">list_of_string_or_placeholder_opt_list</text>
+            <rect x="397" y="69" width="258" height="32"></rect>
+            <rect x="395" y="67" width="258" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="405" y="87">list_of_string_or_placeholder_opt_list</text>
          </a>
          <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
-            <rect x="303" y="145" width="132" height="32"></rect>
-            <rect x="301" y="143" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="311" y="163">opt_as_of_clause</text>
+            <rect x="675" y="69" width="132" height="32"></rect>
+            <rect x="673" y="67" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="683" y="87">opt_as_of_clause</text>
          </a>
          <a xlink:href="#opt_with_restore_options" xlink:title="opt_with_restore_options">
-            <rect x="455" y="145" width="184" height="32"></rect>
-            <rect x="453" y="143" width="184" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="463" y="163">opt_with_restore_options</text>
+            <rect x="827" y="69" width="184" height="32"></rect>
+            <rect x="825" y="67" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="835" y="87">opt_with_restore_options</text>
          </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m82 0 h10 m20 0 h10 m58 0 h10 m0 0 h360 m-458 0 h20 m438 0 h20 m-478 0 q10 0 10 10 m458 0 q0 -10 10 -10 m-468 10 v24 m458 0 v-24 m-458 24 q0 10 10 10 m438 0 q10 0 10 -10 m-448 10 h10 m66 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-612 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m258 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m184 0 h10 m3 0 h-3"></path>
-         <polygon points="657 159 665 155 665 163"></polygon>
-         <polygon points="657 159 649 155 649 163"></polygon>
+         <a xlink:href="#targets" xlink:title="targets">
+            <rect x="45" y="145" width="66" height="32"></rect>
+            <rect x="43" y="143" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="163">targets</text>
+         </a>
+         <rect x="131" y="145" width="58" height="32" rx="10"></rect>
+         <rect x="129" y="143" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="139" y="163">FROM</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="249" y="177" width="158" height="32"></rect>
+            <rect x="247" y="175" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="257" y="195">string_or_placeholder</text>
+         </a>
+         <rect x="427" y="177" width="36" height="32" rx="10"></rect>
+         <rect x="425" y="175" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="435" y="195">IN</text>
+         <a xlink:href="#list_of_string_or_placeholder_opt_list" xlink:title="list_of_string_or_placeholder_opt_list">
+            <rect x="503" y="145" width="258" height="32"></rect>
+            <rect x="501" y="143" width="258" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="511" y="163">list_of_string_or_placeholder_opt_list</text>
+         </a>
+         <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
+            <rect x="781" y="145" width="132" height="32"></rect>
+            <rect x="779" y="143" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="789" y="163">opt_as_of_clause</text>
+         </a>
+         <a xlink:href="#opt_with_restore_options" xlink:title="opt_with_restore_options">
+            <rect x="933" y="145" width="184" height="32"></rect>
+            <rect x="931" y="143" width="184" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="941" y="163">opt_with_restore_options</text>
+         </a>
+         <rect x="229" y="221" width="112" height="32" rx="10"></rect>
+         <rect x="227" y="219" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="237" y="239">REPLICATION</text>
+         <rect x="361" y="221" width="74" height="32" rx="10"></rect>
+         <rect x="359" y="219" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="369" y="239">STREAM</text>
+         <rect x="455" y="221" width="58" height="32" rx="10"></rect>
+         <rect x="453" y="219" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="463" y="239">FROM</text>
+         <a xlink:href="#string_or_placeholder_opt_list" xlink:title="string_or_placeholder_opt_list">
+            <rect x="533" y="221" width="212" height="32"></rect>
+            <rect x="531" y="219" width="212" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="541" y="239">string_or_placeholder_opt_list</text>
+         </a>
+         <a xlink:href="#opt_as_of_clause" xlink:title="opt_as_of_clause">
+            <rect x="765" y="221" width="132" height="32"></rect>
+            <rect x="763" y="219" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="773" y="239">opt_as_of_clause</text>
+         </a>
+         <path class="line" d="m19 17 h2 m0 0 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-134 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m20 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m20 -32 h10 m258 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m184 0 h10 m0 0 h126 m-1132 0 h20 m1112 0 h20 m-1152 0 q10 0 10 10 m1132 0 q0 -10 10 -10 m-1142 10 v56 m1132 0 v-56 m-1132 56 q0 10 10 10 m1112 0 q10 0 10 -10 m-1122 10 h10 m66 0 h10 m0 0 h10 m58 0 h10 m40 0 h10 m0 0 h224 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v12 m254 0 v-12 m-254 12 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m158 0 h10 m0 0 h10 m36 0 h10 m20 -32 h10 m258 0 h10 m0 0 h10 m132 0 h10 m0 0 h10 m184 0 h10 m-928 0 h20 m908 0 h20 m-948 0 q10 0 10 10 m928 0 q0 -10 10 -10 m-938 10 v56 m928 0 v-56 m-928 56 q0 10 10 10 m908 0 q10 0 10 -10 m-918 10 h10 m112 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m212 0 h10 m0 0 h10 m132 0 h10 m0 0 h220 m43 -152 h-3"></path>
+         <polygon points="1175 83 1183 79 1183 87"></polygon>
+         <polygon points="1175 83 1167 79 1167 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -1499,7 +1588,7 @@
             <li><a href="#preparable_stmt" title="preparable_stmt">preparable_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_stmt" href="#show_stmt">show_stmt:</a></p>
-      <svg width="290" height="1224">
+      <svg width="290" height="1356">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -1563,87 +1652,102 @@
             <rect x="49" y="485" width="124" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="505">show_jobs_stmt</text>
          </a>
-         <a xlink:href="#show_schedules_stmt" xlink:title="show_schedules_stmt">
-            <rect x="51" y="531" width="160" height="32"></rect>
-            <rect x="49" y="529" width="160" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="549">show_schedules_stmt</text>
+         <a xlink:href="#show_locality_stmt" xlink:title="show_locality_stmt">
+            <rect x="51" y="531" width="140" height="32"></rect>
+            <rect x="49" y="529" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="549">show_locality_stmt</text>
          </a>
-         <a xlink:href="#show_queries_stmt" xlink:title="show_queries_stmt">
-            <rect x="51" y="575" width="144" height="32"></rect>
-            <rect x="49" y="573" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="593">show_queries_stmt</text>
+         <a xlink:href="#show_schedules_stmt" xlink:title="show_schedules_stmt">
+            <rect x="51" y="575" width="160" height="32"></rect>
+            <rect x="49" y="573" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="593">show_schedules_stmt</text>
+         </a>
+         <a xlink:href="#show_statements_stmt" xlink:title="show_statements_stmt">
+            <rect x="51" y="619" width="170" height="32"></rect>
+            <rect x="49" y="617" width="170" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="637">show_statements_stmt</text>
          </a>
          <a xlink:href="#show_ranges_stmt" xlink:title="show_ranges_stmt">
-            <rect x="51" y="619" width="142" height="32"></rect>
-            <rect x="49" y="617" width="142" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="637">show_ranges_stmt</text>
+            <rect x="51" y="663" width="142" height="32"></rect>
+            <rect x="49" y="661" width="142" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="681">show_ranges_stmt</text>
          </a>
          <a xlink:href="#show_range_for_row_stmt" xlink:title="show_range_for_row_stmt">
-            <rect x="51" y="663" width="192" height="32"></rect>
-            <rect x="49" y="661" width="192" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="681">show_range_for_row_stmt</text>
+            <rect x="51" y="707" width="192" height="32"></rect>
+            <rect x="49" y="705" width="192" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="725">show_range_for_row_stmt</text>
+         </a>
+         <a xlink:href="#show_regions_stmt" xlink:title="show_regions_stmt">
+            <rect x="51" y="751" width="144" height="32"></rect>
+            <rect x="49" y="749" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="769">show_regions_stmt</text>
+         </a>
+         <a xlink:href="#show_survival_goal_stmt" xlink:title="show_survival_goal_stmt">
+            <rect x="51" y="795" width="180" height="32"></rect>
+            <rect x="49" y="793" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="813">show_survival_goal_stmt</text>
          </a>
          <a xlink:href="#show_roles_stmt" xlink:title="show_roles_stmt">
-            <rect x="51" y="707" width="128" height="32"></rect>
-            <rect x="49" y="705" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="725">show_roles_stmt</text>
+            <rect x="51" y="839" width="128" height="32"></rect>
+            <rect x="49" y="837" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="857">show_roles_stmt</text>
          </a>
          <a xlink:href="#show_savepoint_stmt" xlink:title="show_savepoint_stmt">
-            <rect x="51" y="751" width="160" height="32"></rect>
-            <rect x="49" y="749" width="160" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="769">show_savepoint_stmt</text>
+            <rect x="51" y="883" width="160" height="32"></rect>
+            <rect x="49" y="881" width="160" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="901">show_savepoint_stmt</text>
          </a>
          <a xlink:href="#show_schemas_stmt" xlink:title="show_schemas_stmt">
-            <rect x="51" y="795" width="152" height="32"></rect>
-            <rect x="49" y="793" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="813">show_schemas_stmt</text>
-         </a>
-         <a xlink:href="#show_sequences_stmt" xlink:title="show_sequences_stmt">
-            <rect x="51" y="839" width="166" height="32"></rect>
-            <rect x="49" y="837" width="166" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="857">show_sequences_stmt</text>
-         </a>
-         <a xlink:href="#show_session_stmt" xlink:title="show_session_stmt">
-            <rect x="51" y="883" width="146" height="32"></rect>
-            <rect x="49" y="881" width="146" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="901">show_session_stmt</text>
-         </a>
-         <a xlink:href="#show_sessions_stmt" xlink:title="show_sessions_stmt">
             <rect x="51" y="927" width="152" height="32"></rect>
             <rect x="49" y="925" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="945">show_sessions_stmt</text>
+            <text class="nonterminal" x="59" y="945">show_schemas_stmt</text>
+         </a>
+         <a xlink:href="#show_sequences_stmt" xlink:title="show_sequences_stmt">
+            <rect x="51" y="971" width="166" height="32"></rect>
+            <rect x="49" y="969" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="989">show_sequences_stmt</text>
+         </a>
+         <a xlink:href="#show_session_stmt" xlink:title="show_session_stmt">
+            <rect x="51" y="1015" width="146" height="32"></rect>
+            <rect x="49" y="1013" width="146" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1033">show_session_stmt</text>
+         </a>
+         <a xlink:href="#show_sessions_stmt" xlink:title="show_sessions_stmt">
+            <rect x="51" y="1059" width="152" height="32"></rect>
+            <rect x="49" y="1057" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1077">show_sessions_stmt</text>
          </a>
          <a xlink:href="#show_stats_stmt" xlink:title="show_stats_stmt">
-            <rect x="51" y="971" width="130" height="32"></rect>
-            <rect x="49" y="969" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="989">show_stats_stmt</text>
+            <rect x="51" y="1103" width="130" height="32"></rect>
+            <rect x="49" y="1101" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1121">show_stats_stmt</text>
          </a>
          <a xlink:href="#show_tables_stmt" xlink:title="show_tables_stmt">
-            <rect x="51" y="1015" width="136" height="32"></rect>
-            <rect x="49" y="1013" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1033">show_tables_stmt</text>
+            <rect x="51" y="1147" width="136" height="32"></rect>
+            <rect x="49" y="1145" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1165">show_tables_stmt</text>
          </a>
          <a xlink:href="#show_trace_stmt" xlink:title="show_trace_stmt">
-            <rect x="51" y="1059" width="130" height="32"></rect>
-            <rect x="49" y="1057" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1077">show_trace_stmt</text>
+            <rect x="51" y="1191" width="130" height="32"></rect>
+            <rect x="49" y="1189" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1209">show_trace_stmt</text>
          </a>
          <a xlink:href="#show_transactions_stmt" xlink:title="show_transactions_stmt">
-            <rect x="51" y="1103" width="176" height="32"></rect>
-            <rect x="49" y="1101" width="176" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1121">show_transactions_stmt</text>
+            <rect x="51" y="1235" width="176" height="32"></rect>
+            <rect x="49" y="1233" width="176" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1253">show_transactions_stmt</text>
          </a>
          <a xlink:href="#show_users_stmt" xlink:title="show_users_stmt">
-            <rect x="51" y="1147" width="132" height="32"></rect>
-            <rect x="49" y="1145" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1165">show_users_stmt</text>
+            <rect x="51" y="1279" width="132" height="32"></rect>
+            <rect x="49" y="1277" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1297">show_users_stmt</text>
          </a>
          <a xlink:href="#show_zone_stmt" xlink:title="show_zone_stmt">
-            <rect x="51" y="1191" width="128" height="32"></rect>
-            <rect x="49" y="1189" width="128" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="1209">show_zone_stmt</text>
+            <rect x="51" y="1323" width="128" height="32"></rect>
+            <rect x="49" y="1321" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="1341">show_zone_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h50 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m148 0 h10 m0 0 h44 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m168 0 h10 m0 0 h24 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m154 0 h10 m0 0 h38 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m164 0 h10 m0 0 h28 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m140 0 h10 m0 0 h52 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m158 0 h10 m0 0 h34 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m124 0 h10 m0 0 h68 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m144 0 h10 m0 0 h48 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m142 0 h10 m0 0 h50 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m192 0 h10 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m166 0 h10 m0 0 h26 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m136 0 h10 m0 0 h56 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m176 0 h10 m0 0 h16 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m23 -1188 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m142 0 h10 m0 0 h50 m-232 0 h20 m212 0 h20 m-252 0 q10 0 10 10 m232 0 q0 -10 10 -10 m-242 10 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m148 0 h10 m0 0 h44 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m168 0 h10 m0 0 h24 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m154 0 h10 m0 0 h38 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m164 0 h10 m0 0 h28 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m140 0 h10 m0 0 h52 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m138 0 h10 m0 0 h54 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m158 0 h10 m0 0 h34 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m124 0 h10 m0 0 h68 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m140 0 h10 m0 0 h52 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m170 0 h10 m0 0 h22 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m142 0 h10 m0 0 h50 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m192 0 h10 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m144 0 h10 m0 0 h48 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m180 0 h10 m0 0 h12 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m160 0 h10 m0 0 h32 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m166 0 h10 m0 0 h26 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m146 0 h10 m0 0 h46 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m152 0 h10 m0 0 h40 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m136 0 h10 m0 0 h56 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m130 0 h10 m0 0 h62 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m176 0 h10 m0 0 h16 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m132 0 h10 m0 0 h60 m-222 -10 v20 m232 0 v-20 m-232 20 v24 m232 0 v-24 m-232 24 q0 10 10 10 m212 0 q10 0 10 -10 m-222 10 h10 m128 0 h10 m0 0 h64 m23 -1320 h-3"></path>
          <polygon points="281 17 289 13 289 21"></polygon>
          <polygon points="281 17 273 13 273 21"></polygon>
       </svg>
@@ -1946,7 +2050,11 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#alter_database_add_region_stmt" title="alter_database_add_region_stmt">alter_database_add_region_stmt</a></li>
+            <li><a href="#alter_database_drop_region_stmt" title="alter_database_drop_region_stmt">alter_database_drop_region_stmt</a></li>
             <li><a href="#alter_database_owner" title="alter_database_owner">alter_database_owner</a></li>
+            <li><a href="#alter_database_primary_region_stmt" title="alter_database_primary_region_stmt">alter_database_primary_region_stmt</a></li>
+            <li><a href="#alter_database_survival_goal_stmt" title="alter_database_survival_goal_stmt">alter_database_survival_goal_stmt</a></li>
             <li><a href="#alter_database_to_schema_stmt" title="alter_database_to_schema_stmt">alter_database_to_schema_stmt</a></li>
             <li><a href="#alter_rename_database_stmt" title="alter_rename_database_stmt">alter_rename_database_stmt</a></li>
             <li><a href="#alter_zone_database_stmt" title="alter_zone_database_stmt">alter_zone_database_stmt</a></li>
@@ -1957,6 +2065,8 @@
             <li><a href="#show_indexes_stmt" title="show_indexes_stmt">show_indexes_stmt</a></li>
             <li><a href="#show_partitions_stmt" title="show_partitions_stmt">show_partitions_stmt</a></li>
             <li><a href="#show_ranges_stmt" title="show_ranges_stmt">show_ranges_stmt</a></li>
+            <li><a href="#show_regions_stmt" title="show_regions_stmt">show_regions_stmt</a></li>
+            <li><a href="#show_survival_goal_stmt" title="show_survival_goal_stmt">show_survival_goal_stmt</a></li>
             <li><a href="#show_zone_stmt" title="show_zone_stmt">show_zone_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="comment_text" href="#comment_text">comment_text:</a></p>
@@ -2129,6 +2239,7 @@
             <li><a href="#import_format" title="import_format">import_format</a></li>
             <li><a href="#index_elem" title="index_elem">index_elem</a></li>
             <li><a href="#kv_option" title="kv_option">kv_option</a></li>
+            <li><a href="#locality" title="locality">locality</a></li>
             <li><a href="#name_list" title="name_list">name_list</a></li>
             <li><a href="#opt_class" title="opt_class">opt_class</a></li>
             <li><a href="#opt_existing_window_name" title="opt_existing_window_name">opt_existing_window_name</a></li>
@@ -2136,9 +2247,12 @@
             <li><a href="#opt_name" title="opt_name">opt_name</a></li>
             <li><a href="#opt_name_parens" title="opt_name_parens">opt_name_parens</a></li>
             <li><a href="#privilege" title="privilege">privilege</a></li>
+            <li><a href="#qualifiable_schema_name" title="qualifiable_schema_name">qualifiable_schema_name</a></li>
+            <li><a href="#region_name" title="region_name">region_name</a></li>
             <li><a href="#savepoint_name" title="savepoint_name">savepoint_name</a></li>
             <li><a href="#savepoint_stmt" title="savepoint_stmt">savepoint_stmt</a></li>
             <li><a href="#schema_name" title="schema_name">schema_name</a></li>
+            <li><a href="#show_enums_stmt" title="show_enums_stmt">show_enums_stmt</a></li>
             <li><a href="#show_schemas_stmt" title="show_schemas_stmt">show_schemas_stmt</a></li>
             <li><a href="#show_sequences_stmt" title="show_sequences_stmt">show_sequences_stmt</a></li>
             <li><a href="#show_tables_stmt" title="show_tables_stmt">show_tables_stmt</a></li>
@@ -2234,6 +2348,7 @@
       </svg>
       <p>referenced by:
          </p><ul>
+            <li><a href="#create_replication_stream_stmt" title="create_replication_stream_stmt">create_replication_stream_stmt</a></li>
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
             <li><a href="#opt_backup_targets" title="opt_backup_targets">opt_backup_targets</a></li>
             <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
@@ -2260,7 +2375,6 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
-            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
             <li><a href="#family_def" title="family_def">family_def</a></li>
             <li><a href="#for_grantee_clause" title="for_grantee_clause">for_grantee_clause</a></li>
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
@@ -2271,7 +2385,8 @@
             <li><a href="#opt_interleave" title="opt_interleave">opt_interleave</a></li>
             <li><a href="#opt_stats_columns" title="opt_stats_columns">opt_stats_columns</a></li>
             <li><a href="#opt_storing" title="opt_storing">opt_storing</a></li>
-            <li><a href="#partition_by" title="partition_by">partition_by</a></li>
+            <li><a href="#partition_by_inner" title="partition_by_inner">partition_by_inner</a></li>
+            <li><a href="#region_name_list" title="region_name_list">region_name_list</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
             <li><a href="#scrub_option" title="scrub_option">scrub_option</a></li>
             <li><a href="#targets" title="targets">targets</a></li>
@@ -2319,6 +2434,30 @@
             <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
             <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="schema_name_list" href="#schema_name_list">schema_name_list:</a></p>
+      <svg width="280" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#qualifiable_schema_name" xlink:title="qualifiable_schema_name">
+            <rect x="51" y="47" width="182" height="32"></rect>
+            <rect x="49" y="45" width="182" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">qualifiable_schema_name</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m182 0 h10 m-222 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m202 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-202 0 h10 m24 0 h10 m0 0 h158 m23 44 h-3"></path>
+         <polygon points="271 61 279 57 279 65"></polygon>
+         <polygon points="271 61 263 57 263 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
+            <li><a href="#grant_stmt" title="grant_stmt">grant_stmt</a></li>
+            <li><a href="#revoke_stmt" title="revoke_stmt">revoke_stmt</a></li>
+            <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="prep_type_clause" href="#prep_type_clause">prep_type_clause:</a></p>
       <svg width="264" height="56">
          
@@ -2362,17 +2501,18 @@
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#reassign_owned_stmt" title="reassign_owned_stmt">reassign_owned_stmt</a></li>
+            <li><a href="#drop_owned_by_stmt" title="drop_owned_by_stmt">drop_owned_by_stmt</a></li>
+            <li><a href="#reassign_owned_by_stmt" title="reassign_owned_by_stmt">reassign_owned_by_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="role_spec" href="#role_spec">role_spec:</a></p>
-      <svg width="316" height="124">
+      <svg width="250" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#non_reserved_word_or_sconst" xlink:title="non_reserved_word_or_sconst">
-            <rect x="51" y="3" width="218" height="32"></rect>
-            <rect x="49" y="1" width="218" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">non_reserved_word_or_sconst</text>
+         <a xlink:href="#username_or_sconst" xlink:title="username_or_sconst">
+            <rect x="51" y="3" width="152" height="32"></rect>
+            <rect x="49" y="1" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">username_or_sconst</text>
          </a>
          <rect x="51" y="47" width="128" height="32" rx="10"></rect>
          <rect x="49" y="45" width="128" height="32" class="terminal" rx="10"></rect>
@@ -2380,19 +2520,49 @@
          <rect x="51" y="91" width="126" height="32" rx="10"></rect>
          <rect x="49" y="89" width="126" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="109">SESSION_USER</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m218 0 h10 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m128 0 h10 m0 0 h90 m-248 -10 v20 m258 0 v-20 m-258 20 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m126 0 h10 m0 0 h92 m23 -88 h-3"></path>
-         <polygon points="307 17 315 13 315 21"></polygon>
-         <polygon points="307 17 299 13 299 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m152 0 h10 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m128 0 h10 m0 0 h24 m-182 -10 v20 m192 0 v-20 m-192 20 v24 m192 0 v-24 m-192 24 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m126 0 h10 m0 0 h26 m23 -88 h-3"></path>
+         <polygon points="241 17 249 13 249 21"></polygon>
+         <polygon points="241 17 233 13 233 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_database_owner" title="alter_database_owner">alter_database_owner</a></li>
             <li><a href="#alter_schema_stmt" title="alter_schema_stmt">alter_schema_stmt</a></li>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+            <li><a href="#alter_sequence_owner_stmt" title="alter_sequence_owner_stmt">alter_sequence_owner_stmt</a></li>
+            <li><a href="#alter_table_owner_stmt" title="alter_table_owner_stmt">alter_table_owner_stmt</a></li>
             <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
+            <li><a href="#alter_view_owner_stmt" title="alter_view_owner_stmt">alter_view_owner_stmt</a></li>
             <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
-            <li><a href="#reassign_owned_stmt" title="reassign_owned_stmt">reassign_owned_stmt</a></li>
+            <li><a href="#reassign_owned_by_stmt" title="reassign_owned_by_stmt">reassign_owned_by_stmt</a></li>
             <li><a href="#role_spec_list" title="role_spec_list">role_spec_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_drop_behavior" href="#opt_drop_behavior">opt_drop_behavior:</a></p>
+      <svg width="184" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">CASCADE</text>
+         <rect x="51" y="67" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="65" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="85">RESTRICT</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
+         <polygon points="175 5 183 1 183 9"></polygon>
+         <polygon points="175 5 167 1 167 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+            <li><a href="#drop_database_stmt" title="drop_database_stmt">drop_database_stmt</a></li>
+            <li><a href="#drop_index_stmt" title="drop_index_stmt">drop_index_stmt</a></li>
+            <li><a href="#drop_owned_by_stmt" title="drop_owned_by_stmt">drop_owned_by_stmt</a></li>
+            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
+            <li><a href="#drop_sequence_stmt" title="drop_sequence_stmt">drop_sequence_stmt</a></li>
+            <li><a href="#drop_table_stmt" title="drop_table_stmt">drop_table_stmt</a></li>
+            <li><a href="#drop_type_stmt" title="drop_type_stmt">drop_type_stmt</a></li>
+            <li><a href="#drop_view_stmt" title="drop_view_stmt">drop_view_stmt</a></li>
+            <li><a href="#truncate_stmt" title="truncate_stmt">truncate_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="savepoint_name" href="#savepoint_name">savepoint_name:</a></p>
       <svg width="270" height="68">
@@ -2776,6 +2946,7 @@
             <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
             <li><a href="#list_of_string_or_placeholder_opt_list" title="list_of_string_or_placeholder_opt_list">list_of_string_or_placeholder_opt_list</a></li>
             <li><a href="#restore_options" title="restore_options">restore_options</a></li>
+            <li><a href="#restore_stmt" title="restore_stmt">restore_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_as_of_clause" href="#opt_as_of_clause">opt_as_of_clause:</a></p>
       <svg width="200" height="56">
@@ -3025,58 +3196,53 @@
             <li><a href="#create_stmt" title="create_stmt">create_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_ddl_stmt" href="#create_ddl_stmt">create_ddl_stmt:</a></p>
-      <svg width="276" height="388">
+      <svg width="262" height="344">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#create_changefeed_stmt" xlink:title="create_changefeed_stmt">
-            <rect x="51" y="3" width="178" height="32"></rect>
-            <rect x="49" y="1" width="178" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="21">create_changefeed_stmt</text>
-         </a>
          <a xlink:href="#create_database_stmt" xlink:title="create_database_stmt">
-            <rect x="51" y="47" width="164" height="32"></rect>
-            <rect x="49" y="45" width="164" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">create_database_stmt</text>
+            <rect x="51" y="3" width="164" height="32"></rect>
+            <rect x="49" y="1" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">create_database_stmt</text>
          </a>
          <a xlink:href="#create_index_stmt" xlink:title="create_index_stmt">
-            <rect x="51" y="91" width="138" height="32"></rect>
-            <rect x="49" y="89" width="138" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="109">create_index_stmt</text>
+            <rect x="51" y="47" width="138" height="32"></rect>
+            <rect x="49" y="45" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">create_index_stmt</text>
          </a>
          <a xlink:href="#create_schema_stmt" xlink:title="create_schema_stmt">
-            <rect x="51" y="135" width="152" height="32"></rect>
-            <rect x="49" y="133" width="152" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="153">create_schema_stmt</text>
+            <rect x="51" y="91" width="152" height="32"></rect>
+            <rect x="49" y="89" width="152" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">create_schema_stmt</text>
          </a>
          <a xlink:href="#create_table_stmt" xlink:title="create_table_stmt">
-            <rect x="51" y="179" width="136" height="32"></rect>
-            <rect x="49" y="177" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="197">create_table_stmt</text>
+            <rect x="51" y="135" width="136" height="32"></rect>
+            <rect x="49" y="133" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">create_table_stmt</text>
          </a>
          <a xlink:href="#create_table_as_stmt" xlink:title="create_table_as_stmt">
-            <rect x="51" y="223" width="158" height="32"></rect>
-            <rect x="49" y="221" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="241">create_table_as_stmt</text>
+            <rect x="51" y="179" width="158" height="32"></rect>
+            <rect x="49" y="177" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">create_table_as_stmt</text>
          </a>
          <a xlink:href="#create_type_stmt" xlink:title="create_type_stmt">
-            <rect x="51" y="267" width="132" height="32"></rect>
-            <rect x="49" y="265" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="285">create_type_stmt</text>
+            <rect x="51" y="223" width="132" height="32"></rect>
+            <rect x="49" y="221" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">create_type_stmt</text>
          </a>
          <a xlink:href="#create_view_stmt" xlink:title="create_view_stmt">
-            <rect x="51" y="311" width="132" height="32"></rect>
-            <rect x="49" y="309" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="329">create_view_stmt</text>
+            <rect x="51" y="267" width="132" height="32"></rect>
+            <rect x="49" y="265" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">create_view_stmt</text>
          </a>
          <a xlink:href="#create_sequence_stmt" xlink:title="create_sequence_stmt">
-            <rect x="51" y="355" width="164" height="32"></rect>
-            <rect x="49" y="353" width="164" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="373">create_sequence_stmt</text>
+            <rect x="51" y="311" width="164" height="32"></rect>
+            <rect x="49" y="309" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">create_sequence_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m164 0 h10 m0 0 h14 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m138 0 h10 m0 0 h40 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m152 0 h10 m0 0 h26 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m136 0 h10 m0 0 h42 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m158 0 h10 m0 0 h20 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m132 0 h10 m0 0 h46 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m132 0 h10 m0 0 h46 m-208 -10 v20 m218 0 v-20 m-218 20 v24 m218 0 v-24 m-218 24 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m164 0 h10 m0 0 h14 m23 -352 h-3"></path>
-         <polygon points="267 17 275 13 275 21"></polygon>
-         <polygon points="267 17 259 13 259 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m164 0 h10 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m138 0 h10 m0 0 h26 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m152 0 h10 m0 0 h12 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m136 0 h10 m0 0 h28 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m158 0 h10 m0 0 h6 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m132 0 h10 m0 0 h32 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m132 0 h10 m0 0 h32 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m23 -308 h-3"></path>
+         <polygon points="253 17 261 13 261 21"></polygon>
+         <polygon points="253 17 245 13 245 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -3182,6 +3348,83 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-668 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m54 0 h10 m0 0 h10 m212 0 h10 m0 0 h10 m184 0 h10 m0 0 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-400 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m168 0 h10 m0 0 h10 m194 0 h10 m3 0 h-3"></path>
          <polygon points="693 149 701 145 701 153"></polygon>
          <polygon points="693 149 685 145 685 153"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_stmt" title="create_stmt">create_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_changefeed_stmt" href="#create_changefeed_stmt">create_changefeed_stmt:</a></p>
+      <svg width="664" height="102">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE</text>
+         <rect x="121" y="3" width="110" height="32" rx="10"></rect>
+         <rect x="119" y="1" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="21">CHANGEFEED</text>
+         <rect x="251" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="249" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="21">FOR</text>
+         <a xlink:href="#changefeed_targets" xlink:title="changefeed_targets">
+            <rect x="319" y="3" width="148" height="32"></rect>
+            <rect x="317" y="1" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="327" y="21">changefeed_targets</text>
+         </a>
+         <a xlink:href="#opt_changefeed_sink" xlink:title="opt_changefeed_sink">
+            <rect x="487" y="3" width="156" height="32"></rect>
+            <rect x="485" y="1" width="156" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="495" y="21">opt_changefeed_sink</text>
+         </a>
+         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
+            <rect x="507" y="69" width="130" height="32"></rect>
+            <rect x="505" y="67" width="130" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="515" y="87">opt_with_options</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m148 0 h10 m0 0 h10 m156 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m130 0 h10 m3 0 h-3"></path>
+         <polygon points="655 83 663 79 663 87"></polygon>
+         <polygon points="655 83 647 79 647 87"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_stmt" title="create_stmt">create_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_replication_stream_stmt" href="#create_replication_stream_stmt">create_replication_stream_stmt:</a></p>
+      <svg width="678" height="102">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE</text>
+         <rect x="121" y="3" width="112" height="32" rx="10"></rect>
+         <rect x="119" y="1" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="129" y="21">REPLICATION</text>
+         <rect x="253" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="251" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="21">STREAM</text>
+         <rect x="347" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="345" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="355" y="21">FOR</text>
+         <a xlink:href="#targets" xlink:title="targets">
+            <rect x="415" y="3" width="66" height="32"></rect>
+            <rect x="413" y="1" width="66" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="423" y="21">targets</text>
+         </a>
+         <a xlink:href="#opt_changefeed_sink" xlink:title="opt_changefeed_sink">
+            <rect x="501" y="3" width="156" height="32"></rect>
+            <rect x="499" y="1" width="156" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="509" y="21">opt_changefeed_sink</text>
+         </a>
+         <a xlink:href="#opt_with_replication_options" xlink:title="opt_with_replication_options">
+            <rect x="447" y="69" width="204" height="32"></rect>
+            <rect x="445" y="67" width="204" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="455" y="87">opt_with_replication_options</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m156 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-254 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m204 0 h10 m3 0 h-3"></path>
+         <polygon points="669 83 677 79 677 87"></polygon>
+         <polygon points="669 83 661 79 661 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4415,7 +4658,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_create_stmt" href="#show_create_stmt">show_create_stmt:</a></p>
-      <svg width="326" height="36">
+      <svg width="406" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -4426,13 +4669,19 @@
          <rect x="113" y="1" width="70" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="123" y="21">CREATE</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="205" y="3" width="94" height="32"></rect>
-            <rect x="203" y="1" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="213" y="21">table_name</text>
+            <rect x="225" y="3" width="94" height="32"></rect>
+            <rect x="223" y="1" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="21">table_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m94 0 h10 m3 0 h-3"></path>
-         <polygon points="317 17 325 13 325 21"></polygon>
-         <polygon points="317 17 309 13 309 21"></polygon>
+         <rect x="225" y="47" width="44" height="32" rx="10"></rect>
+         <rect x="223" y="45" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="233" y="65">ALL</text>
+         <rect x="289" y="47" width="70" height="32" rx="10"></rect>
+         <rect x="287" y="45" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="297" y="65">TABLES</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 0 h10 m94 0 h10 m0 0 h40 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m44 0 h10 m0 0 h10 m70 0 h10 m23 -44 h-3"></path>
+         <polygon points="397 17 405 13 405 21"></polygon>
+         <polygon points="397 17 389 13 389 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4508,7 +4757,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_enums_stmt" href="#show_enums_stmt">show_enums_stmt:</a></p>
-      <svg width="210" height="36">
+      <svg width="560" height="100">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -4518,9 +4767,25 @@
          <rect x="115" y="3" width="68" height="32" rx="10"></rect>
          <rect x="113" y="1" width="68" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="123" y="21">ENUMS</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m68 0 h10 m3 0 h-3"></path>
-         <polygon points="201 17 209 13 209 21"></polygon>
-         <polygon points="201 17 193 13 193 21"></polygon>
+         <rect x="223" y="35" width="58" height="32" rx="10"></rect>
+         <rect x="221" y="33" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="231" y="53">FROM</text>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="301" y="35" width="54" height="32"></rect>
+            <rect x="299" y="33" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="309" y="53">name</text>
+         </a>
+         <rect x="395" y="67" width="24" height="32" rx="10"></rect>
+         <rect x="393" y="65" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="403" y="85">.</text>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="439" y="67" width="54" height="32"></rect>
+            <rect x="437" y="65" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="447" y="85">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m0 0 h300 m-330 0 h20 m310 0 h20 m-350 0 q10 0 10 10 m330 0 q0 -10 10 -10 m-340 10 v12 m330 0 v-12 m-330 12 q0 10 10 10 m310 0 q10 0 10 -10 m-320 10 h10 m58 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m24 0 h10 m0 0 h10 m54 0 h10 m43 -64 h-3"></path>
+         <polygon points="551 17 559 13 559 21"></polygon>
+         <polygon points="551 17 543 13 543 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4732,6 +4997,25 @@
          </p><ul>
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_locality_stmt" href="#show_locality_stmt">show_locality_stmt:</a></p>
+      <svg width="230" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="115" y="3" width="88" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">LOCALITY</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m3 0 h-3"></path>
+         <polygon points="221 17 229 13 229 21"></polygon>
+         <polygon points="221 17 213 13 213 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_schedules_stmt" href="#show_schedules_stmt">show_schedules_stmt:</a></p>
       <svg width="682" height="112">
          
@@ -4769,8 +5053,8 @@
          </p><ul>
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_queries_stmt" href="#show_queries_stmt">show_queries_stmt:</a></p>
-      <svg width="436" height="68">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_statements_stmt" href="#show_statements_stmt">show_statements_stmt:</a></p>
+      <svg width="524" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -4785,12 +5069,14 @@
             <rect x="217" y="1" width="90" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="227" y="21">opt_cluster</text>
          </a>
-         <rect x="329" y="3" width="80" height="32" rx="10"></rect>
-         <rect x="327" y="1" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="337" y="21">QUERIES</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m90 0 h10 m0 0 h10 m80 0 h10 m3 0 h-3"></path>
-         <polygon points="427 17 435 13 435 21"></polygon>
-         <polygon points="427 17 419 13 419 21"></polygon>
+         <a xlink:href="#statements_or_queries" xlink:title="statements_or_queries">
+            <rect x="329" y="3" width="168" height="32"></rect>
+            <rect x="327" y="1" width="168" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="337" y="21">statements_or_queries</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h54 m-84 0 h20 m64 0 h20 m-104 0 q10 0 10 10 m84 0 q0 -10 10 -10 m-94 10 v12 m84 0 v-12 m-84 12 q0 10 10 10 m64 0 q10 0 10 -10 m-74 10 h10 m44 0 h10 m20 -32 h10 m90 0 h10 m0 0 h10 m168 0 h10 m3 0 h-3"></path>
+         <polygon points="515 17 523 13 523 21"></polygon>
+         <polygon points="515 17 507 13 507 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -4892,6 +5178,78 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m66 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m94 0 h10 m0 0 h42 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m62 0 h10 m0 0 h10 m136 0 h10 m20 -44 h10 m48 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-170 110 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
          <polygon points="737 127 745 123 745 131"></polygon>
          <polygon points="737 127 729 123 729 131"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_regions_stmt" href="#show_regions_stmt">show_regions_stmt:</a></p>
+      <svg width="674" height="188">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="115" y="3" width="82" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">REGIONS</text>
+         <rect x="237" y="35" width="58" height="32" rx="10"></rect>
+         <rect x="235" y="33" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="245" y="53">FROM</text>
+         <rect x="335" y="35" width="80" height="32" rx="10"></rect>
+         <rect x="333" y="33" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="343" y="53">CLUSTER</text>
+         <rect x="335" y="79" width="90" height="32" rx="10"></rect>
+         <rect x="333" y="77" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="343" y="97">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="465" y="111" width="122" height="32"></rect>
+            <rect x="463" y="109" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="473" y="129">database_name</text>
+         </a>
+         <rect x="335" y="155" width="44" height="32" rx="10"></rect>
+         <rect x="333" y="153" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="343" y="173">ALL</text>
+         <rect x="399" y="155" width="100" height="32" rx="10"></rect>
+         <rect x="397" y="153" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="407" y="173">DATABASES</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h400 m-430 0 h20 m410 0 h20 m-450 0 q10 0 10 10 m430 0 q0 -10 10 -10 m-440 10 v12 m430 0 v-12 m-430 12 q0 10 10 10 m410 0 q10 0 10 -10 m-420 10 h10 m58 0 h10 m20 0 h10 m80 0 h10 m0 0 h192 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v24 m312 0 v-24 m-312 24 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m90 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m-282 -42 v20 m312 0 v-20 m-312 20 v56 m312 0 v-56 m-312 56 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m44 0 h10 m0 0 h10 m100 0 h10 m0 0 h108 m43 -152 h-3"></path>
+         <polygon points="665 17 673 13 673 21"></polygon>
+         <polygon points="665 17 657 13 657 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_survival_goal_stmt" href="#show_survival_goal_stmt">show_survival_goal_stmt:</a></p>
+      <svg width="678" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="64" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SHOW</text>
+         <rect x="115" y="3" width="88" height="32" rx="10"></rect>
+         <rect x="113" y="1" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="123" y="21">SURVIVAL</text>
+         <rect x="223" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="221" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="231" y="21">GOAL</text>
+         <rect x="301" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="299" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="309" y="21">FROM</text>
+         <rect x="379" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="377" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="387" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="509" y="35" width="122" height="32"></rect>
+            <rect x="507" y="33" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="517" y="53">database_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m23 -32 h-3"></path>
+         <polygon points="669 17 677 13 677 21"></polygon>
+         <polygon points="669 17 661 13 661 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -5193,7 +5551,7 @@
             <li><a href="#show_stmt" title="show_stmt">show_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="show_zone_stmt" href="#show_zone_stmt">show_zone_stmt:</a></p>
-      <svg width="1040" height="410">
+      <svg width="1050" height="410">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
@@ -5206,72 +5564,72 @@
          <rect x="141" y="69" width="136" height="32" rx="10"></rect>
          <rect x="139" y="67" width="136" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="149" y="87">CONFIGURATION</text>
-         <rect x="297" y="69" width="48" height="32" rx="10"></rect>
-         <rect x="295" y="67" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="305" y="87">FOR</text>
-         <rect x="385" y="69" width="66" height="32" rx="10"></rect>
-         <rect x="383" y="67" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="393" y="87">RANGE</text>
+         <rect x="297" y="69" width="58" height="32" rx="10"></rect>
+         <rect x="295" y="67" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="305" y="87">FROM</text>
+         <rect x="395" y="69" width="66" height="32" rx="10"></rect>
+         <rect x="393" y="67" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="403" y="87">RANGE</text>
          <a xlink:href="#zone_name" xlink:title="zone_name">
-            <rect x="471" y="69" width="94" height="32"></rect>
-            <rect x="469" y="67" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="479" y="87">zone_name</text>
+            <rect x="481" y="69" width="94" height="32"></rect>
+            <rect x="479" y="67" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="489" y="87">zone_name</text>
          </a>
-         <rect x="385" y="113" width="90" height="32" rx="10"></rect>
-         <rect x="383" y="111" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="393" y="131">DATABASE</text>
+         <rect x="395" y="113" width="90" height="32" rx="10"></rect>
+         <rect x="393" y="111" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="403" y="131">DATABASE</text>
          <a xlink:href="#database_name" xlink:title="database_name">
-            <rect x="495" y="113" width="122" height="32"></rect>
-            <rect x="493" y="111" width="122" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="503" y="131">database_name</text>
+            <rect x="505" y="113" width="122" height="32"></rect>
+            <rect x="503" y="111" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="513" y="131">database_name</text>
          </a>
-         <rect x="405" y="157" width="62" height="32" rx="10"></rect>
-         <rect x="403" y="155" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="413" y="175">TABLE</text>
+         <rect x="415" y="157" width="62" height="32" rx="10"></rect>
+         <rect x="413" y="155" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="423" y="175">TABLE</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="487" y="157" width="94" height="32"></rect>
-            <rect x="485" y="155" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="495" y="175">table_name</text>
+            <rect x="497" y="157" width="94" height="32"></rect>
+            <rect x="495" y="155" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="505" y="175">table_name</text>
          </a>
-         <rect x="405" y="201" width="62" height="32" rx="10"></rect>
-         <rect x="403" y="199" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="413" y="219">INDEX</text>
+         <rect x="415" y="201" width="62" height="32" rx="10"></rect>
+         <rect x="413" y="199" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="423" y="219">INDEX</text>
          <a xlink:href="#table_index_name" xlink:title="table_index_name">
-            <rect x="487" y="201" width="136" height="32"></rect>
-            <rect x="485" y="199" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="495" y="219">table_index_name</text>
+            <rect x="497" y="201" width="136" height="32"></rect>
+            <rect x="495" y="199" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="505" y="219">table_index_name</text>
          </a>
          <a xlink:href="#opt_partition" xlink:title="opt_partition">
-            <rect x="663" y="157" width="102" height="32"></rect>
-            <rect x="661" y="155" width="102" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="671" y="175">opt_partition</text>
+            <rect x="673" y="157" width="102" height="32"></rect>
+            <rect x="671" y="155" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="681" y="175">opt_partition</text>
          </a>
-         <rect x="385" y="245" width="96" height="32" rx="10"></rect>
-         <rect x="383" y="243" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="393" y="263">PARTITION</text>
+         <rect x="395" y="245" width="96" height="32" rx="10"></rect>
+         <rect x="393" y="243" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="403" y="263">PARTITION</text>
          <a xlink:href="#partition_name" xlink:title="partition_name">
-            <rect x="501" y="245" width="116" height="32"></rect>
-            <rect x="499" y="243" width="116" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="509" y="263">partition_name</text>
+            <rect x="511" y="245" width="116" height="32"></rect>
+            <rect x="509" y="243" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="519" y="263">partition_name</text>
          </a>
-         <rect x="637" y="245" width="38" height="32" rx="10"></rect>
-         <rect x="635" y="243" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="645" y="263">OF</text>
-         <rect x="715" y="245" width="62" height="32" rx="10"></rect>
-         <rect x="713" y="243" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="723" y="263">TABLE</text>
+         <rect x="647" y="245" width="38" height="32" rx="10"></rect>
+         <rect x="645" y="243" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="655" y="263">OF</text>
+         <rect x="725" y="245" width="62" height="32" rx="10"></rect>
+         <rect x="723" y="243" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="733" y="263">TABLE</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="797" y="245" width="94" height="32"></rect>
-            <rect x="795" y="243" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="805" y="263">table_name</text>
+            <rect x="807" y="245" width="94" height="32"></rect>
+            <rect x="805" y="243" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="815" y="263">table_name</text>
          </a>
-         <rect x="715" y="289" width="62" height="32" rx="10"></rect>
-         <rect x="713" y="287" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="723" y="307">INDEX</text>
+         <rect x="725" y="289" width="62" height="32" rx="10"></rect>
+         <rect x="723" y="287" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="733" y="307">INDEX</text>
          <a xlink:href="#table_index_name" xlink:title="table_index_name">
-            <rect x="797" y="289" width="136" height="32"></rect>
-            <rect x="795" y="287" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="805" y="307">table_index_name</text>
+            <rect x="807" y="289" width="136" height="32"></rect>
+            <rect x="805" y="287" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="815" y="307">table_index_name</text>
          </a>
          <rect x="141" y="333" width="146" height="32" rx="10"></rect>
          <rect x="139" y="331" width="146" height="32" class="terminal" rx="10"></rect>
@@ -5285,9 +5643,9 @@
          <rect x="185" y="377" width="146" height="32" rx="10"></rect>
          <rect x="183" y="375" width="146" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="193" y="395">CONFIGURATIONS</text>
-         <path class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m20 0 h10 m136 0 h10 m0 0 h10 m48 0 h10 m20 0 h10 m66 0 h10 m0 0 h10 m94 0 h10 m0 0 h388 m-608 0 h20 m588 0 h20 m-628 0 q10 0 10 10 m608 0 q0 -10 10 -10 m-618 10 v24 m608 0 v-24 m-608 24 q0 10 10 10 m588 0 q10 0 10 -10 m-598 10 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h336 m-598 -10 v20 m608 0 v-20 m-608 20 v24 m608 0 v-24 m-608 24 q0 10 10 10 m588 0 q10 0 10 -10 m-578 10 h10 m62 0 h10 m0 0 h10 m94 0 h10 m0 0 h42 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m62 0 h10 m0 0 h10 m136 0 h10 m20 -44 h10 m102 0 h10 m0 0 h188 m-598 -10 v20 m608 0 v-20 m-608 20 v68 m608 0 v-68 m-608 68 q0 10 10 10 m588 0 q10 0 10 -10 m-598 10 h10 m96 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m94 0 h10 m0 0 h42 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m62 0 h10 m0 0 h10 m136 0 h10 m-832 -220 h20 m852 0 h20 m-892 0 q10 0 10 10 m872 0 q0 -10 10 -10 m-882 10 v244 m872 0 v-244 m-872 244 q0 10 10 10 m852 0 q10 0 10 -10 m-862 10 h10 m146 0 h10 m0 0 h686 m-968 -264 h20 m968 0 h20 m-1008 0 q10 0 10 10 m988 0 q0 -10 10 -10 m-998 10 v288 m988 0 v-288 m-988 288 q0 10 10 10 m968 0 q10 0 10 -10 m-978 10 h10 m44 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m146 0 h10 m0 0 h662 m23 -308 h-3"></path>
-         <polygon points="1031 83 1039 79 1039 87"></polygon>
-         <polygon points="1031 83 1023 79 1023 87"></polygon>
+         <path class="line" d="m19 17 h2 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-116 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m20 0 h10 m136 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m66 0 h10 m0 0 h10 m94 0 h10 m0 0 h388 m-608 0 h20 m588 0 h20 m-628 0 q10 0 10 10 m608 0 q0 -10 10 -10 m-618 10 v24 m608 0 v-24 m-608 24 q0 10 10 10 m588 0 q10 0 10 -10 m-598 10 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h336 m-598 -10 v20 m608 0 v-20 m-608 20 v24 m608 0 v-24 m-608 24 q0 10 10 10 m588 0 q10 0 10 -10 m-578 10 h10 m62 0 h10 m0 0 h10 m94 0 h10 m0 0 h42 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m62 0 h10 m0 0 h10 m136 0 h10 m20 -44 h10 m102 0 h10 m0 0 h188 m-598 -10 v20 m608 0 v-20 m-608 20 v68 m608 0 v-68 m-608 68 q0 10 10 10 m588 0 q10 0 10 -10 m-598 10 h10 m96 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m0 0 h10 m94 0 h10 m0 0 h42 m-258 0 h20 m238 0 h20 m-278 0 q10 0 10 10 m258 0 q0 -10 10 -10 m-268 10 v24 m258 0 v-24 m-258 24 q0 10 10 10 m238 0 q10 0 10 -10 m-248 10 h10 m62 0 h10 m0 0 h10 m136 0 h10 m-842 -220 h20 m862 0 h20 m-902 0 q10 0 10 10 m882 0 q0 -10 10 -10 m-892 10 v244 m882 0 v-244 m-882 244 q0 10 10 10 m862 0 q10 0 10 -10 m-872 10 h10 m146 0 h10 m0 0 h696 m-978 -264 h20 m978 0 h20 m-1018 0 q10 0 10 10 m998 0 q0 -10 10 -10 m-1008 10 v288 m998 0 v-288 m-998 288 q0 10 10 10 m978 0 q10 0 10 -10 m-988 10 h10 m44 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m146 0 h10 m0 0 h672 m23 -308 h-3"></path>
+         <polygon points="1041 83 1049 79 1049 87"></polygon>
+         <polygon points="1041 83 1033 79 1033 87"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -5328,33 +5686,6 @@
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#truncate_stmt" title="truncate_stmt">truncate_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_drop_behavior" href="#opt_drop_behavior">opt_drop_behavior:</a></p>
-      <svg width="184" height="100">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">CASCADE</text>
-         <rect x="51" y="67" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="65" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="85">RESTRICT</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m82 0 h10 m0 0 h4 m-116 -10 v20 m126 0 v-20 m-126 20 v24 m126 0 v-24 m-126 24 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m23 -76 h-3"></path>
-         <polygon points="175 5 183 1 183 9"></polygon>
-         <polygon points="175 5 167 1 167 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-            <li><a href="#drop_database_stmt" title="drop_database_stmt">drop_database_stmt</a></li>
-            <li><a href="#drop_index_stmt" title="drop_index_stmt">drop_index_stmt</a></li>
-            <li><a href="#drop_schema_stmt" title="drop_schema_stmt">drop_schema_stmt</a></li>
-            <li><a href="#drop_sequence_stmt" title="drop_sequence_stmt">drop_sequence_stmt</a></li>
-            <li><a href="#drop_table_stmt" title="drop_table_stmt">drop_table_stmt</a></li>
-            <li><a href="#drop_type_stmt" title="drop_type_stmt">drop_type_stmt</a></li>
-            <li><a href="#drop_view_stmt" title="drop_view_stmt">drop_view_stmt</a></li>
             <li><a href="#truncate_stmt" title="truncate_stmt">truncate_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="set_clause_list" href="#set_clause_list">set_clause_list:</a></p>
@@ -5607,7 +5938,7 @@
             <li><a href="#values_clause" title="values_clause">values_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="unreserved_keyword" href="#unreserved_keyword">unreserved_keyword:</a></p>
-      <svg width="372" height="14424">
+      <svg width="372" height="15216">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -5647,955 +5978,1009 @@
          <rect x="51" y="487" width="100" height="32" rx="10"></rect>
          <rect x="49" y="485" width="100" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="505">AUTOMATIC</text>
-         <rect x="51" y="531" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="529" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="549">BACKUP</text>
-         <rect x="51" y="575" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="573" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="593">BACKUPS</text>
-         <rect x="51" y="619" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="617" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="637">BEFORE</text>
-         <rect x="51" y="663" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="661" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="681">BEGIN</text>
-         <rect x="51" y="707" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="705" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="725">BINARY</text>
-         <rect x="51" y="751" width="130" height="32" rx="10"></rect>
-         <rect x="49" y="749" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="769">BUCKET_COUNT</text>
-         <rect x="51" y="795" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="793" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="813">BUNDLE</text>
-         <rect x="51" y="839" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="837" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="857">BY</text>
-         <rect x="51" y="883" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="881" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="901">CACHE</text>
-         <rect x="51" y="927" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="925" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="945">CANCEL</text>
-         <rect x="51" y="971" width="120" height="32" rx="10"></rect>
-         <rect x="49" y="969" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="989">CANCELQUERY</text>
-         <rect x="51" y="1015" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="1013" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1033">CASCADE</text>
-         <rect x="51" y="1059" width="110" height="32" rx="10"></rect>
-         <rect x="49" y="1057" width="110" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1077">CHANGEFEED</text>
-         <rect x="51" y="1103" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="1101" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1121">CLOSE</text>
-         <rect x="51" y="1147" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="1145" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1165">CLUSTER</text>
-         <rect x="51" y="1191" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1189" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1209">COLUMNS</text>
+         <rect x="51" y="531" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">AVAILABILITY</text>
+         <rect x="51" y="575" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">BACKUP</text>
+         <rect x="51" y="619" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">BACKUPS</text>
+         <rect x="51" y="663" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">BEFORE</text>
+         <rect x="51" y="707" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">BEGIN</text>
+         <rect x="51" y="751" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">BINARY</text>
+         <rect x="51" y="795" width="130" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">BUCKET_COUNT</text>
+         <rect x="51" y="839" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">BUNDLE</text>
+         <rect x="51" y="883" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">BY</text>
+         <rect x="51" y="927" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">CACHE</text>
+         <rect x="51" y="971" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">CANCEL</text>
+         <rect x="51" y="1015" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">CANCELQUERY</text>
+         <rect x="51" y="1059" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">CASCADE</text>
+         <rect x="51" y="1103" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">CHANGEFEED</text>
+         <rect x="51" y="1147" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">CLOSE</text>
+         <rect x="51" y="1191" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">CLUSTER</text>
          <rect x="51" y="1235" width="88" height="32" rx="10"></rect>
          <rect x="49" y="1233" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1253">COMMENT</text>
-         <rect x="51" y="1279" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="1277" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1297">COMMENTS</text>
-         <rect x="51" y="1323" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="1321" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1341">COMMIT</text>
-         <rect x="51" y="1367" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="1365" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1385">COMMITTED</text>
-         <rect x="51" y="1411" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="1409" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1429">COMPACT</text>
-         <rect x="51" y="1455" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1453" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1473">COMPLETE</text>
-         <rect x="51" y="1499" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="1497" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1517">CONFLICT</text>
-         <rect x="51" y="1543" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="1541" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1561">CONFIGURATION</text>
-         <rect x="51" y="1587" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="1585" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1605">CONFIGURATIONS</text>
-         <rect x="51" y="1631" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="1629" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1649">CONFIGURE</text>
-         <rect x="51" y="1675" width="112" height="32" rx="10"></rect>
-         <rect x="49" y="1673" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1693">CONNECTION</text>
-         <rect x="51" y="1719" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="1717" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1737">CONSTRAINTS</text>
-         <rect x="51" y="1763" width="176" height="32" rx="10"></rect>
-         <rect x="49" y="1761" width="176" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1781">CONTROLCHANGEFEED</text>
-         <rect x="51" y="1807" width="112" height="32" rx="10"></rect>
-         <rect x="49" y="1805" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1825">CONTROLJOB</text>
+         <text class="terminal" x="59" y="1253">COLUMNS</text>
+         <rect x="51" y="1279" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">COMMENT</text>
+         <rect x="51" y="1323" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">COMMENTS</text>
+         <rect x="51" y="1367" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">COMMIT</text>
+         <rect x="51" y="1411" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="1409" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1429">COMMITTED</text>
+         <rect x="51" y="1455" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="1453" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1473">COMPACT</text>
+         <rect x="51" y="1499" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="1497" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1517">COMPLETE</text>
+         <rect x="51" y="1543" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="1541" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1561">CONFLICT</text>
+         <rect x="51" y="1587" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="1585" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1605">CONFIGURATION</text>
+         <rect x="51" y="1631" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="1629" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1649">CONFIGURATIONS</text>
+         <rect x="51" y="1675" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="1673" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1693">CONFIGURE</text>
+         <rect x="51" y="1719" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="1717" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1737">CONNECTION</text>
+         <rect x="51" y="1763" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="1761" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1781">CONSTRAINTS</text>
+         <rect x="51" y="1807" width="176" height="32" rx="10"></rect>
+         <rect x="49" y="1805" width="176" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1825">CONTROLCHANGEFEED</text>
          <rect x="51" y="1851" width="112" height="32" rx="10"></rect>
          <rect x="49" y="1849" width="112" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1869">CONVERSION</text>
-         <rect x="51" y="1895" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="1893" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1913">CONVERT</text>
-         <rect x="51" y="1939" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="1937" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="1957">COPY</text>
-         <rect x="51" y="1983" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="1981" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2001">COVERING</text>
-         <rect x="51" y="2027" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2025" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2045">CREATEDB</text>
-         <rect x="51" y="2071" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="2069" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2089">CREATELOGIN</text>
-         <rect x="51" y="2115" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="2113" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2133">CREATEROLE</text>
-         <rect x="51" y="2159" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="2157" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2177">CUBE</text>
-         <rect x="51" y="2203" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="2201" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2221">CURRENT</text>
-         <rect x="51" y="2247" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="2245" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2265">CYCLE</text>
-         <rect x="51" y="2291" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="2289" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2309">DATA</text>
-         <rect x="51" y="2335" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2333" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2353">DATABASE</text>
-         <rect x="51" y="2379" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="2377" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2397">DATABASES</text>
-         <rect x="51" y="2423" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="2421" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2441">DAY</text>
-         <rect x="51" y="2467" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="2465" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2485">DEALLOCATE</text>
-         <rect x="51" y="2511" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="2509" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2529">DECLARE</text>
-         <rect x="51" y="2555" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="2553" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2573">DELETE</text>
-         <rect x="51" y="2599" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2597" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2617">DEFAULTS</text>
-         <rect x="51" y="2643" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="2641" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2661">DEFERRED</text>
-         <rect x="51" y="2687" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="2685" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2705">DESTINATION</text>
-         <rect x="51" y="2731" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="2729" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2749">DETACHED</text>
-         <rect x="51" y="2775" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="2773" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2793">DISCARD</text>
-         <rect x="51" y="2819" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="2817" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2837">DOMAIN</text>
-         <rect x="51" y="2863" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="2861" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2881">DOUBLE</text>
-         <rect x="51" y="2907" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="2905" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2925">DROP</text>
-         <rect x="51" y="2951" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="2949" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="2969">ENCODING</text>
-         <rect x="51" y="2995" width="208" height="32" rx="10"></rect>
-         <rect x="49" y="2993" width="208" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3013">ENCRYPTION_PASSPHRASE</text>
-         <rect x="51" y="3039" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="3037" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3057">ENUM</text>
-         <rect x="51" y="3083" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3081" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3101">ENUMS</text>
-         <rect x="51" y="3127" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="3125" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3145">ESCAPE</text>
-         <rect x="51" y="3171" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="3169" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3189">EXCLUDE</text>
-         <rect x="51" y="3215" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="3213" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3233">EXCLUDING</text>
-         <rect x="51" y="3259" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="3257" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3277">EXECUTE</text>
-         <rect x="51" y="3303" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">EXECUTION</text>
-         <rect x="51" y="3347" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">EXPERIMENTAL</text>
-         <rect x="51" y="3391" width="174" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="174" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">EXPERIMENTAL_AUDIT</text>
-         <rect x="51" y="3435" width="234" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="234" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">EXPERIMENTAL_FINGERPRINTS</text>
-         <rect x="51" y="3479" width="202" height="32" rx="10"></rect>
-         <rect x="49" y="3477" width="202" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3497">EXPERIMENTAL_RELOCATE</text>
-         <rect x="51" y="3523" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="3521" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3541">EXPERIMENTAL_REPLICA</text>
-         <rect x="51" y="3567" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="3565" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3585">EXPIRATION</text>
-         <rect x="51" y="3611" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="3609" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3629">EXPLAIN</text>
-         <rect x="51" y="3655" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="3653" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3673">EXPORT</text>
-         <rect x="51" y="3699" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="3697" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3717">EXTENSION</text>
-         <rect x="51" y="3743" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="3741" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3761">FILES</text>
-         <rect x="51" y="3787" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="3785" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3805">FILTER</text>
-         <rect x="51" y="3831" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="3829" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3849">FIRST</text>
-         <rect x="51" y="3875" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="3873" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3893">FOLLOWING</text>
-         <rect x="51" y="3919" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="3917" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3937">FORCE_INDEX</text>
-         <rect x="51" y="3963" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="3961" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3981">FUNCTION</text>
-         <rect x="51" y="4007" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="4005" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4025">GENERATED</text>
-         <rect x="51" y="4051" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="4049" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4069">GEOMETRYM</text>
-         <rect x="51" y="4095" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="4093" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4113">GEOMETRYZ</text>
-         <rect x="51" y="4139" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="4137" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4157">GEOMETRYZM</text>
-         <rect x="51" y="4183" width="182" height="32" rx="10"></rect>
-         <rect x="49" y="4181" width="182" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4201">GEOMETRYCOLLECTION</text>
-         <rect x="51" y="4227" width="194" height="32" rx="10"></rect>
-         <rect x="49" y="4225" width="194" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4245">GEOMETRYCOLLECTIONM</text>
-         <rect x="51" y="4271" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="4269" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4289">GEOMETRYCOLLECTIONZ</text>
-         <rect x="51" y="4315" width="202" height="32" rx="10"></rect>
-         <rect x="49" y="4313" width="202" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4333">GEOMETRYCOLLECTIONZM</text>
-         <rect x="51" y="4359" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="4357" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4377">GLOBAL</text>
-         <rect x="51" y="4403" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="4401" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4421">GRANTS</text>
-         <rect x="51" y="4447" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="4445" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4465">GROUPS</text>
-         <rect x="51" y="4491" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="4489" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4509">HASH</text>
-         <rect x="51" y="4535" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="4533" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4553">HIGH</text>
-         <rect x="51" y="4579" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="4577" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4597">HISTOGRAM</text>
-         <rect x="51" y="4623" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="4621" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4641">HOUR</text>
-         <rect x="51" y="4667" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="4665" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4685">IDENTITY</text>
-         <rect x="51" y="4711" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="4709" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4729">IMMEDIATE</text>
-         <rect x="51" y="4755" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="4753" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4773">IMPORT</text>
-         <rect x="51" y="4799" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4797" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4817">INCLUDE</text>
-         <rect x="51" y="4843" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4841" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4861">INCLUDING</text>
-         <rect x="51" y="4887" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="4885" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4905">INCREMENT</text>
-         <rect x="51" y="4931" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="4929" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4949">INCREMENTAL</text>
-         <rect x="51" y="4975" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="4973" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="4993">INDEXES</text>
-         <rect x="51" y="5019" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="5017" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5037">INHERITS</text>
-         <rect x="51" y="5063" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="5061" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5081">INJECT</text>
-         <rect x="51" y="5107" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="5105" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5125">INSERT</text>
-         <rect x="51" y="5151" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="5149" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5169">INTERLEAVE</text>
-         <rect x="51" y="5195" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="5193" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5213">INTO_DB</text>
-         <rect x="51" y="5239" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="5237" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5257">INVERTED</text>
-         <rect x="51" y="5283" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="5281" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5301">ISOLATION</text>
-         <rect x="51" y="5327" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="5325" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5345">JOB</text>
-         <rect x="51" y="5371" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="5369" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5389">JOBS</text>
-         <rect x="51" y="5415" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="5413" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5433">JSON</text>
-         <rect x="51" y="5459" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="5457" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5477">KEY</text>
-         <rect x="51" y="5503" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="5501" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5521">KEYS</text>
-         <rect x="51" y="5547" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="5545" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5565">KMS</text>
-         <rect x="51" y="5591" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="5589" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5609">KV</text>
-         <rect x="51" y="5635" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="5633" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5653">LANGUAGE</text>
-         <rect x="51" y="5679" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="5677" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5697">LAST</text>
-         <rect x="51" y="5723" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="5721" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5741">LATEST</text>
-         <rect x="51" y="5767" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="5765" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5785">LC_COLLATE</text>
-         <rect x="51" y="5811" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="5809" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5829">LC_CTYPE</text>
-         <rect x="51" y="5855" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="5853" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5873">LEASE</text>
-         <rect x="51" y="5899" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="5897" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5917">LESS</text>
-         <rect x="51" y="5943" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="5941" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="5961">LEVEL</text>
-         <rect x="51" y="5987" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="5985" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6005">LINESTRING</text>
-         <rect x="51" y="6031" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="6029" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6049">LIST</text>
-         <rect x="51" y="6075" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6073" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6093">LOCAL</text>
-         <rect x="51" y="6119" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="6117" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6137">LOCKED</text>
-         <rect x="51" y="6163" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="6161" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6181">LOGIN</text>
-         <rect x="51" y="6207" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="6205" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6225">LOOKUP</text>
-         <rect x="51" y="6251" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="6249" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6269">LOW</text>
-         <rect x="51" y="6295" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="6293" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6313">MATCH</text>
-         <rect x="51" y="6339" width="120" height="32" rx="10"></rect>
-         <rect x="49" y="6337" width="120" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6357">MATERIALIZED</text>
-         <rect x="51" y="6383" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="6381" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6401">MAXVALUE</text>
-         <rect x="51" y="6427" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="6425" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6445">MERGE</text>
-         <rect x="51" y="6471" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="6469" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6489">METHOD</text>
-         <rect x="51" y="6515" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="6513" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6533">MINUTE</text>
-         <rect x="51" y="6559" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="6557" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6577">MINVALUE</text>
-         <rect x="51" y="6603" width="196" height="32" rx="10"></rect>
-         <rect x="49" y="6601" width="196" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6621">MODIFYCLUSTERSETTING</text>
-         <rect x="51" y="6647" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="6645" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6665">MULTILINESTRING</text>
-         <rect x="51" y="6691" width="158" height="32" rx="10"></rect>
-         <rect x="49" y="6689" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6709">MULTILINESTRINGM</text>
-         <rect x="51" y="6735" width="154" height="32" rx="10"></rect>
-         <rect x="49" y="6733" width="154" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6753">MULTILINESTRINGZ</text>
-         <rect x="51" y="6779" width="166" height="32" rx="10"></rect>
-         <rect x="49" y="6777" width="166" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6797">MULTILINESTRINGZM</text>
-         <rect x="51" y="6823" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="6821" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6841">MULTIPOINT</text>
-         <rect x="51" y="6867" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="6865" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6885">MULTIPOINTM</text>
-         <rect x="51" y="6911" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="6909" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6929">MULTIPOINTZ</text>
-         <rect x="51" y="6955" width="126" height="32" rx="10"></rect>
-         <rect x="49" y="6953" width="126" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="6973">MULTIPOINTZM</text>
-         <rect x="51" y="6999" width="132" height="32" rx="10"></rect>
-         <rect x="49" y="6997" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7017">MULTIPOLYGON</text>
-         <rect x="51" y="7043" width="142" height="32" rx="10"></rect>
-         <rect x="49" y="7041" width="142" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7061">MULTIPOLYGONM</text>
-         <rect x="51" y="7087" width="140" height="32" rx="10"></rect>
-         <rect x="49" y="7085" width="140" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7105">MULTIPOLYGONZ</text>
-         <rect x="51" y="7131" width="150" height="32" rx="10"></rect>
-         <rect x="49" y="7129" width="150" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7149">MULTIPOLYGONZM</text>
-         <rect x="51" y="7175" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="7173" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7193">MONTH</text>
-         <rect x="51" y="7219" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="7217" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7237">NAMES</text>
-         <rect x="51" y="7263" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="7261" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7281">NAN</text>
-         <rect x="51" y="7307" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7305" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7325">NEVER</text>
-         <rect x="51" y="7351" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="7349" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7369">NEXT</text>
-         <rect x="51" y="7395" width="40" height="32" rx="10"></rect>
-         <rect x="49" y="7393" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7413">NO</text>
-         <rect x="51" y="7439" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="7437" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7457">NORMAL</text>
-         <rect x="51" y="7483" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="7481" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7501">NO_INDEX_JOIN</text>
-         <rect x="51" y="7527" width="110" height="32" rx="10"></rect>
-         <rect x="49" y="7525" width="110" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7545">NOCREATEDB</text>
-         <rect x="51" y="7571" width="136" height="32" rx="10"></rect>
-         <rect x="49" y="7569" width="136" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7589">NOCREATELOGIN</text>
-         <rect x="51" y="7615" width="142" height="32" rx="10"></rect>
-         <rect x="49" y="7613" width="142" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7633">NOCANCELQUERY</text>
-         <rect x="51" y="7659" width="128" height="32" rx="10"></rect>
-         <rect x="49" y="7657" width="128" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7677">NOCREATEROLE</text>
-         <rect x="51" y="7703" width="196" height="32" rx="10"></rect>
-         <rect x="49" y="7701" width="196" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7721">NOCONTROLCHANGEFEED</text>
-         <rect x="51" y="7747" width="134" height="32" rx="10"></rect>
-         <rect x="49" y="7745" width="134" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7765">NOCONTROLJOB</text>
-         <rect x="51" y="7791" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="7789" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7809">NOLOGIN</text>
-         <rect x="51" y="7835" width="216" height="32" rx="10"></rect>
-         <rect x="49" y="7833" width="216" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7853">NOMODIFYCLUSTERSETTING</text>
-         <rect x="51" y="7879" width="142" height="32" rx="10"></rect>
-         <rect x="49" y="7877" width="142" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7897">NOVIEWACTIVITY</text>
-         <rect x="51" y="7923" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="7921" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7941">NOWAIT</text>
-         <rect x="51" y="7967" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="7965" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="7985">NULLS</text>
-         <rect x="51" y="8011" width="190" height="32" rx="10"></rect>
-         <rect x="49" y="8009" width="190" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8029">IGNORE_FOREIGN_KEYS</text>
-         <rect x="51" y="8055" width="38" height="32" rx="10"></rect>
-         <rect x="49" y="8053" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8073">OF</text>
-         <rect x="51" y="8099" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="8097" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8117">OFF</text>
-         <rect x="51" y="8143" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8141" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8161">OIDS</text>
-         <rect x="51" y="8187" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="8185" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8205">OPERATOR</text>
-         <rect x="51" y="8231" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="8229" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8249">OPT</text>
-         <rect x="51" y="8275" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8273" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8293">OPTION</text>
-         <rect x="51" y="8319" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="8317" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8337">OPTIONS</text>
-         <rect x="51" y="8363" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="8361" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8381">ORDINALITY</text>
-         <rect x="51" y="8407" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8405" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8425">OTHERS</text>
-         <rect x="51" y="8451" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8449" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8469">OVER</text>
-         <rect x="51" y="8495" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="8493" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8513">OWNED</text>
-         <rect x="51" y="8539" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="8537" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8557">OWNER</text>
-         <rect x="51" y="8583" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="8581" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8601">PARENT</text>
-         <rect x="51" y="8627" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="8625" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8645">PARTIAL</text>
-         <rect x="51" y="8671" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="8669" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8689">PARTITION</text>
-         <rect x="51" y="8715" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="8713" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8733">PARTITIONS</text>
-         <rect x="51" y="8759" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="8757" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8777">PASSWORD</text>
-         <rect x="51" y="8803" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8801" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8821">PAUSE</text>
-         <rect x="51" y="8847" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="8845" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8865">PAUSED</text>
-         <rect x="51" y="8891" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="8889" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8909">PHYSICAL</text>
-         <rect x="51" y="8935" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="8933" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8953">PLAN</text>
-         <rect x="51" y="8979" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="8977" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="8997">PLANS</text>
-         <rect x="51" y="9023" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="9021" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9041">POINTM</text>
-         <rect x="51" y="9067" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="9065" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9085">POINTZ</text>
-         <rect x="51" y="9111" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="9109" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9129">POINTZM</text>
+         <text class="terminal" x="59" y="1869">CONTROLJOB</text>
+         <rect x="51" y="1895" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="1893" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1913">CONVERSION</text>
+         <rect x="51" y="1939" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="1937" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1957">CONVERT</text>
+         <rect x="51" y="1983" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="1981" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2001">COPY</text>
+         <rect x="51" y="2027" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="2025" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2045">COVERING</text>
+         <rect x="51" y="2071" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2069" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2089">CREATEDB</text>
+         <rect x="51" y="2115" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="2113" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2133">CREATELOGIN</text>
+         <rect x="51" y="2159" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="2157" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2177">CREATEROLE</text>
+         <rect x="51" y="2203" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="2201" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2221">CSV</text>
+         <rect x="51" y="2247" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="2245" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2265">CUBE</text>
+         <rect x="51" y="2291" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="2289" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2309">CURRENT</text>
+         <rect x="51" y="2335" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="2333" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2353">CURSOR</text>
+         <rect x="51" y="2379" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="2377" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2397">CYCLE</text>
+         <rect x="51" y="2423" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="2421" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2441">DATA</text>
+         <rect x="51" y="2467" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2465" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2485">DATABASE</text>
+         <rect x="51" y="2511" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="2509" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2529">DATABASES</text>
+         <rect x="51" y="2555" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="2553" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2573">DAY</text>
+         <rect x="51" y="2599" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="2597" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2617">DEALLOCATE</text>
+         <rect x="51" y="2643" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="2641" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2661">DECLARE</text>
+         <rect x="51" y="2687" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="2685" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2705">DELETE</text>
+         <rect x="51" y="2731" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2729" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2749">DEFAULTS</text>
+         <rect x="51" y="2775" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="2773" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2793">DEFERRED</text>
+         <rect x="51" y="2819" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="2817" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2837">DELIMITER</text>
+         <rect x="51" y="2863" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="2861" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2881">DESTINATION</text>
+         <rect x="51" y="2907" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="2905" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2925">DETACHED</text>
+         <rect x="51" y="2951" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="2949" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="2969">DISCARD</text>
+         <rect x="51" y="2995" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="2993" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3013">DOMAIN</text>
+         <rect x="51" y="3039" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="3037" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3057">DOUBLE</text>
+         <rect x="51" y="3083" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3081" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3101">DROP</text>
+         <rect x="51" y="3127" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="3125" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3145">ENCODING</text>
+         <rect x="51" y="3171" width="208" height="32" rx="10"></rect>
+         <rect x="49" y="3169" width="208" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3189">ENCRYPTION_PASSPHRASE</text>
+         <rect x="51" y="3215" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3213" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3233">ENUM</text>
+         <rect x="51" y="3259" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="3257" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3277">ENUMS</text>
+         <rect x="51" y="3303" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">ESCAPE</text>
+         <rect x="51" y="3347" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">EXCLUDE</text>
+         <rect x="51" y="3391" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">EXCLUDING</text>
+         <rect x="51" y="3435" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">EXECUTE</text>
+         <rect x="51" y="3479" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">EXECUTION</text>
+         <rect x="51" y="3523" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="3521" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3541">EXPERIMENTAL</text>
+         <rect x="51" y="3567" width="174" height="32" rx="10"></rect>
+         <rect x="49" y="3565" width="174" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3585">EXPERIMENTAL_AUDIT</text>
+         <rect x="51" y="3611" width="234" height="32" rx="10"></rect>
+         <rect x="49" y="3609" width="234" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3629">EXPERIMENTAL_FINGERPRINTS</text>
+         <rect x="51" y="3655" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="3653" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3673">EXPERIMENTAL_RELOCATE</text>
+         <rect x="51" y="3699" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="3697" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3717">EXPERIMENTAL_REPLICA</text>
+         <rect x="51" y="3743" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="3741" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3761">EXPIRATION</text>
+         <rect x="51" y="3787" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3785" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3805">EXPLAIN</text>
+         <rect x="51" y="3831" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3829" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3849">EXPORT</text>
+         <rect x="51" y="3875" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="3873" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3893">EXTENSION</text>
+         <rect x="51" y="3919" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="3917" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3937">FAILURE</text>
+         <rect x="51" y="3963" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3961" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3981">FILES</text>
+         <rect x="51" y="4007" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="4005" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4025">FILTER</text>
+         <rect x="51" y="4051" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="4049" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4069">FIRST</text>
+         <rect x="51" y="4095" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="4093" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4113">FOLLOWING</text>
+         <rect x="51" y="4139" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="4137" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4157">FORCE</text>
+         <rect x="51" y="4183" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="4181" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4201">FORCE_INDEX</text>
+         <rect x="51" y="4227" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="4225" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4245">FUNCTION</text>
+         <rect x="51" y="4271" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="4269" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4289">GENERATED</text>
+         <rect x="51" y="4315" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="4313" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4333">GEOMETRYM</text>
+         <rect x="51" y="4359" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="4357" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4377">GEOMETRYZ</text>
+         <rect x="51" y="4403" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="4401" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4421">GEOMETRYZM</text>
+         <rect x="51" y="4447" width="182" height="32" rx="10"></rect>
+         <rect x="49" y="4445" width="182" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4465">GEOMETRYCOLLECTION</text>
+         <rect x="51" y="4491" width="194" height="32" rx="10"></rect>
+         <rect x="49" y="4489" width="194" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4509">GEOMETRYCOLLECTIONM</text>
+         <rect x="51" y="4535" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="4533" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4553">GEOMETRYCOLLECTIONZ</text>
+         <rect x="51" y="4579" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="4577" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4597">GEOMETRYCOLLECTIONZM</text>
+         <rect x="51" y="4623" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4621" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4641">GLOBAL</text>
+         <rect x="51" y="4667" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="4665" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4685">GOAL</text>
+         <rect x="51" y="4711" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="4709" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4729">GRANTS</text>
+         <rect x="51" y="4755" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="4753" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4773">GROUPS</text>
+         <rect x="51" y="4799" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="4797" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4817">HASH</text>
+         <rect x="51" y="4843" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="4841" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4861">HIGH</text>
+         <rect x="51" y="4887" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="4885" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4905">HISTOGRAM</text>
+         <rect x="51" y="4931" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="4929" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4949">HOUR</text>
+         <rect x="51" y="4975" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="4973" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="4993">IDENTITY</text>
+         <rect x="51" y="5019" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="5017" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5037">IMMEDIATE</text>
+         <rect x="51" y="5063" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="5061" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5081">IMPORT</text>
+         <rect x="51" y="5107" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5105" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5125">INCLUDE</text>
+         <rect x="51" y="5151" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5149" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5169">INCLUDING</text>
+         <rect x="51" y="5195" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5193" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5213">INCREMENT</text>
+         <rect x="51" y="5239" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="5237" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5257">INCREMENTAL</text>
+         <rect x="51" y="5283" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="5281" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5301">INDEXES</text>
+         <rect x="51" y="5327" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="5325" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5345">INHERITS</text>
+         <rect x="51" y="5371" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="5369" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5389">INJECT</text>
+         <rect x="51" y="5415" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="5413" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5433">INSERT</text>
+         <rect x="51" y="5459" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="5457" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5477">INTERLEAVE</text>
+         <rect x="51" y="5503" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="5501" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5521">INTO_DB</text>
+         <rect x="51" y="5547" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="5545" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5565">INVERTED</text>
+         <rect x="51" y="5591" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="5589" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5609">ISOLATION</text>
+         <rect x="51" y="5635" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="5633" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5653">JOB</text>
+         <rect x="51" y="5679" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5677" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5697">JOBS</text>
+         <rect x="51" y="5723" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5721" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5741">JSON</text>
+         <rect x="51" y="5767" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="5765" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5785">KEY</text>
+         <rect x="51" y="5811" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="5809" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5829">KEYS</text>
+         <rect x="51" y="5855" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="5853" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5873">KMS</text>
+         <rect x="51" y="5899" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="5897" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5917">KV</text>
+         <rect x="51" y="5943" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="5941" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="5961">LANGUAGE</text>
+         <rect x="51" y="5987" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="5985" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6005">LAST</text>
+         <rect x="51" y="6031" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="6029" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6049">LATEST</text>
+         <rect x="51" y="6075" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="6073" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6093">LC_COLLATE</text>
+         <rect x="51" y="6119" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="6117" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6137">LC_CTYPE</text>
+         <rect x="51" y="6163" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="6161" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6181">LEASE</text>
+         <rect x="51" y="6207" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="6205" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6225">LESS</text>
+         <rect x="51" y="6251" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="6249" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6269">LEVEL</text>
+         <rect x="51" y="6295" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="6293" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6313">LINESTRING</text>
+         <rect x="51" y="6339" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="6337" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6357">LIST</text>
+         <rect x="51" y="6383" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="6381" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6401">LOCAL</text>
+         <rect x="51" y="6427" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="6425" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6445">LOCKED</text>
+         <rect x="51" y="6471" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="6469" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6489">LOGIN</text>
+         <rect x="51" y="6515" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="6513" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6533">LOCALITY</text>
+         <rect x="51" y="6559" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6557" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6577">LOOKUP</text>
+         <rect x="51" y="6603" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="6601" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6621">LOW</text>
+         <rect x="51" y="6647" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="6645" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6665">MATCH</text>
+         <rect x="51" y="6691" width="120" height="32" rx="10"></rect>
+         <rect x="49" y="6689" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6709">MATERIALIZED</text>
+         <rect x="51" y="6735" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="6733" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6753">MAXVALUE</text>
+         <rect x="51" y="6779" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="6777" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6797">MERGE</text>
+         <rect x="51" y="6823" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="6821" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6841">METHOD</text>
+         <rect x="51" y="6867" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="6865" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6885">MINUTE</text>
+         <rect x="51" y="6911" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="6909" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6929">MINVALUE</text>
+         <rect x="51" y="6955" width="196" height="32" rx="10"></rect>
+         <rect x="49" y="6953" width="196" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="6973">MODIFYCLUSTERSETTING</text>
+         <rect x="51" y="6999" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="6997" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7017">MULTILINESTRING</text>
+         <rect x="51" y="7043" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="7041" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7061">MULTILINESTRINGM</text>
+         <rect x="51" y="7087" width="154" height="32" rx="10"></rect>
+         <rect x="49" y="7085" width="154" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7105">MULTILINESTRINGZ</text>
+         <rect x="51" y="7131" width="166" height="32" rx="10"></rect>
+         <rect x="49" y="7129" width="166" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7149">MULTILINESTRINGZM</text>
+         <rect x="51" y="7175" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="7173" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7193">MULTIPOINT</text>
+         <rect x="51" y="7219" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="7217" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7237">MULTIPOINTM</text>
+         <rect x="51" y="7263" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="7261" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7281">MULTIPOINTZ</text>
+         <rect x="51" y="7307" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="7305" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7325">MULTIPOINTZM</text>
+         <rect x="51" y="7351" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="7349" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7369">MULTIPOLYGON</text>
+         <rect x="51" y="7395" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="7393" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7413">MULTIPOLYGONM</text>
+         <rect x="51" y="7439" width="140" height="32" rx="10"></rect>
+         <rect x="49" y="7437" width="140" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7457">MULTIPOLYGONZ</text>
+         <rect x="51" y="7483" width="150" height="32" rx="10"></rect>
+         <rect x="49" y="7481" width="150" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7501">MULTIPOLYGONZM</text>
+         <rect x="51" y="7527" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="7525" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7545">MONTH</text>
+         <rect x="51" y="7571" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="7569" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7589">NAMES</text>
+         <rect x="51" y="7615" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="7613" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7633">NAN</text>
+         <rect x="51" y="7659" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="7657" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7677">NEVER</text>
+         <rect x="51" y="7703" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="7701" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7721">NEXT</text>
+         <rect x="51" y="7747" width="40" height="32" rx="10"></rect>
+         <rect x="49" y="7745" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7765">NO</text>
+         <rect x="51" y="7791" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="7789" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7809">NORMAL</text>
+         <rect x="51" y="7835" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="7833" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7853">NO_INDEX_JOIN</text>
+         <rect x="51" y="7879" width="110" height="32" rx="10"></rect>
+         <rect x="49" y="7877" width="110" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7897">NOCREATEDB</text>
+         <rect x="51" y="7923" width="136" height="32" rx="10"></rect>
+         <rect x="49" y="7921" width="136" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7941">NOCREATELOGIN</text>
+         <rect x="51" y="7967" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="7965" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="7985">NOCANCELQUERY</text>
+         <rect x="51" y="8011" width="128" height="32" rx="10"></rect>
+         <rect x="49" y="8009" width="128" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8029">NOCREATEROLE</text>
+         <rect x="51" y="8055" width="196" height="32" rx="10"></rect>
+         <rect x="49" y="8053" width="196" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8073">NOCONTROLCHANGEFEED</text>
+         <rect x="51" y="8099" width="134" height="32" rx="10"></rect>
+         <rect x="49" y="8097" width="134" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8117">NOCONTROLJOB</text>
+         <rect x="51" y="8143" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="8141" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8161">NOLOGIN</text>
+         <rect x="51" y="8187" width="216" height="32" rx="10"></rect>
+         <rect x="49" y="8185" width="216" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8205">NOMODIFYCLUSTERSETTING</text>
+         <rect x="51" y="8231" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="8229" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8249">NON_VOTERS</text>
+         <rect x="51" y="8275" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="8273" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8293">NOVIEWACTIVITY</text>
+         <rect x="51" y="8319" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="8317" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8337">NOWAIT</text>
+         <rect x="51" y="8363" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="8361" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8381">NULLS</text>
+         <rect x="51" y="8407" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="8405" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8425">IGNORE_FOREIGN_KEYS</text>
+         <rect x="51" y="8451" width="38" height="32" rx="10"></rect>
+         <rect x="49" y="8449" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8469">OF</text>
+         <rect x="51" y="8495" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="8493" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8513">OFF</text>
+         <rect x="51" y="8539" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8537" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8557">OIDS</text>
+         <rect x="51" y="8583" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="8581" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8601">OPERATOR</text>
+         <rect x="51" y="8627" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="8625" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8645">OPT</text>
+         <rect x="51" y="8671" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8669" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8689">OPTION</text>
+         <rect x="51" y="8715" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="8713" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8733">OPTIONS</text>
+         <rect x="51" y="8759" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="8757" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8777">ORDINALITY</text>
+         <rect x="51" y="8803" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="8801" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8821">OTHERS</text>
+         <rect x="51" y="8847" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="8845" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8865">OVER</text>
+         <rect x="51" y="8891" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="8889" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8909">OWNED</text>
+         <rect x="51" y="8935" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="8933" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8953">OWNER</text>
+         <rect x="51" y="8979" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="8977" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="8997">PARENT</text>
+         <rect x="51" y="9023" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="9021" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9041">PARTIAL</text>
+         <rect x="51" y="9067" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="9065" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9085">PARTITION</text>
+         <rect x="51" y="9111" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="9109" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9129">PARTITIONS</text>
          <rect x="51" y="9155" width="100" height="32" rx="10"></rect>
          <rect x="49" y="9153" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9173">POLYGONM</text>
-         <rect x="51" y="9199" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="9197" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9217">POLYGONZ</text>
-         <rect x="51" y="9243" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="9241" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9261">POLYGONZM</text>
-         <rect x="51" y="9287" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="9285" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9305">PRECEDING</text>
-         <rect x="51" y="9331" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="9329" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9349">PREPARE</text>
-         <rect x="51" y="9375" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="9373" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9393">PRESERVE</text>
-         <rect x="51" y="9419" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="9417" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9437">PRIORITY</text>
-         <rect x="51" y="9463" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="9461" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9481">PRIVILEGES</text>
-         <rect x="51" y="9507" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="9505" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9525">PUBLIC</text>
-         <rect x="51" y="9551" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="9549" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9569">PUBLICATION</text>
-         <rect x="51" y="9595" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="9593" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9613">QUERIES</text>
-         <rect x="51" y="9639" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="9637" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9657">QUERY</text>
-         <rect x="51" y="9683" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="9681" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9701">RANGE</text>
-         <rect x="51" y="9727" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="9725" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9745">RANGES</text>
-         <rect x="51" y="9771" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="9769" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9789">READ</text>
-         <rect x="51" y="9815" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="9813" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9833">REASSIGN</text>
-         <rect x="51" y="9859" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="9857" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9877">RECURRING</text>
-         <rect x="51" y="9903" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="9901" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9921">RECURSIVE</text>
-         <rect x="51" y="9947" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="9945" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="9965">REF</text>
+         <text class="terminal" x="59" y="9173">PASSWORD</text>
+         <rect x="51" y="9199" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9197" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9217">PAUSE</text>
+         <rect x="51" y="9243" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="9241" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9261">PAUSED</text>
+         <rect x="51" y="9287" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="9285" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9305">PHYSICAL</text>
+         <rect x="51" y="9331" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="9329" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9349">PLAN</text>
+         <rect x="51" y="9375" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="9373" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9393">PLANS</text>
+         <rect x="51" y="9419" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="9417" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9437">POINTM</text>
+         <rect x="51" y="9463" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="9461" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9481">POINTZ</text>
+         <rect x="51" y="9507" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="9505" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9525">POINTZM</text>
+         <rect x="51" y="9551" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="9549" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9569">POLYGONM</text>
+         <rect x="51" y="9595" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="9593" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9613">POLYGONZ</text>
+         <rect x="51" y="9639" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="9637" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9657">POLYGONZM</text>
+         <rect x="51" y="9683" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="9681" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9701">PRECEDING</text>
+         <rect x="51" y="9727" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="9725" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9745">PREPARE</text>
+         <rect x="51" y="9771" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="9769" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9789">PRESERVE</text>
+         <rect x="51" y="9815" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="9813" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9833">PRIORITY</text>
+         <rect x="51" y="9859" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="9857" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9877">PRIVILEGES</text>
+         <rect x="51" y="9903" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="9901" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9921">PUBLIC</text>
+         <rect x="51" y="9947" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="9945" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="9965">PUBLICATION</text>
          <rect x="51" y="9991" width="80" height="32" rx="10"></rect>
          <rect x="49" y="9989" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10009">REFRESH</text>
-         <rect x="51" y="10035" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="10033" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10053">REINDEX</text>
-         <rect x="51" y="10079" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="10077" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10097">RELEASE</text>
+         <text class="terminal" x="59" y="10009">QUERIES</text>
+         <rect x="51" y="10035" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="10033" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10053">QUERY</text>
+         <rect x="51" y="10079" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="10077" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10097">RANGE</text>
          <rect x="51" y="10123" width="74" height="32" rx="10"></rect>
          <rect x="49" y="10121" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10141">RENAME</text>
-         <rect x="51" y="10167" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="10165" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10185">REPEATABLE</text>
-         <rect x="51" y="10211" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="10209" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10229">REPLACE</text>
-         <rect x="51" y="10255" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="10253" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10273">RESET</text>
-         <rect x="51" y="10299" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="10297" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10317">RESTORE</text>
-         <rect x="51" y="10343" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="10341" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10361">RESTRICT</text>
-         <rect x="51" y="10387" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10385" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10405">RESUME</text>
-         <rect x="51" y="10431" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="10429" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10449">RETRY</text>
-         <rect x="51" y="10475" width="160" height="32" rx="10"></rect>
-         <rect x="49" y="10473" width="160" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10493">REVISION_HISTORY</text>
-         <rect x="51" y="10519" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10517" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10537">REVOKE</text>
-         <rect x="51" y="10563" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="10561" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10581">ROLE</text>
-         <rect x="51" y="10607" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="10605" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10625">ROLES</text>
-         <rect x="51" y="10651" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="10649" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10669">ROLLBACK</text>
-         <rect x="51" y="10695" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="10693" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10713">ROLLUP</text>
-         <rect x="51" y="10739" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="10737" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10757">ROWS</text>
-         <rect x="51" y="10783" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="10781" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10801">RULE</text>
-         <rect x="51" y="10827" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="10825" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10845">RUNNING</text>
-         <rect x="51" y="10871" width="92" height="32" rx="10"></rect>
-         <rect x="49" y="10869" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10889">SCHEDULE</text>
-         <rect x="51" y="10915" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="10913" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10933">SCHEDULES</text>
-         <rect x="51" y="10959" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="10957" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="10977">SETTING</text>
-         <rect x="51" y="11003" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="11001" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11021">SETTINGS</text>
-         <rect x="51" y="11047" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="11045" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11065">STATUS</text>
-         <rect x="51" y="11091" width="98" height="32" rx="10"></rect>
-         <rect x="49" y="11089" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11109">SAVEPOINT</text>
-         <rect x="51" y="11135" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="11133" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11153">SCATTER</text>
-         <rect x="51" y="11179" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="11177" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11197">SCHEMA</text>
-         <rect x="51" y="11223" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="11221" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11241">SCHEMAS</text>
-         <rect x="51" y="11267" width="66" height="32" rx="10"></rect>
-         <rect x="49" y="11265" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11285">SCRUB</text>
-         <rect x="51" y="11311" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="11309" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11329">SEARCH</text>
-         <rect x="51" y="11355" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="11353" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11373">SECOND</text>
-         <rect x="51" y="11399" width="116" height="32" rx="10"></rect>
-         <rect x="49" y="11397" width="116" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11417">SERIALIZABLE</text>
+         <text class="terminal" x="59" y="10141">RANGES</text>
+         <rect x="51" y="10167" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="10165" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10185">READ</text>
+         <rect x="51" y="10211" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="10209" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10229">REASSIGN</text>
+         <rect x="51" y="10255" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="10253" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10273">RECURRING</text>
+         <rect x="51" y="10299" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="10297" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10317">RECURSIVE</text>
+         <rect x="51" y="10343" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="10341" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10361">REF</text>
+         <rect x="51" y="10387" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="10385" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10405">REFRESH</text>
+         <rect x="51" y="10431" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="10429" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10449">REGION</text>
+         <rect x="51" y="10475" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="10473" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10493">REGIONAL</text>
+         <rect x="51" y="10519" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="10517" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10537">REGIONS</text>
+         <rect x="51" y="10563" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="10561" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10581">REINDEX</text>
+         <rect x="51" y="10607" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="10605" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10625">RELEASE</text>
+         <rect x="51" y="10651" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="10649" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10669">RENAME</text>
+         <rect x="51" y="10695" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="10693" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10713">REPEATABLE</text>
+         <rect x="51" y="10739" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="10737" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10757">REPLACE</text>
+         <rect x="51" y="10783" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="10781" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10801">REPLICATION</text>
+         <rect x="51" y="10827" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="10825" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10845">RESET</text>
+         <rect x="51" y="10871" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="10869" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10889">RESTORE</text>
+         <rect x="51" y="10915" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="10913" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10933">RESTRICT</text>
+         <rect x="51" y="10959" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="10957" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="10977">RESUME</text>
+         <rect x="51" y="11003" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="11001" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11021">RETRY</text>
+         <rect x="51" y="11047" width="160" height="32" rx="10"></rect>
+         <rect x="49" y="11045" width="160" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11065">REVISION_HISTORY</text>
+         <rect x="51" y="11091" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11089" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11109">REVOKE</text>
+         <rect x="51" y="11135" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="11133" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11153">ROLE</text>
+         <rect x="51" y="11179" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="11177" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11197">ROLES</text>
+         <rect x="51" y="11223" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="11221" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11241">ROLLBACK</text>
+         <rect x="51" y="11267" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11265" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11285">ROLLUP</text>
+         <rect x="51" y="11311" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="11309" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11329">ROWS</text>
+         <rect x="51" y="11355" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="11353" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11373">RULE</text>
+         <rect x="51" y="11399" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="11397" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11417">RUNNING</text>
          <rect x="51" y="11443" width="92" height="32" rx="10"></rect>
          <rect x="49" y="11441" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11461">SEQUENCE</text>
-         <rect x="51" y="11487" width="102" height="32" rx="10"></rect>
-         <rect x="49" y="11485" width="102" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11505">SEQUENCES</text>
-         <rect x="51" y="11531" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="11529" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11549">SERVER</text>
-         <rect x="51" y="11575" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="11573" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11593">SESSION</text>
-         <rect x="51" y="11619" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="11617" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11637">SESSIONS</text>
-         <rect x="51" y="11663" width="44" height="32" rx="10"></rect>
-         <rect x="49" y="11661" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11681">SET</text>
-         <rect x="51" y="11707" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="11705" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11725">SETS</text>
-         <rect x="51" y="11751" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11749" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11769">SHARE</text>
-         <rect x="51" y="11795" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="11793" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11813">SHOW</text>
-         <rect x="51" y="11839" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="11837" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11857">SIMPLE</text>
-         <rect x="51" y="11883" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="11881" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11901">SKIP</text>
-         <rect x="51" y="11927" width="238" height="32" rx="10"></rect>
-         <rect x="49" y="11925" width="238" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11945">SKIP_MISSING_FOREIGN_KEYS</text>
-         <rect x="51" y="11971" width="214" height="32" rx="10"></rect>
-         <rect x="49" y="11969" width="214" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="11989">SKIP_MISSING_SEQUENCES</text>
-         <rect x="51" y="12015" width="274" height="32" rx="10"></rect>
-         <rect x="49" y="12013" width="274" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12033">SKIP_MISSING_SEQUENCE_OWNERS</text>
-         <rect x="51" y="12059" width="178" height="32" rx="10"></rect>
-         <rect x="49" y="12057" width="178" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12077">SKIP_MISSING_VIEWS</text>
-         <rect x="51" y="12103" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="12101" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12121">SNAPSHOT</text>
-         <rect x="51" y="12147" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="12145" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12165">SPLIT</text>
-         <rect x="51" y="12191" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="12189" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12209">SQL</text>
-         <rect x="51" y="12235" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="12233" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12253">START</text>
-         <rect x="51" y="12279" width="100" height="32" rx="10"></rect>
-         <rect x="49" y="12277" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12297">STATISTICS</text>
-         <rect x="51" y="12323" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="12321" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12341">STDIN</text>
-         <rect x="51" y="12367" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="12365" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12385">STORAGE</text>
-         <rect x="51" y="12411" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="12409" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12429">STORE</text>
-         <rect x="51" y="12455" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="12453" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12473">STORED</text>
-         <rect x="51" y="12499" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="12497" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12517">STORING</text>
-         <rect x="51" y="12543" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="12541" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12561">STRICT</text>
-         <rect x="51" y="12587" width="124" height="32" rx="10"></rect>
-         <rect x="49" y="12585" width="124" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12605">SUBSCRIPTION</text>
-         <rect x="51" y="12631" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="12629" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12649">SYNTAX</text>
-         <rect x="51" y="12675" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="12673" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12693">SYSTEM</text>
-         <rect x="51" y="12719" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="12717" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12737">TABLES</text>
-         <rect x="51" y="12763" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="12761" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12781">TABLESPACE</text>
-         <rect x="51" y="12807" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="12805" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12825">TEMP</text>
-         <rect x="51" y="12851" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="12849" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12869">TEMPLATE</text>
-         <rect x="51" y="12895" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="12893" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12913">TEMPORARY</text>
-         <rect x="51" y="12939" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="12937" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="12957">TENANT</text>
-         <rect x="51" y="12983" width="158" height="32" rx="10"></rect>
-         <rect x="49" y="12981" width="158" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13001">TESTING_RELOCATE</text>
-         <rect x="51" y="13027" width="52" height="32" rx="10"></rect>
-         <rect x="49" y="13025" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13045">TEXT</text>
-         <rect x="51" y="13071" width="50" height="32" rx="10"></rect>
-         <rect x="49" y="13069" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13089">TIES</text>
-         <rect x="51" y="13115" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="13113" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13133">TRACE</text>
-         <rect x="51" y="13159" width="118" height="32" rx="10"></rect>
-         <rect x="49" y="13157" width="118" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13177">TRANSACTION</text>
-         <rect x="51" y="13203" width="126" height="32" rx="10"></rect>
-         <rect x="49" y="13201" width="126" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13221">TRANSACTIONS</text>
-         <rect x="51" y="13247" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="13245" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13265">TRIGGER</text>
-         <rect x="51" y="13291" width="90" height="32" rx="10"></rect>
-         <rect x="49" y="13289" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13309">TRUNCATE</text>
-         <rect x="51" y="13335" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="13333" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13353">TRUSTED</text>
-         <rect x="51" y="13379" width="54" height="32" rx="10"></rect>
-         <rect x="49" y="13377" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13397">TYPE</text>
-         <rect x="51" y="13423" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="13421" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13441">TYPES</text>
-         <rect x="51" y="13467" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="13465" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13485">THROTTLING</text>
-         <rect x="51" y="13511" width="108" height="32" rx="10"></rect>
-         <rect x="49" y="13509" width="108" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13529">UNBOUNDED</text>
-         <rect x="51" y="13555" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="13553" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13573">UNCOMMITTED</text>
-         <rect x="51" y="13599" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="13597" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13617">UNKNOWN</text>
-         <rect x="51" y="13643" width="96" height="32" rx="10"></rect>
-         <rect x="49" y="13641" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13661">UNLOGGED</text>
-         <rect x="51" y="13687" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="13685" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13705">UNSPLIT</text>
-         <rect x="51" y="13731" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="13729" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13749">UNTIL</text>
-         <rect x="51" y="13775" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="13773" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13793">UPDATE</text>
-         <rect x="51" y="13819" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="13817" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13837">UPSERT</text>
-         <rect x="51" y="13863" width="46" height="32" rx="10"></rect>
-         <rect x="49" y="13861" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13881">USE</text>
-         <rect x="51" y="13907" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="13905" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13925">USERS</text>
-         <rect x="51" y="13951" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="13949" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="13969">VALID</text>
-         <rect x="51" y="13995" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="13993" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14013">VALIDATE</text>
-         <rect x="51" y="14039" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="14037" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14057">VALUE</text>
+         <text class="terminal" x="59" y="11461">SCHEDULE</text>
+         <rect x="51" y="11487" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="11485" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11505">SCHEDULES</text>
+         <rect x="51" y="11531" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="11529" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11549">SETTING</text>
+         <rect x="51" y="11575" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="11573" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11593">SETTINGS</text>
+         <rect x="51" y="11619" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="11617" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11637">STATUS</text>
+         <rect x="51" y="11663" width="98" height="32" rx="10"></rect>
+         <rect x="49" y="11661" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11681">SAVEPOINT</text>
+         <rect x="51" y="11707" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="11705" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11725">SCATTER</text>
+         <rect x="51" y="11751" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="11749" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11769">SCHEMA</text>
+         <rect x="51" y="11795" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="11793" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11813">SCHEMAS</text>
+         <rect x="51" y="11839" width="66" height="32" rx="10"></rect>
+         <rect x="49" y="11837" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11857">SCRUB</text>
+         <rect x="51" y="11883" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="11881" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11901">SEARCH</text>
+         <rect x="51" y="11927" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="11925" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11945">SECOND</text>
+         <rect x="51" y="11971" width="116" height="32" rx="10"></rect>
+         <rect x="49" y="11969" width="116" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="11989">SERIALIZABLE</text>
+         <rect x="51" y="12015" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="12013" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12033">SEQUENCE</text>
+         <rect x="51" y="12059" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="12057" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12077">SEQUENCES</text>
+         <rect x="51" y="12103" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="12101" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12121">SERVER</text>
+         <rect x="51" y="12147" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="12145" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12165">SESSION</text>
+         <rect x="51" y="12191" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="12189" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12209">SESSIONS</text>
+         <rect x="51" y="12235" width="44" height="32" rx="10"></rect>
+         <rect x="49" y="12233" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12253">SET</text>
+         <rect x="51" y="12279" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="12277" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12297">SETS</text>
+         <rect x="51" y="12323" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="12321" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12341">SHARE</text>
+         <rect x="51" y="12367" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="12365" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12385">SHOW</text>
+         <rect x="51" y="12411" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="12409" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12429">SIMPLE</text>
+         <rect x="51" y="12455" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="12453" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12473">SKIP</text>
+         <rect x="51" y="12499" width="238" height="32" rx="10"></rect>
+         <rect x="49" y="12497" width="238" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12517">SKIP_MISSING_FOREIGN_KEYS</text>
+         <rect x="51" y="12543" width="214" height="32" rx="10"></rect>
+         <rect x="49" y="12541" width="214" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12561">SKIP_MISSING_SEQUENCES</text>
+         <rect x="51" y="12587" width="274" height="32" rx="10"></rect>
+         <rect x="49" y="12585" width="274" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12605">SKIP_MISSING_SEQUENCE_OWNERS</text>
+         <rect x="51" y="12631" width="178" height="32" rx="10"></rect>
+         <rect x="49" y="12629" width="178" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12649">SKIP_MISSING_VIEWS</text>
+         <rect x="51" y="12675" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="12673" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12693">SNAPSHOT</text>
+         <rect x="51" y="12719" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="12717" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12737">SPLIT</text>
+         <rect x="51" y="12763" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="12761" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12781">SQL</text>
+         <rect x="51" y="12807" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="12805" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12825">START</text>
+         <rect x="51" y="12851" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="12849" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12869">STATEMENTS</text>
+         <rect x="51" y="12895" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="12893" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12913">STATISTICS</text>
+         <rect x="51" y="12939" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="12937" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="12957">STDIN</text>
+         <rect x="51" y="12983" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="12981" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13001">STORAGE</text>
+         <rect x="51" y="13027" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="13025" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13045">STORE</text>
+         <rect x="51" y="13071" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="13069" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13089">STORED</text>
+         <rect x="51" y="13115" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="13113" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13133">STORING</text>
+         <rect x="51" y="13159" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="13157" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13177">STREAM</text>
+         <rect x="51" y="13203" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="13201" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13221">STRICT</text>
+         <rect x="51" y="13247" width="124" height="32" rx="10"></rect>
+         <rect x="49" y="13245" width="124" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13265">SUBSCRIPTION</text>
+         <rect x="51" y="13291" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="13289" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13309">SURVIVE</text>
+         <rect x="51" y="13335" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="13333" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13353">SURVIVAL</text>
+         <rect x="51" y="13379" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="13377" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13397">SYNTAX</text>
+         <rect x="51" y="13423" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="13421" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13441">SYSTEM</text>
+         <rect x="51" y="13467" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="13465" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13485">TABLES</text>
+         <rect x="51" y="13511" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="13509" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13529">TABLESPACE</text>
+         <rect x="51" y="13555" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="13553" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13573">TEMP</text>
+         <rect x="51" y="13599" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="13597" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13617">TEMPLATE</text>
+         <rect x="51" y="13643" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="13641" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13661">TEMPORARY</text>
+         <rect x="51" y="13687" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="13685" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13705">TENANT</text>
+         <rect x="51" y="13731" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="13729" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13749">TESTING_RELOCATE</text>
+         <rect x="51" y="13775" width="52" height="32" rx="10"></rect>
+         <rect x="49" y="13773" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13793">TEXT</text>
+         <rect x="51" y="13819" width="50" height="32" rx="10"></rect>
+         <rect x="49" y="13817" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13837">TIES</text>
+         <rect x="51" y="13863" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="13861" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13881">TRACE</text>
+         <rect x="51" y="13907" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="13905" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13925">TRANSACTION</text>
+         <rect x="51" y="13951" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="13949" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="13969">TRANSACTIONS</text>
+         <rect x="51" y="13995" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="13993" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14013">TRIGGER</text>
+         <rect x="51" y="14039" width="90" height="32" rx="10"></rect>
+         <rect x="49" y="14037" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14057">TRUNCATE</text>
          <rect x="51" y="14083" width="82" height="32" rx="10"></rect>
          <rect x="49" y="14081" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14101">VARYING</text>
-         <rect x="51" y="14127" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="14125" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14145">VIEW</text>
-         <rect x="51" y="14171" width="122" height="32" rx="10"></rect>
-         <rect x="49" y="14169" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14189">VIEWACTIVITY</text>
-         <rect x="51" y="14215" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="14213" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14233">WITHIN</text>
-         <rect x="51" y="14259" width="86" height="32" rx="10"></rect>
-         <rect x="49" y="14257" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14277">WITHOUT</text>
-         <rect x="51" y="14303" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="14301" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14321">WRITE</text>
-         <rect x="51" y="14347" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="14345" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14365">YEAR</text>
-         <rect x="51" y="14391" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="14389" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="14409">ZONE</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h208 m-314 0 h20 m294 0 h20 m-334 0 q10 0 10 10 m314 0 q0 -10 10 -10 m-324 10 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m36 0 h10 m0 0 h238 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m130 0 h10 m0 0 h144 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m120 0 h10 m0 0 h154 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m110 0 h10 m0 0 h164 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m146 0 h10 m0 0 h128 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m176 0 h10 m0 0 h98 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m208 0 h10 m0 0 h66 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m174 0 h10 m0 0 h100 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m234 0 h10 m0 0 h40 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m202 0 h10 m0 0 h72 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m182 0 h10 m0 0 h92 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m194 0 h10 m0 0 h80 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m202 0 h10 m0 0 h72 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m50 0 h10 m0 0 h224 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m120 0 h10 m0 0 h154 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m196 0 h10 m0 0 h78 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m146 0 h10 m0 0 h128 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m158 0 h10 m0 0 h116 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m154 0 h10 m0 0 h120 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m166 0 h10 m0 0 h108 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m126 0 h10 m0 0 h148 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m132 0 h10 m0 0 h142 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m140 0 h10 m0 0 h134 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m150 0 h10 m0 0 h124 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m40 0 h10 m0 0 h234 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m110 0 h10 m0 0 h164 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m128 0 h10 m0 0 h146 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m196 0 h10 m0 0 h78 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m134 0 h10 m0 0 h140 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m216 0 h10 m0 0 h58 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m44 0 h10 m0 0 h230 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m160 0 h10 m0 0 h114 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m44 0 h10 m0 0 h230 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m238 0 h10 m0 0 h36 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m214 0 h10 m0 0 h60 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m274 0 h10 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m178 0 h10 m0 0 h96 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m124 0 h10 m0 0 h150 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m158 0 h10 m0 0 h116 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m50 0 h10 m0 0 h224 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m126 0 h10 m0 0 h148 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m23 -14388 h-3"></path>
+         <text class="terminal" x="59" y="14101">TRUSTED</text>
+         <rect x="51" y="14127" width="54" height="32" rx="10"></rect>
+         <rect x="49" y="14125" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14145">TYPE</text>
+         <rect x="51" y="14171" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="14169" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14189">TYPES</text>
+         <rect x="51" y="14215" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="14213" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14233">THROTTLING</text>
+         <rect x="51" y="14259" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="14257" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14277">UNBOUNDED</text>
+         <rect x="51" y="14303" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="14301" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14321">UNCOMMITTED</text>
+         <rect x="51" y="14347" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="14345" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14365">UNKNOWN</text>
+         <rect x="51" y="14391" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="14389" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14409">UNLOGGED</text>
+         <rect x="51" y="14435" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="14433" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14453">UNSPLIT</text>
+         <rect x="51" y="14479" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="14477" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14497">UNTIL</text>
+         <rect x="51" y="14523" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="14521" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14541">UPDATE</text>
+         <rect x="51" y="14567" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="14565" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14585">UPSERT</text>
+         <rect x="51" y="14611" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="14609" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14629">USE</text>
+         <rect x="51" y="14655" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="14653" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14673">USERS</text>
+         <rect x="51" y="14699" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="14697" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14717">VALID</text>
+         <rect x="51" y="14743" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="14741" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14761">VALIDATE</text>
+         <rect x="51" y="14787" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="14785" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14805">VALUE</text>
+         <rect x="51" y="14831" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="14829" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14849">VARYING</text>
+         <rect x="51" y="14875" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="14873" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14893">VIEW</text>
+         <rect x="51" y="14919" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="14917" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14937">VIEWACTIVITY</text>
+         <rect x="51" y="14963" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="14961" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="14981">VOTERS</text>
+         <rect x="51" y="15007" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="15005" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="15025">WITHIN</text>
+         <rect x="51" y="15051" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="15049" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="15069">WITHOUT</text>
+         <rect x="51" y="15095" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="15093" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="15113">WRITE</text>
+         <rect x="51" y="15139" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="15137" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="15157">YEAR</text>
+         <rect x="51" y="15183" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="15181" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="15201">ZONE</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h208 m-314 0 h20 m294 0 h20 m-334 0 q10 0 10 10 m314 0 q0 -10 10 -10 m-324 10 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m36 0 h10 m0 0 h238 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m130 0 h10 m0 0 h144 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m120 0 h10 m0 0 h154 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m110 0 h10 m0 0 h164 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m146 0 h10 m0 0 h128 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m176 0 h10 m0 0 h98 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m208 0 h10 m0 0 h66 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m174 0 h10 m0 0 h100 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m234 0 h10 m0 0 h40 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m202 0 h10 m0 0 h72 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m182 0 h10 m0 0 h92 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m194 0 h10 m0 0 h80 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m202 0 h10 m0 0 h72 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m58 0 h10 m0 0 h216 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m50 0 h10 m0 0 h224 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m120 0 h10 m0 0 h154 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m196 0 h10 m0 0 h78 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m146 0 h10 m0 0 h128 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m158 0 h10 m0 0 h116 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m154 0 h10 m0 0 h120 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m166 0 h10 m0 0 h108 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m126 0 h10 m0 0 h148 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m132 0 h10 m0 0 h142 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m140 0 h10 m0 0 h134 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m150 0 h10 m0 0 h124 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m40 0 h10 m0 0 h234 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m110 0 h10 m0 0 h164 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m136 0 h10 m0 0 h138 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m128 0 h10 m0 0 h146 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m196 0 h10 m0 0 h78 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m134 0 h10 m0 0 h140 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m216 0 h10 m0 0 h58 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m142 0 h10 m0 0 h132 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m190 0 h10 m0 0 h84 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m38 0 h10 m0 0 h236 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m114 0 h10 m0 0 h160 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m44 0 h10 m0 0 h230 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m112 0 h10 m0 0 h162 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m160 0 h10 m0 0 h114 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m78 0 h10 m0 0 h196 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m98 0 h10 m0 0 h176 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m66 0 h10 m0 0 h208 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m76 0 h10 m0 0 h198 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m116 0 h10 m0 0 h158 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m92 0 h10 m0 0 h182 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m102 0 h10 m0 0 h172 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m44 0 h10 m0 0 h230 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m238 0 h10 m0 0 h36 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m214 0 h10 m0 0 h60 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m274 0 h10 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m178 0 h10 m0 0 h96 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m60 0 h10 m0 0 h214 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m48 0 h10 m0 0 h226 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m100 0 h10 m0 0 h174 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m84 0 h10 m0 0 h190 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m68 0 h10 m0 0 h206 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m124 0 h10 m0 0 h150 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m70 0 h10 m0 0 h204 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m106 0 h10 m0 0 h168 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m88 0 h10 m0 0 h186 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m104 0 h10 m0 0 h170 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m158 0 h10 m0 0 h116 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m52 0 h10 m0 0 h222 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m50 0 h10 m0 0 h224 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m118 0 h10 m0 0 h156 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m126 0 h10 m0 0 h148 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m90 0 h10 m0 0 h184 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m54 0 h10 m0 0 h220 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m108 0 h10 m0 0 h166 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m94 0 h10 m0 0 h180 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m96 0 h10 m0 0 h178 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m80 0 h10 m0 0 h194 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m72 0 h10 m0 0 h202 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m46 0 h10 m0 0 h228 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m62 0 h10 m0 0 h212 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m82 0 h10 m0 0 h192 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m122 0 h10 m0 0 h152 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m74 0 h10 m0 0 h200 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m86 0 h10 m0 0 h188 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m64 0 h10 m0 0 h210 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m-304 -10 v20 m314 0 v-20 m-314 20 v24 m314 0 v-24 m-314 24 q0 10 10 10 m294 0 q10 0 10 -10 m-304 10 h10 m56 0 h10 m0 0 h218 m23 -15180 h-3"></path>
          <polygon points="363 17 371 13 371 21"></polygon>
          <polygon points="363 17 355 13 355 21"></polygon>
       </svg>
@@ -6929,6 +7314,35 @@
             <li><a href="#target_types" title="target_types">target_types</a></li>
             <li><a href="#targets_roles" title="targets_roles">targets_roles</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="qualifiable_schema_name" href="#qualifiable_schema_name">qualifiable_schema_name:</a></p>
+      <svg width="270" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
+         </a>
+         <rect x="125" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="123" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="53">.</text>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="169" y="35" width="54" height="32"></rect>
+            <rect x="167" y="33" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="177" y="53">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h108 m-138 0 h20 m118 0 h20 m-158 0 q10 0 10 10 m138 0 q0 -10 10 -10 m-148 10 v12 m138 0 v-12 m-138 12 q0 10 10 10 m118 0 q10 0 10 -10 m-128 10 h10 m24 0 h10 m0 0 h10 m54 0 h10 m23 -32 h-3"></path>
+         <polygon points="261 17 269 13 269 21"></polygon>
+         <polygon points="261 17 253 13 253 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_schema_stmt" title="alter_schema_stmt">alter_schema_stmt</a></li>
+            <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
+            <li><a href="#opt_schema_name" title="opt_schema_name">opt_schema_name</a></li>
+            <li><a href="#schema_name_list" title="schema_name_list">schema_name_list</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="type_list" href="#type_list">type_list:</a></p>
       <svg width="180" height="80">
          
@@ -6952,7 +7366,7 @@
             <li><a href="#b_expr" title="b_expr">b_expr</a></li>
             <li><a href="#prep_type_clause" title="prep_type_clause">prep_type_clause</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="non_reserved_word_or_sconst" href="#non_reserved_word_or_sconst">non_reserved_word_or_sconst:</a></p>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="username_or_sconst" href="#username_or_sconst">username_or_sconst:</a></p>
       <svg width="246" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
@@ -6971,12 +7385,7 @@
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#opt_encoding_clause" title="opt_encoding_clause">opt_encoding_clause</a></li>
-            <li><a href="#opt_lc_collate_clause" title="opt_lc_collate_clause">opt_lc_collate_clause</a></li>
-            <li><a href="#opt_lc_ctype_clause" title="opt_lc_ctype_clause">opt_lc_ctype_clause</a></li>
-            <li><a href="#opt_template_clause" title="opt_template_clause">opt_template_clause</a></li>
             <li><a href="#role_spec" title="role_spec">role_spec</a></li>
-            <li><a href="#string_or_placeholder" title="string_or_placeholder">string_or_placeholder</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="transaction_mode_list" href="#transaction_mode_list">transaction_mode_list:</a></p>
       <svg width="232" height="80">
@@ -7059,7 +7468,7 @@
             <li><a href="#abort_stmt" title="abort_stmt">abort_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_stmt" href="#alter_table_stmt">alter_table_stmt:</a></p>
-      <svg width="306" height="300">
+      <svg width="306" height="388">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7098,7 +7507,17 @@
             <rect x="49" y="265" width="208" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="285">alter_table_set_schema_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m148 0 h10 m0 0 h60 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m118 0 h10 m0 0 h90 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m134 0 h10 m0 0 h74 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m136 0 h10 m0 0 h72 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m164 0 h10 m0 0 h44 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m180 0 h10 m0 0 h28 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m208 0 h10 m23 -264 h-3"></path>
+         <a xlink:href="#alter_table_locality_stmt" xlink:title="alter_table_locality_stmt">
+            <rect x="51" y="311" width="176" height="32"></rect>
+            <rect x="49" y="309" width="176" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">alter_table_locality_stmt</text>
+         </a>
+         <a xlink:href="#alter_table_owner_stmt" xlink:title="alter_table_owner_stmt">
+            <rect x="51" y="355" width="172" height="32"></rect>
+            <rect x="49" y="353" width="172" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="373">alter_table_owner_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m148 0 h10 m0 0 h60 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m118 0 h10 m0 0 h90 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m134 0 h10 m0 0 h74 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m136 0 h10 m0 0 h72 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m164 0 h10 m0 0 h44 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m180 0 h10 m0 0 h28 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m208 0 h10 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m176 0 h10 m0 0 h32 m-238 -10 v20 m248 0 v-20 m-248 20 v24 m248 0 v-24 m-248 24 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m172 0 h10 m0 0 h36 m23 -352 h-3"></path>
          <polygon points="297 17 305 13 305 21"></polygon>
          <polygon points="297 17 289 13 289 21"></polygon>
       </svg>
@@ -7150,7 +7569,7 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_view_stmt" href="#alter_view_stmt">alter_view_stmt:</a></p>
-      <svg width="304" height="80">
+      <svg width="304" height="124">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7164,7 +7583,12 @@
             <rect x="49" y="45" width="206" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="65">alter_view_set_schema_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m0 0 h28 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m206 0 h10 m23 -44 h-3"></path>
+         <a xlink:href="#alter_view_owner_stmt" xlink:title="alter_view_owner_stmt">
+            <rect x="51" y="91" width="170" height="32"></rect>
+            <rect x="49" y="89" width="170" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="109">alter_view_owner_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m178 0 h10 m0 0 h28 m-246 0 h20 m226 0 h20 m-266 0 q10 0 10 10 m246 0 q0 -10 10 -10 m-256 10 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m206 0 h10 m-236 -10 v20 m246 0 v-20 m-246 20 v24 m246 0 v-24 m-246 24 q0 10 10 10 m226 0 q10 0 10 -10 m-236 10 h10 m170 0 h10 m0 0 h36 m23 -88 h-3"></path>
          <polygon points="295 17 303 13 303 21"></polygon>
          <polygon points="295 17 287 13 287 21"></polygon>
       </svg>
@@ -7173,7 +7597,7 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_sequence_stmt" href="#alter_sequence_stmt">alter_sequence_stmt:</a></p>
-      <svg width="336" height="124">
+      <svg width="336" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7192,7 +7616,12 @@
             <rect x="49" y="89" width="238" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="109">alter_sequence_set_schema_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m210 0 h10 m0 0 h28 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m208 0 h10 m0 0 h30 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m238 0 h10 m23 -88 h-3"></path>
+         <a xlink:href="#alter_sequence_owner_stmt" xlink:title="alter_sequence_owner_stmt">
+            <rect x="51" y="135" width="202" height="32"></rect>
+            <rect x="49" y="133" width="202" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="153">alter_sequence_owner_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m210 0 h10 m0 0 h28 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m208 0 h10 m0 0 h30 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m238 0 h10 m-268 -10 v20 m278 0 v-20 m-278 20 v24 m278 0 v-24 m-278 24 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m202 0 h10 m0 0 h36 m23 -132 h-3"></path>
          <polygon points="327 17 335 13 335 21"></polygon>
          <polygon points="327 17 319 13 319 21"></polygon>
       </svg>
@@ -7201,7 +7630,7 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_stmt" href="#alter_database_stmt">alter_database_stmt:</a></p>
-      <svg width="328" height="168">
+      <svg width="354" height="344">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7225,9 +7654,29 @@
             <rect x="49" y="133" width="230" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="153">alter_database_to_schema_stmt</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m208 0 h10 m0 0 h22 m-270 0 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m192 0 h10 m0 0 h38 m-260 -10 v20 m270 0 v-20 m-270 20 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m164 0 h10 m0 0 h66 m-260 -10 v20 m270 0 v-20 m-270 20 v24 m270 0 v-24 m-270 24 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m230 0 h10 m23 -132 h-3"></path>
-         <polygon points="319 17 327 13 327 21"></polygon>
-         <polygon points="319 17 311 13 311 21"></polygon>
+         <a xlink:href="#alter_database_add_region_stmt" xlink:title="alter_database_add_region_stmt">
+            <rect x="51" y="179" width="232" height="32"></rect>
+            <rect x="49" y="177" width="232" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="197">alter_database_add_region_stmt</text>
+         </a>
+         <a xlink:href="#alter_database_drop_region_stmt" xlink:title="alter_database_drop_region_stmt">
+            <rect x="51" y="223" width="238" height="32"></rect>
+            <rect x="49" y="221" width="238" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="241">alter_database_drop_region_stmt</text>
+         </a>
+         <a xlink:href="#alter_database_survival_goal_stmt" xlink:title="alter_database_survival_goal_stmt">
+            <rect x="51" y="267" width="244" height="32"></rect>
+            <rect x="49" y="265" width="244" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="285">alter_database_survival_goal_stmt</text>
+         </a>
+         <a xlink:href="#alter_database_primary_region_stmt" xlink:title="alter_database_primary_region_stmt">
+            <rect x="51" y="311" width="256" height="32"></rect>
+            <rect x="49" y="309" width="256" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="329">alter_database_primary_region_stmt</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m208 0 h10 m0 0 h48 m-296 0 h20 m276 0 h20 m-316 0 q10 0 10 10 m296 0 q0 -10 10 -10 m-306 10 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m192 0 h10 m0 0 h64 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m164 0 h10 m0 0 h92 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m230 0 h10 m0 0 h26 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m232 0 h10 m0 0 h24 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m238 0 h10 m0 0 h18 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m244 0 h10 m0 0 h12 m-286 -10 v20 m296 0 v-20 m-296 20 v24 m296 0 v-24 m-296 24 q0 10 10 10 m276 0 q10 0 10 -10 m-286 10 h10 m256 0 h10 m23 -308 h-3"></path>
+         <polygon points="345 17 353 13 353 21"></polygon>
+         <polygon points="345 17 337 13 337 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -7270,7 +7719,7 @@
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_schema_stmt" href="#alter_schema_stmt">alter_schema_stmt:</a></p>
-      <svg width="668" height="80">
+      <svg width="740" height="80">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -7280,43 +7729,43 @@
          <rect x="113" y="3" width="76" height="32" rx="10"></rect>
          <rect x="111" y="1" width="76" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="121" y="21">SCHEMA</text>
-         <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="209" y="3" width="110" height="32"></rect>
-            <rect x="207" y="1" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="217" y="21">schema_name</text>
+         <a xlink:href="#qualifiable_schema_name" xlink:title="qualifiable_schema_name">
+            <rect x="209" y="3" width="182" height="32"></rect>
+            <rect x="207" y="1" width="182" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="217" y="21">qualifiable_schema_name</text>
          </a>
-         <rect x="359" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="357" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="367" y="21">RENAME</text>
-         <rect x="453" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="451" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="461" y="21">TO</text>
+         <rect x="431" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="429" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="439" y="21">RENAME</text>
+         <rect x="525" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="523" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="533" y="21">TO</text>
          <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="511" y="3" width="110" height="32"></rect>
-            <rect x="509" y="1" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="519" y="21">schema_name</text>
+            <rect x="583" y="3" width="110" height="32"></rect>
+            <rect x="581" y="1" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="591" y="21">schema_name</text>
          </a>
-         <rect x="359" y="47" width="72" height="32" rx="10"></rect>
-         <rect x="357" y="45" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="367" y="65">OWNER</text>
-         <rect x="451" y="47" width="38" height="32" rx="10"></rect>
-         <rect x="449" y="45" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="459" y="65">TO</text>
+         <rect x="431" y="47" width="72" height="32" rx="10"></rect>
+         <rect x="429" y="45" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="439" y="65">OWNER</text>
+         <rect x="523" y="47" width="38" height="32" rx="10"></rect>
+         <rect x="521" y="45" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="531" y="65">TO</text>
          <a xlink:href="#role_spec" xlink:title="role_spec">
-            <rect x="509" y="47" width="80" height="32"></rect>
-            <rect x="507" y="45" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="517" y="65">role_spec</text>
+            <rect x="581" y="47" width="80" height="32"></rect>
+            <rect x="579" y="45" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="589" y="65">role_spec</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m20 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m110 0 h10 m-302 0 h20 m282 0 h20 m-322 0 q10 0 10 10 m302 0 q0 -10 10 -10 m-312 10 v24 m302 0 v-24 m-302 24 q0 10 10 10 m282 0 q10 0 10 -10 m-292 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h32 m23 -44 h-3"></path>
-         <polygon points="659 17 667 13 667 21"></polygon>
-         <polygon points="659 17 651 13 651 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m182 0 h10 m20 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m110 0 h10 m-302 0 h20 m282 0 h20 m-322 0 q10 0 10 10 m302 0 q0 -10 10 -10 m-312 10 v24 m302 0 v-24 m-302 24 q0 10 10 10 m282 0 q10 0 10 -10 m-292 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h32 m23 -44 h-3"></path>
+         <polygon points="731 17 739 13 739 21"></polygon>
+         <polygon points="731 17 723 13 723 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_ddl_stmt" title="alter_ddl_stmt">alter_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_type_stmt" href="#alter_type_stmt">alter_type_stmt:</a></p>
-      <svg width="762" height="310">
+      <svg width="762" height="354">
          
          <polygon points="11 17 3 13 3 21"></polygon>
          <polygon points="19 17 11 13 11 21"></polygon>
@@ -7354,52 +7803,61 @@
             <rect x="541" y="67" width="172" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="551" y="87">opt_add_val_placement</text>
          </a>
-         <rect x="45" y="145" width="74" height="32" rx="10"></rect>
-         <rect x="43" y="143" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="163">RENAME</text>
-         <rect x="159" y="145" width="64" height="32" rx="10"></rect>
-         <rect x="157" y="143" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="167" y="163">VALUE</text>
-         <rect x="243" y="145" width="76" height="32" rx="10"></rect>
-         <rect x="241" y="143" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="251" y="163">SCONST</text>
-         <rect x="339" y="145" width="38" height="32" rx="10"></rect>
-         <rect x="337" y="143" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="347" y="163">TO</text>
-         <rect x="397" y="145" width="76" height="32" rx="10"></rect>
-         <rect x="395" y="143" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="405" y="163">SCONST</text>
-         <rect x="159" y="189" width="38" height="32" rx="10"></rect>
-         <rect x="157" y="187" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="167" y="207">TO</text>
+         <rect x="45" y="145" width="58" height="32" rx="10"></rect>
+         <rect x="43" y="143" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="163">DROP</text>
+         <rect x="123" y="145" width="64" height="32" rx="10"></rect>
+         <rect x="121" y="143" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="131" y="163">VALUE</text>
+         <rect x="207" y="145" width="76" height="32" rx="10"></rect>
+         <rect x="205" y="143" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="163">SCONST</text>
+         <rect x="45" y="189" width="74" height="32" rx="10"></rect>
+         <rect x="43" y="187" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="207">RENAME</text>
+         <rect x="159" y="189" width="64" height="32" rx="10"></rect>
+         <rect x="157" y="187" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="207">VALUE</text>
+         <rect x="243" y="189" width="76" height="32" rx="10"></rect>
+         <rect x="241" y="187" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="251" y="207">SCONST</text>
+         <rect x="339" y="189" width="38" height="32" rx="10"></rect>
+         <rect x="337" y="187" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="347" y="207">TO</text>
+         <rect x="397" y="189" width="76" height="32" rx="10"></rect>
+         <rect x="395" y="187" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="405" y="207">SCONST</text>
+         <rect x="159" y="233" width="38" height="32" rx="10"></rect>
+         <rect x="157" y="231" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="167" y="251">TO</text>
          <a xlink:href="#name" xlink:title="name">
-            <rect x="217" y="189" width="54" height="32"></rect>
-            <rect x="215" y="187" width="54" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="225" y="207">name</text>
+            <rect x="217" y="233" width="54" height="32"></rect>
+            <rect x="215" y="231" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="225" y="251">name</text>
          </a>
-         <rect x="45" y="233" width="44" height="32" rx="10"></rect>
-         <rect x="43" y="231" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="251">SET</text>
-         <rect x="109" y="233" width="76" height="32" rx="10"></rect>
-         <rect x="107" y="231" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="117" y="251">SCHEMA</text>
+         <rect x="45" y="277" width="44" height="32" rx="10"></rect>
+         <rect x="43" y="275" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="295">SET</text>
+         <rect x="109" y="277" width="76" height="32" rx="10"></rect>
+         <rect x="107" y="275" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="117" y="295">SCHEMA</text>
          <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="205" y="233" width="110" height="32"></rect>
-            <rect x="203" y="231" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="213" y="251">schema_name</text>
+            <rect x="205" y="277" width="110" height="32"></rect>
+            <rect x="203" y="275" width="110" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="213" y="295">schema_name</text>
          </a>
-         <rect x="45" y="277" width="72" height="32" rx="10"></rect>
-         <rect x="43" y="275" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="295">OWNER</text>
-         <rect x="137" y="277" width="38" height="32" rx="10"></rect>
-         <rect x="135" y="275" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="145" y="295">TO</text>
+         <rect x="45" y="321" width="72" height="32" rx="10"></rect>
+         <rect x="43" y="319" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="339">OWNER</text>
+         <rect x="137" y="321" width="38" height="32" rx="10"></rect>
+         <rect x="135" y="319" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="145" y="339">TO</text>
          <a xlink:href="#role_spec" xlink:title="role_spec">
-            <rect x="195" y="277" width="80" height="32"></rect>
-            <rect x="193" y="275" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="295">role_spec</text>
+            <rect x="195" y="321" width="80" height="32"></rect>
+            <rect x="193" y="319" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="203" y="339">role_spec</text>
          </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-298 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m76 0 h10 m0 0 h10 m172 0 h10 m-710 0 h20 m690 0 h20 m-730 0 q10 0 10 10 m710 0 q0 -10 10 -10 m-720 10 v56 m710 0 v-56 m-710 56 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m74 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m-354 0 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v24 m354 0 v-24 m-354 24 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m0 0 h202 m20 -44 h222 m-700 -10 v20 m710 0 v-20 m-710 20 v68 m710 0 v-68 m-710 68 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m44 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h400 m-700 -10 v20 m710 0 v-20 m-710 20 v24 m710 0 v-24 m-710 24 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h440 m23 -208 h-3"></path>
+         <path class="line" d="m19 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-298 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m76 0 h10 m0 0 h10 m172 0 h10 m-710 0 h20 m690 0 h20 m-730 0 q10 0 10 10 m710 0 q0 -10 10 -10 m-720 10 v56 m710 0 v-56 m-710 56 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m58 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h432 m-700 -10 v20 m710 0 v-20 m-710 20 v24 m710 0 v-24 m-710 24 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m74 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m-354 0 h20 m334 0 h20 m-374 0 q10 0 10 10 m354 0 q0 -10 10 -10 m-364 10 v24 m354 0 v-24 m-354 24 q0 10 10 10 m334 0 q10 0 10 -10 m-344 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m0 0 h202 m20 -44 h222 m-700 -10 v20 m710 0 v-20 m-710 20 v68 m710 0 v-68 m-710 68 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m44 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m110 0 h10 m0 0 h400 m-700 -10 v20 m710 0 v-20 m-710 20 v24 m710 0 v-24 m-710 24 q0 10 10 10 m690 0 q10 0 10 -10 m-700 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h440 m23 -252 h-3"></path>
          <polygon points="753 83 761 79 761 87"></polygon>
          <polygon points="753 83 745 79 745 87"></polygon>
       </svg>
@@ -8366,6 +8824,7 @@
             <li><a href="#overlay_placing" title="overlay_placing">overlay_placing</a></li>
             <li><a href="#pause_jobs_stmt" title="pause_jobs_stmt">pause_jobs_stmt</a></li>
             <li><a href="#pause_schedules_stmt" title="pause_schedules_stmt">pause_schedules_stmt</a></li>
+            <li><a href="#replication_options" title="replication_options">replication_options</a></li>
             <li><a href="#resume_jobs_stmt" title="resume_jobs_stmt">resume_jobs_stmt</a></li>
             <li><a href="#resume_schedules_stmt" title="resume_schedules_stmt">resume_schedules_stmt</a></li>
             <li><a href="#show_jobs_stmt" title="show_jobs_stmt">show_jobs_stmt</a></li>
@@ -8419,45 +8878,8 @@
             <li><a href="#resume_jobs_stmt" title="resume_jobs_stmt">resume_jobs_stmt</a></li>
             <li><a href="#show_jobs_stmt" title="show_jobs_stmt">show_jobs_stmt</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_changefeed_stmt" href="#create_changefeed_stmt">create_changefeed_stmt:</a></p>
-      <svg width="664" height="102">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CREATE</text>
-         <rect x="121" y="3" width="110" height="32" rx="10"></rect>
-         <rect x="119" y="1" width="110" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="129" y="21">CHANGEFEED</text>
-         <rect x="251" y="3" width="48" height="32" rx="10"></rect>
-         <rect x="249" y="1" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="259" y="21">FOR</text>
-         <a xlink:href="#changefeed_targets" xlink:title="changefeed_targets">
-            <rect x="319" y="3" width="148" height="32"></rect>
-            <rect x="317" y="1" width="148" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="327" y="21">changefeed_targets</text>
-         </a>
-         <a xlink:href="#opt_changefeed_sink" xlink:title="opt_changefeed_sink">
-            <rect x="487" y="3" width="156" height="32"></rect>
-            <rect x="485" y="1" width="156" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="495" y="21">opt_changefeed_sink</text>
-         </a>
-         <a xlink:href="#opt_with_options" xlink:title="opt_with_options">
-            <rect x="507" y="69" width="130" height="32"></rect>
-            <rect x="505" y="67" width="130" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="515" y="87">opt_with_options</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m148 0 h10 m0 0 h10 m156 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m130 0 h10 m3 0 h-3"></path>
-         <polygon points="655 83 663 79 663 87"></polygon>
-         <polygon points="655 83 647 79 647 87"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_database_stmt" href="#create_database_stmt">create_database_stmt:</a></p>
-      <svg width="720" height="200">
+      <svg width="720" height="266">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -8507,13 +8929,28 @@
             <text class="nonterminal" x="556" y="119">opt_lc_ctype_clause</text>
          </a>
          <a xlink:href="#opt_connection_limit" xlink:title="opt_connection_limit">
-            <rect x="543" y="167" width="150" height="32"></rect>
-            <rect x="541" y="165" width="150" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="551" y="185">opt_connection_limit</text>
+            <rect x="110" y="167" width="150" height="32"></rect>
+            <rect x="108" y="165" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="118" y="185">opt_connection_limit</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m122 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-715 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m152 0 h10 m0 0 h10 m154 0 h10 m0 0 h10 m154 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-197 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m150 0 h10 m3 0 h-3"></path>
-         <polygon points="711 181 719 177 719 185"></polygon>
-         <polygon points="711 181 703 177 703 185"></polygon>
+         <a xlink:href="#opt_primary_region_clause" xlink:title="opt_primary_region_clause">
+            <rect x="280" y="167" width="192" height="32"></rect>
+            <rect x="278" y="165" width="192" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="288" y="185">opt_primary_region_clause</text>
+         </a>
+         <a xlink:href="#opt_regions_list" xlink:title="opt_regions_list">
+            <rect x="492" y="167" width="122" height="32"></rect>
+            <rect x="490" y="165" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="500" y="185">opt_regions_list</text>
+         </a>
+         <a xlink:href="#opt_survival_goal_clause" xlink:title="opt_survival_goal_clause">
+            <rect x="513" y="233" width="180" height="32"></rect>
+            <rect x="511" y="231" width="180" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="521" y="251">opt_survival_goal_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m122 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-715 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m152 0 h10 m0 0 h10 m154 0 h10 m0 0 h10 m154 0 h10 m0 0 h10 m148 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-630 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m150 0 h10 m0 0 h10 m192 0 h10 m0 0 h10 m122 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-145 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m180 0 h10 m3 0 h-3"></path>
+         <polygon points="711 247 719 243 719 251"></polygon>
+         <polygon points="711 247 703 243 703 251"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -8638,31 +9075,31 @@
          <rect x="1093" y="155" width="26" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="1103" y="175">)</text>
          <a xlink:href="#opt_storing" xlink:title="opt_storing">
-            <rect x="403" y="267" width="92" height="32"></rect>
-            <rect x="401" y="265" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="411" y="285">opt_storing</text>
+            <rect x="382" y="267" width="92" height="32"></rect>
+            <rect x="380" y="265" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="390" y="285">opt_storing</text>
          </a>
          <a xlink:href="#opt_interleave" xlink:title="opt_interleave">
-            <rect x="515" y="267" width="112" height="32"></rect>
-            <rect x="513" y="265" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="523" y="285">opt_interleave</text>
+            <rect x="494" y="267" width="112" height="32"></rect>
+            <rect x="492" y="265" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="502" y="285">opt_interleave</text>
          </a>
-         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="647" y="267" width="124" height="32"></rect>
-            <rect x="645" y="265" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="655" y="285">opt_partition_by</text>
+         <a xlink:href="#opt_partition_by_index" xlink:title="opt_partition_by_index">
+            <rect x="626" y="267" width="166" height="32"></rect>
+            <rect x="624" y="265" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="634" y="285">opt_partition_by_index</text>
          </a>
          <a xlink:href="#opt_with_storage_parameter_list" xlink:title="opt_with_storage_parameter_list">
-            <rect x="791" y="267" width="232" height="32"></rect>
-            <rect x="789" y="265" width="232" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="799" y="285">opt_with_storage_parameter_list</text>
+            <rect x="812" y="267" width="232" height="32"></rect>
+            <rect x="810" y="265" width="232" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="820" y="285">opt_with_storage_parameter_list</text>
          </a>
          <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
             <rect x="1259" y="333" width="136" height="32"></rect>
             <rect x="1257" y="331" width="136" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="1267" y="351">opt_where_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m188 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m-1376 0 h20 m1356 0 h20 m-1396 0 q10 0 10 10 m1376 0 q0 -10 10 -10 m-1386 10 v68 m1376 0 v-68 m-1376 68 q0 10 10 10 m1356 0 q10 0 10 -10 m-1366 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h260 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-1042 198 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m232 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m192 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m136 0 h10 m3 0 h-3"></path>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m188 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m-1376 0 h20 m1356 0 h20 m-1396 0 q10 0 10 10 m1376 0 q0 -10 10 -10 m-1386 10 v68 m1376 0 v-68 m-1376 68 q0 10 10 10 m1356 0 q10 0 10 -10 m-1366 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m126 0 h10 m0 0 h180 m-346 0 h20 m326 0 h20 m-366 0 q10 0 10 10 m346 0 q0 -10 10 -10 m-356 10 v24 m346 0 v-24 m-346 24 q0 10 10 10 m326 0 q10 0 10 -10 m-336 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m96 0 h10 m20 -44 h10 m40 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h260 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-1063 198 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m166 0 h10 m0 0 h10 m232 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m171 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m136 0 h10 m3 0 h-3"></path>
          <polygon points="1413 347 1421 343 1421 351"></polygon>
          <polygon points="1413 347 1405 343 1405 351"></polygon>
       </svg>
@@ -8690,10 +9127,10 @@
          <rect x="361" y="35" width="68" height="32" rx="10"></rect>
          <rect x="359" y="33" width="68" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="369" y="53">EXISTS</text>
-         <a xlink:href="#schema_name" xlink:title="schema_name">
-            <rect x="45" y="101" width="110" height="32"></rect>
-            <rect x="43" y="99" width="110" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="53" y="119">schema_name</text>
+         <a xlink:href="#qualifiable_schema_name" xlink:title="qualifiable_schema_name">
+            <rect x="45" y="101" width="182" height="32"></rect>
+            <rect x="43" y="99" width="182" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="53" y="119">qualifiable_schema_name</text>
          </a>
          <a xlink:href="#opt_schema_name" xlink:title="opt_schema_name">
             <rect x="45" y="145" width="140" height="32"></rect>
@@ -8708,7 +9145,7 @@
             <rect x="357" y="143" width="80" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="367" y="163">role_spec</text>
          </a>
-         <path class="line" d="m19 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-468 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m110 0 h10 m0 0 h284 m-434 0 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v24 m434 0 v-24 m-434 24 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m140 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m80 0 h10 m23 -44 h-3"></path>
+         <path class="line" d="m19 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-468 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m182 0 h10 m0 0 h212 m-434 0 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v24 m434 0 v-24 m-434 24 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m140 0 h10 m0 0 h10 m134 0 h10 m0 0 h10 m80 0 h10 m23 -44 h-3"></path>
          <polygon points="477 115 485 111 485 119"></polygon>
          <polygon points="477 115 469 111 469 119"></polygon>
       </svg>
@@ -8717,7 +9154,7 @@
             <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_table_stmt" href="#create_table_stmt">create_table_stmt:</a></p>
-      <svg width="676" height="200">
+      <svg width="712" height="200">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -8742,44 +9179,49 @@
          <rect x="565" y="33" width="68" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="575" y="53">EXISTS</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="27" y="101" width="94" height="32"></rect>
-            <rect x="25" y="99" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="35" y="119">table_name</text>
+            <rect x="25" y="101" width="94" height="32"></rect>
+            <rect x="23" y="99" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="33" y="119">table_name</text>
          </a>
-         <rect x="141" y="101" width="26" height="32" rx="10"></rect>
-         <rect x="139" y="99" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="149" y="119">(</text>
+         <rect x="139" y="101" width="26" height="32" rx="10"></rect>
+         <rect x="137" y="99" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="119">(</text>
          <a xlink:href="#opt_table_elem_list" xlink:title="opt_table_elem_list">
-            <rect x="187" y="101" width="144" height="32"></rect>
-            <rect x="185" y="99" width="144" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="195" y="119">opt_table_elem_list</text>
+            <rect x="185" y="101" width="144" height="32"></rect>
+            <rect x="183" y="99" width="144" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="193" y="119">opt_table_elem_list</text>
          </a>
-         <rect x="351" y="101" width="26" height="32" rx="10"></rect>
-         <rect x="349" y="99" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="359" y="119">)</text>
+         <rect x="349" y="101" width="26" height="32" rx="10"></rect>
+         <rect x="347" y="99" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="357" y="119">)</text>
          <a xlink:href="#opt_interleave" xlink:title="opt_interleave">
-            <rect x="397" y="101" width="112" height="32"></rect>
-            <rect x="395" y="99" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="405" y="119">opt_interleave</text>
+            <rect x="395" y="101" width="112" height="32"></rect>
+            <rect x="393" y="99" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="403" y="119">opt_interleave</text>
          </a>
-         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="529" y="101" width="124" height="32"></rect>
-            <rect x="527" y="99" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="537" y="119">opt_partition_by</text>
+         <a xlink:href="#opt_partition_by_table" xlink:title="opt_partition_by_table">
+            <rect x="527" y="101" width="164" height="32"></rect>
+            <rect x="525" y="99" width="164" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="535" y="119">opt_partition_by_table</text>
          </a>
          <a xlink:href="#opt_table_with" xlink:title="opt_table_with">
-            <rect x="309" y="167" width="116" height="32"></rect>
-            <rect x="307" y="165" width="116" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="317" y="185">opt_table_with</text>
+            <rect x="233" y="167" width="116" height="32"></rect>
+            <rect x="231" y="165" width="116" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="241" y="185">opt_table_with</text>
          </a>
          <a xlink:href="#opt_create_table_on_commit" xlink:title="opt_create_table_on_commit">
-            <rect x="445" y="167" width="204" height="32"></rect>
-            <rect x="443" y="165" width="204" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="453" y="185">opt_create_table_on_commit</text>
+            <rect x="369" y="167" width="204" height="32"></rect>
+            <rect x="367" y="165" width="204" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="377" y="185">opt_create_table_on_commit</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m202 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-672 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m144 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-388 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m204 0 h10 m3 0 h-3"></path>
-         <polygon points="667 181 675 177 675 185"></polygon>
-         <polygon points="667 181 659 177 659 185"></polygon>
+         <a xlink:href="#opt_locality" xlink:title="opt_locality">
+            <rect x="593" y="167" width="92" height="32"></rect>
+            <rect x="591" y="165" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="601" y="185">opt_locality</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m202 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-674 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m144 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m164 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-502 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m116 0 h10 m0 0 h10 m204 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"></path>
+         <polygon points="703 181 711 177 711 185"></polygon>
+         <polygon points="703 181 695 177 695 185"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -8847,7 +9289,7 @@
             <li><a href="#create_ddl_stmt" title="create_ddl_stmt">create_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_type_stmt" href="#create_type_stmt">create_type_stmt:</a></p>
-      <svg width="696" height="36">
+      <svg width="738" height="134">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -8857,31 +9299,40 @@
          <rect x="121" y="3" width="54" height="32" rx="10"></rect>
          <rect x="119" y="1" width="54" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="129" y="21">TYPE</text>
+         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="53">IF</text>
+         <rect x="269" y="35" width="48" height="32" rx="10"></rect>
+         <rect x="267" y="33" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="277" y="53">NOT</text>
+         <rect x="337" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="335" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="345" y="53">EXISTS</text>
          <a xlink:href="#type_name" xlink:title="type_name">
-            <rect x="195" y="3" width="90" height="32"></rect>
-            <rect x="193" y="1" width="90" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="203" y="21">type_name</text>
+            <rect x="445" y="3" width="90" height="32"></rect>
+            <rect x="443" y="1" width="90" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="453" y="21">type_name</text>
          </a>
-         <rect x="305" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="303" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="313" y="21">AS</text>
-         <rect x="363" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="361" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="371" y="21">ENUM</text>
-         <rect x="441" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="439" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="449" y="21">(</text>
+         <rect x="555" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="553" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="563" y="21">AS</text>
+         <rect x="613" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="611" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="621" y="21">ENUM</text>
+         <rect x="691" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="689" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="699" y="21">(</text>
          <a xlink:href="#opt_enum_val_list" xlink:title="opt_enum_val_list">
-            <rect x="487" y="3" width="136" height="32"></rect>
-            <rect x="485" y="1" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="495" y="21">opt_enum_val_list</text>
+            <rect x="529" y="101" width="136" height="32"></rect>
+            <rect x="527" y="99" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="537" y="119">opt_enum_val_list</text>
          </a>
-         <rect x="643" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="641" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="651" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="687 17 695 13 695 21"></polygon>
-         <polygon points="687 17 679 13 679 21"></polygon>
+         <rect x="685" y="101" width="26" height="32" rx="10"></rect>
+         <rect x="683" y="99" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="693" y="119">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m54 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m90 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-232 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="729 115 737 111 737 119"></polygon>
+         <polygon points="729 115 721 111 721 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -9176,6 +9627,84 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_schedule_for_backup_stmt" title="create_schedule_for_backup_stmt">create_schedule_for_backup_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="changefeed_targets" href="#changefeed_targets">changefeed_targets:</a></p>
+      <svg width="358" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="35" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="33" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="53">TABLE</text>
+         <a xlink:href="#single_table_pattern_list" xlink:title="single_table_pattern_list">
+            <rect x="153" y="3" width="178" height="32"></rect>
+            <rect x="151" y="1" width="178" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="161" y="21">single_table_pattern_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -32 h10 m178 0 h10 m3 0 h-3"></path>
+         <polygon points="349 17 357 13 357 21"></polygon>
+         <polygon points="349 17 341 13 341 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_changefeed_sink" href="#opt_changefeed_sink">opt_changefeed_sink:</a></p>
+      <svg width="290" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">INTO</text>
+         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
+            <rect x="105" y="3" width="158" height="32"></rect>
+            <rect x="103" y="1" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="113" y="21">string_or_placeholder</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m158 0 h10 m3 0 h-3"></path>
+         <polygon points="281 17 289 13 289 21"></polygon>
+         <polygon points="281 17 273 13 273 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
+            <li><a href="#create_replication_stream_stmt" title="create_replication_stream_stmt">create_replication_stream_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_replication_options" href="#opt_with_replication_options">opt_with_replication_options:</a></p>
+      <svg width="578" height="100">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITH</text>
+         <a xlink:href="#replication_options_list" xlink:title="replication_options_list">
+            <rect x="149" y="23" width="166" height="32"></rect>
+            <rect x="147" y="21" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="157" y="41">replication_options_list</text>
+         </a>
+         <rect x="149" y="67" width="84" height="32" rx="10"></rect>
+         <rect x="147" y="65" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="157" y="85">OPTIONS</text>
+         <rect x="253" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="251" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="85">(</text>
+         <a xlink:href="#replication_options_list" xlink:title="replication_options_list">
+            <rect x="299" y="67" width="166" height="32"></rect>
+            <rect x="297" y="65" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="307" y="85">replication_options_list</text>
+         </a>
+         <rect x="485" y="67" width="26" height="32" rx="10"></rect>
+         <rect x="483" y="65" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="493" y="85">)</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h490 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v12 m520 0 v-12 m-520 12 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m58 0 h10 m20 0 h10 m166 0 h10 m0 0 h196 m-402 0 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v24 m402 0 v-24 m-402 24 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m166 0 h10 m0 0 h10 m26 0 h10 m43 -76 h-3"></path>
+         <polygon points="569 5 577 1 577 9"></polygon>
+         <polygon points="569 5 561 1 561 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_replication_stream_stmt" title="create_replication_stream_stmt">create_replication_stream_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="with_clause" href="#with_clause">with_clause:</a></p>
       <svg width="356" height="68">
@@ -9512,7 +10041,7 @@
             <li><a href="#drop_ddl_stmt" title="drop_ddl_stmt">drop_ddl_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="drop_schema_stmt" href="#drop_schema_stmt">drop_schema_stmt:</a></p>
-      <svg width="654" height="68">
+      <svg width="710" height="68">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -9528,19 +10057,19 @@
          <rect x="279" y="35" width="68" height="32" rx="10"></rect>
          <rect x="277" y="33" width="68" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="287" y="53">EXISTS</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="387" y="3" width="80" height="32"></rect>
-            <rect x="385" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="395" y="21">name_list</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="387" y="3" width="136" height="32"></rect>
+            <rect x="385" y="1" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="395" y="21">schema_name_list</text>
          </a>
          <a xlink:href="#opt_drop_behavior" xlink:title="opt_drop_behavior">
-            <rect x="487" y="3" width="140" height="32"></rect>
-            <rect x="485" y="1" width="140" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="495" y="21">opt_drop_behavior</text>
+            <rect x="543" y="3" width="140" height="32"></rect>
+            <rect x="541" y="1" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="551" y="21">opt_drop_behavior</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m80 0 h10 m0 0 h10 m140 0 h10 m3 0 h-3"></path>
-         <polygon points="645 17 653 13 653 21"></polygon>
-         <polygon points="645 17 637 13 637 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m136 0 h10 m0 0 h10 m140 0 h10 m3 0 h-3"></path>
+         <polygon points="701 17 709 13 709 21"></polygon>
+         <polygon points="701 17 693 13 693 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -9599,6 +10128,31 @@
          </p><ul>
             <li><a href="#explain_option_list" title="explain_option_list">explain_option_list</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="non_reserved_word_or_sconst" href="#non_reserved_word_or_sconst">non_reserved_word_or_sconst:</a></p>
+      <svg width="246" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#non_reserved_word" xlink:title="non_reserved_word">
+            <rect x="51" y="3" width="148" height="32"></rect>
+            <rect x="49" y="1" width="148" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">non_reserved_word</text>
+         </a>
+         <rect x="51" y="47" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SCONST</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m148 0 h10 m-188 0 h20 m168 0 h20 m-208 0 q10 0 10 10 m188 0 q0 -10 10 -10 m-198 10 v24 m188 0 v-24 m-188 24 q0 10 10 10 m168 0 q10 0 10 -10 m-178 10 h10 m76 0 h10 m0 0 h72 m23 -44 h-3"></path>
+         <polygon points="237 17 245 13 245 21"></polygon>
+         <polygon points="237 17 229 13 229 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_encoding_clause" title="opt_encoding_clause">opt_encoding_clause</a></li>
+            <li><a href="#opt_lc_collate_clause" title="opt_lc_collate_clause">opt_lc_collate_clause</a></li>
+            <li><a href="#opt_lc_ctype_clause" title="opt_lc_ctype_clause">opt_lc_ctype_clause</a></li>
+            <li><a href="#opt_template_clause" title="opt_template_clause">opt_template_clause</a></li>
+            <li><a href="#string_or_placeholder" title="string_or_placeholder">string_or_placeholder</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="kv_option_list" href="#kv_option_list">kv_option_list:</a></p>
       <svg width="180" height="80">
          
@@ -9646,6 +10200,11 @@
             <rect x="49" y="133" width="122" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="153">table_constraint</text>
          </a>
+         <a xlink:href="#opt_validate_behavior" xlink:title="opt_validate_behavior">
+            <rect x="193" y="135" width="162" height="32"></rect>
+            <rect x="191" y="133" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="201" y="153">opt_validate_behavior</text>
+         </a>
          <rect x="51" y="179" width="50" height="32" rx="10"></rect>
          <rect x="49" y="177" width="50" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="197">LIKE</text>
@@ -9659,7 +10218,7 @@
             <rect x="233" y="177" width="154" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="243" y="197">like_table_option_list</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m92 0 h10 m0 0 h246 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m82 0 h10 m0 0 h256 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m84 0 h10 m0 0 h254 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m122 0 h10 m0 0 h216 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m50 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m154 0 h10 m23 -176 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m92 0 h10 m0 0 h246 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m82 0 h10 m0 0 h256 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m84 0 h10 m0 0 h254 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h34 m-368 -10 v20 m378 0 v-20 m-378 20 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m50 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m154 0 h10 m23 -176 h-3"></path>
          <polygon points="427 17 435 13 435 21"></polygon>
          <polygon points="427 17 419 13 419 21"></polygon>
       </svg>
@@ -10132,9 +10691,28 @@
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#show_queries_stmt" title="show_queries_stmt">show_queries_stmt</a></li>
             <li><a href="#show_sessions_stmt" title="show_sessions_stmt">show_sessions_stmt</a></li>
+            <li><a href="#show_statements_stmt" title="show_statements_stmt">show_statements_stmt</a></li>
             <li><a href="#show_transactions_stmt" title="show_transactions_stmt">show_transactions_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="statements_or_queries" href="#statements_or_queries">statements_or_queries:</a></p>
+      <svg width="206" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">STATEMENTS</text>
+         <rect x="51" y="47" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">QUERIES</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m108 0 h10 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m80 0 h10 m0 0 h28 m23 -44 h-3"></path>
+         <polygon points="197 17 205 13 205 21"></polygon>
+         <polygon points="197 17 189 13 189 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#show_statements_stmt" title="show_statements_stmt">show_statements_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_compact" href="#opt_compact">opt_compact:</a></p>
       <svg width="184" height="56">
@@ -10251,8 +10829,12 @@
             <li><a href="#alter_rename_sequence_stmt" title="alter_rename_sequence_stmt">alter_rename_sequence_stmt</a></li>
             <li><a href="#alter_rename_table_stmt" title="alter_rename_table_stmt">alter_rename_table_stmt</a></li>
             <li><a href="#alter_rename_view_stmt" title="alter_rename_view_stmt">alter_rename_view_stmt</a></li>
+            <li><a href="#alter_sequence_owner_stmt" title="alter_sequence_owner_stmt">alter_sequence_owner_stmt</a></li>
             <li><a href="#alter_sequence_set_schema_stmt" title="alter_sequence_set_schema_stmt">alter_sequence_set_schema_stmt</a></li>
+            <li><a href="#alter_table_locality_stmt" title="alter_table_locality_stmt">alter_table_locality_stmt</a></li>
+            <li><a href="#alter_table_owner_stmt" title="alter_table_owner_stmt">alter_table_owner_stmt</a></li>
             <li><a href="#alter_table_set_schema_stmt" title="alter_table_set_schema_stmt">alter_table_set_schema_stmt</a></li>
+            <li><a href="#alter_view_owner_stmt" title="alter_view_owner_stmt">alter_view_owner_stmt</a></li>
             <li><a href="#alter_view_set_schema_stmt" title="alter_view_set_schema_stmt">alter_view_set_schema_stmt</a></li>
             <li><a href="#relation_expr_list" title="relation_expr_list">relation_expr_list</a></li>
             <li><a href="#table_ref" title="table_ref">table_ref</a></li>
@@ -10357,27 +10939,36 @@
             <li><a href="#db_object_name" title="db_object_name">db_object_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="copy_options" href="#copy_options">copy_options:</a></p>
-      <svg width="440" height="80">
+      <svg width="480" height="212">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="114" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="114" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">DESTINATION</text>
-         <rect x="185" y="3" width="30" height="32" rx="10"></rect>
-         <rect x="183" y="1" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="193" y="21">=</text>
+         <rect x="71" y="3" width="114" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">DESTINATION</text>
+         <rect x="205" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="203" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="213" y="21">=</text>
+         <rect x="71" y="47" width="94" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">DELIMITER</text>
+         <rect x="71" y="91" width="56" height="32" rx="10"></rect>
+         <rect x="69" y="89" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="109">NULL</text>
          <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="235" y="3" width="158" height="32"></rect>
-            <rect x="233" y="1" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="243" y="21">string_or_placeholder</text>
+            <rect x="275" y="3" width="158" height="32"></rect>
+            <rect x="273" y="1" width="158" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="283" y="21">string_or_placeholder</text>
          </a>
-         <rect x="51" y="47" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">BINARY</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m114 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m158 0 h10 m-382 0 h20 m362 0 h20 m-402 0 q10 0 10 10 m382 0 q0 -10 10 -10 m-392 10 v24 m382 0 v-24 m-382 24 q0 10 10 10 m362 0 q10 0 10 -10 m-372 10 h10 m72 0 h10 m0 0 h270 m23 -44 h-3"></path>
-         <polygon points="431 17 439 13 439 21"></polygon>
-         <polygon points="431 17 423 13 423 21"></polygon>
+         <rect x="51" y="135" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">BINARY</text>
+         <rect x="51" y="179" width="46" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">CSV</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m114 0 h10 m0 0 h10 m30 0 h10 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m94 0 h10 m0 0 h70 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m56 0 h10 m0 0 h108 m20 -88 h10 m158 0 h10 m-422 0 h20 m402 0 h20 m-442 0 q10 0 10 10 m422 0 q0 -10 10 -10 m-432 10 v112 m422 0 v-112 m-422 112 q0 10 10 10 m402 0 q10 0 10 -10 m-412 10 h10 m72 0 h10 m0 0 h310 m-412 -10 v20 m422 0 v-20 m-422 20 v24 m422 0 v-24 m-422 24 q0 10 10 10 m402 0 q10 0 10 -10 m-412 10 h10 m46 0 h10 m0 0 h336 m23 -176 h-3"></path>
+         <polygon points="471 17 479 13 479 21"></polygon>
+         <polygon points="471 17 463 13 463 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -10543,6 +11134,7 @@
          </p><ul>
             <li><a href="#explain_option_name" title="explain_option_name">explain_option_name</a></li>
             <li><a href="#non_reserved_word_or_sconst" title="non_reserved_word_or_sconst">non_reserved_word_or_sconst</a></li>
+            <li><a href="#username_or_sconst" title="username_or_sconst">username_or_sconst</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="transaction_mode" href="#transaction_mode">transaction_mode:</a></p>
       <svg width="304" height="168">
@@ -10873,6 +11465,85 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-160 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m3 0 h-3"></path>
          <polygon points="653 115 661 111 661 119"></polygon>
          <polygon points="653 115 645 111 645 119"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_stmt" title="alter_table_stmt">alter_table_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_locality_stmt" href="#alter_table_locality_stmt">alter_table_locality_stmt:</a></p>
+      <svg width="654" height="68">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">TABLE</text>
+         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="53">IF</text>
+         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="277" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="377" y="3" width="104" height="32"></rect>
+            <rect x="375" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="385" y="21">relation_expr</text>
+         </a>
+         <rect x="501" y="3" width="44" height="32" rx="10"></rect>
+         <rect x="499" y="1" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="21">SET</text>
+         <a xlink:href="#locality" xlink:title="locality">
+            <rect x="565" y="3" width="62" height="32"></rect>
+            <rect x="563" y="1" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="573" y="21">locality</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m62 0 h10 m3 0 h-3"></path>
+         <polygon points="645 17 653 13 653 21"></polygon>
+         <polygon points="645 17 637 13 637 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_stmt" title="alter_table_stmt">alter_table_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_owner_stmt" href="#alter_table_owner_stmt">alter_table_owner_stmt:</a></p>
+      <svg width="652" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">TABLE</text>
+         <rect x="215" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="213" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="53">IF</text>
+         <rect x="269" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="267" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="277" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="377" y="3" width="104" height="32"></rect>
+            <rect x="375" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="385" y="21">relation_expr</text>
+         </a>
+         <rect x="501" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="499" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="509" y="21">OWNER</text>
+         <rect x="593" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="591" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="601" y="21">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="545" y="101" width="80" height="32"></rect>
+            <rect x="543" y="99" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="553" y="119">role_spec</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-130 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="643 115 651 111 651 119"></polygon>
+         <polygon points="643 115 635 111 635 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -11210,6 +11881,50 @@
          </p><ul>
             <li><a href="#alter_view_stmt" title="alter_view_stmt">alter_view_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_view_owner_stmt" href="#alter_view_owner_stmt">alter_view_owner_stmt:</a></p>
+      <svg width="676" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="133" y="35" width="120" height="32" rx="10"></rect>
+         <rect x="131" y="33" width="120" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="53">MATERIALIZED</text>
+         <rect x="293" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="291" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="301" y="21">VIEW</text>
+         <rect x="389" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="387" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="397" y="53">IF</text>
+         <rect x="443" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="441" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="451" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="551" y="3" width="104" height="32"></rect>
+            <rect x="549" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="559" y="21">relation_expr</text>
+         </a>
+         <rect x="419" y="101" width="72" height="32" rx="10"></rect>
+         <rect x="417" y="99" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="427" y="119">OWNER</text>
+         <rect x="511" y="101" width="38" height="32" rx="10"></rect>
+         <rect x="509" y="99" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="519" y="119">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="569" y="101" width="80" height="32"></rect>
+            <rect x="567" y="99" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="577" y="119">role_spec</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m56 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-280 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="667 115 675 111 675 119"></polygon>
+         <polygon points="667 115 659 111 659 119"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_view_stmt" title="alter_view_stmt">alter_view_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_rename_sequence_stmt" href="#alter_rename_sequence_stmt">alter_rename_sequence_stmt:</a></p>
       <svg width="684" height="134">
          
@@ -11322,6 +12037,47 @@
          <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-160 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m3 0 h-3"></path>
          <polygon points="683 115 691 111 691 119"></polygon>
          <polygon points="683 115 675 111 675 119"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_sequence_stmt" title="alter_sequence_stmt">alter_sequence_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_sequence_owner_stmt" href="#alter_sequence_owner_stmt">alter_sequence_owner_stmt:</a></p>
+      <svg width="682" height="134">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="92" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">SEQUENCE</text>
+         <rect x="245" y="35" width="34" height="32" rx="10"></rect>
+         <rect x="243" y="33" width="34" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="253" y="53">IF</text>
+         <rect x="299" y="35" width="68" height="32" rx="10"></rect>
+         <rect x="297" y="33" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="307" y="53">EXISTS</text>
+         <a xlink:href="#relation_expr" xlink:title="relation_expr">
+            <rect x="407" y="3" width="104" height="32"></rect>
+            <rect x="405" y="1" width="104" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="415" y="21">relation_expr</text>
+         </a>
+         <rect x="531" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="529" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="539" y="21">OWNER</text>
+         <rect x="623" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="621" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="631" y="21">TO</text>
+         <a xlink:href="#role_spec" xlink:title="role_spec">
+            <rect x="575" y="101" width="80" height="32"></rect>
+            <rect x="573" y="99" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="583" y="119">role_spec</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m104 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-130 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="673 115 681 111 681 119"></polygon>
+         <polygon points="673 115 665 111 665 119"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -11470,6 +12226,134 @@
          </p><ul>
             <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_add_region_stmt" href="#alter_database_add_region_stmt">alter_database_add_region_stmt:</a></p>
+      <svg width="656" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="223" y="3" width="122" height="32"></rect>
+            <rect x="221" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="21">database_name</text>
+         </a>
+         <rect x="365" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="363" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="21">ADD</text>
+         <rect x="433" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="431" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="441" y="21">REGION</text>
+         <a xlink:href="#region_name" xlink:title="region_name">
+            <rect x="527" y="3" width="102" height="32"></rect>
+            <rect x="525" y="1" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="535" y="21">region_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m102 0 h10 m3 0 h-3"></path>
+         <polygon points="647 17 655 13 655 21"></polygon>
+         <polygon points="647 17 639 13 639 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_drop_region_stmt" href="#alter_database_drop_region_stmt">alter_database_drop_region_stmt:</a></p>
+      <svg width="666" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="223" y="3" width="122" height="32"></rect>
+            <rect x="221" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="21">database_name</text>
+         </a>
+         <rect x="365" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="363" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="373" y="21">DROP</text>
+         <rect x="443" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="441" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="451" y="21">REGION</text>
+         <a xlink:href="#region_name" xlink:title="region_name">
+            <rect x="537" y="3" width="102" height="32"></rect>
+            <rect x="535" y="1" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="545" y="21">region_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m102 0 h10 m3 0 h-3"></path>
+         <polygon points="657 17 665 13 665 21"></polygon>
+         <polygon points="657 17 649 13 649 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_survival_goal_stmt" href="#alter_database_survival_goal_stmt">alter_database_survival_goal_stmt:</a></p>
+      <svg width="542" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="223" y="3" width="122" height="32"></rect>
+            <rect x="221" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="21">database_name</text>
+         </a>
+         <a xlink:href="#survival_goal_clause" xlink:title="survival_goal_clause">
+            <rect x="365" y="3" width="150" height="32"></rect>
+            <rect x="363" y="1" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="21">survival_goal_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m150 0 h10 m3 0 h-3"></path>
+         <polygon points="533 17 541 13 541 21"></polygon>
+         <polygon points="533 17 525 13 525 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_database_primary_region_stmt" href="#alter_database_primary_region_stmt">alter_database_primary_region_stmt:</a></p>
+      <svg width="554" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="62" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">ALTER</text>
+         <rect x="113" y="3" width="90" height="32" rx="10"></rect>
+         <rect x="111" y="1" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="121" y="21">DATABASE</text>
+         <a xlink:href="#database_name" xlink:title="database_name">
+            <rect x="223" y="3" width="122" height="32"></rect>
+            <rect x="221" y="1" width="122" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="231" y="21">database_name</text>
+         </a>
+         <a xlink:href="#primary_region_clause" xlink:title="primary_region_clause">
+            <rect x="365" y="3" width="162" height="32"></rect>
+            <rect x="363" y="1" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="373" y="21">primary_region_clause</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m162 0 h10 m3 0 h-3"></path>
+         <polygon points="545 17 553 13 553 21"></polygon>
+         <polygon points="545 17 537 13 537 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_stmt" title="alter_database_stmt">alter_database_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_zone_range_stmt" href="#alter_zone_range_stmt">alter_zone_range_stmt:</a></p>
       <svg width="464" height="36">
          
@@ -11579,7 +12463,6 @@
             <li><a href="#alter_table_set_schema_stmt" title="alter_table_set_schema_stmt">alter_table_set_schema_stmt</a></li>
             <li><a href="#alter_type_stmt" title="alter_type_stmt">alter_type_stmt</a></li>
             <li><a href="#alter_view_set_schema_stmt" title="alter_view_set_schema_stmt">alter_view_set_schema_stmt</a></li>
-            <li><a href="#create_schema_stmt" title="create_schema_stmt">create_schema_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_add_val_placement" href="#opt_add_val_placement">opt_add_val_placement:</a></p>
       <svg width="306" height="100">
@@ -11973,48 +12856,6 @@
          </p><ul>
             <li><a href="#a_expr" title="a_expr">a_expr</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="changefeed_targets" href="#changefeed_targets">changefeed_targets:</a></p>
-      <svg width="358" height="68">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="35" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="33" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="53">TABLE</text>
-         <a xlink:href="#single_table_pattern_list" xlink:title="single_table_pattern_list">
-            <rect x="153" y="3" width="178" height="32"></rect>
-            <rect x="151" y="1" width="178" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="161" y="21">single_table_pattern_list</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m20 -32 h10 m178 0 h10 m3 0 h-3"></path>
-         <polygon points="349 17 357 13 357 21"></polygon>
-         <polygon points="349 17 341 13 341 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_changefeed_sink" href="#opt_changefeed_sink">opt_changefeed_sink:</a></p>
-      <svg width="290" height="36">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="54" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">INTO</text>
-         <a xlink:href="#string_or_placeholder" xlink:title="string_or_placeholder">
-            <rect x="105" y="3" width="158" height="32"></rect>
-            <rect x="103" y="1" width="158" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="113" y="21">string_or_placeholder</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m0 0 h10 m158 0 h10 m3 0 h-3"></path>
-         <polygon points="281 17 289 13 289 21"></polygon>
-         <polygon points="281 17 273 13 273 21"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#create_changefeed_stmt" title="create_changefeed_stmt">create_changefeed_stmt</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_template_clause" href="#opt_template_clause">opt_template_clause:</a></p>
       <svg width="528" height="56">
          
@@ -12143,6 +12984,68 @@
          <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h430 m-460 0 h20 m440 0 h20 m-480 0 q10 0 10 10 m460 0 q0 -10 10 -10 m-470 10 v12 m460 0 v-12 m-460 12 q0 10 10 10 m440 0 q10 0 10 -10 m-450 10 h10 m112 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m106 0 h10 m23 -32 h-3"></path>
          <polygon points="509 5 517 1 517 9"></polygon>
          <polygon points="509 5 501 1 501 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_database_stmt" title="create_database_stmt">create_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_primary_region_clause" href="#opt_primary_region_clause">opt_primary_region_clause:</a></p>
+      <svg width="260" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#primary_region_clause" xlink:title="primary_region_clause">
+            <rect x="51" y="23" width="162" height="32"></rect>
+            <rect x="49" y="21" width="162" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">primary_region_clause</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h172 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v12 m202 0 v-12 m-202 12 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m162 0 h10 m23 -32 h-3"></path>
+         <polygon points="251 5 259 1 259 9"></polygon>
+         <polygon points="251 5 243 1 243 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_database_stmt" title="create_database_stmt">create_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_regions_list" href="#opt_regions_list">opt_regions_list:</a></p>
+      <svg width="432" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">REGIONS</text>
+         <a xlink:href="#opt_equal" xlink:title="opt_equal">
+            <rect x="153" y="23" width="84" height="32"></rect>
+            <rect x="151" y="21" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="161" y="41">opt_equal</text>
+         </a>
+         <a xlink:href="#region_name_list" xlink:title="region_name_list">
+            <rect x="257" y="23" width="128" height="32"></rect>
+            <rect x="255" y="21" width="128" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="265" y="41">region_name_list</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h344 m-374 0 h20 m354 0 h20 m-394 0 q10 0 10 10 m374 0 q0 -10 10 -10 m-384 10 v12 m374 0 v-12 m-374 12 q0 10 10 10 m354 0 q10 0 10 -10 m-364 10 h10 m82 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m128 0 h10 m23 -32 h-3"></path>
+         <polygon points="423 5 431 1 431 9"></polygon>
+         <polygon points="423 5 415 1 415 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_database_stmt" title="create_database_stmt">create_database_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_survival_goal_clause" href="#opt_survival_goal_clause">opt_survival_goal_clause:</a></p>
+      <svg width="248" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#survival_goal_clause" xlink:title="survival_goal_clause">
+            <rect x="51" y="23" width="150" height="32"></rect>
+            <rect x="49" y="21" width="150" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">survival_goal_clause</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h160 m-190 0 h20 m170 0 h20 m-210 0 q10 0 10 10 m190 0 q0 -10 10 -10 m-200 10 v12 m190 0 v-12 m-190 12 q0 10 10 10 m170 0 q10 0 10 -10 m-180 10 h10 m150 0 h10 m23 -32 h-3"></path>
+         <polygon points="239 5 247 1 247 9"></polygon>
+         <polygon points="239 5 231 1 231 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -12337,7 +13240,7 @@
             <li><a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</a></li>
             <li><a href="#index_def" title="index_def">index_def</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_partition_by" href="#opt_partition_by">opt_partition_by:</a></p>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_partition_by_index" href="#opt_partition_by_index">opt_partition_by_index:</a></p>
       <svg width="194" height="56">
          
          <polygon points="9 5 1 1 1 9"></polygon>
@@ -12355,10 +13258,7 @@
          </p><ul>
             <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
             <li><a href="#create_index_stmt" title="create_index_stmt">create_index_stmt</a></li>
-            <li><a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</a></li>
             <li><a href="#index_def" title="index_def">index_def</a></li>
-            <li><a href="#list_partition" title="list_partition">list_partition</a></li>
-            <li><a href="#range_partition" title="range_partition">range_partition</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_with_storage_parameter_list" href="#opt_with_storage_parameter_list">opt_with_storage_parameter_list:</a></p>
       <svg width="396" height="36">
@@ -12390,18 +13290,18 @@
             <li><a href="#opt_table_with" title="opt_table_with">opt_table_with</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_schema_name" href="#opt_schema_name">opt_schema_name:</a></p>
-      <svg width="142" height="36">
+      <svg width="280" height="56">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#opt_name" xlink:title="opt_name">
-            <rect x="31" y="3" width="84" height="32"></rect>
-            <rect x="29" y="1" width="84" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">opt_name</text>
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#qualifiable_schema_name" xlink:title="qualifiable_schema_name">
+            <rect x="51" y="23" width="182" height="32"></rect>
+            <rect x="49" y="21" width="182" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">qualifiable_schema_name</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m84 0 h10 m3 0 h-3"></path>
-         <polygon points="133 17 141 13 141 21"></polygon>
-         <polygon points="133 17 125 13 125 21"></polygon>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h192 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v12 m222 0 v-12 m-222 12 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m182 0 h10 m23 -32 h-3"></path>
+         <polygon points="271 5 279 1 279 9"></polygon>
+         <polygon points="271 5 263 1 263 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -12459,6 +13359,24 @@
          </p><ul>
             <li><a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_partition_by_table" href="#opt_partition_by_table">opt_partition_by_table:</a></p>
+      <svg width="234" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#partition_by_table" xlink:title="partition_by_table">
+            <rect x="51" y="23" width="136" height="32"></rect>
+            <rect x="49" y="21" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">partition_by_table</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m136 0 h10 m23 -32 h-3"></path>
+         <polygon points="225 5 233 1 233 9"></polygon>
+         <polygon points="225 5 217 1 217 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_table_with" href="#opt_table_with">opt_table_with:</a></p>
       <svg width="290" height="36">
          
@@ -12502,6 +13420,24 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_table_as_stmt" title="create_table_as_stmt">create_table_as_stmt</a></li>
+            <li><a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_locality" href="#opt_locality">opt_locality:</a></p>
+      <svg width="160" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#locality" xlink:title="locality">
+            <rect x="51" y="23" width="62" height="32"></rect>
+            <rect x="49" y="21" width="62" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">locality</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h72 m-102 0 h20 m82 0 h20 m-122 0 q10 0 10 10 m102 0 q0 -10 10 -10 m-112 10 v12 m102 0 v-12 m-102 12 q0 10 10 10 m82 0 q10 0 10 -10 m-92 10 h10 m62 0 h10 m23 -32 h-3"></path>
+         <polygon points="151 5 159 1 159 9"></polygon>
+         <polygon points="151 5 143 1 143 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
             <li><a href="#create_table_stmt" title="create_table_stmt">create_table_stmt</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_as_opt_col_list" href="#create_as_opt_col_list">create_as_opt_col_list:</a></p>
@@ -12604,6 +13540,48 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#create_sequence_stmt" title="create_sequence_stmt">create_sequence_stmt</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="single_table_pattern_list" href="#single_table_pattern_list">single_table_pattern_list:</a></p>
+      <svg width="192" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#table_name" xlink:title="table_name">
+            <rect x="51" y="47" width="94" height="32"></rect>
+            <rect x="49" y="45" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">table_name</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m23 44 h-3"></path>
+         <polygon points="183 61 191 57 191 65"></polygon>
+         <polygon points="183 61 175 57 175 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#changefeed_targets" title="changefeed_targets">changefeed_targets</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="replication_options_list" href="#replication_options_list">replication_options_list:</a></p>
+      <svg width="238" height="80">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#replication_options" xlink:title="replication_options">
+            <rect x="51" y="47" width="140" height="32"></rect>
+            <rect x="49" y="45" width="140" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">replication_options</text>
+         </a>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m140 0 h10 m-180 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m160 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-160 0 h10 m24 0 h10 m0 0 h116 m23 44 h-3"></path>
+         <polygon points="229 61 237 57 237 65"></polygon>
+         <polygon points="229 61 221 57 221 65"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_with_replication_options" title="opt_with_replication_options">opt_with_replication_options</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="cte_list" href="#cte_list">cte_list:</a></p>
       <svg width="246" height="80">
@@ -12926,7 +13904,7 @@
             <li><a href="#table_elem" title="table_elem">table_elem</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="index_def" href="#index_def">index_def:</a></p>
-      <svg width="1202" height="178">
+      <svg width="1058" height="178">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -12967,11 +13945,6 @@
             <rect x="903" y="1" width="112" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="913" y="21">opt_interleave</text>
          </a>
-         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="1037" y="3" width="124" height="32"></rect>
-            <rect x="1035" y="1" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="1045" y="21">opt_partition_by</text>
-         </a>
          <rect x="51" y="79" width="88" height="32" rx="10"></rect>
          <rect x="49" y="77" width="88" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="97">INVERTED</text>
@@ -12994,19 +13967,24 @@
          <rect x="519" y="79" width="26" height="32" rx="10"></rect>
          <rect x="517" y="77" width="26" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="527" y="97">)</text>
+         <a xlink:href="#opt_partition_by_index" xlink:title="opt_partition_by_index">
+            <rect x="457" y="145" width="166" height="32"></rect>
+            <rect x="455" y="143" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="465" y="163">opt_partition_by_index</text>
+         </a>
          <a xlink:href="#opt_with_storage_parameter_list" xlink:title="opt_with_storage_parameter_list">
-            <rect x="787" y="145" width="232" height="32"></rect>
-            <rect x="785" y="143" width="232" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="795" y="163">opt_with_storage_parameter_list</text>
+            <rect x="643" y="145" width="232" height="32"></rect>
+            <rect x="641" y="143" width="232" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="651" y="163">opt_with_storage_parameter_list</text>
          </a>
          <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
-            <rect x="1039" y="145" width="136" height="32"></rect>
-            <rect x="1037" y="143" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="1047" y="163">opt_where_clause</text>
+            <rect x="895" y="145" width="136" height="32"></rect>
+            <rect x="893" y="143" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="903" y="163">opt_where_clause</text>
          </a>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m62 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m-1150 0 h20 m1130 0 h20 m-1170 0 q10 0 10 10 m1150 0 q0 -10 10 -10 m-1160 10 v56 m1150 0 v-56 m-1150 56 q0 10 10 10 m1130 0 q10 0 10 -10 m-1140 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h616 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-438 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m232 0 h10 m0 0 h10 m136 0 h10 m3 0 h-3"></path>
-         <polygon points="1193 159 1201 155 1201 163"></polygon>
-         <polygon points="1193 159 1185 155 1185 163"></polygon>
+         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h84 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v12 m114 0 v-12 m-114 12 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -32 h10 m62 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m-1006 0 h20 m986 0 h20 m-1026 0 q10 0 10 10 m1006 0 q0 -10 10 -10 m-1016 10 v56 m1006 0 v-56 m-1006 56 q0 10 10 10 m986 0 q10 0 10 -10 m-996 10 h10 m88 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h472 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-624 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m166 0 h10 m0 0 h10 m232 0 h10 m0 0 h10 m136 0 h10 m3 0 h-3"></path>
+         <polygon points="1049 159 1057 155 1057 163"></polygon>
+         <polygon points="1049 159 1041 155 1041 163"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -13066,6 +14044,26 @@
          <path class="line" d="m17 17 h2 m20 0 h10 m0 0 h264 m-294 0 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v12 m294 0 v-12 m-294 12 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m108 0 h10 m0 0 h10 m126 0 h10 m20 -32 h10 m120 0 h10 m3 0 h-3"></path>
          <polygon points="483 17 491 13 491 21"></polygon>
          <polygon points="483 17 475 13 475 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+            <li><a href="#table_elem" title="table_elem">table_elem</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_validate_behavior" href="#opt_validate_behavior">opt_validate_behavior:</a></p>
+      <svg width="228" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">NOT</text>
+         <rect x="119" y="23" width="62" height="32" rx="10"></rect>
+         <rect x="117" y="21" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="127" y="41">VALID</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m48 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
+         <polygon points="219 5 227 1 227 9"></polygon>
+         <polygon points="219 5 211 1 211 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -13460,20 +14458,25 @@
             <li><a href="#var_value" title="var_value">var_value</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="targets_roles" href="#targets_roles">targets_roles:</a></p>
-      <svg width="314" height="168">
+      <svg width="330" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="69" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="21">ROLE</text>
-         <rect x="71" y="47" width="76" height="32" rx="10"></rect>
-         <rect x="69" y="45" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="65">SCHEMA</text>
+         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">ROLE</text>
          <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="187" y="3" width="80" height="32"></rect>
-            <rect x="185" y="1" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="195" y="21">name_list</text>
+            <rect x="127" y="3" width="80" height="32"></rect>
+            <rect x="125" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="135" y="21">name_list</text>
+         </a>
+         <rect x="51" y="47" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">SCHEMA</text>
+         <a xlink:href="#schema_name_list" xlink:title="schema_name_list">
+            <rect x="147" y="47" width="136" height="32"></rect>
+            <rect x="145" y="45" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="155" y="65">schema_name_list</text>
          </a>
          <rect x="51" y="91" width="54" height="32" rx="10"></rect>
          <rect x="49" y="89" width="54" height="32" class="terminal" rx="10"></rect>
@@ -13488,9 +14491,9 @@
             <rect x="49" y="133" width="66" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="59" y="153">targets</text>
          </a>
-         <path class="line" d="m17 17 h2 m40 0 h10 m56 0 h10 m0 0 h20 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m20 -44 h10 m80 0 h10 m-256 0 h20 m236 0 h20 m-276 0 q10 0 10 10 m256 0 q0 -10 10 -10 m-266 10 v68 m256 0 v-68 m-256 68 q0 10 10 10 m236 0 q10 0 10 -10 m-246 10 h10 m54 0 h10 m0 0 h10 m116 0 h10 m0 0 h26 m-246 -10 v20 m256 0 v-20 m-256 20 v24 m256 0 v-24 m-256 24 q0 10 10 10 m236 0 q10 0 10 -10 m-246 10 h10 m66 0 h10 m0 0 h150 m23 -132 h-3"></path>
-         <polygon points="305 17 313 13 313 21"></polygon>
-         <polygon points="305 17 297 13 297 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h10 m80 0 h10 m0 0 h76 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m76 0 h10 m0 0 h10 m136 0 h10 m-262 -10 v20 m272 0 v-20 m-272 20 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m54 0 h10 m0 0 h10 m116 0 h10 m0 0 h42 m-262 -10 v20 m272 0 v-20 m-272 20 v24 m272 0 v-24 m-272 24 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m66 0 h10 m0 0 h166 m23 -132 h-3"></path>
+         <polygon points="321 17 329 13 329 21"></polygon>
+         <polygon points="321 17 313 13 313 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -13707,7 +14710,7 @@
             <li><a href="#unrestricted_name" title="unrestricted_name">unrestricted_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="reserved_keyword" href="#reserved_keyword">reserved_keyword:</a></p>
-      <svg width="362" height="3512">
+      <svg width="362" height="3556">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -13936,24 +14939,27 @@
          <rect x="51" y="3259" width="86" height="32" rx="10"></rect>
          <rect x="49" y="3257" width="86" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="3277">VARIADIC</text>
-         <rect x="51" y="3303" width="62" height="32" rx="10"></rect>
-         <rect x="49" y="3301" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3321">WHEN</text>
-         <rect x="51" y="3347" width="68" height="32" rx="10"></rect>
-         <rect x="49" y="3345" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3365">WHERE</text>
-         <rect x="51" y="3391" width="84" height="32" rx="10"></rect>
-         <rect x="49" y="3389" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3409">WINDOW</text>
-         <rect x="51" y="3435" width="58" height="32" rx="10"></rect>
-         <rect x="49" y="3433" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="3453">WITH</text>
+         <rect x="51" y="3303" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="3301" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3321">VISIBLE</text>
+         <rect x="51" y="3347" width="62" height="32" rx="10"></rect>
+         <rect x="49" y="3345" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3365">WHEN</text>
+         <rect x="51" y="3391" width="68" height="32" rx="10"></rect>
+         <rect x="49" y="3389" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3409">WHERE</text>
+         <rect x="51" y="3435" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="3433" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3453">WINDOW</text>
+         <rect x="51" y="3479" width="58" height="32" rx="10"></rect>
+         <rect x="49" y="3477" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="3497">WITH</text>
          <a xlink:href="#cockroachdb_extra_reserved_keyword" xlink:title="cockroachdb_extra_reserved_keyword">
-            <rect x="51" y="3479" width="264" height="32"></rect>
-            <rect x="49" y="3477" width="264" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="3497">cockroachdb_extra_reserved_keyword</text>
+            <rect x="51" y="3523" width="264" height="32"></rect>
+            <rect x="49" y="3521" width="264" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="3541">cockroachdb_extra_reserved_keyword</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h220 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m38 0 h10 m0 0 h226 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m46 0 h10 m0 0 h218 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m110 0 h10 m0 0 h154 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m64 0 h10 m0 0 h200 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m78 0 h10 m0 0 h186 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m130 0 h10 m0 0 h134 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m108 0 h10 m0 0 h156 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m70 0 h10 m0 0 h194 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m156 0 h10 m0 0 h108 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m126 0 h10 m0 0 h138 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m128 0 h10 m0 0 h136 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m148 0 h10 m0 0 h116 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m124 0 h10 m0 0 h140 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m170 0 h10 m0 0 h94 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m128 0 h10 m0 0 h136 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m106 0 h10 m0 0 h158 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m86 0 h10 m0 0 h178 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m40 0 h10 m0 0 h224 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m52 0 h10 m0 0 h212 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m70 0 h10 m0 0 h194 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m68 0 h10 m0 0 h196 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m74 0 h10 m0 0 h190 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m36 0 h10 m0 0 h228 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m90 0 h10 m0 0 h174 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m94 0 h10 m0 0 h170 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m78 0 h10 m0 0 h186 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m98 0 h10 m0 0 h166 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m144 0 h10 m0 0 h120 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m72 0 h10 m0 0 h192 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m40 0 h10 m0 0 h224 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m40 0 h10 m0 0 h224 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m106 0 h10 m0 0 h158 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m100 0 h10 m0 0 h164 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m70 0 h10 m0 0 h194 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m126 0 h10 m0 0 h138 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m100 0 h10 m0 0 h164 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m38 0 h10 m0 0 h226 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m86 0 h10 m0 0 h178 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m74 0 h10 m0 0 h190 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m64 0 h10 m0 0 h200 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m86 0 h10 m0 0 h178 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m68 0 h10 m0 0 h196 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m84 0 h10 m0 0 h180 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m264 0 h10 m23 -3476 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m44 0 h10 m0 0 h220 m-304 0 h20 m284 0 h20 m-324 0 q10 0 10 10 m304 0 q0 -10 10 -10 m-314 10 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m38 0 h10 m0 0 h226 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m46 0 h10 m0 0 h218 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m110 0 h10 m0 0 h154 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m64 0 h10 m0 0 h200 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m78 0 h10 m0 0 h186 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m130 0 h10 m0 0 h134 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m108 0 h10 m0 0 h156 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m70 0 h10 m0 0 h194 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m156 0 h10 m0 0 h108 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m126 0 h10 m0 0 h138 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m128 0 h10 m0 0 h136 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m148 0 h10 m0 0 h116 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m124 0 h10 m0 0 h140 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m170 0 h10 m0 0 h94 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m128 0 h10 m0 0 h136 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m106 0 h10 m0 0 h158 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m86 0 h10 m0 0 h178 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m40 0 h10 m0 0 h224 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m52 0 h10 m0 0 h212 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m70 0 h10 m0 0 h194 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m68 0 h10 m0 0 h196 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m74 0 h10 m0 0 h190 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m36 0 h10 m0 0 h228 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m90 0 h10 m0 0 h174 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m94 0 h10 m0 0 h170 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m78 0 h10 m0 0 h186 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m98 0 h10 m0 0 h166 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m144 0 h10 m0 0 h120 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m48 0 h10 m0 0 h216 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m72 0 h10 m0 0 h192 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m40 0 h10 m0 0 h224 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m40 0 h10 m0 0 h224 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m80 0 h10 m0 0 h184 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m82 0 h10 m0 0 h182 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m106 0 h10 m0 0 h158 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m100 0 h10 m0 0 h164 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m70 0 h10 m0 0 h194 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m126 0 h10 m0 0 h138 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m100 0 h10 m0 0 h164 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m38 0 h10 m0 0 h226 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m86 0 h10 m0 0 h178 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m54 0 h10 m0 0 h210 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m66 0 h10 m0 0 h198 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m74 0 h10 m0 0 h190 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m56 0 h10 m0 0 h208 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m64 0 h10 m0 0 h200 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m86 0 h10 m0 0 h178 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m74 0 h10 m0 0 h190 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m62 0 h10 m0 0 h202 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m68 0 h10 m0 0 h196 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m84 0 h10 m0 0 h180 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m58 0 h10 m0 0 h206 m-294 -10 v20 m304 0 v-20 m-304 20 v24 m304 0 v-24 m-304 24 q0 10 10 10 m284 0 q10 0 10 -10 m-294 10 h10 m264 0 h10 m23 -3520 h-3"></path>
          <polygon points="353 17 361 13 361 21"></polygon>
          <polygon points="353 17 345 13 345 21"></polygon>
       </svg>
@@ -14146,6 +15152,74 @@
             <li><a href="#alter_zone_range_stmt" title="alter_zone_range_stmt">alter_zone_range_stmt</a></li>
             <li><a href="#alter_zone_table_stmt" title="alter_zone_table_stmt">alter_zone_table_stmt</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="locality" href="#locality">locality:</a></p>
+      <svg width="734" height="418">
+         
+         <polygon points="11 17 3 13 3 21"></polygon>
+         <polygon points="19 17 11 13 11 21"></polygon>
+         <rect x="33" y="3" width="88" height="32" rx="10"></rect>
+         <rect x="31" y="1" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="41" y="21">LOCALITY</text>
+         <rect x="45" y="69" width="74" height="32" rx="10"></rect>
+         <rect x="43" y="67" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="87">GLOBAL</text>
+         <rect x="45" y="113" width="90" height="32" rx="10"></rect>
+         <rect x="43" y="111" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="53" y="131">REGIONAL</text>
+         <rect x="175" y="145" width="38" height="32" rx="10"></rect>
+         <rect x="173" y="143" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="183" y="163">BY</text>
+         <rect x="253" y="145" width="62" height="32" rx="10"></rect>
+         <rect x="251" y="143" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="163">TABLE</text>
+         <rect x="355" y="177" width="36" height="32" rx="10"></rect>
+         <rect x="353" y="175" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="363" y="195">IN</text>
+         <a xlink:href="#region_name" xlink:title="region_name">
+            <rect x="431" y="177" width="102" height="32"></rect>
+            <rect x="429" y="175" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="439" y="195">region_name</text>
+         </a>
+         <rect x="431" y="221" width="82" height="32" rx="10"></rect>
+         <rect x="429" y="219" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="439" y="239">PRIMARY</text>
+         <rect x="533" y="221" width="74" height="32" rx="10"></rect>
+         <rect x="531" y="219" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="541" y="239">REGION</text>
+         <rect x="253" y="265" width="54" height="32" rx="10"></rect>
+         <rect x="251" y="263" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="283">ROW</text>
+         <rect x="347" y="297" width="38" height="32" rx="10"></rect>
+         <rect x="345" y="295" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="355" y="315">AS</text>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="405" y="297" width="54" height="32"></rect>
+            <rect x="403" y="295" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="413" y="315">name</text>
+         </a>
+         <rect x="175" y="341" width="36" height="32" rx="10"></rect>
+         <rect x="173" y="339" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="183" y="359">IN</text>
+         <a xlink:href="#region_name" xlink:title="region_name">
+            <rect x="251" y="341" width="102" height="32"></rect>
+            <rect x="249" y="339" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="259" y="359">region_name</text>
+         </a>
+         <rect x="251" y="385" width="82" height="32" rx="10"></rect>
+         <rect x="249" y="383" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="259" y="403">PRIMARY</text>
+         <rect x="353" y="385" width="74" height="32" rx="10"></rect>
+         <rect x="351" y="383" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="361" y="403">REGION</text>
+         <path class="line" d="m19 17 h2 m0 0 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m74 0 h10 m0 0 h568 m-682 0 h20 m662 0 h20 m-702 0 q10 0 10 10 m682 0 q0 -10 10 -10 m-692 10 v24 m682 0 v-24 m-682 24 q0 10 10 10 m662 0 q10 0 10 -10 m-672 10 h10 m90 0 h10 m20 0 h10 m0 0 h502 m-532 0 h20 m512 0 h20 m-552 0 q10 0 10 10 m532 0 q0 -10 10 -10 m-542 10 v12 m532 0 v-12 m-532 12 q0 10 10 10 m512 0 q10 0 10 -10 m-522 10 h10 m38 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h282 m-312 0 h20 m292 0 h20 m-332 0 q10 0 10 10 m312 0 q0 -10 10 -10 m-322 10 v12 m312 0 v-12 m-312 12 q0 10 10 10 m292 0 q10 0 10 -10 m-302 10 h10 m36 0 h10 m20 0 h10 m102 0 h10 m0 0 h74 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m82 0 h10 m0 0 h10 m74 0 h10 m-394 -76 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v100 m434 0 v-100 m-434 100 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m54 0 h10 m20 0 h10 m0 0 h122 m-152 0 h20 m132 0 h20 m-172 0 q10 0 10 10 m152 0 q0 -10 10 -10 m-162 10 v12 m152 0 v-12 m-152 12 q0 10 10 10 m132 0 q10 0 10 -10 m-142 10 h10 m38 0 h10 m0 0 h10 m54 0 h10 m20 -32 h168 m-502 -130 v20 m532 0 v-20 m-532 20 v176 m532 0 v-176 m-532 176 q0 10 10 10 m512 0 q10 0 10 -10 m-522 10 h10 m36 0 h10 m20 0 h10 m102 0 h10 m0 0 h74 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v24 m216 0 v-24 m-216 24 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m82 0 h10 m0 0 h10 m74 0 h10 m20 -44 h220 m43 -272 h-3"></path>
+         <polygon points="725 83 733 79 733 87"></polygon>
+         <polygon points="725 83 717 79 717 87"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_locality_stmt" title="alter_table_locality_stmt">alter_table_locality_stmt</a></li>
+            <li><a href="#opt_locality" title="opt_locality">opt_locality</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_index_cmds" href="#alter_index_cmds">alter_index_cmds:</a></p>
       <svg width="222" height="80">
          
@@ -14185,6 +15259,88 @@
          </p><ul>
             <li><a href="#alter_sequence_options_stmt" title="alter_sequence_options_stmt">alter_sequence_options_stmt</a></li>
             <li><a href="#opt_sequence_option_list" title="opt_sequence_option_list">opt_sequence_option_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="region_name" href="#region_name">region_name:</a></p>
+      <svg width="112" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name" xlink:title="name">
+            <rect x="31" y="3" width="54" height="32"></rect>
+            <rect x="29" y="1" width="54" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m54 0 h10 m3 0 h-3"></path>
+         <polygon points="103 17 111 13 111 21"></polygon>
+         <polygon points="103 17 95 13 95 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_add_region_stmt" title="alter_database_add_region_stmt">alter_database_add_region_stmt</a></li>
+            <li><a href="#alter_database_drop_region_stmt" title="alter_database_drop_region_stmt">alter_database_drop_region_stmt</a></li>
+            <li><a href="#locality" title="locality">locality</a></li>
+            <li><a href="#primary_region_clause" title="primary_region_clause">primary_region_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="survival_goal_clause" href="#survival_goal_clause">survival_goal_clause:</a></p>
+      <svg width="474" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SURVIVE</text>
+         <a xlink:href="#opt_equal" xlink:title="opt_equal">
+            <rect x="131" y="3" width="84" height="32"></rect>
+            <rect x="129" y="1" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="139" y="21">opt_equal</text>
+         </a>
+         <rect x="255" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="253" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="263" y="21">REGION</text>
+         <rect x="255" y="47" width="56" height="32" rx="10"></rect>
+         <rect x="253" y="45" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="263" y="65">ZONE</text>
+         <rect x="369" y="3" width="78" height="32" rx="10"></rect>
+         <rect x="367" y="1" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="377" y="21">FAILURE</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m80 0 h10 m0 0 h10 m84 0 h10 m20 0 h10 m74 0 h10 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m56 0 h10 m0 0 h18 m20 -44 h10 m78 0 h10 m3 0 h-3"></path>
+         <polygon points="465 17 473 13 473 21"></polygon>
+         <polygon points="465 17 457 13 457 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_survival_goal_stmt" title="alter_database_survival_goal_stmt">alter_database_survival_goal_stmt</a></li>
+            <li><a href="#opt_survival_goal_clause" title="opt_survival_goal_clause">opt_survival_goal_clause</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="primary_region_clause" href="#primary_region_clause">primary_region_clause:</a></p>
+      <svg width="460" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="82" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">PRIMARY</text>
+         <rect x="133" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="131" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="141" y="21">REGION</text>
+         <a xlink:href="#opt_equal" xlink:title="opt_equal">
+            <rect x="227" y="3" width="84" height="32"></rect>
+            <rect x="225" y="1" width="84" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="235" y="21">opt_equal</text>
+         </a>
+         <a xlink:href="#region_name" xlink:title="region_name">
+            <rect x="331" y="3" width="102" height="32"></rect>
+            <rect x="329" y="1" width="102" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="339" y="21">region_name</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m82 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m102 0 h10 m3 0 h-3"></path>
+         <polygon points="451 17 459 13 459 21"></polygon>
+         <polygon points="451 17 443 13 443 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_database_primary_region_stmt" title="alter_database_primary_region_stmt">alter_database_primary_region_stmt</a></li>
+            <li><a href="#opt_primary_region_clause" title="opt_primary_region_clause">opt_primary_region_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="role_option" href="#role_option">role_option:</a></p>
       <svg width="314" height="872">
@@ -14519,27 +15675,6 @@
          </p><ul>
             <li><a href="#subquery_op" title="subquery_op">subquery_op</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="single_table_pattern_list" href="#single_table_pattern_list">single_table_pattern_list:</a></p>
-      <svg width="192" height="80">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="51" y="47" width="94" height="32"></rect>
-            <rect x="49" y="45" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">table_name</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m23 44 h-3"></path>
-         <polygon points="183 61 191 57 191 65"></polygon>
-         <polygon points="183 61 175 57 175 65"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#changefeed_targets" title="changefeed_targets">changefeed_targets</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_equal" href="#opt_equal">opt_equal:</a></p>
       <svg width="128" height="56">
          
@@ -14558,7 +15693,10 @@
             <li><a href="#opt_encoding_clause" title="opt_encoding_clause">opt_encoding_clause</a></li>
             <li><a href="#opt_lc_collate_clause" title="opt_lc_collate_clause">opt_lc_collate_clause</a></li>
             <li><a href="#opt_lc_ctype_clause" title="opt_lc_ctype_clause">opt_lc_ctype_clause</a></li>
+            <li><a href="#opt_regions_list" title="opt_regions_list">opt_regions_list</a></li>
             <li><a href="#opt_template_clause" title="opt_template_clause">opt_template_clause</a></li>
+            <li><a href="#primary_region_clause" title="primary_region_clause">primary_region_clause</a></li>
+            <li><a href="#survival_goal_clause" title="survival_goal_clause">survival_goal_clause</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="signed_iconst" href="#signed_iconst">signed_iconst:</a></p>
       <svg width="238" height="80">
@@ -14583,6 +15721,24 @@
             <li><a href="#opt_connection_limit" title="opt_connection_limit">opt_connection_limit</a></li>
             <li><a href="#signed_iconst64" title="signed_iconst64">signed_iconst64</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="region_name_list" href="#region_name_list">region_name_list:</a></p>
+      <svg width="138" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="31" y="3" width="80" height="32"></rect>
+            <rect x="29" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">name_list</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m80 0 h10 m3 0 h-3"></path>
+         <polygon points="129 17 137 13 137 21"></polygon>
+         <polygon points="129 17 121 13 121 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#opt_regions_list" title="opt_regions_list">opt_regions_list</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_name" href="#opt_name">opt_name:</a></p>
       <svg width="152" height="56">
          
@@ -14602,7 +15758,6 @@
             <li><a href="#index_def" title="index_def">index_def</a></li>
             <li><a href="#opt_family_name" title="opt_family_name">opt_family_name</a></li>
             <li><a href="#opt_index_name" title="opt_index_name">opt_index_name</a></li>
-            <li><a href="#opt_schema_name" title="opt_schema_name">opt_schema_name</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="index_elem" href="#index_elem">index_elem:</a></p>
       <svg width="428" height="124">
@@ -14666,75 +15821,31 @@
             <li><a href="#opt_storing" title="opt_storing">opt_storing</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="partition_by" href="#partition_by">partition_by:</a></p>
-      <svg width="626" height="190">
+      <svg width="368" height="36">
          
-         <polygon points="11 17 3 13 3 21"></polygon>
-         <polygon points="19 17 11 13 11 21"></polygon>
-         <rect x="33" y="3" width="96" height="32" rx="10"></rect>
-         <rect x="31" y="1" width="96" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="41" y="21">PARTITION</text>
-         <rect x="149" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="147" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="157" y="21">BY</text>
-         <rect x="65" y="69" width="50" height="32" rx="10"></rect>
-         <rect x="63" y="67" width="50" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="73" y="87">LIST</text>
-         <rect x="135" y="69" width="26" height="32" rx="10"></rect>
-         <rect x="133" y="67" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="87">(</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="181" y="69" width="80" height="32"></rect>
-            <rect x="179" y="67" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="189" y="87">name_list</text>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="96" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">PARTITION</text>
+         <rect x="147" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="145" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="21">BY</text>
+         <a xlink:href="#partition_by_inner" xlink:title="partition_by_inner">
+            <rect x="205" y="3" width="136" height="32"></rect>
+            <rect x="203" y="1" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="213" y="21">partition_by_inner</text>
          </a>
-         <rect x="281" y="69" width="26" height="32" rx="10"></rect>
-         <rect x="279" y="67" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="289" y="87">)</text>
-         <rect x="327" y="69" width="26" height="32" rx="10"></rect>
-         <rect x="325" y="67" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="335" y="87">(</text>
-         <a xlink:href="#list_partitions" xlink:title="list_partitions">
-            <rect x="373" y="69" width="106" height="32"></rect>
-            <rect x="371" y="67" width="106" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="381" y="87">list_partitions</text>
-         </a>
-         <rect x="65" y="113" width="66" height="32" rx="10"></rect>
-         <rect x="63" y="111" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="73" y="131">RANGE</text>
-         <rect x="151" y="113" width="26" height="32" rx="10"></rect>
-         <rect x="149" y="111" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="159" y="131">(</text>
-         <a xlink:href="#name_list" xlink:title="name_list">
-            <rect x="197" y="113" width="80" height="32"></rect>
-            <rect x="195" y="111" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="205" y="131">name_list</text>
-         </a>
-         <rect x="297" y="113" width="26" height="32" rx="10"></rect>
-         <rect x="295" y="111" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="305" y="131">)</text>
-         <rect x="343" y="113" width="26" height="32" rx="10"></rect>
-         <rect x="341" y="111" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="351" y="131">(</text>
-         <a xlink:href="#range_partitions" xlink:title="range_partitions">
-            <rect x="389" y="113" width="124" height="32"></rect>
-            <rect x="387" y="111" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="397" y="131">range_partitions</text>
-         </a>
-         <rect x="553" y="69" width="26" height="32" rx="10"></rect>
-         <rect x="551" y="67" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="561" y="87">)</text>
-         <rect x="45" y="157" width="84" height="32" rx="10"></rect>
-         <rect x="43" y="155" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="53" y="175">NOTHING</text>
-         <path class="line" d="m19 17 h2 m0 0 h10 m96 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-206 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m50 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-488 0 h20 m468 0 h20 m-508 0 q10 0 10 10 m488 0 q0 -10 10 -10 m-498 10 v24 m488 0 v-24 m-488 24 q0 10 10 10 m468 0 q10 0 10 -10 m-478 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m124 0 h10 m20 -44 h10 m26 0 h10 m-574 0 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v68 m574 0 v-68 m-574 68 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m84 0 h10 m0 0 h450 m23 -88 h-3"></path>
-         <polygon points="617 83 625 79 625 87"></polygon>
-         <polygon points="617 83 609 79 609 87"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m96 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m136 0 h10 m3 0 h-3"></path>
+         <polygon points="359 17 367 13 367 21"></polygon>
+         <polygon points="359 17 351 13 351 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#alter_index_cmd" title="alter_index_cmd">alter_index_cmd</a></li>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
             <li><a href="#opt_partition_by" title="opt_partition_by">opt_partition_by</a></li>
+            <li><a href="#opt_partition_by_index" title="opt_partition_by_index">opt_partition_by_index</a></li>
+            <li><a href="#partition_by_index" title="partition_by_index">partition_by_index</a></li>
+            <li><a href="#partition_by_table" title="partition_by_table">partition_by_table</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="storage_parameter_list" href="#storage_parameter_list">storage_parameter_list:</a></p>
       <svg width="240" height="80">
@@ -14756,6 +15867,39 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#opt_with_storage_parameter_list" title="opt_with_storage_parameter_list">opt_with_storage_parameter_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="partition_by_table" href="#partition_by_table">partition_by_table:</a></p>
+      <svg width="472" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#partition_by" xlink:title="partition_by">
+            <rect x="51" y="3" width="96" height="32"></rect>
+            <rect x="49" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="21">partition_by</text>
+         </a>
+         <rect x="51" y="47" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">PARTITION</text>
+         <rect x="167" y="47" width="44" height="32" rx="10"></rect>
+         <rect x="165" y="45" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="175" y="65">ALL</text>
+         <rect x="231" y="47" width="38" height="32" rx="10"></rect>
+         <rect x="229" y="45" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="239" y="65">BY</text>
+         <a xlink:href="#partition_by_inner" xlink:title="partition_by_inner">
+            <rect x="289" y="47" width="136" height="32"></rect>
+            <rect x="287" y="45" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="297" y="65">partition_by_inner</text>
+         </a>
+         <path class="line" d="m17 17 h2 m20 0 h10 m96 0 h10 m0 0 h278 m-414 0 h20 m394 0 h20 m-434 0 q10 0 10 10 m414 0 q0 -10 10 -10 m-424 10 v24 m414 0 v-24 m-414 24 q0 10 10 10 m394 0 q10 0 10 -10 m-404 10 h10 m96 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m136 0 h10 m23 -44 h-3"></path>
+         <polygon points="463 17 471 13 471 21"></polygon>
+         <polygon points="463 17 455 13 455 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+            <li><a href="#opt_partition_by_table" title="opt_partition_by_table">opt_partition_by_table</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_as_table_defs" href="#create_as_table_defs">create_as_table_defs:</a></p>
       <svg width="510" height="222">
@@ -14821,6 +15965,33 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#opt_enum_val_list" title="opt_enum_val_list">opt_enum_val_list</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="replication_options" href="#replication_options">replication_options:</a></p>
+      <svg width="308" height="80">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">CURSOR</text>
+         <rect x="147" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="145" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="155" y="21">=</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="197" y="3" width="64" height="32"></rect>
+            <rect x="195" y="1" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="205" y="21">a_expr</text>
+         </a>
+         <rect x="51" y="47" width="92" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">DETACHED</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m76 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m64 0 h10 m-250 0 h20 m230 0 h20 m-270 0 q10 0 10 10 m250 0 q0 -10 10 -10 m-260 10 v24 m250 0 v-24 m-250 24 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m92 0 h10 m0 0 h118 m23 -44 h-3"></path>
+         <polygon points="299 17 307 13 307 21"></polygon>
+         <polygon points="299 17 291 13 291 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#replication_options_list" title="replication_options_list">replication_options_list</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="common_table_expr" href="#common_table_expr">common_table_expr:</a></p>
       <svg width="622" height="134">
@@ -15066,7 +16237,7 @@
             <li><a href="#table_constraint" title="table_constraint">table_constraint</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="constraint_elem" href="#constraint_elem">constraint_elem:</a></p>
-      <svg width="1076" height="168">
+      <svg width="1136" height="168">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -15087,36 +16258,41 @@
          <rect x="51" y="47" width="74" height="32" rx="10"></rect>
          <rect x="49" y="45" width="74" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="65">UNIQUE</text>
-         <rect x="145" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="143" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="153" y="65">(</text>
-         <a xlink:href="#index_params" xlink:title="index_params">
-            <rect x="191" y="47" width="108" height="32"></rect>
-            <rect x="189" y="45" width="108" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="199" y="65">index_params</text>
+         <a xlink:href="#opt_without_index" xlink:title="opt_without_index">
+            <rect x="145" y="47" width="138" height="32"></rect>
+            <rect x="143" y="45" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="153" y="65">opt_without_index</text>
          </a>
-         <rect x="319" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="317" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="327" y="65">)</text>
+         <rect x="303" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="301" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="311" y="65">(</text>
+         <a xlink:href="#index_params" xlink:title="index_params">
+            <rect x="349" y="47" width="108" height="32"></rect>
+            <rect x="347" y="45" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="357" y="65">index_params</text>
+         </a>
+         <rect x="477" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="475" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="485" y="65">)</text>
          <a xlink:href="#opt_storing" xlink:title="opt_storing">
-            <rect x="365" y="47" width="92" height="32"></rect>
-            <rect x="363" y="45" width="92" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="373" y="65">opt_storing</text>
+            <rect x="523" y="47" width="92" height="32"></rect>
+            <rect x="521" y="45" width="92" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="531" y="65">opt_storing</text>
          </a>
          <a xlink:href="#opt_interleave" xlink:title="opt_interleave">
-            <rect x="477" y="47" width="112" height="32"></rect>
-            <rect x="475" y="45" width="112" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="485" y="65">opt_interleave</text>
+            <rect x="635" y="47" width="112" height="32"></rect>
+            <rect x="633" y="45" width="112" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="643" y="65">opt_interleave</text>
          </a>
-         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="609" y="47" width="124" height="32"></rect>
-            <rect x="607" y="45" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="617" y="65">opt_partition_by</text>
+         <a xlink:href="#opt_partition_by_index" xlink:title="opt_partition_by_index">
+            <rect x="767" y="47" width="166" height="32"></rect>
+            <rect x="765" y="45" width="166" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="775" y="65">opt_partition_by_index</text>
          </a>
          <a xlink:href="#opt_where_clause" xlink:title="opt_where_clause">
-            <rect x="753" y="47" width="136" height="32"></rect>
-            <rect x="751" y="45" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="761" y="65">opt_where_clause</text>
+            <rect x="953" y="47" width="136" height="32"></rect>
+            <rect x="951" y="45" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="961" y="65">opt_where_clause</text>
          </a>
          <rect x="51" y="91" width="82" height="32" rx="10"></rect>
          <rect x="49" y="89" width="82" height="32" class="terminal" rx="10"></rect>
@@ -15185,9 +16361,9 @@
             <rect x="895" y="133" width="132" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="905" y="153">reference_actions</text>
          </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h738 m-1018 0 h20 m998 0 h20 m-1038 0 q10 0 10 10 m1018 0 q0 -10 10 -10 m-1028 10 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m136 0 h10 m0 0 h140 m-1008 -10 v20 m1018 0 v-20 m-1018 20 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h318 m-1008 -10 v20 m1018 0 v-20 m-1018 20 v24 m1018 0 v-24 m-1018 24 q0 10 10 10 m998 0 q10 0 10 -10 m-1008 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m23 -132 h-3"></path>
-         <polygon points="1067 17 1075 13 1075 21"></polygon>
-         <polygon points="1067 17 1059 13 1059 21"></polygon>
+         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h798 m-1078 0 h20 m1058 0 h20 m-1098 0 q10 0 10 10 m1078 0 q0 -10 10 -10 m-1088 10 v24 m1078 0 v-24 m-1078 24 q0 10 10 10 m1058 0 q10 0 10 -10 m-1068 10 h10 m74 0 h10 m0 0 h10 m138 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m166 0 h10 m0 0 h10 m136 0 h10 m-1068 -10 v20 m1078 0 v-20 m-1078 20 v24 m1078 0 v-24 m-1078 24 q0 10 10 10 m1058 0 q10 0 10 -10 m-1068 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h378 m-1068 -10 v20 m1078 0 v-20 m-1078 20 v24 m1078 0 v-24 m-1078 24 q0 10 10 10 m1058 0 q10 0 10 -10 m-1068 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m118 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m0 0 h60 m23 -132 h-3"></path>
+         <polygon points="1127 17 1135 13 1135 21"></polygon>
+         <polygon points="1127 17 1119 13 1119 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -15965,7 +17141,7 @@
             <li><a href="#transaction_user_priority" title="transaction_user_priority">transaction_user_priority</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_table_cmd" href="#alter_table_cmd">alter_table_cmd:</a></p>
-      <svg width="1082" height="792">
+      <svg width="1082" height="748">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -16178,23 +17354,12 @@
             <rect x="307" y="669" width="94" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="317" y="689">audit_mode</text>
          </a>
-         <a xlink:href="#partition_by" xlink:title="partition_by">
-            <rect x="51" y="715" width="96" height="32"></rect>
-            <rect x="49" y="713" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="733">partition_by</text>
+         <a xlink:href="#partition_by_table" xlink:title="partition_by_table">
+            <rect x="51" y="715" width="136" height="32"></rect>
+            <rect x="49" y="713" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="733">partition_by_table</text>
          </a>
-         <rect x="51" y="759" width="72" height="32" rx="10"></rect>
-         <rect x="49" y="757" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="777">OWNER</text>
-         <rect x="143" y="759" width="38" height="32" rx="10"></rect>
-         <rect x="141" y="757" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="151" y="777">TO</text>
-         <a xlink:href="#role_spec" xlink:title="role_spec">
-            <rect x="201" y="759" width="80" height="32"></rect>
-            <rect x="199" y="757" width="80" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="209" y="777">role_spec</text>
-         </a>
-         <path class="line" d="m17 17 h2 m20 0 h10 m74 0 h10 m20 0 h10 m92 0 h10 m0 0 h16 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m108 0 h10 m20 -44 h10 m106 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m106 0 h10 m0 0 h432 m-1024 0 h20 m1004 0 h20 m-1044 0 q10 0 10 10 m1024 0 q0 -10 10 -10 m-1034 10 v68 m1024 0 v-68 m-1024 68 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m92 0 h10 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v56 m520 0 v-56 m-520 56 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h176 m20 -76 h396 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v100 m1024 0 v-100 m-1024 100 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m62 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m106 0 h10 m20 0 h10 m152 0 h10 m0 0 h432 m-624 0 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m58 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m74 0 h10 m0 0 h50 m20 -44 h342 m-614 -10 v20 m624 0 v-20 m-624 20 v68 m624 0 v-68 m-624 68 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m44 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h396 m-614 -10 v20 m624 0 v-20 m-624 20 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m106 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m172 0 h10 m-882 -176 h20 m882 0 h20 m-922 0 q10 0 10 10 m902 0 q0 -10 10 -10 m-912 10 v200 m902 0 v-200 m-902 200 q0 10 10 10 m882 0 q10 0 10 -10 m-892 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m-994 -230 v20 m1024 0 v-20 m-1024 20 v244 m1024 0 v-244 m-1024 244 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m58 0 h10 m20 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m106 0 h10 m0 0 h36 m-476 0 h20 m456 0 h20 m-496 0 q10 0 10 10 m476 0 q0 -10 10 -10 m-486 10 v56 m476 0 v-56 m-476 56 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m126 0 h10 m20 -76 h10 m140 0 h10 m0 0 h270 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v132 m1024 0 v-132 m-1024 132 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m86 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m126 0 h10 m0 0 h624 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m174 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m94 0 h10 m0 0 h632 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m96 0 h10 m0 0 h888 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m80 0 h10 m0 0 h754 m23 -756 h-3"></path>
+         <path class="line" d="m17 17 h2 m20 0 h10 m74 0 h10 m20 0 h10 m92 0 h10 m0 0 h16 m-148 0 h20 m128 0 h20 m-168 0 q10 0 10 10 m148 0 q0 -10 10 -10 m-158 10 v24 m148 0 v-24 m-148 24 q0 10 10 10 m128 0 q10 0 10 -10 m-138 10 h10 m108 0 h10 m20 -44 h10 m106 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m106 0 h10 m0 0 h432 m-1024 0 h20 m1004 0 h20 m-1044 0 q10 0 10 10 m1024 0 q0 -10 10 -10 m-1034 10 v68 m1024 0 v-68 m-1024 68 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m48 0 h10 m40 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m40 -32 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m34 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m92 0 h10 m-520 0 h20 m500 0 h20 m-540 0 q10 0 10 10 m520 0 q0 -10 10 -10 m-530 10 v56 m520 0 v-56 m-520 56 q0 10 10 10 m500 0 q10 0 10 -10 m-510 10 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h176 m20 -76 h396 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v100 m1024 0 v-100 m-1024 100 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m62 0 h10 m20 0 h10 m92 0 h10 m0 0 h10 m106 0 h10 m20 0 h10 m152 0 h10 m0 0 h432 m-624 0 h20 m604 0 h20 m-644 0 q10 0 10 10 m624 0 q0 -10 10 -10 m-634 10 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m58 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m74 0 h10 m0 0 h50 m20 -44 h342 m-614 -10 v20 m624 0 v-20 m-624 20 v68 m624 0 v-68 m-624 68 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m44 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h396 m-614 -10 v20 m624 0 v-20 m-624 20 v24 m624 0 v-24 m-624 24 q0 10 10 10 m604 0 q10 0 10 -10 m-614 10 h10 m106 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m172 0 h10 m-882 -176 h20 m882 0 h20 m-922 0 q10 0 10 10 m902 0 q0 -10 10 -10 m-912 10 v200 m902 0 v-200 m-902 200 q0 10 10 10 m882 0 q10 0 10 -10 m-892 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m140 0 h10 m0 0 h10 m112 0 h10 m0 0 h10 m-994 -230 v20 m1024 0 v-20 m-1024 20 v244 m1024 0 v-244 m-1024 244 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m58 0 h10 m20 0 h10 m92 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m106 0 h10 m0 0 h36 m-476 0 h20 m456 0 h20 m-496 0 q10 0 10 10 m476 0 q0 -10 10 -10 m-486 10 v56 m476 0 v-56 m-476 56 q0 10 10 10 m456 0 q10 0 10 -10 m-466 10 h10 m108 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m34 0 h10 m0 0 h10 m68 0 h10 m20 -32 h10 m126 0 h10 m20 -76 h10 m140 0 h10 m0 0 h270 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v132 m1024 0 v-132 m-1024 132 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m86 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m126 0 h10 m0 0 h624 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m174 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m94 0 h10 m0 0 h632 m-1014 -10 v20 m1024 0 v-20 m-1024 20 v24 m1024 0 v-24 m-1024 24 q0 10 10 10 m1004 0 q10 0 10 -10 m-1014 10 h10 m136 0 h10 m0 0 h848 m23 -712 h-3"></path>
          <polygon points="1073 17 1081 13 1081 21"></polygon>
          <polygon points="1073 17 1065 13 1065 21"></polygon>
       </svg>
@@ -16263,25 +17428,25 @@
             <li><a href="#set_zone_config" title="set_zone_config">set_zone_config</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="alter_index_cmd" href="#alter_index_cmd">alter_index_cmd:</a></p>
-      <svg width="154" height="36">
+      <svg width="196" height="36">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#partition_by" xlink:title="partition_by">
-            <rect x="31" y="3" width="96" height="32"></rect>
-            <rect x="29" y="1" width="96" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">partition_by</text>
+         <a xlink:href="#partition_by_index" xlink:title="partition_by_index">
+            <rect x="31" y="3" width="138" height="32"></rect>
+            <rect x="29" y="1" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">partition_by_index</text>
          </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m96 0 h10 m3 0 h-3"></path>
-         <polygon points="145 17 153 13 153 21"></polygon>
-         <polygon points="145 17 137 13 137 21"></polygon>
+         <path class="line" d="m17 17 h2 m0 0 h10 m138 0 h10 m3 0 h-3"></path>
+         <polygon points="187 17 195 13 195 21"></polygon>
+         <polygon points="187 17 179 13 179 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_index_cmds" title="alter_index_cmds">alter_index_cmds</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="sequence_option_elem" href="#sequence_option_elem">sequence_option_elem:</a></p>
-      <svg width="476" height="496">
+      <svg width="476" height="540">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
@@ -16311,33 +17476,36 @@
             <rect x="219" y="177" width="100" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="229" y="197">column_path</text>
          </a>
-         <rect x="71" y="223" width="98" height="32" rx="10"></rect>
-         <rect x="69" y="221" width="98" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="241">INCREMENT</text>
-         <rect x="209" y="255" width="38" height="32" rx="10"></rect>
-         <rect x="207" y="253" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="217" y="273">BY</text>
-         <rect x="71" y="299" width="90" height="32" rx="10"></rect>
-         <rect x="69" y="297" width="90" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="317">MINVALUE</text>
-         <rect x="71" y="343" width="92" height="32" rx="10"></rect>
-         <rect x="69" y="341" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="361">MAXVALUE</text>
-         <rect x="71" y="387" width="62" height="32" rx="10"></rect>
-         <rect x="69" y="385" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="405">START</text>
-         <rect x="173" y="419" width="58" height="32" rx="10"></rect>
-         <rect x="171" y="417" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="181" y="437">WITH</text>
+         <rect x="71" y="223" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="221" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="241">CACHE</text>
+         <rect x="71" y="267" width="90" height="32" rx="10"></rect>
+         <rect x="69" y="265" width="90" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="285">MINVALUE</text>
+         <rect x="71" y="311" width="92" height="32" rx="10"></rect>
+         <rect x="69" y="309" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="329">MAXVALUE</text>
+         <rect x="71" y="355" width="98" height="32" rx="10"></rect>
+         <rect x="69" y="353" width="98" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="373">INCREMENT</text>
+         <rect x="209" y="387" width="38" height="32" rx="10"></rect>
+         <rect x="207" y="385" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="217" y="405">BY</text>
+         <rect x="71" y="431" width="62" height="32" rx="10"></rect>
+         <rect x="69" y="429" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="449">START</text>
+         <rect x="173" y="463" width="58" height="32" rx="10"></rect>
+         <rect x="171" y="461" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="181" y="481">WITH</text>
          <a xlink:href="#signed_iconst64" xlink:title="signed_iconst64">
             <rect x="307" y="223" width="122" height="32"></rect>
             <rect x="305" y="221" width="122" height="32" class="nonterminal"></rect>
             <text class="nonterminal" x="315" y="241">signed_iconst64</text>
          </a>
-         <rect x="51" y="463" width="78" height="32" rx="10"></rect>
-         <rect x="49" y="461" width="78" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="481">VIRTUAL</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m40 0 h10 m20 0 h10 m64 0 h10 m0 0 h28 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m90 0 h10 m0 0 h2 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m20 -88 h186 m-418 0 h20 m398 0 h20 m-438 0 q10 0 10 10 m418 0 q0 -10 10 -10 m-428 10 v112 m418 0 v-112 m-418 112 q0 10 10 10 m398 0 q10 0 10 -10 m-408 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m58 0 h10 m0 0 h42 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -44 h88 m-408 -10 v20 m418 0 v-20 m-418 20 v68 m418 0 v-68 m-418 68 q0 10 10 10 m398 0 q10 0 10 -10 m-388 10 h10 m98 0 h10 m20 0 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m-216 -32 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v56 m236 0 v-56 m-236 56 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m90 0 h10 m0 0 h106 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m92 0 h10 m0 0 h104 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m62 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h16 m20 -164 h10 m122 0 h10 m-408 -10 v20 m418 0 v-20 m-418 20 v220 m418 0 v-220 m-418 220 q0 10 10 10 m398 0 q10 0 10 -10 m-408 10 h10 m78 0 h10 m0 0 h300 m23 -460 h-3"></path>
+         <rect x="51" y="507" width="78" height="32" rx="10"></rect>
+         <rect x="49" y="505" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="525">VIRTUAL</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m40 0 h10 m20 0 h10 m64 0 h10 m0 0 h28 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m90 0 h10 m0 0 h2 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m20 -88 h186 m-418 0 h20 m398 0 h20 m-438 0 q10 0 10 10 m418 0 q0 -10 10 -10 m-428 10 v112 m418 0 v-112 m-418 112 q0 10 10 10 m398 0 q10 0 10 -10 m-408 10 h10 m72 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m58 0 h10 m0 0 h42 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m100 0 h10 m20 -44 h88 m-408 -10 v20 m418 0 v-20 m-418 20 v68 m418 0 v-68 m-418 68 q0 10 10 10 m398 0 q10 0 10 -10 m-388 10 h10 m64 0 h10 m0 0 h132 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m90 0 h10 m0 0 h106 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m92 0 h10 m0 0 h104 m-226 -10 v20 m236 0 v-20 m-236 20 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m98 0 h10 m20 0 h10 m0 0 h48 m-78 0 h20 m58 0 h20 m-98 0 q10 0 10 10 m78 0 q0 -10 10 -10 m-88 10 v12 m78 0 v-12 m-78 12 q0 10 10 10 m58 0 q10 0 10 -10 m-68 10 h10 m38 0 h10 m-206 -42 v20 m236 0 v-20 m-236 20 v56 m236 0 v-56 m-236 56 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m62 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h16 m20 -208 h10 m122 0 h10 m-408 -10 v20 m418 0 v-20 m-418 20 v264 m418 0 v-264 m-418 264 q0 10 10 10 m398 0 q10 0 10 -10 m-408 10 h10 m78 0 h10 m0 0 h300 m23 -504 h-3"></path>
          <polygon points="467 17 475 13 475 21"></polygon>
          <polygon points="467 17 459 13 459 21"></polygon>
       </svg>
@@ -16814,47 +17982,69 @@
          </p><ul>
             <li><a href="#index_elem" title="index_elem">index_elem</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="list_partitions" href="#list_partitions">list_partitions:</a></p>
-      <svg width="196" height="80">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="partition_by_inner" href="#partition_by_inner">partition_by_inner:</a></p>
+      <svg width="632" height="124">
          
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#list_partition" xlink:title="list_partition">
-            <rect x="51" y="47" width="98" height="32"></rect>
-            <rect x="49" y="45" width="98" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">list_partition</text>
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="71" y="3" width="50" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="50" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">LIST</text>
+         <rect x="141" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="139" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="21">(</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="187" y="3" width="80" height="32"></rect>
+            <rect x="185" y="1" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="195" y="21">name_list</text>
          </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m23 44 h-3"></path>
-         <polygon points="187 61 195 57 195 65"></polygon>
-         <polygon points="187 61 179 57 179 65"></polygon>
+         <rect x="287" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="285" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="295" y="21">)</text>
+         <rect x="333" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="331" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="341" y="21">(</text>
+         <a xlink:href="#list_partitions" xlink:title="list_partitions">
+            <rect x="379" y="3" width="106" height="32"></rect>
+            <rect x="377" y="1" width="106" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="387" y="21">list_partitions</text>
+         </a>
+         <rect x="71" y="47" width="66" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">RANGE</text>
+         <rect x="157" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="155" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="165" y="65">(</text>
+         <a xlink:href="#name_list" xlink:title="name_list">
+            <rect x="203" y="47" width="80" height="32"></rect>
+            <rect x="201" y="45" width="80" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="211" y="65">name_list</text>
+         </a>
+         <rect x="303" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="301" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="311" y="65">)</text>
+         <rect x="349" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="347" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="357" y="65">(</text>
+         <a xlink:href="#range_partitions" xlink:title="range_partitions">
+            <rect x="395" y="47" width="124" height="32"></rect>
+            <rect x="393" y="45" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="403" y="65">range_partitions</text>
+         </a>
+         <rect x="559" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="557" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="567" y="21">)</text>
+         <rect x="51" y="91" width="84" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">NOTHING</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m50 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m106 0 h10 m0 0 h34 m-488 0 h20 m468 0 h20 m-508 0 q10 0 10 10 m488 0 q0 -10 10 -10 m-498 10 v24 m488 0 v-24 m-488 24 q0 10 10 10 m468 0 q10 0 10 -10 m-478 10 h10 m66 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m124 0 h10 m20 -44 h10 m26 0 h10 m-574 0 h20 m554 0 h20 m-594 0 q10 0 10 10 m574 0 q0 -10 10 -10 m-584 10 v68 m574 0 v-68 m-574 68 q0 10 10 10 m554 0 q10 0 10 -10 m-564 10 h10 m84 0 h10 m0 0 h450 m23 -88 h-3"></path>
+         <polygon points="623 17 631 13 631 21"></polygon>
+         <polygon points="623 17 615 13 615 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
             <li><a href="#partition_by" title="partition_by">partition_by</a></li>
-         </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="range_partitions" href="#range_partitions">range_partitions:</a></p>
-      <svg width="216" height="80">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <a xlink:href="#range_partition" xlink:title="range_partition">
-            <rect x="51" y="47" width="118" height="32"></rect>
-            <rect x="49" y="45" width="118" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="65">range_partition</text>
-         </a>
-         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">,</text>
-         <path class="line" d="m17 61 h2 m20 0 h10 m118 0 h10 m-158 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m138 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-138 0 h10 m24 0 h10 m0 0 h94 m23 44 h-3"></path>
-         <polygon points="207 61 215 57 215 65"></polygon>
-         <polygon points="207 61 199 57 199 65"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#partition_by" title="partition_by">partition_by</a></li>
+            <li><a href="#partition_by_table" title="partition_by_table">partition_by_table</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="storage_parameter" href="#storage_parameter">storage_parameter:</a></p>
       <svg width="326" height="80">
@@ -17080,6 +18270,26 @@
          </p><ul>
             <li><a href="#col_qual_list" title="col_qual_list">col_qual_list</a></li>
          </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_without_index" href="#opt_without_index">opt_without_index:</a></p>
+      <svg width="266" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <rect x="51" y="23" width="86" height="32" rx="10"></rect>
+         <rect x="49" y="21" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="41">WITHOUT</text>
+         <rect x="157" y="23" width="62" height="32" rx="10"></rect>
+         <rect x="155" y="21" width="62" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="165" y="41">INDEX</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h178 m-208 0 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v12 m208 0 v-12 m-208 12 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m86 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
+         <polygon points="257 5 265 1 265 9"></polygon>
+         <polygon points="257 5 249 1 249 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#col_qualification_elem" title="col_qualification_elem">col_qualification_elem</a></li>
+            <li><a href="#constraint_elem" title="constraint_elem">constraint_elem</a></li>
+         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="key_match" href="#key_match">key_match:</a></p>
       <svg width="294" height="100">
          
@@ -17254,7 +18464,7 @@
             <li><a href="#for_locking_item" title="for_locking_item">for_locking_item</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_join_hint" href="#opt_join_hint">opt_join_hint:</a></p>
-      <svg width="176" height="144">
+      <svg width="186" height="188">
          
          <polygon points="9 5 1 1 1 9"></polygon>
          <polygon points="17 5 9 1 9 9"></polygon>
@@ -17267,9 +18477,12 @@
          <rect x="51" y="111" width="78" height="32" rx="10"></rect>
          <rect x="49" y="109" width="78" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="129">LOOKUP</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h88 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v12 m118 0 v-12 m-118 12 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m58 0 h10 m0 0 h20 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m66 0 h10 m0 0 h12 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m23 -120 h-3"></path>
-         <polygon points="167 5 175 1 175 9"></polygon>
-         <polygon points="167 5 159 1 159 9"></polygon>
+         <rect x="51" y="155" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="153" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="173">INVERTED</text>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h98 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v12 m128 0 v-12 m-128 12 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m58 0 h10 m0 0 h30 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m66 0 h10 m0 0 h22 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m78 0 h10 m0 0 h10 m-118 -10 v20 m128 0 v-20 m-128 20 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m23 -164 h-3"></path>
+         <polygon points="177 5 185 1 185 9"></polygon>
+         <polygon points="177 5 169 1 169 9"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -17803,25 +19016,6 @@
          </p><ul>
             <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_validate_behavior" href="#opt_validate_behavior">opt_validate_behavior:</a></p>
-      <svg width="228" height="56">
-         
-         <polygon points="9 5 1 1 1 9"></polygon>
-         <polygon points="17 5 9 1 9 9"></polygon>
-         <rect x="51" y="23" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="21" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="41">NOT</text>
-         <rect x="119" y="23" width="62" height="32" rx="10"></rect>
-         <rect x="117" y="21" width="62" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="127" y="41">VALID</text>
-         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h140 m-170 0 h20 m150 0 h20 m-190 0 q10 0 10 10 m170 0 q0 -10 10 -10 m-180 10 v12 m170 0 v-12 m-170 12 q0 10 10 10 m150 0 q10 0 10 -10 m-160 10 h10 m48 0 h10 m0 0 h10 m62 0 h10 m23 -32 h-3"></path>
-         <polygon points="219 5 227 1 227 9"></polygon>
-         <polygon points="219 5 211 1 211 9"></polygon>
-      </svg>
-      <p>referenced by:
-         </p><ul>
-            <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
-         </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="audit_mode" href="#audit_mode">audit_mode:</a></p>
       <svg width="238" height="80">
          
@@ -17843,6 +19037,24 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#alter_table_cmd" title="alter_table_cmd">alter_table_cmd</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="partition_by_index" href="#partition_by_index">partition_by_index:</a></p>
+      <svg width="154" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#partition_by" xlink:title="partition_by">
+            <rect x="31" y="3" width="96" height="32"></rect>
+            <rect x="29" y="1" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">partition_by</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m96 0 h10 m3 0 h-3"></path>
+         <polygon points="145 17 153 13 153 21"></polygon>
+         <polygon points="145 17 137 13 137 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#alter_index_cmd" title="alter_index_cmd">alter_index_cmd</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="signed_iconst64" href="#signed_iconst64">signed_iconst64:</a></p>
       <svg width="164" height="36">
@@ -18345,99 +19557,47 @@
          </p><ul>
             <li><a href="#index_elem_options" title="index_elem_options">index_elem_options</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="list_partition" href="#list_partition">list_partition:</a></p>
-      <svg width="608" height="36">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="list_partitions" href="#list_partitions">list_partitions:</a></p>
+      <svg width="196" height="80">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#partition" xlink:title="partition">
-            <rect x="31" y="3" width="72" height="32"></rect>
-            <rect x="29" y="1" width="72" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">partition</text>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#list_partition" xlink:title="list_partition">
+            <rect x="51" y="47" width="98" height="32"></rect>
+            <rect x="49" y="45" width="98" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">list_partition</text>
          </a>
-         <rect x="123" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="121" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="131" y="21">VALUES</text>
-         <rect x="215" y="3" width="36" height="32" rx="10"></rect>
-         <rect x="213" y="1" width="36" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="21">IN</text>
-         <rect x="271" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="269" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="279" y="21">(</text>
-         <a xlink:href="#expr_list" xlink:title="expr_list">
-            <rect x="317" y="3" width="74" height="32"></rect>
-            <rect x="315" y="1" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="325" y="21">expr_list</text>
-         </a>
-         <rect x="411" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="409" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="419" y="21">)</text>
-         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="457" y="3" width="124" height="32"></rect>
-            <rect x="455" y="1" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="465" y="21">opt_partition_by</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
-         <polygon points="599 17 607 13 607 21"></polygon>
-         <polygon points="599 17 591 13 591 21"></polygon>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m23 44 h-3"></path>
+         <polygon points="187 61 195 57 195 65"></polygon>
+         <polygon points="187 61 179 57 179 65"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#list_partitions" title="list_partitions">list_partitions</a></li>
+            <li><a href="#partition_by_inner" title="partition_by_inner">partition_by_inner</a></li>
          </ul>
-      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="range_partition" href="#range_partition">range_partition:</a></p>
-      <svg width="724" height="102">
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="range_partitions" href="#range_partitions">range_partitions:</a></p>
+      <svg width="216" height="80">
          
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <a xlink:href="#partition" xlink:title="partition">
-            <rect x="31" y="3" width="72" height="32"></rect>
-            <rect x="29" y="1" width="72" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="39" y="21">partition</text>
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <a xlink:href="#range_partition" xlink:title="range_partition">
+            <rect x="51" y="47" width="118" height="32"></rect>
+            <rect x="49" y="45" width="118" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="65">range_partition</text>
          </a>
-         <rect x="123" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="121" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="131" y="21">VALUES</text>
-         <rect x="215" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="213" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="223" y="21">FROM</text>
-         <rect x="293" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="291" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="301" y="21">(</text>
-         <a xlink:href="#expr_list" xlink:title="expr_list">
-            <rect x="339" y="3" width="74" height="32"></rect>
-            <rect x="337" y="1" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="347" y="21">expr_list</text>
-         </a>
-         <rect x="433" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="431" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="441" y="21">)</text>
-         <rect x="479" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="477" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="487" y="21">TO</text>
-         <rect x="537" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="535" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="545" y="21">(</text>
-         <a xlink:href="#expr_list" xlink:title="expr_list">
-            <rect x="583" y="3" width="74" height="32"></rect>
-            <rect x="581" y="1" width="74" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="591" y="21">expr_list</text>
-         </a>
-         <rect x="677" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="675" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="685" y="21">)</text>
-         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
-            <rect x="573" y="69" width="124" height="32"></rect>
-            <rect x="571" y="67" width="124" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="581" y="87">opt_partition_by</text>
-         </a>
-         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-174 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m124 0 h10 m3 0 h-3"></path>
-         <polygon points="715 83 723 79 723 87"></polygon>
-         <polygon points="715 83 707 79 707 87"></polygon>
+         <rect x="51" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m118 0 h10 m-158 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m138 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-138 0 h10 m24 0 h10 m0 0 h94 m23 44 h-3"></path>
+         <polygon points="207 61 215 57 215 65"></polygon>
+         <polygon points="207 61 199 57 199 65"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
-            <li><a href="#range_partitions" title="range_partitions">range_partitions</a></li>
+            <li><a href="#partition_by_inner" title="partition_by_inner">partition_by_inner</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_as_col_qualification" href="#create_as_col_qualification">create_as_col_qualification:</a></p>
       <svg width="326" height="80">
@@ -18496,110 +19656,124 @@
             <li><a href="#create_as_constraint_def" title="create_as_constraint_def">create_as_constraint_def</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="col_qualification_elem" href="#col_qualification_elem">col_qualification_elem:</a></p>
-      <svg width="810" height="364">
+      <svg width="810" height="464">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="35" width="48" height="32" rx="10"></rect>
-         <rect x="69" y="33" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="53">NOT</text>
-         <rect x="159" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="157" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="167" y="21">NULL</text>
-         <rect x="51" y="79" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="77" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="97">UNIQUE</text>
-         <rect x="51" y="123" width="82" height="32" rx="10"></rect>
-         <rect x="49" y="121" width="82" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="141">PRIMARY</text>
-         <rect x="153" y="123" width="46" height="32" rx="10"></rect>
-         <rect x="151" y="121" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="161" y="141">KEY</text>
-         <rect x="239" y="155" width="64" height="32" rx="10"></rect>
-         <rect x="237" y="153" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="247" y="173">USING</text>
-         <rect x="323" y="155" width="58" height="32" rx="10"></rect>
-         <rect x="321" y="153" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="331" y="173">HASH</text>
-         <rect x="401" y="155" width="58" height="32" rx="10"></rect>
-         <rect x="399" y="153" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="409" y="173">WITH</text>
-         <rect x="479" y="155" width="130" height="32" rx="10"></rect>
-         <rect x="477" y="153" width="130" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="487" y="173">BUCKET_COUNT</text>
-         <rect x="629" y="155" width="30" height="32" rx="10"></rect>
-         <rect x="627" y="153" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="637" y="173">=</text>
-         <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="679" y="155" width="64" height="32"></rect>
-            <rect x="677" y="153" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="687" y="173">a_expr</text>
+         <rect x="51" y="3" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">NOT</text>
+         <rect x="139" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="137" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="21">NULL</text>
+         <rect x="139" y="47" width="74" height="32" rx="10"></rect>
+         <rect x="137" y="45" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="147" y="65">VISIBLE</text>
+         <rect x="51" y="91" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">NULL</text>
+         <rect x="51" y="135" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">UNIQUE</text>
+         <a xlink:href="#opt_without_index" xlink:title="opt_without_index">
+            <rect x="145" y="135" width="138" height="32"></rect>
+            <rect x="143" y="133" width="138" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="153" y="153">opt_without_index</text>
          </a>
-         <rect x="51" y="199" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="197" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="217">CHECK</text>
-         <rect x="135" y="199" width="26" height="32" rx="10"></rect>
-         <rect x="133" y="197" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="143" y="217">(</text>
+         <rect x="51" y="179" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">PRIMARY</text>
+         <rect x="153" y="179" width="46" height="32" rx="10"></rect>
+         <rect x="151" y="177" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="161" y="197">KEY</text>
+         <rect x="239" y="211" width="64" height="32" rx="10"></rect>
+         <rect x="237" y="209" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="247" y="229">USING</text>
+         <rect x="323" y="211" width="58" height="32" rx="10"></rect>
+         <rect x="321" y="209" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="331" y="229">HASH</text>
+         <rect x="401" y="211" width="58" height="32" rx="10"></rect>
+         <rect x="399" y="209" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="409" y="229">WITH</text>
+         <rect x="479" y="211" width="130" height="32" rx="10"></rect>
+         <rect x="477" y="209" width="130" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="487" y="229">BUCKET_COUNT</text>
+         <rect x="629" y="211" width="30" height="32" rx="10"></rect>
+         <rect x="627" y="209" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="637" y="229">=</text>
          <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="181" y="199" width="64" height="32"></rect>
-            <rect x="179" y="197" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="189" y="217">a_expr</text>
+            <rect x="679" y="211" width="64" height="32"></rect>
+            <rect x="677" y="209" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="687" y="229">a_expr</text>
          </a>
-         <rect x="265" y="199" width="26" height="32" rx="10"></rect>
-         <rect x="263" y="197" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="273" y="217">)</text>
-         <rect x="51" y="243" width="80" height="32" rx="10"></rect>
-         <rect x="49" y="241" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="261">DEFAULT</text>
+         <rect x="51" y="255" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="253" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="273">CHECK</text>
+         <rect x="135" y="255" width="26" height="32" rx="10"></rect>
+         <rect x="133" y="253" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="143" y="273">(</text>
+         <a xlink:href="#a_expr" xlink:title="a_expr">
+            <rect x="181" y="255" width="64" height="32"></rect>
+            <rect x="179" y="253" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="189" y="273">a_expr</text>
+         </a>
+         <rect x="265" y="255" width="26" height="32" rx="10"></rect>
+         <rect x="263" y="253" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="273" y="273">)</text>
+         <rect x="51" y="299" width="80" height="32" rx="10"></rect>
+         <rect x="49" y="297" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="317">DEFAULT</text>
          <a xlink:href="#b_expr" xlink:title="b_expr">
-            <rect x="151" y="243" width="64" height="32"></rect>
-            <rect x="149" y="241" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="159" y="261">b_expr</text>
+            <rect x="151" y="299" width="64" height="32"></rect>
+            <rect x="149" y="297" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="159" y="317">b_expr</text>
          </a>
-         <rect x="51" y="287" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="285" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="305">REFERENCES</text>
+         <rect x="51" y="343" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="341" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="361">REFERENCES</text>
          <a xlink:href="#table_name" xlink:title="table_name">
-            <rect x="177" y="287" width="94" height="32"></rect>
-            <rect x="175" y="285" width="94" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="185" y="305">table_name</text>
+            <rect x="177" y="343" width="94" height="32"></rect>
+            <rect x="175" y="341" width="94" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="185" y="361">table_name</text>
          </a>
          <a xlink:href="#opt_name_parens" xlink:title="opt_name_parens">
-            <rect x="291" y="287" width="136" height="32"></rect>
-            <rect x="289" y="285" width="136" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="299" y="305">opt_name_parens</text>
+            <rect x="291" y="343" width="136" height="32"></rect>
+            <rect x="289" y="341" width="136" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="299" y="361">opt_name_parens</text>
          </a>
          <a xlink:href="#key_match" xlink:title="key_match">
-            <rect x="447" y="287" width="88" height="32"></rect>
-            <rect x="445" y="285" width="88" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="455" y="305">key_match</text>
+            <rect x="447" y="343" width="88" height="32"></rect>
+            <rect x="445" y="341" width="88" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="455" y="361">key_match</text>
          </a>
          <a xlink:href="#reference_actions" xlink:title="reference_actions">
-            <rect x="555" y="287" width="132" height="32"></rect>
-            <rect x="553" y="285" width="132" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="563" y="305">reference_actions</text>
+            <rect x="555" y="343" width="132" height="32"></rect>
+            <rect x="553" y="341" width="132" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="563" y="361">reference_actions</text>
          </a>
          <a xlink:href="#generated_as" xlink:title="generated_as">
-            <rect x="51" y="331" width="108" height="32"></rect>
-            <rect x="49" y="329" width="108" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="59" y="349">generated_as</text>
+            <rect x="51" y="387" width="108" height="32"></rect>
+            <rect x="49" y="385" width="108" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="405">generated_as</text>
          </a>
-         <rect x="179" y="331" width="26" height="32" rx="10"></rect>
-         <rect x="177" y="329" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="187" y="349">(</text>
+         <rect x="179" y="387" width="26" height="32" rx="10"></rect>
+         <rect x="177" y="385" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="187" y="405">(</text>
          <a xlink:href="#a_expr" xlink:title="a_expr">
-            <rect x="225" y="331" width="64" height="32"></rect>
-            <rect x="223" y="329" width="64" height="32" class="nonterminal"></rect>
-            <text class="nonterminal" x="233" y="349">a_expr</text>
+            <rect x="225" y="387" width="64" height="32"></rect>
+            <rect x="223" y="385" width="64" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="233" y="405">a_expr</text>
          </a>
-         <rect x="309" y="331" width="26" height="32" rx="10"></rect>
-         <rect x="307" y="329" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="317" y="349">)</text>
-         <rect x="355" y="331" width="74" height="32" rx="10"></rect>
-         <rect x="353" y="329" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="363" y="349">STORED</text>
-         <path class="line" d="m17 17 h2 m40 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m20 -32 h10 m56 0 h10 m0 0 h548 m-752 0 h20 m732 0 h20 m-772 0 q10 0 10 10 m752 0 q0 -10 10 -10 m-762 10 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m74 0 h10 m0 0 h638 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m20 0 h10 m0 0 h514 m-544 0 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v12 m544 0 v-12 m-544 12 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m64 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m64 0 h10 m-722 -42 v20 m752 0 v-20 m-752 20 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h472 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m80 0 h10 m0 0 h10 m64 0 h10 m0 0 h548 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m0 0 h76 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h334 m23 -328 h-3"></path>
+         <rect x="309" y="387" width="26" height="32" rx="10"></rect>
+         <rect x="307" y="385" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="317" y="405">)</text>
+         <rect x="375" y="387" width="74" height="32" rx="10"></rect>
+         <rect x="373" y="385" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="383" y="405">STORED</text>
+         <rect x="375" y="431" width="78" height="32" rx="10"></rect>
+         <rect x="373" y="429" width="78" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="383" y="449">VIRTUAL</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m48 0 h10 m20 0 h10 m56 0 h10 m0 0 h18 m-114 0 h20 m94 0 h20 m-134 0 q10 0 10 10 m114 0 q0 -10 10 -10 m-124 10 v24 m114 0 v-24 m-114 24 q0 10 10 10 m94 0 q10 0 10 -10 m-104 10 h10 m74 0 h10 m20 -44 h530 m-752 0 h20 m732 0 h20 m-772 0 q10 0 10 10 m752 0 q0 -10 10 -10 m-762 10 v68 m752 0 v-68 m-752 68 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m56 0 h10 m0 0 h656 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m74 0 h10 m0 0 h10 m138 0 h10 m0 0 h480 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m82 0 h10 m0 0 h10 m46 0 h10 m20 0 h10 m0 0 h514 m-544 0 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v12 m544 0 v-12 m-544 12 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m64 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m130 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m64 0 h10 m-722 -42 v20 m752 0 v-20 m-752 20 v56 m752 0 v-56 m-752 56 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m0 0 h472 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m80 0 h10 m0 0 h10 m64 0 h10 m0 0 h548 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m106 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m132 0 h10 m0 0 h76 m-742 -10 v20 m752 0 v-20 m-752 20 v24 m752 0 v-24 m-752 24 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m108 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m74 0 h10 m0 0 h4 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m20 -44 h290 m23 -384 h-3"></path>
          <polygon points="801 17 809 13 809 21"></polygon>
          <polygon points="801 17 793 13 793 21"></polygon>
       </svg>
@@ -18828,37 +20002,109 @@
             <li><a href="#const_datetime" title="const_datetime">const_datetime</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="geo_shape_type" href="#geo_shape_type">geo_shape_type:</a></p>
-      <svg width="280" height="344">
+      <svg width="300" height="1400">
          
          <polygon points="9 17 1 13 1 21"></polygon>
          <polygon points="17 17 9 13 9 21"></polygon>
          <rect x="51" y="3" width="64" height="32" rx="10"></rect>
          <rect x="49" y="1" width="64" height="32" class="terminal" rx="10"></rect>
          <text class="terminal" x="59" y="21">POINT</text>
-         <rect x="51" y="47" width="104" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="104" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">LINESTRING</text>
-         <rect x="51" y="91" width="88" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">POLYGON</text>
-         <rect x="51" y="135" width="106" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="106" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">MULTIPOINT</text>
-         <rect x="51" y="179" width="146" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="146" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">MULTILINESTRING</text>
-         <rect x="51" y="223" width="132" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">MULTIPOLYGON</text>
-         <rect x="51" y="267" width="182" height="32" rx="10"></rect>
-         <rect x="49" y="265" width="182" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="285">GEOMETRYCOLLECTION</text>
-         <rect x="51" y="311" width="94" height="32" rx="10"></rect>
-         <rect x="49" y="309" width="94" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="329">GEOMETRY</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h118 m-222 0 h20 m202 0 h20 m-242 0 q10 0 10 10 m222 0 q0 -10 10 -10 m-232 10 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m104 0 h10 m0 0 h78 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m88 0 h10 m0 0 h94 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m106 0 h10 m0 0 h76 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m146 0 h10 m0 0 h36 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m132 0 h10 m0 0 h50 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m182 0 h10 m-212 -10 v20 m222 0 v-20 m-222 20 v24 m222 0 v-24 m-222 24 q0 10 10 10 m202 0 q10 0 10 -10 m-212 10 h10 m94 0 h10 m0 0 h88 m23 -308 h-3"></path>
-         <polygon points="271 17 279 13 279 21"></polygon>
-         <polygon points="271 17 263 13 263 21"></polygon>
+         <rect x="51" y="47" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">POINTM</text>
+         <rect x="51" y="91" width="72" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">POINTZ</text>
+         <rect x="51" y="135" width="82" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="82" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">POINTZM</text>
+         <rect x="51" y="179" width="104" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="104" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">LINESTRING</text>
+         <rect x="51" y="223" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">LINESTRINGM</text>
+         <rect x="51" y="267" width="112" height="32" rx="10"></rect>
+         <rect x="49" y="265" width="112" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="285">LINESTRINGZ</text>
+         <rect x="51" y="311" width="122" height="32" rx="10"></rect>
+         <rect x="49" y="309" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="329">LINESTRINGZM</text>
+         <rect x="51" y="355" width="88" height="32" rx="10"></rect>
+         <rect x="49" y="353" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="373">POLYGON</text>
+         <rect x="51" y="399" width="100" height="32" rx="10"></rect>
+         <rect x="49" y="397" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="417">POLYGONM</text>
+         <rect x="51" y="443" width="96" height="32" rx="10"></rect>
+         <rect x="49" y="441" width="96" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="461">POLYGONZ</text>
+         <rect x="51" y="487" width="108" height="32" rx="10"></rect>
+         <rect x="49" y="485" width="108" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="505">POLYGONZM</text>
+         <rect x="51" y="531" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="529" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="549">MULTIPOINT</text>
+         <rect x="51" y="575" width="118" height="32" rx="10"></rect>
+         <rect x="49" y="573" width="118" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="593">MULTIPOINTM</text>
+         <rect x="51" y="619" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="617" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="637">MULTIPOINTZ</text>
+         <rect x="51" y="663" width="126" height="32" rx="10"></rect>
+         <rect x="49" y="661" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="681">MULTIPOINTZM</text>
+         <rect x="51" y="707" width="146" height="32" rx="10"></rect>
+         <rect x="49" y="705" width="146" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="725">MULTILINESTRING</text>
+         <rect x="51" y="751" width="158" height="32" rx="10"></rect>
+         <rect x="49" y="749" width="158" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="769">MULTILINESTRINGM</text>
+         <rect x="51" y="795" width="154" height="32" rx="10"></rect>
+         <rect x="49" y="793" width="154" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="813">MULTILINESTRINGZ</text>
+         <rect x="51" y="839" width="166" height="32" rx="10"></rect>
+         <rect x="49" y="837" width="166" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="857">MULTILINESTRINGZM</text>
+         <rect x="51" y="883" width="132" height="32" rx="10"></rect>
+         <rect x="49" y="881" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="901">MULTIPOLYGON</text>
+         <rect x="51" y="927" width="142" height="32" rx="10"></rect>
+         <rect x="49" y="925" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="945">MULTIPOLYGONM</text>
+         <rect x="51" y="971" width="140" height="32" rx="10"></rect>
+         <rect x="49" y="969" width="140" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="989">MULTIPOLYGONZ</text>
+         <rect x="51" y="1015" width="150" height="32" rx="10"></rect>
+         <rect x="49" y="1013" width="150" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1033">MULTIPOLYGONZM</text>
+         <rect x="51" y="1059" width="182" height="32" rx="10"></rect>
+         <rect x="49" y="1057" width="182" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1077">GEOMETRYCOLLECTION</text>
+         <rect x="51" y="1103" width="194" height="32" rx="10"></rect>
+         <rect x="49" y="1101" width="194" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1121">GEOMETRYCOLLECTIONM</text>
+         <rect x="51" y="1147" width="190" height="32" rx="10"></rect>
+         <rect x="49" y="1145" width="190" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1165">GEOMETRYCOLLECTIONZ</text>
+         <rect x="51" y="1191" width="202" height="32" rx="10"></rect>
+         <rect x="49" y="1189" width="202" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1209">GEOMETRYCOLLECTIONZM</text>
+         <rect x="51" y="1235" width="94" height="32" rx="10"></rect>
+         <rect x="49" y="1233" width="94" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1253">GEOMETRY</text>
+         <rect x="51" y="1279" width="106" height="32" rx="10"></rect>
+         <rect x="49" y="1277" width="106" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1297">GEOMETRYM</text>
+         <rect x="51" y="1323" width="102" height="32" rx="10"></rect>
+         <rect x="49" y="1321" width="102" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1341">GEOMETRYZ</text>
+         <rect x="51" y="1367" width="114" height="32" rx="10"></rect>
+         <rect x="49" y="1365" width="114" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="1385">GEOMETRYZM</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m64 0 h10 m0 0 h138 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m74 0 h10 m0 0 h128 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m72 0 h10 m0 0 h130 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m82 0 h10 m0 0 h120 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m114 0 h10 m0 0 h88 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m112 0 h10 m0 0 h90 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m122 0 h10 m0 0 h80 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m88 0 h10 m0 0 h114 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m100 0 h10 m0 0 h102 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m96 0 h10 m0 0 h106 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m108 0 h10 m0 0 h94 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m106 0 h10 m0 0 h96 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m118 0 h10 m0 0 h84 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m114 0 h10 m0 0 h88 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m126 0 h10 m0 0 h76 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m146 0 h10 m0 0 h56 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m158 0 h10 m0 0 h44 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m154 0 h10 m0 0 h48 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m166 0 h10 m0 0 h36 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m132 0 h10 m0 0 h70 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m142 0 h10 m0 0 h60 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m140 0 h10 m0 0 h62 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m150 0 h10 m0 0 h52 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m182 0 h10 m0 0 h20 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m194 0 h10 m0 0 h8 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m190 0 h10 m0 0 h12 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m202 0 h10 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m94 0 h10 m0 0 h108 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m106 0 h10 m0 0 h96 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m102 0 h10 m0 0 h100 m-232 -10 v20 m242 0 v-20 m-242 20 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m114 0 h10 m0 0 h88 m23 -1364 h-3"></path>
+         <polygon points="291 17 299 13 299 21"></polygon>
+         <polygon points="291 17 283 13 283 21"></polygon>
       </svg>
       <p>referenced by:
          </p><ul>
@@ -19176,6 +20422,100 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#expr_tuple_unambiguous" title="expr_tuple_unambiguous">expr_tuple_unambiguous</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="list_partition" href="#list_partition">list_partition:</a></p>
+      <svg width="608" height="36">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#partition" xlink:title="partition">
+            <rect x="31" y="3" width="72" height="32"></rect>
+            <rect x="29" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">partition</text>
+         </a>
+         <rect x="123" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="121" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="131" y="21">VALUES</text>
+         <rect x="215" y="3" width="36" height="32" rx="10"></rect>
+         <rect x="213" y="1" width="36" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="21">IN</text>
+         <rect x="271" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="269" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="279" y="21">(</text>
+         <a xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="317" y="3" width="74" height="32"></rect>
+            <rect x="315" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="325" y="21">expr_list</text>
+         </a>
+         <rect x="411" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="409" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="419" y="21">)</text>
+         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
+            <rect x="457" y="3" width="124" height="32"></rect>
+            <rect x="455" y="1" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="465" y="21">opt_partition_by</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m124 0 h10 m3 0 h-3"></path>
+         <polygon points="599 17 607 13 607 21"></polygon>
+         <polygon points="599 17 591 13 591 21"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#list_partitions" title="list_partitions">list_partitions</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="range_partition" href="#range_partition">range_partition:</a></p>
+      <svg width="724" height="102">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <a xlink:href="#partition" xlink:title="partition">
+            <rect x="31" y="3" width="72" height="32"></rect>
+            <rect x="29" y="1" width="72" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="39" y="21">partition</text>
+         </a>
+         <rect x="123" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="121" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="131" y="21">VALUES</text>
+         <rect x="215" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="213" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="223" y="21">FROM</text>
+         <rect x="293" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="291" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="301" y="21">(</text>
+         <a xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="339" y="3" width="74" height="32"></rect>
+            <rect x="337" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="347" y="21">expr_list</text>
+         </a>
+         <rect x="433" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="431" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="441" y="21">)</text>
+         <rect x="479" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="477" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="487" y="21">TO</text>
+         <rect x="537" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="535" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="545" y="21">(</text>
+         <a xlink:href="#expr_list" xlink:title="expr_list">
+            <rect x="583" y="3" width="74" height="32"></rect>
+            <rect x="581" y="1" width="74" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="591" y="21">expr_list</text>
+         </a>
+         <rect x="677" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="675" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="685" y="21">)</text>
+         <a xlink:href="#opt_partition_by" xlink:title="opt_partition_by">
+            <rect x="573" y="69" width="124" height="32"></rect>
+            <rect x="571" y="67" width="124" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="581" y="87">opt_partition_by</text>
+         </a>
+         <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m0 0 h10 m72 0 h10 m0 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-174 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m124 0 h10 m3 0 h-3"></path>
+         <polygon points="715 83 723 79 723 87"></polygon>
+         <polygon points="715 83 707 79 707 87"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#range_partitions" title="range_partitions">range_partitions</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_as_col_qualification_elem" href="#create_as_col_qualification_elem">create_as_col_qualification_elem:</a></p>
       <svg width="206" height="36">
@@ -19561,6 +20901,25 @@
       <p>referenced by:
          </p><ul>
             <li><a href="#special_function" title="special_function">special_function</a></li>
+         </ul>
+      <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="opt_partition_by" href="#opt_partition_by">opt_partition_by:</a></p>
+      <svg width="194" height="56">
+         
+         <polygon points="9 5 1 1 1 9"></polygon>
+         <polygon points="17 5 9 1 9 9"></polygon>
+         <a xlink:href="#partition_by" xlink:title="partition_by">
+            <rect x="51" y="23" width="96" height="32"></rect>
+            <rect x="49" y="21" width="96" height="32" class="nonterminal"></rect>
+            <text class="nonterminal" x="59" y="41">partition_by</text>
+         </a>
+         <path class="line" d="m17 5 h2 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m23 -32 h-3"></path>
+         <polygon points="185 5 193 1 193 9"></polygon>
+         <polygon points="185 5 177 1 177 9"></polygon>
+      </svg>
+      <p>referenced by:
+         </p><ul>
+            <li><a href="#list_partition" title="list_partition">list_partition</a></li>
+            <li><a href="#range_partition" title="range_partition">range_partition</a></li>
          </ul>
       <p></p><br/><p style="font-size: 14px; font-weight:bold"><a name="create_as_param" href="#create_as_param">create_as_param:</a></p>
       <svg width="164" height="36">


### PR DESCRIPTION
This PR includes the full SQL grammar diagram for 21.1 (built on https://github.com/cockroachdb/cockroach/pull/63168/commits/56fc9e44fc57ccbd95e1e2bc87028dbfb33a389f).

This PR needs to be merged into master in order to merge PRs with SQL diagrams containing updated 21.1 SQL syntax https://github.com/cockroachdb/cockroach/pull/63168.