### PR TITLE
Correction org setting cdc

### DIFF
--- a/v20.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v20.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -710,12 +710,12 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 4. Set your organization name and [enterprise license](enterprise-licensing.html) key that you received via email:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~ sql
     > SET CLUSTER SETTING cluster.organization = '<organization name>';
     ~~~
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~ sql
     > SET CLUSTER SETTING enterprise.license = '<secret>';
     ~~~
 
@@ -766,7 +766,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE TABLE employees (
-         dog_id INT REFERENCES office_dogs_avro (id),
+         dog_id INT REFERENCES office_dogs (id),
          employee_name STRING);
     ~~~
 

--- a/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -710,12 +710,12 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 4. Set your organization name and [enterprise license](enterprise-licensing.html) key that you received via email:
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~ sql
     > SET CLUSTER SETTING cluster.organization = '<organization name>';
     ~~~
 
     {% include copy-clipboard.html %}
-    ~~~ shell
+    ~~~ sql
     > SET CLUSTER SETTING enterprise.license = '<secret>';
     ~~~
 
@@ -766,7 +766,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
     {% include copy-clipboard.html %}
     ~~~ sql
     > CREATE TABLE employees (
-         dog_id INT REFERENCES office_dogs_avro (id),
+         dog_id INT REFERENCES office_dogs (id),
          employee_name STRING);
     ~~~
 


### PR DESCRIPTION
Closes #10698 

Corrected the syntax on the code block that was preventing the `SET CLUSTER` setting from showing up in the rendered page. Also corrected a incorrect table name that would create an error in the example.