### PR TITLE
Added missing info to PGX tutorial

### DIFF
--- a/v20.2/build-a-go-app-with-cockroachdb.md
+++ b/v20.2/build-a-go-app-with-cockroachdb.md
@@ -68,6 +68,12 @@ config, err := pgx.ParseConfig("postgresql://{user}:{password}@{globalhost}:2625
 
 {% include {{page.version.version}}/app/cc-free-tier-params.md %}
 
+Then, remove the following line of code:
+
+~~~ go
+config.TLSConfig.ServerName = "localhost"
+~~~
+
 </section>
 
 {{site.data.alerts.callout_success}}

--- a/v21.1/build-a-go-app-with-cockroachdb.md
+++ b/v21.1/build-a-go-app-with-cockroachdb.md
@@ -68,6 +68,12 @@ config, err := pgx.ParseConfig("postgresql://{user}:{password}@{globalhost}:2625
 
 {% include {{page.version.version}}/app/cc-free-tier-params.md %}
 
+Then, remove the following line of code:
+
+~~~ go
+config.TLSConfig.ServerName = "localhost"
+~~~
+
 </section>
 
 {{site.data.alerts.callout_success}}


### PR DESCRIPTION
The PGX hello world tutorial won't run for CockroachCloud with the following line of code:

```
config.TLSConfig.ServerName = "localhost"
```

I believe this line is required to run the app against the demo cluster, which uses the `require` SSL mode.

Thanks @kathancox for finding this bug!