### PR TITLE
Added detail to other backups in privileges section

### DIFF
--- a/v20.2/backup.md
+++ b/v20.2/backup.md
@@ -40,7 +40,7 @@ To view the contents of an enterprise backup created with the `BACKUP` statement
 ## Required privileges
 
 - [Full cluster backups](take-full-and-incremental-backups.html#full-backups) can only be run by members of the [`admin` role](authorization.html#admin-role). By default, the `root` user belongs to the `admin` role.
-- For all other backups, the user must have [read access](authorization.html#assign-privileges) (`SELECT` or `USAGE`) on all objects being backed up.
+- For all other backups, the user must have [read access](authorization.html#assign-privileges) on all objects being backed up. Database and table backups require `SELECT` privileges. Backups of user-defined schemas, or backups containing user-defined types, require `USAGE` privileges.
 - `BACKUP` requires full read and write (including delete and overwrite) permissions to its target destination.
 
 ### Destination privileges

--- a/v21.1/backup.md
+++ b/v21.1/backup.md
@@ -48,7 +48,7 @@ To backup interleaved data in v21.1, a `BACKUP` statement must include the [`INC
 ## Required privileges
 
 - [Full cluster backups](take-full-and-incremental-backups.html#full-backups) can only be run by members of the [`admin` role](authorization.html#admin-role). By default, the `root` user belongs to the `admin` role.
-- For all other backups, the user must have [read access](authorization.html#assign-privileges) (`SELECT` or `USAGE`) on all objects being backed up.
+- For all other backups, the user must have [read access](authorization.html#assign-privileges) on all objects being backed up. Database and table backups require `SELECT` privileges. Backups of user-defined schemas, or backups containing user-defined types, require `USAGE` privileges.
 - `BACKUP` requires full read and write (including delete and overwrite) permissions to its target destination.
 
 ### Destination privileges


### PR DESCRIPTION
Included more definition to "other backups" for db + tables and UDT + UDS. 

I *think* external storage and cluster backups are covered here already.

Closes #10400