### PR TITLE
Remove unnecessary enterprise license prereq

### DIFF
--- a/v21.1/demo-low-latency-multi-region-deployment.md
+++ b/v21.1/demo-low-latency-multi-region-deployment.md
@@ -29,7 +29,6 @@ Because the instructions on this page describe how to simulate a multi-region cl
 
 ## Prerequisites
 
-- [A CockroachDB trial enterprise license](#a-cockroachdb-trial-enterprise-license)
 - [A basic understanding of the MovR application](#a-basic-understanding-of-the-movr-application)
 - [Docker](https://www.docker.com) installed on the local machine
 


### PR DESCRIPTION
A temporary enterprise license comes built-in with `cockroach demo`.