### PR TITLE
Added link text to cloud storage bulk operations

### DIFF
--- a/v20.2/take-full-and-incremental-backups.md
+++ b/v20.2/take-full-and-incremental-backups.md
@@ -18,7 +18,7 @@ There are two main types of backups:
 
 ## Perform backup and restore
 
-You can use the [`BACKUP`](backup.html) statement to efficiently back up your cluster's schemas and data to popular cloud services such as AWS S3, Google Cloud Storage, or NFS, and the [`RESTORE`](restore.html) statement to efficiently restore schema and data as necessary.
+You can use the [`BACKUP`](backup.html) statement to efficiently back up your cluster's schemas and data to popular cloud services such as AWS S3, Google Cloud Storage, or NFS, and the [`RESTORE`](restore.html) statement to efficiently restore schema and data as necessary. For more information, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
 
 {{site.data.alerts.callout_success}}
 <span class="version-tag">New in v20.2:</span> You can create [schedules for periodic backups](manage-a-backup-schedule.html) in CockroachDB. We recommend using scheduled backups to automate daily backups of your cluster.

--- a/v21.1/take-full-and-incremental-backups.md
+++ b/v21.1/take-full-and-incremental-backups.md
@@ -16,7 +16,7 @@ There are two main types of backups:
 - [Full backups](#full-backups)
 - [Incremental backups](#incremental-backups)
 
-You can use the [`BACKUP`][backup] statement to efficiently back up your cluster's schemas and data to popular cloud services such as AWS S3, Google Cloud Storage, or NFS, and the [`RESTORE`][restore] statement to efficiently restore schema and data as necessary.
+You can use the [`BACKUP`](backup.html) statement to efficiently back up your cluster's schemas and data to popular cloud services such as AWS S3, Google Cloud Storage, or NFS, and the [`RESTORE`](restore.html) statement to efficiently restore schema and data as necessary. For more information, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
 
 {{site.data.alerts.callout_success}}
  You can create [schedules for periodic backups](manage-a-backup-schedule.html) in CockroachDB. We recommend using scheduled backups to automate daily backups of your cluster.


### PR DESCRIPTION
Added the link to the end of this paragraph in its own sentence. Avoiding a long link out in the middle of the current sentence and making it clearer to the reader what page they're heading to re cloud storage.

Closes #10573 