### PR TITLE
Tweak multi-region tutorial

### DIFF
--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -90,7 +90,7 @@
                 ]
               },
               {
-                "title": "Multi-Region Topologies",
+                "title": "Multi-Region Performance",
                 "urls": [
                   "/${VERSION}/demo-low-latency-multi-region-deployment.html"
                 ]


### PR DESCRIPTION
- Minor language tweaks.
- Added explicit commands for applying REGIONAL BY ROW
  to all relevant tables. This was a burden to do manualy
  when I was testing the tutorial.
- Renamed tutorial in sidenav.