### PR TITLE
Linking changed doc content to the preview build.

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -2,7 +2,7 @@ name: List files changed as GitHub comment
 
 on:
   pull_request
-      
+
 jobs:
   list-files-changed:
     runs-on: ubuntu-latest
@@ -10,26 +10,35 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-          
+
       - name: Get changed files
         id: changed_files
         uses: tj-actions/changed-files@v4.2
-        with:
-          separator: ","
-          
+
       - name: Format list of changed files
         id: format
         run: |
-          body=${{ steps.changed_files.outputs.all_modified_files }}
-          body="${body//,/$'\n'}"
-          body="${body//$'\n'/'%0A'}"
+          declare -a output
+
+          files=${{ steps.changed_files.outputs.all_modified_files }}
+          pr_num=${{ github.event.pull_request.number }}
+          for file in $files; do
+            # only create links for Markdown files that are not includes
+            if [[ $file == *.md ]] && [[ $file != _* ]]
+            then
+              html_file=${file%.md}.html
+              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\">$file</a>"
+            fi
+            output+="$file\n"
+          done;
+          body="${files//$'\n'/'%0A'}"
           echo ::set-output name=body::$body
-        
+
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             Files changed:
-            
+
             ${{ steps.format.outputs.body }}

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           declare -a output
 
-          files='${{ steps.changed_files.outputs.all_modified_files }}'
+          files=(${{ steps.changed_files.outputs.all_modified_files }})
           pr_num=${{ github.event.pull_request.number }}
           for file in $files; do
             # only create links for Markdown files that are not includes

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -29,9 +29,9 @@ jobs:
               html_file=${file%.md}.html
               file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target="_blank">$file</a>"
             fi
-            output+="$file\n"
+            output+="$file%0A"
           done;
-          body="${output[@]//$'\n'/'%0A'}"
+          body="${output[@]}"
           echo ::set-output name=body::$body
 
       - name: Create comment

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -27,7 +27,7 @@ jobs:
             if [[ $file == *.md ]] && [[ $file != _* ]]
             then
               html_file=${file%.md}.html
-              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\">$file</a>"
+              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target="_blank">$file</a>"
             fi
             output+="$file\n"
           done;

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -31,7 +31,7 @@ jobs:
             fi
             output+="$file\n"
           done;
-          body="${files//$'\n'/'%0A'}"
+          body="${output[@]//$'\n'/'%0A'}"
           echo ::set-output name=body::$body
 
       - name: Create comment

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -27,7 +27,7 @@ jobs:
             if [[ $file == *.md ]] && [[ $file != _* ]]
             then
               html_file=${file%.md}.html
-              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target="_blank">$file</a>"
+              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target=\"_blank\">$file</a>"
             fi
             output+="$file%0A"
           done;

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -22,7 +22,7 @@ jobs:
 
           files=(${{ steps.changed_files.outputs.all_modified_files }})
           pr_num=${{ github.event.pull_request.number }}
-          for file in $files; do
+          for file in ${files[@]}; do
             # only create links for Markdown files that are not includes
             if [[ $file == *.md ]] && [[ $file != _* ]]
             then

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -34,10 +34,20 @@ jobs:
           body="${output[@]}"
           echo ::set-output name=body::$body
 
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Files changed
+
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1
         with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
           body: |
             Files changed:
 

--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           declare -a output
 
-          files=${{ steps.changed_files.outputs.all_modified_files }}
+          files='${{ steps.changed_files.outputs.all_modified_files }}'
           pr_num=${{ github.event.pull_request.number }}
           for file in $files; do
             # only create links for Markdown files that are not includes

--- a/_includes/v21.1/demo_movr.md
+++ b/_includes/v21.1/demo_movr.md
@@ -4,3 +4,7 @@ Start the [MovR database](movr.html) on a 3-node CockroachDB demo cluster with a
 ~~~ shell
 cockroach demo movr --num-histories 250000 --num-promo-codes 250000 --num-rides 125000 --num-users 12500 --num-vehicles 3750 --nodes 3
 ~~~
+
+{% comment %}
+This is a test
+{% endcomment %}

--- a/v21.1/make-queries-fast.md
+++ b/v21.1/make-queries-fast.md
@@ -38,6 +38,10 @@ It's common to offer users promo codes to increase usage and customer loyalty. I
 
 To phrase it in the form of a question: "Who are the top 10 users by number of rides on a given date?"
 
+{% comment %}
+This is a test
+{% endcomment %}
+
 ### Rule 1. Scan as few rows as possible
 
 First, let's study the schema so we understand the relationships between the tables.


### PR DESCRIPTION
Modifies the GitHub action to link changed documentation topics to the Netlify preview site for the PR.

We can anticipate the preview site URL using the PR number and the changed file. Non-Markdown files and Markdown files that are in directories that begin with an underscore (e.g. `_includes/v21.1/file.md`) are not linked.

I also added a step to update any existing changed file comment so the action doesn't create multiple comments.