### PR TITLE
Update cockroach version docs for v20.2

### DIFF
--- a/v20.2/cockroach-version.md
+++ b/v20.2/cockroach-version.md
@@ -6,7 +6,7 @@ redirect_from: view-version-details.html
 key: view-version-details.html
 ---
 
-To view version details for a specific `cockroach` binary, run the `cockroach version` [command](cockroach-commands.html):
+To view version details for a specific `cockroach` binary, run the `cockroach version` [command](cockroach-commands.html), or run `cockroach --version`:
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -24,17 +24,19 @@ Build SHA-1:  5b757262d33d814bda1deb2af20161a1f7749df3
 Build Type:   release
 ~~~
 
+## Response
+
 The `cockroach version` command outputs the following fields:
 
 Field | Description
 ------|------------
-`Build Tag` | The CockroachDB version.
+`Build Tag` | The CockroachDB version. To return just the build tag, use `cockroach version --build-tag`.
 `Build Time` | The date and time when the binary was built.
 `Distribution` | The scope of the binary. If `CCL`, the binary contains functionality covered by both the CockroachDB Community License (CCL) and the Business Source License (BSL). If `OSS`, the binary contains only functionality covered by the Apache 2.0 license. The v19.2 release converts to Apache 2.0 as of Oct 1, 2022, at which time you can use the `make buildoss` command to build a pure open-source binary. For more details about licensing, see the [Licensing FAQs](licensing-faqs.html).
 `Platform` | The platform that the binary can run on.
 `Go Version` | The version of Go in which the source code is written.
 `C Compiler` | The C compiler used to build the binary.
-`Build SHA-1` | The SHA-1 hash of the commit used to build the binary.
+`Build Commit ID` | The SHA-1 hash of the commit used to build the binary.
 `Build Type` | The type of release. If `release`, `release-gnu`, or `release-musl`, the binary is for a [production release](../releases/#production-releases). If `development`, the binary is for a [testing release](../releases/#testing-releases).
 
 ## See also


### PR DESCRIPTION
Fixes #9955
Fixes #9954

Backport of https://github.com/cockroachdb/docs/pull/10490.