### PR TITLE
Add Cluster API v2 doc to complement its reference page

### DIFF
--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -2721,7 +2721,7 @@
             "urls": [
               "/api/cluster/v2.html"
             ]
-          }
+          },
           {
             "title": "Cluster Settings",
             "items": [

--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -965,6 +965,12 @@
                 "urls": [
                   "/${VERSION}/monitor-cockroachdb-with-prometheus.html"
                 ]
+              },
+              {
+                "title": "Cluster API",
+                "urls": [
+                  "/${VERSION}/cluster-api.html"
+                ]
               }
             ]
           },
@@ -2710,6 +2716,12 @@
               }
             ]
           },
+          {
+            "title": "Cluster API",
+            "urls": [
+              "/api/cluster/v2.html"
+            ]
+          }
           {
             "title": "Cluster Settings",
             "items": [

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -1,12 +1,12 @@
 ---
-title: Cluster API
+title: Cluster API v2.0
 summary: Programmatically access and monitor cluster and node status information with a RESTful API.
 toc: true
 ---
 
 The CockroachDB Cluster API is a REST API that provides information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console](ui-overview.html) user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
 
-The Cluster API is hosted by all nodes of your cluster and provides information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console.
+The Cluster API is hosted by all nodes of your cluster and provides information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console. This defaults to `8080` and can be specified using `--listen-addr` when configuring your node.
 
 ## Resources
 
@@ -17,51 +17,49 @@ Each listed endpoint links to its full [API reference documentation](https://coc
 Endpoint | Name | Description
 --- | --- | ---
 [`/health`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/health) | Check node health | Determine if the node is running and ready to accept SQL connections.
-[`/nodes`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodes) | List nodes | Get information on all nodes in the cluster including node IDs, software versions, and hardware.
-[`/nodes/{node_id}/ranges`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, obtain details on the ranges that it hosts. 
+[`/nodes`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodes) | List nodes | Get details on all nodes in the cluster, including node IDs, software versions, and hardware.
+[`/nodes/{node_id}/ranges`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, get details on the ranges that it hosts. 
 [`/ranges/hot`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listHotRanges) | List hot ranges | Get information on ranges receiving a high number of reads or writes.
-[`/ranges/{range_id}`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically of use only to Cockroach Labs engineers.
-[`/sessions`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listSessions) | List sessions | Get details of all current users' SQL sessions or sessions by a specific user.
-[`/login`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/login) | Log in | Authenticate as an admin on the cluster to retrieve a session token to use with further API calls.
+[`/ranges/{range_id}`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically used by Cockroach Labs engineers.
+[`/sessions`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listSessions) | List sessions | Get SQL session details of all current users or a specified user.
+[`/login`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/login) | Log in | Authenticate as a [SQL role](create-role.html#create-a-role-that-can-log-in-to-the-database) that is a member of the [admin role](authorization.html#admin-role) to retrieve a session token to use with further API calls.
 [`/logout`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/logout) | Log out | Invalidate the session token.
 
 ## Requirements
 
+All endpoints except `/health` and `/login` require authentication using a session token. To obtain a session token, you will need:
+
+* A [SQL role](create-role.html) that is a member of the [`admin` role](authorization.html#admin-role) and has login permissions and a password. You will use these credentials with the `/login` endpoint to retrieve the session token which you can then use with further API calls.
+
 To connect with the API on a secure cluster, you will need:
 
-* A [client TLS certificate generated for the SQL role](cockroach-cert.html#create-the-certificate-and-key-pair-for-a-client), using the same CA cert used by the cluster. 
-
-All endpoints except `health/` and `login/` require authentication using a session token. To obtain a session token, you will need:
-
-* A [SQL role](create-role.html) that is a member of the admin role and has login permissions and a password. You will use these credentials with the `login/` endpoint to retrieve the session token which you can then use with further API cals.
+* The CA cert used by the cluster or any intermediary proxy server, either in the client's cert store as a trusted certificate authority or as a file manually specified by the HTTP request (for example, using curl's [cacert](https://curl.se/docs/manpage.html#--cacert)).  
 
 ## Authentication
 
-1. Retrieve a session token using the `login/` endpoint. For example:
+1. Retrieve a session token using the `/login` endpoint. For example:
 
-   ``` shell
+   ~~~ shell
    curl -d "username=user&password=pass" \
    -H 'Content-Type: application/x-www-form-urlencoded' \
-   --cacert certs/ca.crt \
    https://localhost:8080/api/v2/login/
-   ```
+   ~~~
 
    A token is returned.
 
-   ``` shell
+   ~~~ shell
    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
-   ```
+   ~~~
 
 2. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
 
-   ``` shell
-   curl -H "X-Cockroach-API-Session: <token>" \
-   --cacert certs/ca.crt \
+   ~~~ shell
+   curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
    https://localhost:8080/api/v2/nodes/
-   ```
+   ~~~
 
 ## Versioning and Stability
 
-Future versions of CockroachDB will continue to provide access to the v2.0 API until it is deprecated and may conconurrently provide multiple API versions.
+Future versions of CockroachDB may provide multiple API versions and will continue to provide access to this v2.0 API until it is deprecated. 
 
-All endpoint paths and payloads will remain available within a major API version number (v2.x). Minor versions could add new endpoints but would not remove existing endpoints.
+All endpoint paths and payloads will remain available within a major API version number (v2.x). Minor versions could add new endpoints but will not remove existing endpoints.

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -37,29 +37,29 @@ To connect with the API on a secure cluster, you will need:
 
 ## Authentication
 
-1. Retrieve a session token using the `/login` endpoint. For example:
+1. Request a session token using the `/login` endpoint. For example:
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    curl -d "username=user&password=pass" \
-    -H 'Content-Type: application/x-www-form-urlencoded' \
-    https://localhost:8080/api/v2/login/
-    ~~~
+{% include copy-clipboard.html %}
+~~~ shell
+curl -d "username=user&password=pass" \
+-H 'Content-Type: application/x-www-form-urlencoded' \
+https://localhost:8080/api/v2/login/
+~~~
 
-  A token is returned.
+1. Record the token (`session` value) that is returned.
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
-    ~~~
+{% include copy-clipboard.html %}
+~~~ shell
+{"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
+~~~
 
-1. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
+1. Pass the token with each call using the `X-Cockroach-API-Session` header. For example:
 
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
-    https://localhost:8080/api/v2/nodes/
-    ~~~
+{% include copy-clipboard.html %}
+~~~ shell
+curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
+https://localhost:8080/api/v2/nodes/
+~~~
 
 ## Versioning and Stability
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -59,3 +59,9 @@ All endpoints except `health/` and `login/` require authentication using a sessi
    --cacert certs/ca.crt \
    https://localhost:8080/api/v2/nodes/
    ```
+
+## Versioning and Stability
+
+Future versions of CockroachDB will continue to provide access to the v2.0 API until it is deprecated and may conconurrently provide multiple API versions.
+
+All endpoint paths and payloads will remain available within a major API version number (v2.x). Minor versions could add new endpoints but would not remove existing endpoints.

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -45,15 +45,15 @@ To connect with the API on a secure cluster, you will need:
    -H 'Content-Type: application/x-www-form-urlencoded' \
    https://localhost:8080/api/v2/login/
    ~~~
-
+   
    A token is returned.
-
+   
    {% include copy-clipboard.html %}
    ~~~ shell
    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
    ~~~
 
-2. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
+1. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
 
    {% include copy-clipboard.html %}
    ~~~ shell

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -39,6 +39,7 @@ To connect with the API on a secure cluster, you will need:
 
 1. Retrieve a session token using the `/login` endpoint. For example:
 
+   {% include copy-clipboard.html %}
    ~~~ shell
    curl -d "username=user&password=pass" \
    -H 'Content-Type: application/x-www-form-urlencoded' \
@@ -47,12 +48,14 @@ To connect with the API on a secure cluster, you will need:
 
    A token is returned.
 
+   {% include copy-clipboard.html %}
    ~~~ shell
    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
    ~~~
 
 2. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
 
+   {% include copy-clipboard.html %}
    ~~~ shell
    curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
    https://localhost:8080/api/v2/nodes/

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -1,6 +1,6 @@
 ---
 title: Cluster API
-summary: Programmatically access and monitor cluster and node status information with this RESTful API.
+summary: Programmatically access and monitor cluster and node status information with a RESTful API.
 toc: true
 ---
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -39,27 +39,27 @@ To connect with the API on a secure cluster, you will need:
 
 1. Retrieve a session token using the `/login` endpoint. For example:
 
-   {% include copy-clipboard.html %}
-   ~~~ shell
-   curl -d "username=user&password=pass" \
-   -H 'Content-Type: application/x-www-form-urlencoded' \
-   https://localhost:8080/api/v2/login/
-   ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    curl -d "username=user&password=pass" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    https://localhost:8080/api/v2/login/
+    ~~~
 
-   A token is returned.
+  A token is returned.
 
-   {% include copy-clipboard.html %}
-   ~~~ shell
-   {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
-   ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
+    ~~~
 
 1. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
 
-   {% include copy-clipboard.html %}
-   ~~~ shell
-   curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
-   https://localhost:8080/api/v2/nodes/
-   ~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
+    https://localhost:8080/api/v2/nodes/
+    ~~~
 
 ## Versioning and Stability
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -45,9 +45,9 @@ To connect with the API on a secure cluster, you will need:
    -H 'Content-Type: application/x-www-form-urlencoded' \
    https://localhost:8080/api/v2/login/
    ~~~
-   
+
    A token is returned.
-   
+
    {% include copy-clipboard.html %}
    ~~~ shell
    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -4,9 +4,9 @@ summary: Programmatically access and monitor cluster and node status information
 toc: true
 ---
 
-The CockroachDB Cluster API enables you to obtain information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console]() user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
+The CockroachDB Cluster API enables you to obtain information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console](ui-overview.html) user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
 
-The Cluster API is hosted by all nodes of your cluster and offers information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console.
+The Cluster API is hosted by all nodes of your cluster and provides information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console.
 
 ## Resources
 
@@ -33,7 +33,7 @@ To connect with the API on a secure cluster, you will need:
 
 All endpoints except `health/` and `login/` require authentication using a session token. To obtain a session token, you will need:
 
-* A [SQL role](../v21.1/create-role) that is a member of the admin role and has login permissions and a password. You will use these credentials with the `login/` endpoint to retrieve the session token which you can then use with further API cals.
+* A [SQL role](create-role.html) that is a member of the admin role and has login permissions and a password. You will use these credentials with the `login/` endpoint to retrieve the session token which you can then use with further API cals.
 
 ## Authentication
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -12,18 +12,18 @@ The Cluster API is hosted by all nodes of your cluster and provides information 
 
 The following endpoints are available as URLs under the `/api/v2` base path (for example, `https://localhost:8080/api/v2/health/`). Additional endpoints are planned for future versions of CockroachDB.
 
-Each listed endpoint links to its full [API reference documentation](https://www.cockroachlabs.com/docs/api/cluster/v2.html).
+Each listed endpoint links to its full [API reference documentation](https://cockroachlabs.com/docs/api/cluster/v2.html).
 
 Endpoint | Name | Description
 --- | --- | ---
-[`/health`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/health) | Check node health | Determine if the node is running and ready to accept SQL connections.
-[`/nodes`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodes) | List nodes | Get information on all nodes in the cluster including node IDs, software versions, and hardware.
-[`/nodes/{node_id}/ranges`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, obtain details on the ranges that it hosts. 
-[`/ranges/hot`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listHotRanges) | List hot ranges | Get information on ranges receiving a high number of reads or writes.
-[`/ranges/{range_id}`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically of use only to Cockroach Labs engineers.
-[`/sessions`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listSessions) | List sessions | Get details of all current users' SQL sessions or sessions by a specific user.
-[`/login`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/login) | Log in | Authenticate as an admin on the cluster to retrieve a session token to use with further API calls.
-[`/logout`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/logout) | Log out | Invalidate the session token.
+[`/health`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/health) | Check node health | Determine if the node is running and ready to accept SQL connections.
+[`/nodes`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodes) | List nodes | Get information on all nodes in the cluster including node IDs, software versions, and hardware.
+[`/nodes/{node_id}/ranges`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, obtain details on the ranges that it hosts. 
+[`/ranges/hot`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listHotRanges) | List hot ranges | Get information on ranges receiving a high number of reads or writes.
+[`/ranges/{range_id}`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically of use only to Cockroach Labs engineers.
+[`/sessions`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/listSessions) | List sessions | Get details of all current users' SQL sessions or sessions by a specific user.
+[`/login`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/login) | Log in | Authenticate as an admin on the cluster to retrieve a session token to use with further API calls.
+[`/logout`](https://cockroachlabs.com/docs/api/cluster/v2.html#operation/logout) | Log out | Invalidate the session token.
 
 ## Requirements
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -6,7 +6,7 @@ toc: true
 
 The CockroachDB Cluster API is a REST API that provides information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console](ui-overview.html) user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
 
-The Cluster API is hosted by all nodes of your cluster and provides information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console. This defaults to `8080` and can be specified using `--listen-addr` when configuring your node.
+The Cluster API is hosted by all nodes of your cluster and provides information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console. This defaults to `8080` and can be specified using `--http-addr={server}:{port}` when configuring your node.
 
 ## Resources
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -38,17 +38,22 @@ All endpoints except `health/` and `login/` require authentication using a sessi
 ## Authentication
 
 1. Retrieve a session token using the `login/` endpoint. For example:
+
    ``` shell
    curl -d "username=user&password=pass" \
    -H 'Content-Type: application/x-www-form-urlencoded' \
    --cacert certs/ca.crt \
    https://localhost:8080/api/v2/login/
    ```
+
    A token is returned.
+
    ``` shell
    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
    ```
+
 2. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
+
    ``` shell
    curl -H "X-Cockroach-API-Session: <token>" \
    --cacert certs/ca.crt \

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -39,27 +39,27 @@ To connect with the API on a secure cluster, you will need:
 
 1. Request a session token using the `/login` endpoint. For example:
 
-{% include copy-clipboard.html %}
-~~~ shell
-curl -d "username=user&password=pass" \
--H 'Content-Type: application/x-www-form-urlencoded' \
-https://localhost:8080/api/v2/login/
-~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    curl -d "username=user&password=pass" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    https://localhost:8080/api/v2/login/
+    ~~~
 
-1. Record the token (`session` value) that is returned.
+2. Record the token (`session` value) that is returned.
 
-{% include copy-clipboard.html %}
-~~~ shell
-{"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
-~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
+    ~~~
 
-1. Pass the token with each call using the `X-Cockroach-API-Session` header. For example:
+3. Pass the token with each call using the `X-Cockroach-API-Session` header. For example:
 
-{% include copy-clipboard.html %}
-~~~ shell
-curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
-https://localhost:8080/api/v2/nodes/
-~~~
+    {% include copy-clipboard.html %}
+    ~~~ shell
+    curl -H "X-Cockroach-API-Session: CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow==" \
+    https://localhost:8080/api/v2/nodes/
+    ~~~
 
 ## Versioning and Stability
 

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -4,7 +4,7 @@ summary: Programmatically access and monitor cluster and node status information
 toc: true
 ---
 
-The CockroachDB Cluster API enables you to obtain information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console](ui-overview.html) user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
+The CockroachDB Cluster API is a REST API that provides information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console](ui-overview.html) user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
 
 The Cluster API is hosted by all nodes of your cluster and provides information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console.
 
@@ -12,7 +12,7 @@ The Cluster API is hosted by all nodes of your cluster and provides information 
 
 The following endpoints are available as URLs under the `/api/v2` base path (for example, `https://localhost:8080/api/v2/health/`). Additional endpoints are planned for future versions of CockroachDB.
 
-Each endpoint links to full [API reference documentation](../api/cluster/v2.html).
+Each listed endpoint links to its full [API reference documentation](../api/cluster/v2.html).
 
 Endpoint | Name | Description
 --- | --- | ---

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -1,0 +1,56 @@
+---
+title: Cluster API
+summary: Programmatically access and monitor cluster and node status information with this RESTful API.
+toc: true
+---
+
+The CockroachDB Cluster API enables you to obtain information about a cluster and its nodes. The API offers programmatic access to much of the information available in the [DB Console]() user interface, enabling you to monitor and troubleshoot your cluster using your choice of tooling.
+
+The Cluster API is hosted by all nodes of your cluster and offers information about all nodes. The API is available on the same port that is listening for HTTP connections to the DB Console.
+
+## Resources
+
+The following endpoints are available as URLs under the `/api/v2` base path (for example, `https://localhost:8080/api/v2/health/`). Additional endpoints are planned for future versions of CockroachDB.
+
+Each endpoint links to full [API reference documentation](../api/cluster/v2.html).
+
+Endpoint | Name | Description
+--- | --- | ---
+[`/health`](../api/cluster/v2.html#operation/health) | Check node health | Determine if the node is running and ready to accept SQL connections.
+[`/nodes`](../api/cluster/v2.html#operation/listNodes) | List nodes | Get information on all nodes in the cluster including node IDs, software versions, and hardware.
+[`/nodes/{node_id}/ranges`](../api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, obtain details on the ranges that it hosts. 
+[`/ranges/hot`](../api/cluster/v2.html#operation/listHotRanges) | List hot ranges | Get information on ranges receiving a high number of reads or writes.
+[`/ranges/{range_id}`](../api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically of use only to Cockroach Labs engineers.
+[`/sessions`](../api/cluster/v2.html#operation/listSessions) | List sessions | Get details of all current users' SQL sessions or sessions by a specific user.
+[`/login`](../api/cluster/v2.html#operation/login) | Log in | Authenticate as an admin on the cluster to retrieve a session token to use with further API calls.
+[`/logout`](../api/cluster/v2.html#operation/logout) | Log out | Invalidate the session token.
+
+## Requirements
+
+To connect with the API on a secure cluster, you will need:
+
+* A [client TLS certificate generated for the SQL role](cockroach-cert.html#create-the-certificate-and-key-pair-for-a-client), using the same CA cert used by the cluster. 
+
+All endpoints except `health/` and `login/` require authentication using a session token. To obtain a session token, you will need:
+
+* A [SQL role](../v21.1/create-role) that is a member of the admin role and has login permissions and a password. You will use these credentials with the `login/` endpoint to retrieve the session token which you can then use with further API cals.
+
+## Authentication
+
+1. Retrieve a session token using the `login/` endpoint. For example:
+   ``` shell
+   curl -d "username=user&password=pass" \
+   -H 'Content-Type: application/x-www-form-urlencoded' \
+   --cacert certs/ca.crt \
+   https://localhost:8080/api/v2/login/
+   ```
+   A token is returned.
+   ``` shell
+   {"session":"CIGAiPis4fj3CBIQ3u0rRQJ3tD8yIqee4hipow=="}
+   ```
+2. Pass the token (`session` value) with each call using the `X-Cockroach-API-Session` header. For example:
+   ``` shell
+   curl -H "X-Cockroach-API-Session: <token>" \
+   --cacert certs/ca.crt \
+   https://localhost:8080/api/v2/nodes/
+   ```

--- a/v21.1/cluster-api.md
+++ b/v21.1/cluster-api.md
@@ -12,18 +12,18 @@ The Cluster API is hosted by all nodes of your cluster and provides information 
 
 The following endpoints are available as URLs under the `/api/v2` base path (for example, `https://localhost:8080/api/v2/health/`). Additional endpoints are planned for future versions of CockroachDB.
 
-Each listed endpoint links to its full [API reference documentation](../api/cluster/v2.html).
+Each listed endpoint links to its full [API reference documentation](https://www.cockroachlabs.com/docs/api/cluster/v2.html).
 
 Endpoint | Name | Description
 --- | --- | ---
-[`/health`](../api/cluster/v2.html#operation/health) | Check node health | Determine if the node is running and ready to accept SQL connections.
-[`/nodes`](../api/cluster/v2.html#operation/listNodes) | List nodes | Get information on all nodes in the cluster including node IDs, software versions, and hardware.
-[`/nodes/{node_id}/ranges`](../api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, obtain details on the ranges that it hosts. 
-[`/ranges/hot`](../api/cluster/v2.html#operation/listHotRanges) | List hot ranges | Get information on ranges receiving a high number of reads or writes.
-[`/ranges/{range_id}`](../api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically of use only to Cockroach Labs engineers.
-[`/sessions`](../api/cluster/v2.html#operation/listSessions) | List sessions | Get details of all current users' SQL sessions or sessions by a specific user.
-[`/login`](../api/cluster/v2.html#operation/login) | Log in | Authenticate as an admin on the cluster to retrieve a session token to use with further API calls.
-[`/logout`](../api/cluster/v2.html#operation/logout) | Log out | Invalidate the session token.
+[`/health`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/health) | Check node health | Determine if the node is running and ready to accept SQL connections.
+[`/nodes`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodes) | List nodes | Get information on all nodes in the cluster including node IDs, software versions, and hardware.
+[`/nodes/{node_id}/ranges`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listNodeRanges) | List node ranges | For a specified node, obtain details on the ranges that it hosts. 
+[`/ranges/hot`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listHotRanges) | List hot ranges | Get information on ranges receiving a high number of reads or writes.
+[`/ranges/{range_id}`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listRange) | Get range details | Get detailed technical information on a range. Typically of use only to Cockroach Labs engineers.
+[`/sessions`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/listSessions) | List sessions | Get details of all current users' SQL sessions or sessions by a specific user.
+[`/login`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/login) | Log in | Authenticate as an admin on the cluster to retrieve a session token to use with further API calls.
+[`/logout`](https://www.cockroachlabs.com/docs/api/cluster/v2.html#operation/logout) | Log out | Invalidate the session token.
 
 ## Requirements
 

--- a/v21.1/monitoring-and-alerting.md
+++ b/v21.1/monitoring-and-alerting.md
@@ -20,7 +20,17 @@ The DB Console is accessible from every node at `http://<host>:<http-port>`, or 
 Because the DB Console is built into CockroachDB, if a cluster becomes unavailable, most of the DB Console becomes unavailable as well. Therefore, it's essential to plan additional methods of monitoring cluster health as described below.
 {{site.data.alerts.end}}
 
+### Cluster API
+
+The [Cluster API](cluster-api.html) provides much of the same information about your cluster and nodes as is available in the DB Console. It is accessible at the same address and port on each node.
+
+For more information, see the Cluster API [overview](cluster-api.html) and [reference](../api/cluster/v2.html).
+
 ### Prometheus endpoint
+
+{{site.data.alerts.callout_info}}
+The listed `/_status/vars` endpoint is deprecated in favor of the [Cluster API](#cluster-api).
+{{site.data.alerts.end}}
 
 Every node of a CockroachDB cluster exports granular timeseries metrics at `http://<host>:<http-port>/_status/vars`. The metrics are formatted for easy integration with [Prometheus](https://prometheus.io/), an open source tool for storing, aggregating, and querying timeseries data, but the format is **easy-to-parse** and can be massaged to work with other third-party monitoring systems (e.g., [Sysdig](https://sysdig.atlassian.net/wiki/plugins/servlet/mobile?contentId=64946336#content/view/64946336) and [Stackdriver](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd)).
 
@@ -52,6 +62,8 @@ replicas_quiescent{store="1"} 20
 ### Health endpoints
 
 CockroachDB provides two HTTP endpoints for checking the health of individual nodes.
+
+Note that these are also available as part of the [Cluster API](cluster-api.html) under `/v2/health/`.
 
 #### /health
 
@@ -109,6 +121,10 @@ Otherwise, it returns an HTTP `200 OK` status response code with an empty body:
 ~~~
 
 ### Raw status endpoints
+
+{{site.data.alerts.callout_info}}
+These endpoints are deprecated in favor of the [Cluster API](#cluster-api).
+{{site.data.alerts.end}}
 
 Several endpoints return raw status metrics in JSON at `http://<host>:<http-port>/#/debug`. Feel free to investigate and use these endpoints, but note that they are subject to change.  
 

--- a/v21.1/monitoring-and-alerting.md
+++ b/v21.1/monitoring-and-alerting.md
@@ -22,7 +22,9 @@ Because the DB Console is built into CockroachDB, if a cluster becomes unavailab
 
 ### Cluster API
 
-The [Cluster API](cluster-api.html) provides much of the same information about your cluster and nodes as is available in the DB Console. It is accessible at the same address and port on each node.
+The [Cluster API](cluster-api.html) is a REST API that provides much of the same information about your cluster and nodes as is available from the DB Console.
+
+The API is accessible from each node at the same address and port as the DB Console.
 
 For more information, see the Cluster API [overview](cluster-api.html) and [reference](../api/cluster/v2.html).
 


### PR DESCRIPTION
This is an enhanced version of the doc originally reviewed by @piyush-singh and @itsbilal. It still needs a thorough review for technical accuracy as it has had many updates.

Preview:  
https://deploy-preview-10532--cockroachdb-docs.netlify.app/docs/v21.1/cluster-api  
https://deploy-preview-10532--cockroachdb-docs.netlify.app/docs/v21.1/monitoring-and-alerting

Please also see the linked [API reference](https://cockroachlabs.com/docs/api/cluster/v2.html). Further enhancements to that page will come in separate PRs, but recommendations are welcome. Intended improvements include the following, though not all may be completed prior to the CRDB v21.1 release:

* Template/Redoc settings
   - Limit request sample languages: perhaps just to shell+curl, maybe a couple others in addition.
   - Remove the Powered by Redoc link in the left nav; maybe replace with link to 'edit this page' and move redoc link to bottom of main column.
   - Tweaking other redoc [options](https://github.com/Redocly/redoc#redoc-options-object).
* Spec
   - Add some remaining missing lower-level parameters.
   - Confirm that parameters described as internal should be so.
   - Refine parameter descriptions.
   - Make the `https` URLs for API endpoints the defaults in the drop-down and code samples, if possible, instead of the `http` URLs.
   - Add `--cacert` to curl calls since this the API will almost always be used for secure clusters.
   - Add custom example JSON responses where especially helpful.
   - Link back to this API doc (cluster-api.md).
 * Other
   - Troubleshoot {range_id} and {node_id} showing up in URLs in examples as %7Brange_id%7D and %7Bnode_id%7D. (Possibly implement a manual spec edit, but if this is coming from one of the scripts to transform the spec, we could follow them by a sed command in the build script to find/replace.)