### PR TITLE
Corrected mistake in core changefeed example

### DIFF
--- a/_includes/v20.2/cdc/create-core-changefeed.md
+++ b/_includes/v20.2/cdc/create-core-changefeed.md
@@ -4,7 +4,7 @@ In this example, you'll set up a core changefeed for a single-node cluster.
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach start \
+    $ cockroach start-single-node \
     --insecure \
     --listen-addr=localhost \
     --background

--- a/_includes/v21.1/cdc/create-core-changefeed.md
+++ b/_includes/v21.1/cdc/create-core-changefeed.md
@@ -4,7 +4,7 @@ In this example, you'll set up a core changefeed for a single-node cluster.
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach start \
+    $ cockroach start-single-node \
     --insecure \
     --listen-addr=localhost \
     --background


### PR DESCRIPTION
Corrected the missing `start-single-node` to the core changefeed example

Closes #9805 