### PR TITLE
21.1 SQL Support Updates

### DIFF
--- a/v20.2/sql-feature-support.md
+++ b/v20.2/sql-feature-support.md
@@ -26,27 +26,31 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers)
- `INT` | ✓ | Standard | [`INT` documentation](int.html)
- `FLOAT`, `REAL` | ✓ | Standard | [`FLOAT` documentation](float.html)
- `BOOLEAN` | ✓ | Standard | [`BOOL` documentation](bool.html)
- `DECIMAL`, `NUMERIC` | ✓ | Standard | [`DECIMAL` documentation](decimal.html)
- `NULL` | ✓ | Standard | [*NULL*-handling documentation](null-handling.html)
- `BYTES` | ✓ | CockroachDB Extension | [`BYTES` documentation](bytes.html)
- Automatic key generation | ✓ | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
- `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
- `COLLATE` | ✓ | Standard | [`COLLATE` documentation](collate.html)
- `AUTO INCREMENT` | Alternative | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
- Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
  `ARRAY` | ✓ | Standard | [`ARRAY` documentation](array.html)
- `UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
- JSON | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
- `TIME` | ✓ | Standard | [`TIME` documentation](time.html)
- XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
- `UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
- `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
- `INET` | ✓ | PostgreSQL Extension | [`INET` documentation](inet.html)
+ `AUTO INCREMENT`<br>(Automatic key generation) | Alternative | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
+ `BIT` | ✓ | Standard | [`BIT` documentation](bit.html)
+ `BYTES` | ✓ | CockroachDB Extension | [`BYTES` documentation](bytes.html)
+ `BOOLEAN` | ✓ | Standard | [`BOOL` documentation](bool.html)
+ `COLLATE` | ✓ | Standard | [`COLLATE` documentation](collate.html)
+ `DATE` | ✓ | Standard | [`DATE` documentation](date.html)
+ `DECIMAL`, `NUMERIC` | ✓ | Standard | [`DECIMAL` documentation](decimal.html)
  `ENUM` | ✓ | PostgreSQL Extension | <span class="version-tag">New in v20.2:</span> [`ENUM` documentation](enum.html)
+ `FLOAT`, `REAL` | ✓ | Standard | [`FLOAT` documentation](float.html)
+ `INET` | ✓ | PostgreSQL Extension | [`INET` documentation](inet.html)
+ `INT` | ✓ | Standard | [`INT` documentation](int.html)
+ `INTERVAL` | ✓ | Standard | [`INTERVAL` documentation](interval.html)
+ `JSON`/`JSONB` | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
+ `NULL` | ✓ | Standard | [*NULL*-handling documentation](null-handling.html)
+ `SERIAL`| ✓ | PostgreSQL Extension | [`SERIAL` documentation](serial.html)
+ `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
+ `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
+ `TIME` | ✓ | Standard | [`TIME` documentation](time.html)
+ `TIMESTAMP`/`TIMESTAMPTZ` | ✓ | Standard | [`TIMESTAMP` documentation](timestamp.html)
+ `UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
+ `UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
+  Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers)
+  Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
+  XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
 
 ### Constraints
 
@@ -110,7 +114,7 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Common statements | ✓ | Standard | [SQL Statements documentation](sql-statements.html)
+ Common statements | ✓ | Standard, PostgreSQL/CockroachDB Extension | [SQL Statements documentation](sql-statements.html)
  `UPSERT` | ✓ | PostgreSQL, MSSQL Extension | [`UPSERT` documentation](upsert.html)
  `EXPLAIN` | ✓ | Common Extension | [`EXPLAIN` documentation](explain.html)
  `SELECT INTO` | Alternative | Common Extension | You can replicate similar functionality using [`CREATE TABLE`](create-table.html) and then `INSERT INTO ... SELECT ...`.
@@ -160,7 +164,9 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Users | ✓ | Standard | [`GRANT` documentation](grant.html)
+ Users | ✓ | Standard | [Users documentation](authorization.html#sql-users)
+ Roles | ✓ | Standard | [Roles documentation](authorization.html#roles)
+ Object ownership | ✓ | Common Extension | <span class="version-tag">New in v20.2:</span> [Ownership documentation](authorization.html#object-ownership)
  Privileges | ✓ | Standard | [Privileges documentation](authorization.html#assign-privileges)
 
 ### Miscellaneous

--- a/v20.2/sql-feature-support.md
+++ b/v20.2/sql-feature-support.md
@@ -164,7 +164,7 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Users | ✓ | Standard | [Users documentation](authorization.html#sql-users)
+ Users | ✓ | Standard | [Users documentation](authorization.html#users)
  Roles | ✓ | Standard | [Roles documentation](authorization.html#roles)
  Object ownership | ✓ | Common Extension | <span class="version-tag">New in v20.2:</span> [Ownership documentation](authorization.html#object-ownership)
  Privileges | ✓ | Standard | [Privileges documentation](authorization.html#assign-privileges)

--- a/v21.1/postgresql-compatibility.md
+++ b/v21.1/postgresql-compatibility.md
@@ -17,7 +17,18 @@ This document currently only covers unsupported SQL and how to rewrite SQL expre
 
 ## Unsupported Features
 
+### Unsupported PostgreSQL features
+
+The following PostgreSQL features are not supported in CockroachDB {{ page.version.version }}:
+
 {% include {{page.version.version}}/sql/unsupported-postgres-features.md %}
+
+### Unsupported PostgreSQL wire protocol features
+
+The following features of the PostgreSQL wire protocol are not supported in CockroachDB {{ page.version.version }}:
+
+- [Multiple active portals](https://github.com/cockroachdb/cockroach/issues/40195)
+- [Query cancellation](https://github.com/cockroachdb/cockroach/issues/41335)
 
 ## Features that differ from PostgreSQL
 

--- a/v21.1/sql-feature-support.md
+++ b/v21.1/sql-feature-support.md
@@ -26,27 +26,30 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers)
- `INT` | ✓ | Standard | [`INT` documentation](int.html)
- `FLOAT`, `REAL` | ✓ | Standard | [`FLOAT` documentation](float.html)
- `BOOLEAN` | ✓ | Standard | [`BOOL` documentation](bool.html)
- `DECIMAL`, `NUMERIC` | ✓ | Standard | [`DECIMAL` documentation](decimal.html)
- `NULL` | ✓ | Standard | [*NULL*-handling documentation](null-handling.html)
- `BYTES` | ✓ | CockroachDB Extension | [`BYTES` documentation](bytes.html)
- Automatic key generation | ✓ | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
- `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
- `COLLATE` | ✓ | Standard | [`COLLATE` documentation](collate.html)
- `AUTO INCREMENT` | Alternative | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
- Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
  `ARRAY` | ✓ | Standard | [`ARRAY` documentation](array.html)
- `UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
- JSON | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
- `TIME` | ✓ | Standard | [`TIME` documentation](time.html)
- XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
- `UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
- `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
- `INET` | ✓ | PostgreSQL Extension | [`INET` documentation](inet.html)
+ `AUTO INCREMENT`<br>(Automatic key generation) | Alternative | Common Extension | [Automatic key generation FAQ](sql-faqs.html#how-do-i-auto-generate-unique-row-ids-in-cockroachdb)
+ `BIT` | ✓ | Standard | [`BIT` documentation](bit.html)
+ `BYTES` | ✓ | CockroachDB Extension | [`BYTES` documentation](bytes.html)
+ `BOOLEAN` | ✓ | Standard | [`BOOL` documentation](bool.html)
+ `COLLATE` | ✓ | Standard | [`COLLATE` documentation](collate.html)
+ `DATE` | ✓ | Standard | [`DATE` documentation](date.html)
+ `DECIMAL`, `NUMERIC` | ✓ | Standard | [`DECIMAL` documentation](decimal.html)
  `ENUM` | ✓ | PostgreSQL Extension |  [`ENUM` documentation](enum.html)
+ `FLOAT`, `REAL` | ✓ | Standard | [`FLOAT` documentation](float.html)
+ `INET` | ✓ | PostgreSQL Extension | [`INET` documentation](inet.html)
+ `INT` | ✓ | Standard | [`INT` documentation](int.html)
+ `INTERVAL` | ✓ | Standard | [`INTERVAL` documentation](interval.html)
+ `JSON`/`JSONB` | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
+ `NULL` | ✓ | Standard | [*NULL*-handling documentation](null-handling.html)
+ `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
+ `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
+ `TIME` | ✓ | Standard | [`TIME` documentation](time.html)
+ `TIMESTAMP`/`TIMESTAMPTZ` | ✓ | Standard | [`TIMESTAMP` documentation](timestamp.html)
+ `UNSIGNED INT` | ✗ | Common Extension | `UNSIGNED INT` causes numerous casting issues, so we do not plan to support it.
+ `UUID` | ✓ | PostgreSQL Extension | [`UUID` documentation](uuid.html)
+  Identifiers | ✓ | Standard | [Identifiers documentation](keywords-and-identifiers.html#identifiers)
+  Key-value pairs | Alternative | Extension | [Key-Value FAQ](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store)
+  XML | ✗ | Standard | XML data can be stored as `BYTES`, but we do not offer XML parsing.
 
 ### Constraints
 

--- a/v21.1/sql-feature-support.md
+++ b/v21.1/sql-feature-support.md
@@ -41,6 +41,7 @@ table tr td:nth-child(2) {
  `INTERVAL` | ✓ | Standard | [`INTERVAL` documentation](interval.html)
  `JSON`/`JSONB` | ✓ | Common Extension | [`JSONB` documentation](jsonb.html)
  `NULL` | ✓ | Standard | [*NULL*-handling documentation](null-handling.html)
+ `SERIAL`| ✓ | PostgreSQL Extension | [`SERIAL` documentation](serial.html)
  `SET`| ✗ | MySQL| Only allow rows to contain values from a defined set of terms.
  `STRING`, `CHARACTER` | ✓ | Standard | [`STRING` documentation](string.html)
  `TIME` | ✓ | Standard | [`TIME` documentation](time.html)
@@ -113,7 +114,7 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Common statements | ✓ | Standard | [SQL Statements documentation](sql-statements.html)
+ Common statements | ✓ | Standard, PostgreSQL/CockroachDB Extension | [SQL Statements documentation](sql-statements.html)
  `UPSERT` | ✓ | PostgreSQL, MSSQL Extension | [`UPSERT` documentation](upsert.html)
  `EXPLAIN` | ✓ | Common Extension | [`EXPLAIN` documentation](explain.html)
  `SELECT INTO` | Alternative | Common Extension | You can replicate similar functionality using [`CREATE TABLE`](create-table.html) and then `INSERT INTO ... SELECT ...`.
@@ -163,7 +164,9 @@ table tr td:nth-child(2) {
 
  Component | Supported | Type | Details
 -----------|-----------|------|---------
- Users | ✓ | Standard | [`GRANT` documentation](grant.html)
+ Users | ✓ | Standard | [Users documentation](authorization.html#sql-users)
+ Roles | ✓ | Standard | [Roles documentation](authorization.html#roles)
+ Object ownership | ✓ | Common Extension | [Ownership documentation](authorization.html#object-ownership)
  Privileges | ✓ | Standard | [Privileges documentation](authorization.html#assign-privileges)
 
 ### Miscellaneous
@@ -171,13 +174,15 @@ table tr td:nth-child(2) {
  Component | Supported | Type | Details
 -----------|-----------|------|---------
  Column families | ✓ | CockroachDB Extension | [Column Families documentation](column-families.html)
+ Computed columns (stored and virtual) | ✓ | Common Extension | [Computed Columns documentation](computed-columns.html)
  Interleaved tables | ✓ | CockroachDB Extension | [Interleaved Tables documentation](interleave-in-parent.html)<br>{% include {{ page.version.version }}/misc/interleave-deprecation-note.md %}
- Information Schema | ✓ | Standard | [Information Schema documentation](information-schema.html)
+ Multi-region capabilities | ✓ | CockroachDB Extension | [Multi-region documentation](multiregion-overview.html)
+ System catalog schemas | ✓ | Standard, PostgreSQL/CockroachDB Extension | [`crdb_internal`](crdb-internal.html) (CockroachDB Extension)<br>[`information_schema`](information-schema.html) (Standard)<br>[`pg_catalog`](pg_catalog.html) (PostgreSQL Extension)<br>[`pg_extension`](pg_extension.html) (PostgreSQL Extension)
+ Sequences |  ✓ | Common Extension | [`CREATE SEQUENCE` documentation](create-sequence.html)
  Views | ✓ | Standard | [Views documentation](views.html)
  Materialized views | ✓ | Common Extension |  [Materialized views documentation](views.html#materialized-views)
  Window functions | ✓ | Standard | [Window Functions documentation](window-functions.html)
- Common Table Expressions | Partial | Common Extension | [Common Table Expressions documentation](common-table-expressions.html)
- Stored Procedures | Planned | Common Extension | Execute a procedure explicitly.
+ Common table expressions | Partial | Common Extension | [Common Table Expressions documentation](common-table-expressions.html)
+ Stored procedures | Planned | Common Extension | Execute a procedure explicitly.
  Cursors | ✗ | Standard | Traverse a table's rows.
  Triggers | ✗ | Standard | Execute a set of commands whenever a specified event occurs.
- Sequences |  ✓ | Common Extension | [`CREATE SEQUENCE` documentation](create-sequence.html)

--- a/v21.1/sql-feature-support.md
+++ b/v21.1/sql-feature-support.md
@@ -177,7 +177,7 @@ table tr td:nth-child(2) {
  Computed columns (stored and virtual) | ✓ | Common Extension | [Computed Columns documentation](computed-columns.html)
  Interleaved tables | ✓ | CockroachDB Extension | [Interleaved Tables documentation](interleave-in-parent.html)<br>{% include {{ page.version.version }}/misc/interleave-deprecation-note.md %}
  Multi-region capabilities | ✓ | CockroachDB Extension | [Multi-region documentation](multiregion-overview.html)
- System catalog schemas | ✓ | Standard, PostgreSQL/CockroachDB Extension | [`crdb_internal`](crdb-internal.html) (CockroachDB Extension)<br>[`information_schema`](information-schema.html) (Standard)<br>[`pg_catalog`](pg_catalog.html) (PostgreSQL Extension)<br>[`pg_extension`](pg_extension.html) (PostgreSQL Extension)
+ System catalog schemas | ✓ | Standard, PostgreSQL/CockroachDB Extension | [`crdb_internal`](crdb-internal.html) (CockroachDB Extension)<br>[`information_schema`](information-schema.html) (Standard)<br>[`pg_catalog`](pg-catalog.html) (PostgreSQL Extension)<br>[`pg_extension`](pg-extension.html) (PostgreSQL Extension)
  Sequences |  ✓ | Common Extension | [`CREATE SEQUENCE` documentation](create-sequence.html)
  Views | ✓ | Standard | [Views documentation](views.html)
  Materialized views | ✓ | Common Extension |  [Materialized views documentation](views.html#materialized-views)


### PR DESCRIPTION
See commits for details.

Fixes https://github.com/cockroachdb/docs/issues/10524.
Fixes https://github.com/cockroachdb/docs/issues/10361.
Fixes https://github.com/cockroachdb/docs/issues/10349.

TBH, there weren't that many SQL feature updates to add this release. Feel free to request additions - happy to make any revisions.