### PR TITLE
Disk spilling support for hash aggregations

### DIFF
--- a/_includes/v20.2/known-limitations/unordered-operations.md
+++ b/_includes/v20.2/known-limitations/unordered-operations.md
@@ -1,3 +1,7 @@
-Unordered aggregation operations do not support disk spilling, and are limited by the `--max-sql-memory` setting. If unordered aggregation operations exceed the amount of memory available to the SQL layer, CockroachDB will throw an error, and in some circumstances could crash.
+Unordered aggregation operations do not support disk spilling, and are limited by the [`--max-sql-memory`](cockroach-start#general) setting. If unordered aggregation operations exceed the amount of memory available to the SQL layer, CockroachDB will throw an error, and in some circumstances could crash.
+
+{{site.data.alerts.callout_info}}
+Setting `--max-sql-memory` too high could result in performance problems due to increased memory consumption.
+{{site.data.alerts.end}}
 
 See the [GitHub tracking issue](https://github.com/cockroachdb/cockroach/issues/42485) for details.

--- a/_includes/v20.2/known-limitations/unordered-operations.md
+++ b/_includes/v20.2/known-limitations/unordered-operations.md
@@ -1,0 +1,3 @@
+Unordered aggregation operations do not support disk spilling, and are limited by the `--max-sql-memory` setting. If unordered aggregation operations exceed the amount of memory available to the SQL layer, CockroachDB will throw an error, and in some circumstances could crash.
+
+See the [GitHub tracking issue](https://github.com/cockroachdb/cockroach/issues/42485) for details.

--- a/_includes/v21.1/known-limitations/unordered-distinct-operations.md
+++ b/_includes/v21.1/known-limitations/unordered-distinct-operations.md
@@ -1,0 +1,8 @@
+Disk spilling [isn't supported](https://github.com/cockroachdb/cockroach/issues/61411) when running `UPSERT` statements that have `nulls are distinct` and `error on duplicate` markers. You can check this by using `EXPLAIN` and looking at the statement plan.
+
+~~~
+        ├── distinct                     |                     |
+        │    │                           | distinct on         | ...
+        │    │                           | nulls are distinct  |
+        │    │                           | error on duplicate  |
+~~~

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -547,6 +547,10 @@ If the execution of a [join](joins.html) query exceeds the limit set for memory-
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/35706)
 
+### Disk-spilling not supported for unordered aggregation operations
+
+{% include {{ page.version.version }}/known-limitations/unordered-operations.md %}
+
 ### Inverted indexes cannot be partitioned
 
 CockroachDB does not support partitioning inverted indexes, including [spatial indexes](spatial-indexes.html).

--- a/v20.2/vectorized-execution.md
+++ b/v20.2/vectorized-execution.md
@@ -62,9 +62,9 @@ You can also configure a node's total budget for in-memory query processing at n
 
 ## Known limitations
 
-### Unordered aggregations
+### Unordered aggregation operations
 
-Unordered aggregations do not support disk spilling, and are limited by the `--max-sql-memory` setting. If unordered aggregation operations exceed the amount of memory available to the SQL layer, CockroachDB will throw an error.
+{% include {{ page.version.version }}/known-limitations/unordered-operations.md %}
 
 ### Unsupported queries
 

--- a/v20.2/vectorized-execution.md
+++ b/v20.2/vectorized-execution.md
@@ -56,11 +56,15 @@ The following operations require [memory buffering](https://en.wikipedia.org/wik
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 - [Window functions](window-functions.html). Note that [support for window functions is limited in the vectorized execution engine](#window-functions).
 
-If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk. By default, the memory limit allocated per operator is 64MiB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
+If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk if the operation supports disk spilling. By default, the memory limit allocated per operator is 64MiB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
 
-You can also configure a node's total budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If the queries running on the node exceed the memory budget, the node spills intermediate execution results to disk. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity. If the maximum on-disk storage capacity is reached, the query will return an error during execution.
+You can also configure a node's total budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If the queries running on the node exceed the memory budget, the node spills intermediate execution results to disk, if possible. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity. If the maximum on-disk storage capacity is reached, the query will return an error during execution.
 
 ## Known limitations
+
+### Unordered aggregations
+
+Unordered aggregations do not support disk spilling, and are limited by the `--max-sql-memory` setting. If unordered aggregation operations exceed the amount of memory available to the SQL layer, CockroachDB will throw an error.
 
 ### Unsupported queries
 

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -540,6 +540,10 @@ If the execution of a [join](joins.html) query exceeds the limit set for memory-
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/35706)
 
+### Disk-spilling not supported for some unordered distinct operations
+
+{% include {{ page.version.version }}/known-limitations/unordered-distinct-operations.md %}
+
 ### Inverted indexes cannot be partitioned
 
 CockroachDB does not support partitioning inverted indexes, including [spatial indexes](spatial-indexes.html).

--- a/v21.1/vectorized-execution.md
+++ b/v21.1/vectorized-execution.md
@@ -77,14 +77,7 @@ The vectorized engine does not support [working with spatial data](spatial-data.
 
 ### Unordered distinct operations
 
-Disk spilling isn't supported when running `UPSERT` statements that have `nulls are distinct` and `error on duplicate` markers. You can check this by using `EXPLAIN` and looking at the statement plan.
-
-~~~
-        ├── distinct                     |                     |
-        │    │                           | distinct on         | ...
-        │    │                           | nulls are distinct  |
-        │    │                           | error on duplicate  |
-~~~
+{% include {{ page.version.version }}/known-limitations/unordered-distinct-operations.md %}
 
 ## See also
 

--- a/v21.1/vectorized-execution.md
+++ b/v21.1/vectorized-execution.md
@@ -75,7 +75,7 @@ Support for certain [window functions](window-functions.html) is limited in the 
 
 The vectorized engine does not support [working with spatial data](spatial-data.html). Queries with [geospatial functions](functions-and-operators.html#spatial-functions) or [spatial data](spatial-data.html) will revert to the row-oriented execution engine.
 
-### Unordered distinct aggregations
+### Unordered distinct operations
 
 Disk spilling isn't supported when running `UPSERT` statements that have `nulls are distinct` and `error on duplicate` markers. You can check this by using `EXPLAIN` and looking at the statement plan.
 

--- a/v21.1/vectorized-execution.md
+++ b/v21.1/vectorized-execution.md
@@ -55,7 +55,7 @@ The following operations require [memory buffering](https://en.wikipedia.org/wik
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 - [Window functions](window-functions.html). Note that [support for window functions is limited in the vectorized execution engine](#window-functions).
 
-If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk. By default, the memory limit allocated per operator is 64MB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
+If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk. By default, the memory limit allocated per operator is 64MiB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
 
 You can also configure a node's total budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If the queries running on the node exceed the memory budget, the node spills intermediate execution results to disk. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity. If the maximum on-disk storage capacity is reached, the query will return an error during execution.
 

--- a/v21.1/vectorized-execution.md
+++ b/v21.1/vectorized-execution.md
@@ -55,7 +55,7 @@ The following operations require [memory buffering](https://en.wikipedia.org/wik
 - [Merge joins](joins.html#merge-joins) on non-unique columns. Merge joins on columns that are guaranteed to have one row per value, also known as "key columns", can execute entirely in-memory.
 - [Window functions](window-functions.html). Note that [support for window functions is limited in the vectorized execution engine](#window-functions).
 
-If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk. By default, the memory limit allocated per operator is 64MiB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
+If there is not enough memory allocated for an operation, CockroachDB will spill the intermediate execution results to disk. By default, the memory limit allocated per operator is 64MB. You can change this limit with the `sql.distsql.temp_storage.workmem` [cluster setting](cluster-settings.html).
 
 You can also configure a node's total budget for in-memory query processing at node startup with the [`--max-sql-memory` flag](cockroach-start.html#general). If the queries running on the node exceed the memory budget, the node spills intermediate execution results to disk. The [`--max-disk-temp-storage` flag](cockroach-start.html#general) sets the maximum on-disk storage capacity. If the maximum on-disk storage capacity is reached, the query will return an error during execution.
 
@@ -74,6 +74,17 @@ Support for certain [window functions](window-functions.html) is limited in the 
 ### Spatial features
 
 The vectorized engine does not support [working with spatial data](spatial-data.html). Queries with [geospatial functions](functions-and-operators.html#spatial-functions) or [spatial data](spatial-data.html) will revert to the row-oriented execution engine.
+
+### Unordered distinct aggregations
+
+Disk spilling isn't supported when running `UPSERT` statements that have `nulls are distinct` and `error on duplicate` markers. You can check this by using `EXPLAIN` and looking at the statement plan.
+
+~~~
+        ├── distinct                     |                     |
+        │    │                           | distinct on         | ...
+        │    │                           | nulls are distinct  |
+        │    │                           | error on duplicate  |
+~~~
 
 ## See also
 


### PR DESCRIPTION
Fixes #9609
Fixes #9922

Also clarifies the lack of support for disk spilling for hash aggregations in 20.2 docs.