### PR TITLE
Add docs for spatial storage of Z/M coordinates

### DIFF
--- a/_includes/v21.1/spatial/zmcoords.md
+++ b/_includes/v21.1/spatial/zmcoords.md
@@ -1,0 +1,27 @@
+<span class="version-tag">New in v21.1:</span> You can also store a `{{page.title}}` with the following additional dimensions:
+
+- A third dimension coordinate `Z` (`{{page.title}}Z`).
+- A measure coordinate `M` (`{{page.title}}M`).
+- Both a third dimension and a measure coordinate (`{{page.title}}ZM`).
+
+The `Z` and `M` dimensions can be accessed or modified using a number of [built-in functions](functions-and-operators.html#spatial-functions), including:
+
+- `ST_Z`
+- `ST_M`
+- `ST_Affine`
+- `ST_Zmflag`
+- `ST_MakePoint`
+- `ST_MakePointM`
+- `ST_Force3D`
+- `ST_Force3DZ`
+- `ST_Force3DM`
+- `ST_Force4D`
+- `ST_Snap`
+- `ST_SnapToGrid`
+- `ST_RotateZ`
+- `ST_AddMeasure`
+
+Note that CockroachDB's [spatial indexing](spatial-indexes.html) is still based on the 2D coordinate system.  This means that:
+
+- The Z/M dimension is not index accelerated when using spatial predicates.
+- Some spatial functions ignore the Z/M dimension, with transformations discarding the Z/M value.

--- a/v21.1/geometrycollection.md
+++ b/v21.1/geometrycollection.md
@@ -6,6 +6,8 @@ toc: true
 
 A `GEOMETRYCOLLECTION` is a collection of heterogeneous [spatial objects](spatial-features.html#spatial-objects), such as [Points](point.html), [LineStrings](linestring.html), [Polygons](polygon.html), or other `GEOMETRYCOLLECTION`s.  It provides a way of referring to a group of spatial objects as one "thing" so that you can operate on it/them more conveniently using various SQL functions.
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 A GeometryCollection can be created from SQL by calling the `st_geomfromtext` function on a GeometryCollection definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format as shown below.

--- a/v21.1/linestring.md
+++ b/v21.1/linestring.md
@@ -8,6 +8,8 @@ A `LINESTRING` is a collection of [Points](point.html) that are "strung together
 
 The coordinates of each Point that makes up the LineString are translated according to the current [spatial reference system](spatial-glossary.html#spatial-reference-system) (denoted by an [SRID](spatial-glossary.html#srid)) to determine what the Point "is", or what it "means" relative to the [other spatial objects](spatial-features.html#spatial-objects) (if any) in the data set.
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 A LineString can be created from SQL by calling the `st_geomfromtext` function on a LineString definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format as shown below.

--- a/v21.1/multilinestring.md
+++ b/v21.1/multilinestring.md
@@ -6,6 +6,8 @@ toc: true
 
 A `MULTILINESTRING` is a collection of [LineStrings](linestring.html).  MultiLineStrings are useful for gathering a group of LineStrings into one geometry. For example, you may want to gather the LineStrings denoting all of the roads in a particular municipality.
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 ### Well known text

--- a/v21.1/multipoint.md
+++ b/v21.1/multipoint.md
@@ -6,6 +6,8 @@ toc: true
 
 A `MULTIPOINT` is a collection of [Points](point.html).  MultiPoints are useful for gathering a group of Points into one geometry. For example, you may want to gather the points denoting all of the State Capitols in the U.S. into a single geometry.
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 ### SQL

--- a/v21.1/multipolygon.md
+++ b/v21.1/multipolygon.md
@@ -6,6 +6,8 @@ toc: true
 
 A `MULTIPOLYGON` is a collection of [Polygons](polygon.html).  MultiPolygons are useful for gathering a group of Polygons into one geometry. For example, you may want to gather the Polygons denoting a group of properties in a particular municipality.  Another use of MultiPolygons is to represent states or countries that include islands, or that are otherwise made up of non-overlapping shapes.
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 A MultiPolygon can be created from SQL by calling the `st_geomfromtext` function on a MultiPolygon definition expressed in the [Well Known Text (WKT)](spatial-glossary.html#wkt) format.

--- a/v21.1/point.md
+++ b/v21.1/point.md
@@ -6,6 +6,8 @@ toc: true
 
 A `POINT` is a sizeless location identified by its X and Y coordinates. These coordinates are then translated according to the current [spatial reference system](spatial-glossary.html#spatial-reference-system) (denoted by an [SRID](spatial-glossary.html#srid)) to determine what the Point "is", or what it "means" relative to the [other spatial objects](spatial-features.html#spatial-objects) (if any) in the data set. 
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 ### SQL

--- a/v21.1/polygon.md
+++ b/v21.1/polygon.md
@@ -8,6 +8,8 @@ A `POLYGON` is a shape with a closed exterior that is made up of lines. Polygons
 
 The coordinates of each Point and line that make up the Polygon are translated according to the current [spatial reference system](spatial-glossary.html#spatial-reference-system) (denoted by an [SRID](spatial-glossary.html#srid)) to determine what the point "is", or what it "means" relative to the [other spatial objects](spatial-features.html#spatial-objects) (if any) in the data set.
 
+{% include {{page.version.version}}/spatial/zmcoords.md %}
+
 ## Examples
 
 ### Well known text

--- a/v21.1/spatial-glossary.md
+++ b/v21.1/spatial-glossary.md
@@ -48,7 +48,14 @@ This page is provided for reference purposes only. The inclusion of a term in th
 
 <a name="geometry"></a>
 
-- `GEOMETRY`: Used to represent shapes relative to 2-, 3-, or higher-dimensional plane geometry.
+- `GEOMETRY`: Used to represent shapes relative to 2-, 3-, or higher-dimensional plane geometry.  For more information about the spatial objects used to represent geometries, see:
+  - [`POINT`](point.html)
+  - [`LINESTRING`](linestring.html)
+  - [`POLYGON`](polygon.html)
+  - [`MULTIPOINT`](multipoint.html)
+  - [`MULTILINESTRING`](multilinestring.html)
+  - [`MULTIPOLYGON`](multipolygon.html)
+  - [`GEOMETRYCOLLECTION`](geometrycollection.html)
 
 <a name="geography"></a>
 


### PR DESCRIPTION
Fixes #9706.

Summary of changes:

- Update the following pages to describe that we also support Z and M
  coords:
  - POINT
  - LINESTRING
  - POLYGON
  - MULTIPOINT
  - MULTILINESTRING
  - MULTIPOLYGON
  - GEOMETRYCOLLECTION

- For the GEOMETRY data type, we update its entry in the 'Spatial
  Glossary' to point to the above docs, which give specifics