### PR TITLE
Remove duplicated text in multiregion-overview.md

### DIFF
--- a/v21.1/multiregion-overview.md
+++ b/v21.1/multiregion-overview.md
@@ -138,14 +138,6 @@ Table locality settings are used for optimizing latency under different read/wri
 
 {% include {{page.version.version}}/sql/regional-by-row-table-description.md %}
 
-In _regional by row_ tables, individual rows are optimized for access from different regions. This setting divides a table and all of [its indexes](#indexes-on-regional-by-row-tables) into [partitions](partitioning.html), with each partition optimized for access from a different region. Like [regional tables](#regional-tables), _regional by row_ tables are optimized for access from a single region. However, that region is specified at the row level instead of applying to the whole table.
-
-Use regional by row tables when your application requires low-latency reads and writes at a row level where individual rows are primarily accessed from a single region. For example, a users table in a global application may need to keep some users' data in specific regions due to regulations (such as GDPR), for better performance, or both.
-
-For an example of a table that can benefit from the _regional by row_ setting in a multi-region deployment, see the `users` table from the [MovR application](movr.html).
-
-For instructions showing how to set a table's locality to `REGIONAL BY ROW`, see [`ALTER TABLE ... SET LOCALITY`](set-locality.html#regional-by-row)
-
 ### Global tables
 
 {% include {{page.version.version}}/sql/global-table-description.md %}


### PR DESCRIPTION
Looks like whenever this was moved into an include, they used copy instead of cut.