### PR TITLE
Restore /stable and /dev as canonical links

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,12 +10,7 @@
   <meta name="robots" content="nocache">
 {% endif %}
 <title>{{ page.title }} | {{ site.site_title }}</title>
-{% assign page_url = page.url | relative_url | split: "/" %}
-{% if page.version %}
-  <link rel="canonical" href="{{ site.versions["stable"] | absolute_url | append: "/" | append: page_url[3] }}">
-{% else %}
-  <link rel="canonical" href="{{ page.canonical | absolute_url }}">
-{% endif %}
+<link rel="canonical" href="{{ page.canonical | absolute_url }}">
 <link rel="shortcut icon" href="{{ 'images/favicon.png' | relative_url }}" type="image/png">
 
 {% if page.comparison == true %}<link rel="stylesheet" type="text/css" href="{{ 'css/select2.min.css' | relative_url }}">{% endif %}

--- a/_redirects
+++ b/_redirects
@@ -22,7 +22,7 @@ layout: null
 {% endif %}
 
 {%- for version in site.versions -%}
-{{ version[0]|relative_url }}/* {{ version[1]|relative_url }}/:splat 301
+{{ version[0]|relative_url }}/* {{ version[1]|relative_url }}/:splat 200
 {% endfor -%}
 
 # Redirects for DockerHub


### PR DESCRIPTION
Restores /stable and /dev as canonical links instead of using versioned URLs.