### PR TITLE
v21.1.0-beta.5 release notes

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -79,10 +79,10 @@ release_info:
     start_time: 2021-03-29 11:01:26.34274101 +0000 UTC
     version: v20.2.7
   v21.1:
-    build_time: 2021/4/19 11:00:26 (go1.15.5)
+    build_time: 2021/4/26 11:00:26 (go1.15.5)
     docker_image: cockroachdb/cockroach-unstable
     name: v21.1.0
-    start_time: 2021-4-19 11:01:26.34274101 +0000 UTC
-    version: v21.1.0-beta.4
+    start_time: 2021-4-26 11:01:26.34274101 +0000 UTC
+    version: v21.1.0-beta.5
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -225,6 +225,8 @@
       no_windows: true
 - title: Testing releases
   releases:
+    - date: Apr 26, 2021
+      version: v21.1.0-beta.5
     - date: Apr 19, 2021
       version: v21.1.0-beta.4
     - date: Apr 12, 2021

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -73,7 +73,8 @@
         "/releases/v21.1.0-beta.1.html",
         "/releases/v21.1.0-beta.2.html",
         "/releases/v21.1.0-beta.3.html",
-        "/releases/v21.1.0-beta.4.html"
+        "/releases/v21.1.0-beta.4.html",
+        "/releases/v21.1.0-beta.5.html"
       ]
     },
     {

--- a/releases/v21.1.0-beta.5.md
+++ b/releases/v21.1.0-beta.5.md
@@ -1,0 +1,120 @@
+---
+title: What&#39;s New in v21.1.0-beta.5
+toc: true
+summary: Additions and changes in CockroachDB version v21.1.0-beta.5 since version v21.1.0-beta.4
+---
+
+## April 26, 2021
+
+Get future release notes emailed to you:
+
+{% include marketo.html %}
+
+### Downloads
+
+<div id="os-tabs" class="filters clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.1.0-beta.5.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.1.0-beta.5.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.1.0-beta.5.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.1.0-beta.5.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes"></a>
+</div>
+
+<section class="filter-content" data-scope="windows">
+{% include windows_warning.md %}
+</section>
+
+### Docker image
+
+{% include copy-clipboard.html %}
+~~~shell
+$ docker pull cockroachdb/cockroach-unstable:v21.1.0-beta.5
+~~~
+
+### Backward-incompatible changes
+
+- The internal representation of the `voter_constraints` zone configuration attribute (new in 21.1) has been altered in a way that's partially incompatible with the representation used by previous 21.1 betas (and the alphas that include this attribute). This means that Users who directly set the `voter_constraints` attribute to an empty list _will lose_ those constraints and will have to reset them. [#63674][#63674]
+
+### General changes
+
+- Upgrade the CRDB binary to Go 1.15.10 [#63865][#63865]
+
+### Enterprise edition changes
+
+- Changefeeds will now fail on any regional by row table with an error such as:      CHANGEFEED cannot target REGIONAL BY ROW tables: TABLE_NAME  This is to prevent unexpected changefeed behavior until we can offer full support for regional by row tables. [#63542][#63542]
+
+### SQL language changes
+
+- RESTORE now re-validates restored indexes if they were restored from an incremental backup that was taken while the index was being created. [#63320][#63320]
+- Fix ST_Segmentize panicking when the number of segments to generate exceeds math.MaxInt64. [#63758][#63758]
+- Earlier st_simplify with NaN caused node to crash. This fixes the behaviour to align it more to PostGIS. [#63797][#63797]
+- `sql.distsql.temp_storage.workmem` cluster setting is now marked as public and is included into the documentation. It determines how much RAM a single operation of a single query can use before it must spill to temporary storage. Note the operations that don't support the disk spilling will ignore this setting and are subject only to `--max-sql-memory` startup argument. [#63997][#63997]
+
+### Command-line changes
+
+- Added --verbose flag to debug doctor command. [#63949][#63949]
+- The doctor debug tool now has new 'examine' and 'recreate' commands. The new 'debug doctor examine' invocation replaces the old 'debug doctor' invocation. The new 'debug doctor recreate' invocation prints SQL statements which will recreate the descriptor and namespace state when run in a new, empty cluster. [#63949][#63949]
+
+### Bug fixes
+
+- Lease acquisitions of descriptor in a offline state may starve out bulk operations (backup / restore) [#63558][#63558]
+- Fixed bugs where TRUNCATE concurrent with index construction and other schema changes could result in corruption. [#63143][#63143]
+- Fixed a panic which can occur in cases after a RESTORE of a table using user defined types. [#63549][#63549]
+- Error gracefully when attempting to run ST_Segmentize and generating more than MaxInt64 points on a GEOGRAPHY. [#63758][#63758]
+- Use existing primary key to validate indexes built for ALTER PRIMARY KEY changes. [#63609][#63609]
+- Fixed occasional stalls and excessive CPU usage under macOS Big Sur when built with Go 1.14 or newer. [#63789][#63789]
+- Fix a bug where crdb_internal.validate_multi_region_zone_configs() fails during a REGIONAL BY ROW locality transition. [#63834][#63834]
+- Fixed an internal error that could occur when executing queries using an inverted index. The error was an index out of range error, and could occur in rare cases when a filter or join predicate contained at least two JSON, Array, Geometry or Geography expressions that were combined with AND. This has now been fixed. [#63811][#63811]
+- A bug leading to crashes with the message "writing below closed ts" has been fixed. [#63861][#63861]
+- Previously if a user altered a table to REGIONAL BY ROW when a region was being dropped, and the drop failed and had to be rolled back, it could have resulted in the Regional By Row table missing a partition for this region. This is now fixed and region drop failure rollbacks are sane. [#63793][#63793]
+- Fix crdb_internal.encode_key for user defined types. This would previously error. This will also fix SHOW RANGE FOR ROW for tables with user-defined types as their PRIMARY KEY. [#63878][#63878]
+
+### Performance improvements
+
+- A series of heap allocations performed when serving read-only queries are now avoided. [#63972][#63972]
+
+### Miscellaneous
+
+#### Missing category
+
+- Bug fix; correctly account for used memory when closing compressed files. [#63917][#63917]
+- Kafka and cloud storage sinks use memory monitor to limit the amount of memory that can be used in internal buffers. [#63611][#63611]
+
+#### Changes without release note annotation
+
+- [#63768][#63768] [3da670d4a][3da670d4a] release-21.1: kv: don't commit-wait on each columnBackfiller chunk (Nathan VanBenschoten <nvanbenschoten@gmail.com>)
+
+### Doc updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 48 merged PRs by 23 authors.
+We would like to thank the following contributors from the CockroachDB community:
+
+- Miguel Novelo (first-time contributor)
+- Rupesh Harode (first-time contributor)
+
+[#63143]: https://github.com/cockroachdb/cockroach/pull/63143
+[#63320]: https://github.com/cockroachdb/cockroach/pull/63320
+[#63542]: https://github.com/cockroachdb/cockroach/pull/63542
+[#63549]: https://github.com/cockroachdb/cockroach/pull/63549
+[#63558]: https://github.com/cockroachdb/cockroach/pull/63558
+[#63609]: https://github.com/cockroachdb/cockroach/pull/63609
+[#63611]: https://github.com/cockroachdb/cockroach/pull/63611
+[#63674]: https://github.com/cockroachdb/cockroach/pull/63674
+[#63758]: https://github.com/cockroachdb/cockroach/pull/63758
+[#63768]: https://github.com/cockroachdb/cockroach/pull/63768
+[#63789]: https://github.com/cockroachdb/cockroach/pull/63789
+[#63793]: https://github.com/cockroachdb/cockroach/pull/63793
+[#63797]: https://github.com/cockroachdb/cockroach/pull/63797
+[#63811]: https://github.com/cockroachdb/cockroach/pull/63811
+[#63834]: https://github.com/cockroachdb/cockroach/pull/63834
+[#63861]: https://github.com/cockroachdb/cockroach/pull/63861
+[#63865]: https://github.com/cockroachdb/cockroach/pull/63865
+[#63878]: https://github.com/cockroachdb/cockroach/pull/63878
+[#63917]: https://github.com/cockroachdb/cockroach/pull/63917
+[#63949]: https://github.com/cockroachdb/cockroach/pull/63949
+[#63972]: https://github.com/cockroachdb/cockroach/pull/63972
+[#63997]: https://github.com/cockroachdb/cockroach/pull/63997
+[3da670d4a]: https://github.com/cockroachdb/cockroach/commit/3da670d4a


### PR DESCRIPTION
Follow up to PR https://github.com/cockroachdb/docs/pull/10356 / issue https://github.com/cockroachdb/docs/issues/8938. (No issue was created for 21.1.0 beta 5+.)