### PR TITLE
Multiregion things require an enterprise license

### DIFF
--- a/v21.1/choosing-a-multi-region-configuration.md
+++ b/v21.1/choosing-a-multi-region-configuration.md
@@ -6,6 +6,8 @@ toc: true
 
 This page has high-level information about how to configure a [multi-region cluster's](multiregion-overview.html) [survival goals](multiregion-overview.html#survival-goals) and [table locality](multiregion-overview.html#table-locality).
 
+{% include enterprise-feature.md %}
+
 The options for configuring your multi-region cluster include:
 
 - _Change nothing_: Using the [default settings](multiregion-overview.html#default-settings), you get:

--- a/v21.1/multiregion-overview.md
+++ b/v21.1/multiregion-overview.md
@@ -6,7 +6,7 @@ toc: true
 
 ## Overview
 
-<span class="version-tag">New in v21.1:</span> CockroachDB has improved multi-region capabilities that make it easier to run global applications. It is intended that these capabilities will supersede the current set of [Multi-region Topology Patterns](topology-patterns.html#multi-region). The capabilities described here are still in development; they are available in [testing releases of v21.1](../releases/#testing-releases).
+<span class="version-tag">New in v21.1:</span> CockroachDB has improved multi-region capabilities that make it easier to run global applications.
 
 To take advantage of these improved capabilities, you will need to understand the following concepts:
 
@@ -28,9 +28,7 @@ The steps above describe the simplest case, where you accept all of the default 
 
 For more information about CockroachDB's multi-region capabilities and the customization options that are available, see below.
 
-{{site.data.alerts.callout_info}}
-The documentation for the new multi-region features described below is still in development. More documentation on these features will be published in the run-up to the v21.1 release.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 ## Cluster Regions
 

--- a/v21.1/partitioning.md
+++ b/v21.1/partitioning.md
@@ -6,9 +6,7 @@ toc: true
 
 CockroachDB allows you to define table partitions, thus giving you row-level control of how and where your data is stored. Partitioning enables you to reduce latencies and costs and can assist in meeting regulatory requirements for your data.
 
-{{site.data.alerts.callout_info}}
-Table partitioning is an [enterprise-only](enterprise-licensing.html) feature. For insight into how to use this feature to get low latency reads and writes in multi-region deployments, see the [Geo-Partitioned Replicas](topology-geo-partitioned-replicas.html) and [Geo-Partitioned Leaseholders](topology-geo-partitioned-leaseholders.html) topology patterns.
-{{site.data.alerts.end}}
+{% include enterprise-feature.md %}
 
 ## Why use table partitioning
 

--- a/v21.1/when-to-use-regional-vs-global-tables.md
+++ b/v21.1/when-to-use-regional-vs-global-tables.md
@@ -25,6 +25,8 @@ Use [`GLOBAL` tables](multiregion-overview.html#global-tables) if:
 For more information about how to choose an overall multi-region configuration, see [Choosing a multi-region configuration](choosing-a-multi-region-configuration.html).
 {{site.data.alerts.end}}
 
+{% include enterprise-feature.md %}
+
 ## See also
 
 - [Multi-region Overview](multiregion-overview.html)

--- a/v21.1/when-to-use-zone-vs-region-survival-goals.md
+++ b/v21.1/when-to-use-zone-vs-region-survival-goals.md
@@ -24,6 +24,8 @@ Set a [`REGION` survival goal](multiregion-overview.html#surviving-region-failur
 For more information about how to choose a multi-region configuration, see [Choosing a multi-region configuration](choosing-a-multi-region-configuration.html).
 {{site.data.alerts.end}}
 
+{% include enterprise-feature.md %}
+
 ## See also
 
 + [Multi-region overview](multiregion-overview.html)


### PR DESCRIPTION
This is the analogue to #10052 (ALTER DATABASE ... ADD REGION) where we
mark various high-level pages describing multi-region capabilities with
the "enterprise feature" tag so users know about it up front.