### PR TITLE
Use front-matter field for CC referral ID for sample app tutorials

### DIFF
--- a/_includes/cockroachcloud/quickstart/create-a-free-cluster.md
+++ b/_includes/cockroachcloud/quickstart/create-a-free-cluster.md
@@ -1,4 +1,4 @@
-1. If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs_quickstart_free" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
+1. If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId={{page.referral_id}}" rel="noopener" target="_blank">sign up for a CockroachCloud account</a>.
 1. [Log in](https://cockroachlabs.cloud/) to your CockroachCloud account.
 1. On the **Clusters** page, click **Create Cluster**.
 1. On the **Create your cluster** page, select the **Free Plan**.

--- a/v20.2/build-a-c++-app-with-cockroachdb.md
+++ b/v20.2/build-a-c++-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a C++ App with CockroachDB and libpqxx
 summary: Learn how to use CockroachDB from a simple C++ application with a low-level client driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_c++_libpgxx
 ---
 
 This tutorial shows you how build a simple C++ application with CockroachDB and the C++ libpqxx driver.

--- a/v20.2/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v20.2/build-a-go-app-with-cockroachdb-gorm.md
@@ -3,6 +3,7 @@ title: Build a Go App with CockroachDB and GORM
 summary: Learn how to use CockroachDB from a simple Go application with the GORM ORM.
 toc: true
 twitter: false
+referral_id: docs_hello_world_go_gorm
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-go-app-with-cockroachdb-pq.md
+++ b/v20.2/build-a-go-app-with-cockroachdb-pq.md
@@ -3,6 +3,7 @@ title: Build a Go App with CockroachDB the Go pq Driver
 summary: Learn how to use CockroachDB from a simple Go application with the Go pq driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_go_pq
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-go-app-with-cockroachdb.md
+++ b/v20.2/build-a-go-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Go App with CockroachDB the Go pgx Driver
 summary: Learn how to use CockroachDB from a simple Go application with the Go pgx driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_go_pgx
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-java-app-with-cockroachdb-hibernate.md
+++ b/v20.2/build-a-java-app-with-cockroachdb-hibernate.md
@@ -3,6 +3,7 @@ title: Build a Java App with CockroachDB and Hibernate
 summary: Learn how to use CockroachDB from a simple Java application with the Hibernate ORM.
 toc: true
 twitter: false
+referral_id: docs_hello_world_java_hibernate
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-java-app-with-cockroachdb.md
+++ b/v20.2/build-a-java-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Java App with CockroachDB and JDBC
 summary: Learn how to use CockroachDB from a simple Java application with the JDBC driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_java_jdbc
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v20.2/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -3,6 +3,7 @@ title: Build a Node.js App with CockroachDB and Sequelize
 summary: Learn how to use CockroachDB from a simple Node.js application with the Sequelize ORM.
 toc: true
 twitter: false
+referral_id: docs_hello_world_nodejs_sequelize
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-nodejs-app-with-cockroachdb.md
+++ b/v20.2/build-a-nodejs-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Node.js App with CockroachDB and the Node.js pg Driver
 summary: Learn how to use CockroachDB from a simple Node.js application with the Node.js pg driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_nodejs_pg
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-python-app-with-cockroachdb-django.md
+++ b/v20.2/build-a-python-app-with-cockroachdb-django.md
@@ -3,6 +3,7 @@ title: Build a Python App with CockroachDB and Django
 summary: Learn how to use CockroachDB from a simple Django application.
 toc: true
 twitter: false
+referral_id: docs_hello_world_python_django
 ---
 
 <div class="filters clearfix">

--- a/v20.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v20.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -3,6 +3,7 @@ title: Build a Python App with CockroachDB and SQLAlchemy
 summary: Learn how to use CockroachDB from a simple Python application with SQLAlchemy.
 toc: true
 twitter: false
+referral_id: docs_hello_world_python_sqlalchemy
 ---
 
 <div class="filters clearfix">

--- a/v20.2/build-a-ruby-app-with-cockroachdb-activerecord.md
+++ b/v20.2/build-a-ruby-app-with-cockroachdb-activerecord.md
@@ -3,6 +3,7 @@ title: Build a Ruby App with CockroachDB and ActiveRecord
 summary: Learn how to use CockroachDB from a simple Ruby script with the ActiveRecord gem.
 toc: true
 twitter: false
+referral_id: docs_hello_world_ruby_activerecord
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-ruby-app-with-cockroachdb.md
+++ b/v20.2/build-a-ruby-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Ruby App with CockroachDB and the Ruby pg Driver
 summary: Learn how to use CockroachDB from a simple Ruby application with the pg client driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_ruby_pg
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-spring-app-with-cockroachdb-jdbc.md
+++ b/v20.2/build-a-spring-app-with-cockroachdb-jdbc.md
@@ -3,6 +3,7 @@ title: Build a Spring App with CockroachDB and JDBC
 summary: Learn how to use CockroachDB from a Spring application with the JDBC driver.
 toc: true
 twitter: false
+referral_id: docs_roach_data_java_spring_jdbc
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-spring-app-with-cockroachdb-jpa.md
+++ b/v20.2/build-a-spring-app-with-cockroachdb-jpa.md
@@ -3,6 +3,7 @@ title: Build a Spring App with CockroachDB and JPA
 summary: Learn how to use CockroachDB from a Spring application with Spring Data JPA and Hibernate.
 toc: true
 twitter: false
+referral_id: docs_roach_data_java_spring_jpa
 ---
 
 <div class="filters filters-big clearfix">

--- a/v20.2/build-a-typescript-app-with-cockroachdb.md
+++ b/v20.2/build-a-typescript-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a TypeScript App with CockroachDB and TypeORM
 summary: Learn how to use CockroachDB with the TypeORM framework.
 toc: true
 twitter: false
+referral_id: docs_hello_world_typescript_typeorm
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-c++-app-with-cockroachdb.md
+++ b/v21.1/build-a-c++-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a C++ App with CockroachDB and libpqxx
 summary: Learn how to use CockroachDB from a simple C++ application with a low-level client driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_c++_libpgxx
 ---
 
 This tutorial shows you how build a simple C++ application with CockroachDB and the C++ libpqxx driver.

--- a/v21.1/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v21.1/build-a-go-app-with-cockroachdb-gorm.md
@@ -3,6 +3,7 @@ title: Build a Go App with CockroachDB and GORM
 summary: Learn how to use CockroachDB from a simple Go application with the GORM ORM.
 toc: true
 twitter: false
+referral_id: docs_hello_world_go_gorm
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-go-app-with-cockroachdb-pq.md
+++ b/v21.1/build-a-go-app-with-cockroachdb-pq.md
@@ -3,6 +3,7 @@ title: Build a Go App with CockroachDB the Go pq Driver
 summary: Learn how to use CockroachDB from a simple Go application with the Go pq driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_go_pq
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-go-app-with-cockroachdb.md
+++ b/v21.1/build-a-go-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Go App with CockroachDB the Go pgx Driver
 summary: Learn how to use CockroachDB from a simple Go application with the Go pgx driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_go_pgx
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-java-app-with-cockroachdb-hibernate.md
+++ b/v21.1/build-a-java-app-with-cockroachdb-hibernate.md
@@ -3,6 +3,7 @@ title: Build a Java App with CockroachDB and Hibernate
 summary: Learn how to use CockroachDB from a simple Java application with the Hibernate ORM.
 toc: true
 twitter: false
+referral_id: docs_hello_world_java_hibernate
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-java-app-with-cockroachdb.md
+++ b/v21.1/build-a-java-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Java App with CockroachDB and JDBC
 summary: Learn how to use CockroachDB from a simple Java application with the JDBC driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_java_jdbc
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -3,6 +3,7 @@ title: Build a Node.js App with CockroachDB and Sequelize
 summary: Learn how to use CockroachDB from a simple Node.js application with the Sequelize ORM.
 toc: true
 twitter: false
+referral_id: docs_hello_world_nodejs_sequelize
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-nodejs-app-with-cockroachdb.md
+++ b/v21.1/build-a-nodejs-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Node.js App with CockroachDB and the Node.js pg Driver
 summary: Learn how to use CockroachDB from a simple Node.js application with the Node.js pg driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_nodejs_pg
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-python-app-with-cockroachdb-django.md
+++ b/v21.1/build-a-python-app-with-cockroachdb-django.md
@@ -3,6 +3,7 @@ title: Build a Python App with CockroachDB and Django
 summary: Learn how to use CockroachDB from a simple Django application.
 toc: true
 twitter: false
+referral_id: docs_hello_world_python_django
 ---
 
 <div class="filters clearfix">

--- a/v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -3,6 +3,7 @@ title: Build a Python App with CockroachDB and SQLAlchemy
 summary: Learn how to use CockroachDB from a simple Python application with SQLAlchemy.
 toc: true
 twitter: false
+referral_id: docs_hello_world_python_sqlalchemy
 ---
 
 <div class="filters clearfix">

--- a/v21.1/build-a-python-app-with-cockroachdb.md
+++ b/v21.1/build-a-python-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Python App with CockroachDB and psycopg2
 summary: Learn how to use CockroachDB from a simple Python application with the psycopg2 driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_python_psycopg2
 ---
 
 <div class="filters clearfix">

--- a/v21.1/build-a-ruby-app-with-cockroachdb-activerecord.md
+++ b/v21.1/build-a-ruby-app-with-cockroachdb-activerecord.md
@@ -3,6 +3,7 @@ title: Build a Ruby App with CockroachDB and ActiveRecord
 summary: Learn how to use CockroachDB from a simple Ruby script with the ActiveRecord gem.
 toc: true
 twitter: false
+referral_id: docs_hello_world_ruby_activerecord
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-ruby-app-with-cockroachdb.md
+++ b/v21.1/build-a-ruby-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a Ruby App with CockroachDB and the Ruby pg Driver
 summary: Learn how to use CockroachDB from a simple Ruby application with the pg client driver.
 toc: true
 twitter: false
+referral_id: docs_hello_world_ruby_pg
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-spring-app-with-cockroachdb-jdbc.md
+++ b/v21.1/build-a-spring-app-with-cockroachdb-jdbc.md
@@ -3,6 +3,7 @@ title: Build a Spring App with CockroachDB and JDBC
 summary: Learn how to use CockroachDB from a Spring application with the JDBC driver.
 toc: true
 twitter: false
+referral_id: docs_roach_data_java_spring_jdbc
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-spring-app-with-cockroachdb-jpa.md
+++ b/v21.1/build-a-spring-app-with-cockroachdb-jpa.md
@@ -3,6 +3,7 @@ title: Build a Spring App with CockroachDB and JPA
 summary: Learn how to use CockroachDB from a Spring application with Spring Data JPA and Hibernate.
 toc: true
 twitter: false
+referral_id: docs_roach_data_java_spring_jpa
 ---
 
 <div class="filters filters-big clearfix">

--- a/v21.1/build-a-typescript-app-with-cockroachdb.md
+++ b/v21.1/build-a-typescript-app-with-cockroachdb.md
@@ -3,6 +3,7 @@ title: Build a TypeScript App with CockroachDB and TypeORM
 summary: Learn how to use CockroachDB with the TypeORM framework.
 toc: true
 twitter: false
+referral_id: docs_hello_world_typescript_typeorm
 ---
 
 <div class="filters filters-big clearfix">


### PR DESCRIPTION
This PR customizes the CC referral IDs for our sample app tutorials. 

- Each tutorial page has a front-matter field with its referral ID, e.g., `referral_id: docs_hello_world_python_sqlalchemy`.
- Each tutorial page includes a snippet for setting up a free tier cluster.
- That included snippet uses Liquid to pull in the referral ID from the page on which it’s included, e.g., `<a href="https://cockroachlabs.cloud/signup?referralId={{page.referral_id}}" rel="noopener" target="_blank">`

Fixes #10548