### PR TITLE
Timezone db now built into cockroach

### DIFF
--- a/v21.1/install-cockroachdb-windows.html
+++ b/v21.1/install-cockroachdb-windows.html
@@ -30,9 +30,6 @@ Use one of the options below to install CockroachDB.
       <p>Download and extract the <a href="https://binaries.cockroachdb.com/cockroach-{{ page.release_info.version }}.windows-6.2-amd64.zip" class="windows-binary-download" id="windows-binary-download-{{page.version.version}}" data-eventcategory="windows-binary-download">CockroachDB {{ page.release_info.version }} archive for Windows</a>.</p>
     </li>
     <li>
-      <p>To ensure that CockroachDB can use location-based names as time zone identifiers, download Go's official <a href="https://github.com/golang/go/raw/master/lib/time/zoneinfo.zip">zoneinfo.zip</a> and <a href="https://www.techjunkie.com/environment-variables-windows-10/">set the <code>ZONEINFO</code> environment variable</a> to point to the zip file.</p>
-    </li>
-    <li>
       <p>Open PowerShell, navigate to the directory containing the executable, and make sure it works:</p>
       <div class="copy-clipboard">
         <svg data-eventcategory="windows-binary-button" id="copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.st0{fill:#A2A2A2;}</style><title>icon/buttons/copy</title><g id="Mask"><path id="path-1_1_" class="st0" d="M4.9 4.9v6h6v-6h-6zM3.8 3.8H12V12H3.8V3.8zM2.7 7.1v1.1H.1S0 5.5 0 0h8.2v2.7H7.1V1.1h-6v6h1.6z"/></g></svg>

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -189,18 +189,6 @@ Before increasing this value, however, verify that you will not end up saturatin
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/37906)
 
-### Location-based time zone names
-
-Certain features of CockroachDB require time zone data, for example, to support using location-based names as time zone identifiers. When starting a CockroachDB node on a machine missing time zone data, the node will not start.
-
-To resolve this issue on Linux, install the [`tzdata`](https://www.iana.org/time-zones) library (sometimes called `tz` or `zoneinfo`).
-
-To resolve this issue on Windows, download Go's official [zoneinfo.zip](https://github.com/golang/go/raw/master/lib/time/zoneinfo.zip) and set the `ZONEINFO` environment variable to point to the zip file. For step-by-step guidance on setting environment variables on Windows, see this [external article](https://www.techjunkie.com/environment-variables-windows-10/).
-
-Make sure to do this across all nodes in the cluster and to keep this time zone data up-to-date.
-
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/36864)
-
 ### Change data capture
 
 Change data capture (CDC) provides efficient, distributed, row-level change feeds into Apache Kafka for downstream processing such as reporting, caching, or full-text indexing.

--- a/v21.1/recommended-production-settings.md
+++ b/v21.1/recommended-production-settings.md
@@ -292,7 +292,7 @@ Library | Description
 -----------|------------
 [`glibc`](https://www.gnu.org/software/libc/libc.html) | The standard C library.<br><br>If you build CockroachDB from source, rather than use the official CockroachDB binary for Linux, you can use any C standard library, including MUSL, the C standard library used on Alpine.
 `libncurses` | Required by the [built-in SQL shell](cockroach-sql.html).
-[`tzdata`](https://www.iana.org/time-zones) | Required by certain features of CockroachDB that use time zone data, for example, to support using location-based names as time zone identifiers. This library is sometimes called `tz` or `zoneinfo`. On Windows, time zone data is derived from a `zoneinfo.zip` file.<br><br>If a machine running a CockroachDB node is missing this time zone data, the node will not be able to start. For workaround steps, see this [known limitation](known-limitations.html#location-based-time-zone-names).
+[`tzdata`](https://www.iana.org/time-zones) | Required by certain features of CockroachDB that use time zone data, for example, to support using location-based names as time zone identifiers. This library is sometimes called `tz` or `zoneinfo`.<br><br><span class="version-tag">New in v21.1:</span> The CockroachDB binary now includes Go's copy of the `tzdata` library. If CockroachDB can't find the `tzdata` library externally, it will use this built-in copy.
 
 These libraries are found by default on nearly all Linux distributions, with Alpine as the notable exception, but it's nevertheless important to confirm that they are installed and kept up-to-date. For the time zone data in particular, it's important for all nodes to have the same version; when updating the library, do so as quickly as possible across all nodes.
 


### PR DESCRIPTION
- Remove zoneinfo step from Windows install doc.
- Remove tzdata known limitation.
- Update tzdata dependency in product checklist.

Fixes #9082