### PR TITLE
removed text that says "and click CockroachDB answers to view related documentation." in v20.2 & v21.1

### DIFF
--- a/v20.2/cockroachdb-in-comparison.md
+++ b/v20.2/cockroachdb-in-comparison.md
@@ -6,7 +6,7 @@ toc: false
 comparison: true
 ---
 
-This page shows you how the key features of CockroachDB stack up against other databases. Hover over the features for their intended meanings, and click CockroachDB answers to view related documentation.
+This page shows you how the key features of CockroachDB stack up against other databases. Hover over the features for their intended meanings.
 
 <table class="comparison-chart">
   <tr>

--- a/v21.1/cockroachdb-in-comparison.md
+++ b/v21.1/cockroachdb-in-comparison.md
@@ -6,7 +6,7 @@ toc: false
 comparison: true
 ---
 
-This page shows you how the key features of CockroachDB stack up against other databases. Hover over the features for their intended meanings, and click CockroachDB answers to view related documentation.
+This page shows you how the key features of CockroachDB stack up against other databases. Hover over the features for their intended meanings.
 
 <table class="comparison-chart">
   <tr>


### PR DESCRIPTION
@jseldess issue is done! if anything needs to be edited, let me know :) 
issue: #10243 