### PR TITLE
Add /stable links to sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-# If you modify this file, you'll need to build a new version of the
-# docs-builder Docker image to keep things speedy in CI. See ci/README.md for
-# instructions.
-
 gem "jekyll", "~> 4.2"
 gem "jekyll-redirect-from", "~> 0.15"
 gem "jekyll-sitemap", "~> 1.3.1"

--- a/_config_base.yml
+++ b/_config_base.yml
@@ -37,6 +37,21 @@ defaults:
     path: "v19.1/**/*"
   values:
     sitemap:  false
+-
+  scope:
+    path: "v19.2/**/*"
+  values:
+    sitemap:  false
+-
+  scope:
+    path: "v20.1/**/*"
+  values:
+    sitemap:  false
+-
+  scope:
+    path: "v20.2/**/*"
+  values:
+    sitemap:  false
 exclude:
 - __tests__
 - netlify

--- a/netlify/build
+++ b/netlify/build
@@ -11,12 +11,17 @@ npx snippet-enricher-cli --targets="shell_curl" --input=spec_30.json > spec_30_e
 rm spec_30.json
 popd
 
+# Generate site
 gem install bundler
 bundle install
 build _config_cockroachdb.yml
 
 cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
+
+# Use /stable links in sitemap
+stable_version=$(awk '/(stable: )(v.*)/{print $2}' _config_cockroachdb.yml)
+sed -in 's/docs\/'"$stable_version"'/docs\/stable/g' _site/docs/sitemap.xml
 
 # Set up htmltest
 go get -u github.com/cockroachdb/htmltest


### PR DESCRIPTION
Use straightforward text find-and-replace to modify the sitemap such that it uses /stable links instead of versioned URLs.

I ran this approach by @anagio.

Preview of modified sitemap: https://deploy-preview-10643--cockroachdb-docs.netlify.app/docs/sitemap.xml