### PR TITLE
Inverted index on RBR table is auto-partitioned

### DIFF
--- a/v21.1/indexes.md
+++ b/v21.1/indexes.md
@@ -123,6 +123,8 @@ For best practices, see [Add a Secondary Index: Best Practices](schema-design-in
 
 {% include {{page.version.version}}/sql/indexes-regional-by-row.md %}
 
+Note that the behavior described above also applies to [inverted indexes](inverted-indexes.html).
+
 For an example that uses unique indexes but applies to all indexes on `REGIONAL BY ROW` tables, see [Add a unique index to a `REGIONAL BY ROW` table](add-constraint.html#add-a-unique-index-to-a-regional-by-row-table).
 
 ## See also

--- a/v21.1/inverted-indexes.md
+++ b/v21.1/inverted-indexes.md
@@ -156,6 +156,12 @@ CREATE TABLE test (
 );
 ~~~
 
+## Inverted indexes on `REGIONAL BY ROW` tables in multi-region databases
+
+{% include {{page.version.version}}/sql/indexes-regional-by-row.md %}
+
+For an example that uses unique indexes but applies to all indexes on `REGIONAL BY ROW` tables, see [Add a unique index to a `REGIONAL BY ROW` table](add-constraint.html#add-a-unique-index-to-a-regional-by-row-table).
+
 ## Examples
 
 ### Create a table with inverted index on a JSONB column

--- a/v21.1/multiregion-overview.md
+++ b/v21.1/multiregion-overview.md
@@ -160,7 +160,9 @@ The features listed in this section are designed to make working with multi-regi
 
 {% include {{page.version.version}}/sql/indexes-regional-by-row.md %}
 
-For an example that uses unique indexes, see [Add a unique index to a `REGIONAL BY ROW` table](add-constraint.html#add-a-unique-index-to-a-regional-by-row-table).
+Note that the behavior described above also applies to [inverted indexes](inverted-indexes.html).
+
+For an example that uses unique indexes but applies to all indexes on `REGIONAL BY ROW` tables, see [Add a unique index to a `REGIONAL BY ROW` table](add-constraint.html#add-a-unique-index-to-a-regional-by-row-table).
 
 ## Next steps
 


### PR DESCRIPTION
Fixes #10066

Summary of changes:

- Update 'Multi-Region Overview' and 'Indexes' pages to note that the
  auto-partitioning of indexes on REGIONAL BY ROW tables also applies to
  inverted indexes

- Update 'Inverted Indexes' page with a new section noting the above
  behavior