### PR TITLE
Added note to confirm RESTORE does not support newer version backups

### DIFF
--- a/v21.1/restore.md
+++ b/v21.1/restore.md
@@ -19,6 +19,10 @@ You can restore:
 - [Tables](#tables)
 
 {{site.data.alerts.callout_info}}
+`RESTORE` cannot restore backups made by newer versions of CockroachDB.
+{{site.data.alerts.end}}
+
+{{site.data.alerts.callout_info}}
 `RESTORE` is a blocking statement. To run a restore job asynchronously, use the `DETACHED` option. See the [options](#options) below.
 {{site.data.alerts.end}}
 


### PR DESCRIPTION
Closes #10374 

Added note to `RESTORE` page to confirm that it doesn't support restoring backups made by newer versions. 
