### PR TITLE
Move sidebar JS later in the page to avoid blocking rendering

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,5 +1,4 @@
 <div class="col-sidebar">
-  <script src="{{ 'js/initSidebar.js' | relative_url }}"></script>
   <div class="col-sidebar-content">
     <div class="mb-3 px-3">
       <form action="/docs/search.html">
@@ -8,115 +7,7 @@
     </div>
     <ul id="sidebar" class="js-sidebar nav {% if page.name == 'index.md' %}nav--home{% endif %}{% if page.url == '/search.html'%}nav--search{% endif %}  pt-0" style="display: none">
       <div class="sidenav-arrow mr-4"></div>
-
-      <script>
-        (function () {
-          var baseUrl = "{{ site.baseurl }}";
-
-          var isVersionDirectory = function (d) {
-            // Version directories either are one of the named version
-            // aliases specifed in _config.yml or have the form "vX.X",
-            // like "v1.0" or "v1.10".
-            return {{ site.versions | jsonify }}[d] || /^v\d+.\d+$/.test(d);
-          };
-
-          // We derive the version from the URL rather than hardcoding
-          // `page.version` so that the source of pages for "named"
-          // versions, like stable and edge, can be identical to the
-          // source for the underlying version, like v1.0 or v1.1.
-          // Otherwise, the sidebar for a `stable` page would
-          // inappropriately link to the underlying `v1.0` page instead
-          // of the `stable` alias.
-          var pageVersion = (function () {
-            var pathComponents = location.pathname
-              .replace(baseUrl, '')
-              .replace(/^\//, '')
-              .split('/');
-            // The version is the first directory component in the URL,
-            // if it exists.
-            if (pathComponents.length > 1 && isVersionDirectory(pathComponents[0])) {
-              return pathComponents[0];
-            }
-            // Non-versioned pages link to stable docs.
-            return "stable";
-          })();
-
-          // Given a sidebar hierarchy (see _data/sidebar-data-v1.0.json
-          // for an example), returns a jQuery <ul> element with the
-          // following structure:
-          //
-          // <ul>
-          //   <li class="tier-1">
-          //    <a href="{{ item.url }}">{{ item.title }}</a>
-          //     <ul>
-          //       {% for item in item.items %}
-          //         <li class="tier-2">...</li>
-          //       {% endfor %}
-          //     </ul>
-          //   </li>
-          // </ul>
-          //
-          // Additionally injects breadcrumbs for the active sidebar
-          // entry, if any, into the `.collapsed-header` element above.
-          function renderItems(items, paths) {
-            if (!items || items.length == 0)
-                return $();
-
-            var lis = items.map(function (item) {
-              var urls = (item.urls || []).map(function (url) {
-                var url = url.replace("${VERSION}", pageVersion);
-                // This condition makes it possible to use external
-                // urls in the sidebar.
-                if (!/^https?:/.test(url)) {
-                  url = baseUrl + url;
-                }
-                return url;
-              });
-
-              // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
-              var activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
-
-              var active = (urls.indexOf(activePathname) !== -1);
-              if (active) {
-                // This mutation inside an otherwise pure function is
-                // unfortunate, but doing it here avoids a separate
-                // traversal of the sidebar data.
-                var breadcrumbs = $("<div>")
-                  .addClass("collapsed-header__pre")
-                  .html(paths.join("<div class=\"arrow-down arrow-down--pre\"></div>\n"));
-
-                var title = $("<div>").html(item.title);
-                $(".collapsed-header").empty().append(breadcrumbs, title);
-              }
-
-              var subitems = renderItems(item.items, paths.concat(item.title));
-              var a = $("<a>")
-                .attr("href", urls[0] || "#")
-                .html(item.title);
-
-              if (subitems.length > 0 && !item.is_top_level) {
-                  a.append(" ").append($("<div>").addClass("nav-expand"));
-              }
-
-              return $("<li>")
-                .addClass("tier-" + (paths.length + 1))
-                .toggleClass("active", active)
-                .toggleClass("visited", active)
-                .append(a)
-                .append(subitems);
-            });
-
-            return $("<ul>").append(lis);
-          }
-
-          document.getElementById('sidebar').innerHTML = renderItems({% include {{ page.sidebar_data }} %}, []).html();
-        })();
-      </script>
     </ul>
   </div>
   <div class="stiky-spacer"></div>
-  <script src="{{ 'js/searchInputRendering.js' | relative_url }}"></script>
 </div>
-
-<!-- this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above.-->
-<script>$("#sidebar").find("li.active").parents('li').toggleClass("active");</script>

--- a/_includes/sidebar.js.html
+++ b/_includes/sidebar.js.html
@@ -1,0 +1,111 @@
+  <script src="{{ 'js/initSidebar.js' | relative_url }}" defer></script>
+
+  <script>
+    (function () {
+      var baseUrl = "{{ site.baseurl }}";
+
+      var isVersionDirectory = function (d) {
+        // Version directories either are one of the named version
+        // aliases specifed in _config.yml or have the form "vX.X",
+        // like "v1.0" or "v1.10".
+        return {{ site.versions | jsonify }}[d] || /^v\d+.\d+$/.test(d);
+      };
+
+      // We derive the version from the URL rather than hardcoding
+      // `page.version` so that the source of pages for "named"
+      // versions, like stable and edge, can be identical to the
+      // source for the underlying version, like v1.0 or v1.1.
+      // Otherwise, the sidebar for a `stable` page would
+      // inappropriately link to the underlying `v1.0` page instead
+      // of the `stable` alias.
+      var pageVersion = (function () {
+        var pathComponents = location.pathname
+          .replace(baseUrl, '')
+          .replace(/^\//, '')
+          .split('/');
+        // The version is the first directory component in the URL,
+        // if it exists.
+        if (pathComponents.length > 1 && isVersionDirectory(pathComponents[0])) {
+          return pathComponents[0];
+        }
+        // Non-versioned pages link to stable docs.
+        return "stable";
+      })();
+
+      // Given a sidebar hierarchy (see _data/sidebar-data-v1.0.json
+      // for an example), returns a jQuery <ul> element with the
+      // following structure:
+      //
+      // <ul>
+      //   <li class="tier-1">
+      //    <a href="{{ item.url }}">{{ item.title }}</a>
+      //     <ul>
+      //       {% for item in item.items %}
+      //         <li class="tier-2">...</li>
+      //       {% endfor %}
+      //     </ul>
+      //   </li>
+      // </ul>
+      //
+      // Additionally injects breadcrumbs for the active sidebar
+      // entry, if any, into the `.collapsed-header` element above.
+      function renderItems(items, paths) {
+        if (!items || items.length == 0)
+            return $();
+
+        var lis = items.map(function (item) {
+          var urls = (item.urls || []).map(function (url) {
+            var url = url.replace("${VERSION}", pageVersion);
+            // This condition makes it possible to use external
+            // urls in the sidebar.
+            if (!/^https?:/.test(url)) {
+              url = baseUrl + url;
+            }
+            return url;
+          });
+
+          // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
+          var activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
+
+          var active = (urls.indexOf(activePathname) !== -1);
+          if (active) {
+            // This mutation inside an otherwise pure function is
+            // unfortunate, but doing it here avoids a separate
+            // traversal of the sidebar data.
+            var breadcrumbs = $("<div>")
+              .addClass("collapsed-header__pre")
+              .html(paths.join("<div class=\"arrow-down arrow-down--pre\"></div>\n"));
+
+            var title = $("<div>").html(item.title);
+            $(".collapsed-header").empty().append(breadcrumbs, title);
+          }
+
+          var subitems = renderItems(item.items, paths.concat(item.title));
+          var a = $("<a>")
+            .attr("href", urls[0] || "#")
+            .html(item.title);
+
+          if (subitems.length > 0 && !item.is_top_level) {
+              a.append(" ").append($("<div>").addClass("nav-expand"));
+          }
+
+          return $("<li>")
+            .addClass("tier-" + (paths.length + 1))
+            .toggleClass("active", active)
+            .toggleClass("visited", active)
+            .append(a)
+            .append(subitems);
+        });
+
+        return $("<ul>").append(lis);
+      }
+
+      let items = {%- include {{ page.sidebar_data }} -%};
+      document.getElementById('sidebar').innerHTML = renderItems(items, []).html();
+    })();
+
+    // this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above.
+    $("#sidebar").find("li.active").parents('li').toggleClass("active");
+</script>
+
+<script src="{{ 'js/searchInputRendering.js' | relative_url }}" async></script>

--- a/_includes/sidebar.js.html
+++ b/_includes/sidebar.js.html
@@ -1,111 +1,21 @@
-  <script src="{{ 'js/initSidebar.js' | relative_url }}" defer></script>
+<script src="{{ 'js/initSidebar.js' | relative_url }}"></script>
 
-  <script>
-    (function () {
-      var baseUrl = "{{ site.baseurl }}";
-
-      var isVersionDirectory = function (d) {
+<script>
+  (function(){
+    const sidebar = {
+      baseUrl: "{{ site.baseurl }}",
+      isVersionDirectory: function (d) {
         // Version directories either are one of the named version
         // aliases specifed in _config.yml or have the form "vX.X",
         // like "v1.0" or "v1.10".
         return {{ site.versions | jsonify }}[d] || /^v\d+.\d+$/.test(d);
-      };
+      },
+      items: {%- include {{ page.sidebar_data }} -%}
+    };
 
-      // We derive the version from the URL rather than hardcoding
-      // `page.version` so that the source of pages for "named"
-      // versions, like stable and edge, can be identical to the
-      // source for the underlying version, like v1.0 or v1.1.
-      // Otherwise, the sidebar for a `stable` page would
-      // inappropriately link to the underlying `v1.0` page instead
-      // of the `stable` alias.
-      var pageVersion = (function () {
-        var pathComponents = location.pathname
-          .replace(baseUrl, '')
-          .replace(/^\//, '')
-          .split('/');
-        // The version is the first directory component in the URL,
-        // if it exists.
-        if (pathComponents.length > 1 && isVersionDirectory(pathComponents[0])) {
-          return pathComponents[0];
-        }
-        // Non-versioned pages link to stable docs.
-        return "stable";
-      })();
-
-      // Given a sidebar hierarchy (see _data/sidebar-data-v1.0.json
-      // for an example), returns a jQuery <ul> element with the
-      // following structure:
-      //
-      // <ul>
-      //   <li class="tier-1">
-      //    <a href="{{ item.url }}">{{ item.title }}</a>
-      //     <ul>
-      //       {% for item in item.items %}
-      //         <li class="tier-2">...</li>
-      //       {% endfor %}
-      //     </ul>
-      //   </li>
-      // </ul>
-      //
-      // Additionally injects breadcrumbs for the active sidebar
-      // entry, if any, into the `.collapsed-header` element above.
-      function renderItems(items, paths) {
-        if (!items || items.length == 0)
-            return $();
-
-        var lis = items.map(function (item) {
-          var urls = (item.urls || []).map(function (url) {
-            var url = url.replace("${VERSION}", pageVersion);
-            // This condition makes it possible to use external
-            // urls in the sidebar.
-            if (!/^https?:/.test(url)) {
-              url = baseUrl + url;
-            }
-            return url;
-          });
-
-          // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
-          var activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
-
-          var active = (urls.indexOf(activePathname) !== -1);
-          if (active) {
-            // This mutation inside an otherwise pure function is
-            // unfortunate, but doing it here avoids a separate
-            // traversal of the sidebar data.
-            var breadcrumbs = $("<div>")
-              .addClass("collapsed-header__pre")
-              .html(paths.join("<div class=\"arrow-down arrow-down--pre\"></div>\n"));
-
-            var title = $("<div>").html(item.title);
-            $(".collapsed-header").empty().append(breadcrumbs, title);
-          }
-
-          var subitems = renderItems(item.items, paths.concat(item.title));
-          var a = $("<a>")
-            .attr("href", urls[0] || "#")
-            .html(item.title);
-
-          if (subitems.length > 0 && !item.is_top_level) {
-              a.append(" ").append($("<div>").addClass("nav-expand"));
-          }
-
-          return $("<li>")
-            .addClass("tier-" + (paths.length + 1))
-            .toggleClass("active", active)
-            .toggleClass("visited", active)
-            .append(a)
-            .append(subitems);
-        });
-
-        return $("<ul>").append(lis);
-      }
-
-      let items = {%- include {{ page.sidebar_data }} -%};
-      document.getElementById('sidebar').innerHTML = renderItems(items, []).html();
-    })();
-
-    // this highlights the active parent class in the navgoco sidebar. this is critical so that the parent expands when you're viewing a page. This must appear below the sidebar code above.
-    $("#sidebar").find("li.active").parents('li').toggleClass("active");
+    // implemented in initSidebar.js
+    renderSidebar(sidebar);
+  })();
 </script>
 
 <script src="{{ 'js/searchInputRendering.js' | relative_url }}" async></script>

--- a/_includes/version-switcher.html
+++ b/_includes/version-switcher.html
@@ -1,13 +1,12 @@
 <div class="mt-3 mb-4">
 <div id="version-switcher">
-  <script src="{{ 'js/initVersionSwitcher.js' | relative_url }}"></script>
-  <ul class="nav" style="display: none">
+  <ul class="nav">
     <li class="tier-1">
       <a href="#">
         Version <span class="version-name">{{ page.version.name }}</span>
         <div class="arrow"></div>
       </a>
-      <ul class="list-unstyled">
+      <ul class="list-unstyled"  style="display: none">
         {% for v in page.versions %}
         <li class="tier-2 {% if v.version == page.version %}active{% endif %}">
           <a
@@ -43,3 +42,5 @@
   </ul>
 </div>
 </div>
+
+<script src="{{ 'js/initVersionSwitcher.js' | relative_url }}" async></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,9 +49,10 @@
       </div>
     </div>
 
-          {% include_cached footer.html %}
+    {% include_cached footer.html %}
 
-    
+    {% include sidebar.js.html %}
+
     <script src="{{ 'js/jquery.cookie.min.js' | relative_url }}"></script>
     <script src="{{ 'js/jquery.navgoco.min.js' | relative_url }}"></script>
     <!-- bs 4.X -->

--- a/js/initSidebar.js
+++ b/js/initSidebar.js
@@ -137,9 +137,9 @@ function renderSidebar(sidebar) {
   }
 
   const $sidebar = $('#sidebar');
-  const html = renderItems(sidebar.items, []).html();
+  const $html = renderItems(sidebar.items, []).html();
 
-  $sidebar.html(html)
+  $sidebar.html($html)
     .find("li.active")
     .parents('li')
     .toggleClass("active");

--- a/js/initSidebar.js
+++ b/js/initSidebar.js
@@ -1,8 +1,8 @@
 $(function() {
-  var $sidebar = $('#sidebar');
-  var $sidebars = $('.js-sidebar');
+  const $sidebar = $('#sidebar');
+  const $sidebars = $('.js-sidebar');
 
-  var navgocoOptions = {
+  const navgocoOptions = {
     caretHtml: '',
     accordion: true,
     openClass: 'active',
@@ -43,5 +43,106 @@ $(function() {
     // }));
     // sidebar.show();
   });
-
 });
+
+// called from sidebar.js.html
+function renderSidebar(sidebar) {
+  // We derive the version from the URL rather than hardcoding
+  // `page.version` so that the source of pages for "named"
+  // versions, like stable and edge, can be identical to the
+  // source for the underlying version, like v1.0 or v1.1.
+  // Otherwise, the sidebar for a `stable` page would
+  // inappropriately link to the underlying `v1.0` page instead
+  // of the `stable` alias.
+  var pageVersion = (function () {
+    var pathComponents = location.pathname
+      .replace(sidebar.baseUrl, '')
+      .replace(/^\//, '')
+      .split('/');
+    // The version is the first directory component in the URL,
+    // if it exists.
+    if (pathComponents.length > 1 && sidebar.isVersionDirectory(pathComponents[0])) {
+      return pathComponents[0];
+    }
+    // Non-versioned pages link to stable docs.
+    return "stable";
+  })();
+
+  // Given a sidebar hierarchy (see _data/sidebar-data-v1.0.json
+  // for an example), returns a jQuery <ul> element with the
+  // following structure:
+  //
+  // <ul>
+  //   <li class="tier-1">
+  //    <a href="{{ item.url }}">{{ item.title }}</a>
+  //     <ul>
+  //       {% for item in item.items %}
+  //         <li class="tier-2">...</li>
+  //       {% endfor %}
+  //     </ul>
+  //   </li>
+  // </ul>
+  //
+  // Additionally injects breadcrumbs for the active sidebar
+  // entry, if any, into the `.collapsed-header` element above.
+  function renderItems(items, paths) {
+    if (!items || items.length == 0)
+        return $();
+
+    var lis = items.map(function (item) {
+      var urls = (item.urls || []).map(function (url) {
+        var url = url.replace("${VERSION}", pageVersion);
+        // This condition makes it possible to use external
+        // urls in the sidebar.
+        if (!/^https?:/.test(url)) {
+          url = sidebar.baseUrl + url;
+        }
+        return url;
+      });
+
+      // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
+      var activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
+
+      var active = (urls.indexOf(activePathname) !== -1);
+      if (active) {
+        // This mutation inside an otherwise pure function is
+        // unfortunate, but doing it here avoids a separate
+        // traversal of the sidebar data.
+        var breadcrumbs = $("<div>")
+          .addClass("collapsed-header__pre")
+          .html(paths.join("<div class=\"arrow-down arrow-down--pre\"></div>\n"));
+
+        var title = $("<div>").html(item.title);
+        $(".collapsed-header").empty().append(breadcrumbs, title);
+      }
+
+      var subitems = renderItems(item.items, paths.concat(item.title));
+      var a = $("<a>")
+        .attr("href", urls[0] || "#")
+        .html(item.title);
+
+      if (subitems.length > 0 && !item.is_top_level) {
+          a.append(" ").append($("<div>").addClass("nav-expand"));
+      }
+
+      return $("<li>")
+        .addClass("tier-" + (paths.length + 1))
+        .toggleClass("active", active)
+        .toggleClass("visited", active)
+        .append(a)
+        .append(subitems);
+    });
+
+    return $("<ul>").append(lis);
+  }
+
+  const $sidebar = $('#sidebar');
+  const html = renderItems(sidebar.items, []).html();
+
+  $sidebar.html(html)
+    .find("li.active")
+    .parents('li')
+    .toggleClass("active");
+};
+
+

--- a/js/initSidebar.js
+++ b/js/initSidebar.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(function() {
   var $sidebar = $('#sidebar');
   var $sidebars = $('.js-sidebar');
 

--- a/js/initSidebar.js
+++ b/js/initSidebar.js
@@ -54,8 +54,8 @@ function renderSidebar(sidebar) {
   // Otherwise, the sidebar for a `stable` page would
   // inappropriately link to the underlying `v1.0` page instead
   // of the `stable` alias.
-  var pageVersion = (function () {
-    var pathComponents = location.pathname
+  const pageVersion = (function () {
+    const pathComponents = location.pathname
       .replace(sidebar.baseUrl, '')
       .replace(/^\//, '')
       .split('/');
@@ -89,8 +89,8 @@ function renderSidebar(sidebar) {
     if (!items || items.length == 0)
         return $();
 
-    var lis = items.map(function (item) {
-      var urls = (item.urls || []).map(function (url) {
+    const lis = items.map(function (item) {
+      const urls = (item.urls || []).map(function (url) {
         var url = url.replace("${VERSION}", pageVersion);
         // This condition makes it possible to use external
         // urls in the sidebar.
@@ -101,23 +101,23 @@ function renderSidebar(sidebar) {
       });
 
       // this ensures page will be highlighted in sidebar even if URL is accessed without `.html` appended
-      var activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
+      const activePathname = location.pathname.slice(-5) === '.html' ? location.pathname : location.pathname + '.html';
 
-      var active = (urls.indexOf(activePathname) !== -1);
+      const active = (urls.indexOf(activePathname) !== -1);
       if (active) {
         // This mutation inside an otherwise pure function is
         // unfortunate, but doing it here avoids a separate
         // traversal of the sidebar data.
-        var breadcrumbs = $("<div>")
+        const breadcrumbs = $("<div>")
           .addClass("collapsed-header__pre")
           .html(paths.join("<div class=\"arrow-down arrow-down--pre\"></div>\n"));
 
-        var title = $("<div>").html(item.title);
+        const title = $("<div>").html(item.title);
         $(".collapsed-header").empty().append(breadcrumbs, title);
       }
 
-      var subitems = renderItems(item.items, paths.concat(item.title));
-      var a = $("<a>")
+      const subitems = renderItems(item.items, paths.concat(item.title));
+      const a = $("<a>")
         .attr("href", urls[0] || "#")
         .html(item.title);
 


### PR DESCRIPTION
Make scripts defer and async where appropriate. Tweak version menu to avoid layout shift.

Motivated by Lighthouse recommendation.

Addresses https://github.com/cockroachdb/docs/issues/10697