### PR TITLE
CC machine type, storage, and IOPS info

### DIFF
--- a/_includes/cockroachcloud/cockroachcloud-pricing.md
+++ b/_includes/cockroachcloud/cockroachcloud-pricing.md
@@ -1,10 +1,10 @@
 The choice of the cloud provider decides the price per node. For pricing comparison, refer to the following table:
 
- Hardware configuration            | GCP Pricing (per node, per hour)	  | AWS Pricing (per node, per hour)
------------------------------------+------------------------------------+-----------------------------------
-`Option 1` (2 vCPU, 60 GiB disk)   | $0.50	                            | $0.55
-`Option 2` (4 vCPU, 150 GiB disk)  | $0.89                            	| $1.02
-`Option 3` (8 vCPU, 500 GiB disk)  | $1.78                              | $2.00
-`Option 4` (16 vCPU, 900 GiB disk) | $3.38                              | $3.83
+ Hardware configuration            | AWS IOPS                        | GCP Pricing (per node, per hour)	  | AWS Pricing (per node, per hour) 
+-----------------------------------+---------------------------------+------------------------------------+------------------------------------
+`Option 1` (2 vCPU, 60 GiB disk)   | 600	                           | $0.50	                            | $0.55
+`Option 2` (4 vCPU, 150 GiB disk)  | 900	                           | $0.89                            	| $1.02
+`Option 3` (8 vCPU, 500 GiB disk)  | 1800	                           | $1.78                              | $2.00
+`Option 4` (16 vCPU, 900 GiB disk) | 2000	                           | $3.38                              | $3.83
 
 CockroachCloud does not charge you for data transfer costs.

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -78,7 +78,7 @@ Node Size  | IOPS
 8 vCPU     | 1800
 16 vCPU    | 2000
  
-To change the hardware configuration after the cluster is created, you will have to [contact us](https://support.cockroachlabs.com/hc/en-us/requests/new).
+To change the hardware configuration after the cluster is created, [contact Support](https://support.cockroachlabs.com).
 
 See [Example](#example) for further guidance.
 

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -28,6 +28,8 @@ To create and connect to a 30-day free CockroachCloud cluster and run your first
 
 On the **Create new cluster** page, select either **Google Cloud** or **AWS** as your preferred cloud provider.
 
+CockroachCloud GCP clusters use [N1 standard](https://cloud.google.com/compute/docs/machine-types#n1_machine_types) machine types and [Persistent Disk storage](https://cloud.google.com/compute/docs/disks#pdspecs). AWS clusters use [C5 instance types](https://aws.amazon.com/ec2/instance-types/c5/#Product_Details) and [Elastic Block Store (EBS)](https://aws.amazon.com/ebs/features/). The IOPS associated with each node size in GCP is equal to 30 times the storage size, and the IOPS for AWS nodes is listed below.
+
 {% include cockroachcloud/cockroachcloud-pricing.md %}
 
 ## Step 3. Select the region
@@ -68,15 +70,6 @@ Replication | The default replication factor for a CockroachCloud cluster is 3.
 Buffer | Additional buffer (overhead data, accounting for data growth, etc.). If you are importing an existing dataset, we recommend you provision at least 50% additional storage to account for the import functionality.
 Compression | The percentage of savings you can expect to achieve with compression. With CockroachDB's default compression algorithm, we typically see about a 40% savings on raw data size.
 Transactions per second | Each vCPU can handle around 1000 transactions per second. Hence an `Option 1` node (2vCPUs) can handle 2000 transactions per second and an `Option 2` node (4vCPUs) can handle 4000 transactions per second. If you need more than 4000 transactions per second per node, [contact us](https://support.cockroachlabs.com/hc/en-us/requests/new).
-
-CockroachCloud GCP clusters use [N1 standard](https://cloud.google.com/compute/docs/machine-types#n1_machine_types) machine types and [Persistent Disk storage](https://cloud.google.com/compute/docs/disks#pdspecs). AWS clusters use [C5 instance types](https://aws.amazon.com/ec2/instance-types/c5/#Product_Details) and [Elastic Block Store (EBS)](https://aws.amazon.com/ebs/features/). The IOPS associated with each node size in AWS is as follows:
-
-Node Size  | IOPS
------------+-------
-2 vCPU     | 600
-4 vCPU     | 900
-8 vCPU     | 1800
-16 vCPU    | 2000
  
 To change the hardware configuration after the cluster is created, [contact Support](https://support.cockroachlabs.com).
 

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -69,6 +69,15 @@ Buffer | Additional buffer (overhead data, accounting for data growth, etc.). If
 Compression | The percentage of savings you can expect to achieve with compression. With CockroachDB's default compression algorithm, we typically see about a 40% savings on raw data size.
 Transactions per second | Each vCPU can handle around 1000 transactions per second. Hence an `Option 1` node (2vCPUs) can handle 2000 transactions per second and an `Option 2` node (4vCPUs) can handle 4000 transactions per second. If you need more than 4000 transactions per second per node, [contact us](https://support.cockroachlabs.com/hc/en-us/requests/new).
 
+CockroachCloud GCP clusters use [N1 standard](https://cloud.google.com/compute/docs/machine-types#n1_machine_types) machine types and [Persistent Disk storage](https://cloud.google.com/compute/docs/disks#pdspecs). AWS clusters use [C5 instance types](https://aws.amazon.com/ec2/instance-types/c5/#Product_Details) and [Elastic Block Store (EBS)](https://aws.amazon.com/ebs/features/). The IOPS associated with each node size in AWS is as follows:
+
+Node Size  | IOPS
+-----------+-------
+2 vCPU     | 600
+4 vCPU     | 900
+8 vCPU     | 1800
+16 vCPU    | 2000
+ 
 To change the hardware configuration after the cluster is created, you will have to [contact us](https://support.cockroachlabs.com/hc/en-us/requests/new).
 
 See [Example](#example) for further guidance.


### PR DESCRIPTION
Specified machine types, storage types, and AWS IOPS per node in Step 5 of **Create Your Cluster** page.

Closes: https://cockroachlabs.atlassian.net/browse/CC-3698?atlOrigin=eyJpIjoiNjAwMWVlYWI3Y2U4NDlkMzg2ODUxOTkyY2FjN2U4Y2YiLCJwIjoiaiJ9

Question: Do we want to include IOPS for GCP cluster?