### PR TITLE
Update Licensing Timelines for 21.1

### DIFF
--- a/releases/release-support-policy.md
+++ b/releases/release-support-policy.md
@@ -37,6 +37,12 @@ Date format: MM/DD/YY
 			<th>Assistance Support ends (EOL Date)</th>
 		</tr>
 	</thead>
+  <tr>
+    <td><a href="v21.1.0.html">v21.1</a></td>
+    <td>5/18/21</td>
+    <td>5/18/22</td>
+    <td>11/18/22</td>
+  </tr>
 	<tr>
 		<td><a href="v20.2.0.html">v20.2</a></td>
 		<td>11/10/20</td>
@@ -49,11 +55,11 @@ Date format: MM/DD/YY
 		<td>5/12/21</td>
 		<td>11/12/21</td>
 	</tr>
-	<tr>
+	<tr class=eol>
 		<td><a href="v19.2.0.html">v19.2</a></td>
 		<td>11/12/19</td>
 		<td>11/12/20</td>
-		<td>5/12/21</td>
+		<td>5/12/21*</td>
 	</tr>
 	<tr class=eol>
 		<td><a href="v19.1.0.html">v19.1</a></td>

--- a/v20.2/licensing-faqs.md
+++ b/v20.2/licensing-faqs.md
@@ -35,6 +35,7 @@ For each BSL release all associated alpha, beta, major, and minor (point) releas
 
 CockroachDB version | License | Converts to Apache 2.0   
 --------------------|---------|----------------------------
+21.1 | Business Source License | May 18, 2024
 20.2 | Business Source License | Nov 10, 2023 
 20.1 | Business Source License | May 12, 2023  
 19.2 | Business Source License | Oct 01, 2022

--- a/v21.1/licensing-faqs.md
+++ b/v21.1/licensing-faqs.md
@@ -35,6 +35,7 @@ For each BSL release all associated alpha, beta, major, and minor (point) releas
 
 CockroachDB version | License | Converts to Apache 2.0   
 --------------------|---------|----------------------------
+21.1 | Business Source License | May 18, 2024
 20.2 | Business Source License | Nov 10, 2023
 20.1 | Business Source License | May 12, 2023  
 19.2 | Business Source License | Oct 01, 2022


### PR DESCRIPTION
Closes #10351
- Updated timelines for 20.2 and 21.1 Licensing FAQs
- Updated release support policy/EOL timeline
- No feature licensing needs to be changed as far as I can tell