### PR TITLE
Add OpenShift and IBM reference to 21.1 Kubernetes tutorial

### DIFF
--- a/_includes/v21.1/sql/unsupported-postgres-features.md
+++ b/_includes/v21.1/sql/unsupported-postgres-features.md
@@ -1,7 +1,7 @@
 - Stored procedures and functions
 - Triggers
 - Events
-- User-defined functions
+- User-defined functions (UDF)
 - FULLTEXT functions and indexes
 - Drop primary key
 - XML Functions

--- a/jekyll-algolia-dev/lib/jekyll/algolia/indexer.rb
+++ b/jekyll-algolia-dev/lib/jekyll/algolia/indexer.rb
@@ -315,6 +315,12 @@ module Jekyll
           synonyms: ['db console', 'admin ui', 'web ui']
         }, false)
 
+        index.save_synonym('technical advisory', {
+          objectID: 'technical advisory',
+          type: 'synonym',
+          synonyms: ['tech advisory', 'advisory']
+        }, false)
+
         return
       end
 


### PR DESCRIPTION
Searching for IBM currently returns no results. It's a somewhat
recurring search query, so this change should at least return
something, which is better than nothing.