### PR TITLE
Removed pgwire version from PostgreSQL Compatibility page

### DIFF
--- a/v20.2/postgresql-compatibility.md
+++ b/v20.2/postgresql-compatibility.md
@@ -5,7 +5,7 @@ toc: true
 redirect_from: porting-postgres.html
 ---
 
-CockroachDB supports v3.0 of the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
+CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
 
 CockroachDB is compatible with PostgreSQL 9.5 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](build-an-app-with-cockroachdb.html).
 

--- a/v21.1/postgresql-compatibility.md
+++ b/v21.1/postgresql-compatibility.md
@@ -5,7 +5,7 @@ toc: true
 redirect_from: porting-postgres.html
 ---
 
-CockroachDB supports v3.0 of the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
+CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
 
 CockroachDB is wire-compatible with PostgreSQL 13 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](build-an-app-with-cockroachdb.html).
 


### PR DESCRIPTION
Background: https://cockroachlabs.slack.com/archives/C01PHNMUFLN/p1621525420022500