### PR TITLE
Update Go version requirement for building 21.1 from source

### DIFF
--- a/v21.1/install-cockroachdb-linux.html
+++ b/v21.1/install-cockroachdb-linux.html
@@ -174,7 +174,7 @@ true
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.13.9+ is required, but 1.14 and above is not recommended. Older versions might work via <code>make build IGNORE_GOVERS=1</code>.</td>
+          <td>Version 1.15.11+ is required. Older versions might work via <code>make build IGNORE_GOVERS=1</code>.</td>
         </tr>
         <tr>
           <td>Bash</td>
@@ -186,7 +186,7 @@ true
         </tr>
         <tr>
           <td>Autoconf</td>
-          <td>Version 2.68 or higher is required.</td>
+          <td>Version 2.68+ is required.</td>
         </tr>
       </table>
       <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>

--- a/v21.1/install-cockroachdb-mac.html
+++ b/v21.1/install-cockroachdb-mac.html
@@ -189,7 +189,7 @@ true
         </tr>
         <tr>
           <td>Go</td>
-          <td>Version 1.13.9+ is required, but 1.14 and above is not recommended. Older versions might work via <code>make build IGNORE_GOVERS=1</code>.</td>
+          <td>Version 1.15.11+ is required. Older versions might work via <code>make build IGNORE_GOVERS=1</code>.</td>
         </tr>
         <tr>
           <td>Bash</td>
@@ -201,7 +201,7 @@ true
         </tr>
         <tr>
           <td>Autoconf</td>
-          <td>Version 2.68 or higher is required.</td>
+          <td>Version 2.68+ is required.</td>
         </tr>
       </table>
       <p>A 64-bit system is strongly recommended. Building or running CockroachDB on 32-bit systems has not been tested. You'll also need at least 2GB of RAM. If you plan to run our test suite, you'll need closer to 4GB of RAM.</p>


### PR DESCRIPTION
Technically, the minimum required is 1.15.3:
https://github.com/cockroachdb/cockroach/blob/release-21.1/build/go-version-check.sh#L10

However, 1.15.11 avoids these Go bugs:
https://github.com/golang/go/issues/45076
https://github.com/golang/go/issues/45187
https://github.com/golang/go/issues/42884

So to prevent users from running into those, we listing
1.15.11 as the minimum required version, followed by
a note that you can use IGNORE_GOVERS=1 to try building
with older versions.

Fixes #10468
Fixes #9081