### PR TITLE
Updated cdc known limitations for primary key changes

### DIFF
--- a/_includes/v21.1/known-limitations/cdc.md
+++ b/_includes/v21.1/known-limitations/cdc.md
@@ -4,6 +4,6 @@
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html).
 - Partial or intermittent sink unavailability may impact changefeed stability; however, [ordering guarantees](stream-data-out-of-cockroachdb-using-changefeeds.html#ordering-guarantees) will still hold for as long as a changefeed [remains active](stream-data-out-of-cockroachdb-using-changefeeds.html#monitor-a-changefeed).
 - Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).
-- Additional target options will be added, including partitions and ranges of primary key rows.
+- Additional target options will be added, including partitions.
 - Changefeeds do not pick up data ingested with the [`IMPORT INTO`](import-into.html) statement.
 - Using a [cloud storage sink](create-changefeed.html#cloud-storage-sink) only works with `JSON` and emits [newline-delimited json](http://ndjson.org) files.


### PR DESCRIPTION
Updated cdc known limitations list to remove primary key changes from the "additional target options to be added" bullet. 

Closes #10050 