### PR TITLE
Document workaround for IMPORT into RBR limitation

### DIFF
--- a/_includes/v21.1/sql/import-into-regional-by-row-table.md
+++ b/_includes/v21.1/sql/import-into-regional-by-row-table.md
@@ -1,0 +1,1 @@
+`IMPORT` and `IMPORT INTO` cannot directly import data to [`REGIONAL BY ROW`](set-locality.html#regional-by-row) tables that are part of [multi-region databases](multiregion-overview.html).  For more information, including a workaround for this limitation, see [Known Limitations](known-limitations.html#import-into-a-regional-by-row-table).

--- a/v21.1/import-into.md
+++ b/v21.1/import-into.md
@@ -13,6 +13,7 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimit
 - `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` does not offer `SELECT` or `WHERE` clauses to specify subsets of rows. To do this, use [`INSERT`](insert.html#insert-from-a-select-statement).
 - `IMPORT INTO` will cause any [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) running on the targeted table to fail.
+- {% include {{page.version.version}}/sql/import-into-regional-by-row-table.md %}
 
 ## Required privileges
 

--- a/v21.1/import.md
+++ b/v21.1/import.md
@@ -25,6 +25,10 @@ The `IMPORT` [statement](sql-statements.html) imports the following types of dat
 `IMPORT` cannot be used within a [rolling upgrade](upgrade-cockroach-version.html).
 {{site.data.alerts.end}}
 
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/sql/import-into-regional-by-row-table.md %}
+{{site.data.alerts.end}}
+
 ## Required privileges
 
 #### Table privileges


### PR DESCRIPTION
Fixes #10226

Summary of changes:

- Add to Known Limitations that we can't currently IMPORT seamlessly
  into REGIONAL BY ROW tables.  Document a workaround from the CRDB
  tests.

- Add a side limitation that we can't ALTER COLUMN to make something
  hidden (yet).

- Add notes and links to the above from the IMPORT and IMPORT INTO
  pages.