### PR TITLE
Remove old cockroachcloud redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,7 +4,6 @@ layout: null
 
 {%- if site.baseurl == "/docs" %}
 / /docs/ 301!
-/docs/cockroachcloud /docs/cockroachcloud/stable/ 301!
 /docs/v2.2/* /docs/v19.1/:splat 301!
 /docs/managed/* /docs/cockroachcloud/:splat 301!
 /docs/releases/ /docs/releases/index.html 200!


### PR DESCRIPTION
This redirect was redirecting from /docs/cockroachcloud
to /docs/cockroachcloud/stable. It dates from when CC
docs were versioned. They are no longer versioned.