### PR TITLE
Added cloud toggle examples to BACKUP & RESTORE pages v21.1

### DIFF
--- a/_includes/v20.2/backups/bulk-auth-options.md
+++ b/_includes/v20.2/backups/bulk-auth-options.md
@@ -1,0 +1,1 @@
+The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).

--- a/_includes/v21.1/backups/bulk-auth-options.md
+++ b/_includes/v21.1/backups/bulk-auth-options.md
@@ -1,0 +1,1 @@
+The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).

--- a/v21.1/backup.md
+++ b/v21.1/backup.md
@@ -150,7 +150,7 @@ The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually mea
 
 Per our guidance in the [Performance](#performance) section, we recommend starting backups from a time at least 10 seconds in the past using [`AS OF SYSTEM TIME`](as-of-system-time.html). Each example below follows this guidance.
 
-The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+{% include {{ page.version.version }}/backups/bulk-auth-options.md %}
 
 <div class="filters clearfix">
   <button class="filter-button" data-scope="s3">Amazon S3</button>
@@ -166,7 +166,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 ### Backup a cluster
 
-To take a [full backup](take-full-and-incremental-backups.html#full-backups) a cluster:
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -177,7 +177,7 @@ AS OF SYSTEM TIME '-10s';
 
 ### Backup a database
 
-To take a [full backup](take-full-and-incremental-backups.html#full-backups) a single database:
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -262,7 +262,7 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 ### Backup a cluster
 
-To take a [full backup](take-full-and-incremental-backups.html#full-backups) a cluster:
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -273,7 +273,7 @@ AS OF SYSTEM TIME '-10s';
 
 ### Backup a database
 
-To take a [full backup](take-full-and-incremental-backups.html#full-backups) a single database:
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -362,7 +362,7 @@ The examples in this section use the `AUTH=specified` parameter, which will be t
 
 ### Backup a cluster
 
-To take a [full backup](take-full-and-incremental-backups.html#full-backups) a cluster:
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -373,7 +373,7 @@ AS OF SYSTEM TIME '-10s';
 
 ### Backup a database
 
-To take a [full backup](take-full-and-incremental-backups.html#full-backups) a single database:
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v21.1/backup.md
+++ b/v21.1/backup.md
@@ -150,6 +150,20 @@ The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually mea
 
 Per our guidance in the [Performance](#performance) section, we recommend starting backups from a time at least 10 seconds in the past using [`AS OF SYSTEM TIME`](as-of-system-time.html). Each example below follows this guidance.
 
+The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="s3">Amazon S3</button>
+  <button class="filter-button" data-scope="azure">Azure Storage</button>
+  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="s3">
+
+{{site.data.alerts.callout_info}}
+The examples in this section use the **default** `AUTH=specified` parameter. For more detail on how to use `implicit` authentication with Amazon S3 buckets, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+{{site.data.alerts.end}}
+
 ### Backup a cluster
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) a cluster:
@@ -157,7 +171,7 @@ To take a [full backup](take-full-and-incremental-backups.html#full-backups) a c
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
-'s3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+'s3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -168,7 +182,7 @@ To take a [full backup](take-full-and-incremental-backups.html#full-backups) a s
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
-INTO 's3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -177,7 +191,7 @@ To take a [full backup](take-full-and-incremental-backups.html#full-backups) of 
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
-INTO 's3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -188,7 +202,7 @@ To take a [full backup](take-full-and-incremental-backups.html#full-backups) of 
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
-INTO 's3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -197,7 +211,7 @@ To take a [full backup](take-full-and-incremental-backups.html#full-backups) of 
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
-INTO 's3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -208,7 +222,7 @@ If you backup to a destination already containing a [full backup](take-full-and-
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
-'s3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+'s3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
@@ -219,7 +233,7 @@ Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html
 {% include copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
-'s3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+'s3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s'
 WITH DETACHED;
 ~~~
@@ -241,6 +255,204 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
 (1 row)
 ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="azure">
+
+### Backup a cluster
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) a cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP INTO \
+'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Backup a database
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) a single database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank \
+INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank, employees \
+INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Backup a table or view
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP bank.customers \
+INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP bank.customers, bank.accounts \
+INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Create incremental backups
+
+If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP INTO LATEST IN \
+'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Run a backup asynchronously
+
+Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP INTO \
+'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s'
+WITH DETACHED;
+~~~
+
+The job ID is returned immediately without waiting for the job to finish:
+
+~~~
+        job_id
+----------------------
+  592786066399264769
+(1 row)
+~~~
+
+**Without** the `DETACHED` option, `BACKUP` will block the SQL connection until the job completes. Once finished, the job status and more detailed job data is returned:
+
+~~~
+job_id             |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+--------
+652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
+(1 row)
+~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gcs">
+
+{{site.data.alerts.callout_info}}
+The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+{{site.data.alerts.end}}
+
+### Backup a cluster
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) a cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP INTO \
+'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Backup a database
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) a single database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank \
+INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP DATABASE bank, employees \
+INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Backup a table or view
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP bank.customers \
+INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP bank.customers, bank.accounts \
+INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Create incremental backups
+
+If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP INTO LATEST IN \
+'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+### Run a backup asynchronously
+
+Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP INTO \
+'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s'
+WITH DETACHED;
+~~~
+
+The job ID is returned immediately without waiting for the job to finish:
+
+~~~
+        job_id
+----------------------
+  592786066399264769
+(1 row)
+~~~
+
+**Without** the `DETACHED` option, `BACKUP` will block the SQL connection until the job completes. Once finished, the job status and more detailed job data is returned:
+
+~~~
+job_id             |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+--------
+652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
+(1 row)
+~~~
+
+</section>
 
 ### Advanced examples
 

--- a/v21.1/manage-a-backup-schedule.md
+++ b/v21.1/manage-a-backup-schedule.md
@@ -19,7 +19,7 @@ To create a new backup schedule, use the [`CREATE SCHEDULE FOR BACKUP`](create-s
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE schedule_label
-  FOR BACKUP INTO 's3://test/backups/test_schedule_1?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=123'
+  FOR BACKUP INTO 's3://test/backups/test_schedule_1?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH revision_history
     RECURRING '@daily'
     WITH SCHEDULE OPTIONS first_run = 'now';
@@ -28,6 +28,10 @@ To create a new backup schedule, use the [`CREATE SCHEDULE FOR BACKUP`](create-s
 In this example, a schedule labeled `schedule_label` is created to take daily (incremental) backups with revision history in AWS S3, with the first backup being taken now. A second [schedule for weekly full backups](create-schedule-for-backup.html#full-backup-clause) is also created by default. Both schedules have the same `label` (i.e., `schedule_label`).
 
 For more information about the different options available when creating a backup schedule, see [`CREATE SCHEDULE FOR BACKUP`](create-schedule-for-backup.html).
+
+{{site.data.alerts.callout_info}}
+Further guidance on connecting to Amazon S3, Google Cloud Storage, Azure Storage, and other storage options is outlined in [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
+{{site.data.alerts.end}}
 
 ## Set up monitoring for the backup schedule
 
@@ -253,7 +257,7 @@ To restore from a scheduled backup, use the [`RESTORE`](restore.html) statement:
 {% include copy-clipboard.html %}
 ~~~ sql
 > RESTORE
-    FROM 's3://test/backups/test_schedule_1/2020/08/19-035600.00?AWS_ACCESS_KEY_ID=x&AWS_SECRET_ACCESS_KEY=x'
+    FROM 's3://test/backups/test_schedule_1/2020/08/19-035600.00?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     AS OF SYSTEM TIME '2020-08-19 03:50:00+00:00';
 ~~~
 

--- a/v21.1/restore.md
+++ b/v21.1/restore.md
@@ -184,7 +184,7 @@ If initiated correctly, the statement returns when the restore is finished or if
 
 ## Examples
 
-The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+{% include {{ page.version.version }}/backups/bulk-auth-options.md %}
 
 <div class="filters clearfix">
   <button class="filter-button" data-scope="s3">Amazon S3</button>
@@ -200,7 +200,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 ### View the backup subdirectories
 
-<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`]:
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -230,6 +230,8 @@ To restore a full cluster:
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
 
 ### Restore a database
+
+To restore a database:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -280,9 +282,7 @@ FROM 's3://{bucket_name}/database-bank-2017-03-27-weekly?AWS_ACCESS_KEY_ID={key_
 ~~~
 
 {{site.data.alerts.callout_info}}
-<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version, but restored from a newer version.
-
-Incremental backups created by v20.2.2 and prior v20.2.x releases or v20.1.4 and prior v20.1.x releases may include incomplete data for indexes that were in the process of being created. Therefore, when incremental backups taken by these versions are restored by v21.1.0+, any indexes created during those incremental backups will be re-validated by `RESTORE`.
+<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version (v20.2.2 and earlier or v20.1.4 and earlier), but restored by a newer version (v21.1.0+). These earlier releases may have included incomplete data for indexes that were in the process of being created.
 {{site.data.alerts.end}}
 
 ### Restore a backup asynchronously
@@ -329,7 +329,7 @@ WITH into_db = 'newdb';
 
 #### Remove the foreign key before restore
 
-By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
+By default, tables with [foreign key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the foreign key constraint from the table and then restore it.
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -344,6 +344,8 @@ The `system.users` table stores your cluster's usernames and their hashed passwo
 
 After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
 
+First, create the new database that you'll restore the `system.users` table into:
+
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE DATABASE newdb;
@@ -356,181 +358,7 @@ FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id
 WITH into_db = 'newdb';
 ~~~
 
-{% include copy-clipboard.html %}
-~~~ sql
-> INSERT INTO system.users SELECT * FROM newdb.users;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> DROP TABLE newdb.users;
-~~~
-
-</section>
-
-<section class="filter-content" markdown="1" data-scope="gcs">
-
-{{site.data.alerts.callout_info}}
-The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
-{{site.data.alerts.end}}
-
-### View the backup subdirectories
-
-<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`]:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> SHOW BACKUPS IN 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
-(3 rows)
-~~~
-
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
-
-### Restore a cluster
-
-To restore a full cluster:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
-
-### Restore a database
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE DATABASE bank FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
-
-{{site.data.alerts.callout_info}}
-`RESTORE DATABASE` can only be used if the entire database was backed up.
-{{site.data.alerts.end}}
-
-### Restore a table
-
-To restore a single table:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE TABLE bank.customers FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-To restore multiple tables:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE TABLE bank.customers, bank.accounts FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
-
-### Restore from incremental backups
-
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers \
-FROM 'gs://{bucket name}/database-bank-2017-03-27-weekly?AUTH=specified&CREDENTIALS={encoded key}', \
-'gs://{bucket name}/database-bank-2017-03-28-nightly?AUTH=specified&CREDENTIALS={encoded key}', \
-'gs://{bucket name}/database-bank-2017-03-29-nightly?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-{{site.data.alerts.callout_info}}
-<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version, but restored from a newer version.
-
-Incremental backups created by v20.2.2 and prior v20.2.x releases or v20.1.4 and prior v20.1.x releases may include incomplete data for indexes that were in the process of being created. Therefore, when incremental backups taken by these versions are restored by v21.1.0+, any indexes created during those incremental backups will be re-validated by `RESTORE`.
-{{site.data.alerts.end}}
-
-### Restore a backup asynchronously
-
-Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE FROM \
-'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
-WITH DETACHED;
-~~~
-
-The job ID is returned immediately without waiting for the job to finish:
-
-~~~
-        job_id
-----------------------
-  592786066399264769
-(1 row)
-~~~
-
-**Without** the `DETACHED` option, `RESTORE` will block the SQL connection until the job completes. Once finished, the job status and more detailed job data is returned:
-
-~~~
-job_id             |  status   | fraction_completed | rows | index_entries | bytes
----------------------+-----------+--------------------+------+---------------+--------
-652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
-(1 row)
-~~~
-
-### Other restore usages
-
-#### Restore tables into a different database
-
-By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers \
-FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
-WITH into_db = 'newdb';
-~~~
-
-#### Remove the foreign key before restore
-
-By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.accounts \
-FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
-WITH skip_missing_foreign_keys;
-~~~
-
-#### Restoring users from `system.users` backup
-
-The `system.users` table stores your cluster's usernames and their hashed passwords. To restore them, you must restore the `system.users` table into a new database because you cannot drop the existing `system.users` table.
-
-After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> CREATE DATABASE newdb;
-~~~
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE system.users \
-FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
-WITH into_db = 'newdb';
-~~~
+After the restore completes, add the `users` to the existing `system.users` table:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -548,7 +376,7 @@ WITH into_db = 'newdb';
 
 ### View the backup subdirectories
 
-<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`]:
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -578,6 +406,8 @@ To restore a full cluster:
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
 
 ### Restore a database
+
+To restore a database:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -628,9 +458,7 @@ FROM 'azure://{container name}/database-bank-2017-03-27-weekly?AZURE_ACCOUNT_NAM
 ~~~
 
 {{site.data.alerts.callout_info}}
-<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version, but restored from a newer version.
-
-Incremental backups created by v20.2.2 and prior v20.2.x releases or v20.1.4 and prior v20.1.x releases may include incomplete data for indexes that were in the process of being created. Therefore, when incremental backups taken by these versions are restored by v21.1.0+, any indexes created during those incremental backups will be re-validated by `RESTORE`.
+<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version (v20.2.2 and earlier or v20.1.4 and earlier), but restored by a newer version (v21.1.0+). These earlier releases may have included incomplete data for indexes that were in the process of being created.
 {{site.data.alerts.end}}
 
 ### Restore a backup asynchronously
@@ -677,7 +505,7 @@ WITH into_db = 'newdb';
 
 #### Remove the foreign key before restore
 
-By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
+By default, tables with [foreign key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the foreign key constraint from the table and then restore it.
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -692,6 +520,8 @@ The `system.users` table stores your cluster's usernames and their hashed passwo
 
 After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
 
+First, create the new database that you'll restore the `system.users` table into:
+
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE DATABASE newdb;
@@ -703,6 +533,188 @@ After it's restored into a new database, you can write the restored `users` tabl
 FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
 WITH into_db = 'newdb';
 ~~~
+
+After the restore completes, add the `users` to the existing `system.users` table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO system.users SELECT * FROM newdb.users;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DROP TABLE newdb.users;
+~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gcs">
+
+{{site.data.alerts.callout_info}}
+The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+{{site.data.alerts.end}}
+
+### View the backup subdirectories
+
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW BACKUPS IN 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+~~~
+        path
+------------------------
+2021/03/23-213101.37
+2021/03/24-172553.85
+2021/03/24-210532.53
+(3 rows)
+~~~
+
+When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+
+### Restore a cluster
+
+To restore a full cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+### Restore a database
+
+To restore a database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE DATABASE bank FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+{{site.data.alerts.callout_info}}
+`RESTORE DATABASE` can only be used if the entire database was backed up.
+{{site.data.alerts.end}}
+
+### Restore a table
+
+To restore a single table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE TABLE bank.customers FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To restore multiple tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE TABLE bank.customers, bank.accounts FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+### Restore from incremental backups
+
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'gs://{bucket name}/database-bank-2017-03-27-weekly?AUTH=specified&CREDENTIALS={encoded key}', \
+'gs://{bucket name}/database-bank-2017-03-28-nightly?AUTH=specified&CREDENTIALS={encoded key}', \
+'gs://{bucket name}/database-bank-2017-03-29-nightly?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version (v20.2.2 and earlier or v20.1.4 and earlier), but restored by a newer version (v21.1.0+). These earlier releases may have included incomplete data for indexes that were in the process of being created.
+{{site.data.alerts.end}}
+
+### Restore a backup asynchronously
+
+Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH DETACHED;
+~~~
+
+The job ID is returned immediately without waiting for the job to finish:
+
+~~~
+        job_id
+----------------------
+  592786066399264769
+(1 row)
+~~~
+
+**Without** the `DETACHED` option, `RESTORE` will block the SQL connection until the job completes. Once finished, the job status and more detailed job data is returned:
+
+~~~
+job_id             |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+--------
+652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
+(1 row)
+~~~
+
+### Other restore usages
+
+#### Restore tables into a different database
+
+By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH into_db = 'newdb';
+~~~
+
+#### Remove the foreign key before restore
+
+By default, tables with [foreign key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the foreign key constraint from the table and then restore it.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.accounts \
+FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH skip_missing_foreign_keys;
+~~~
+
+#### Restoring users from `system.users` backup
+
+The `system.users` table stores your cluster's usernames and their hashed passwords. To restore them, you must restore the `system.users` table into a new database because you cannot drop the existing `system.users` table.
+
+After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
+
+First, create the new database that you'll restore the `system.users` table into:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE DATABASE newdb;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE system.users \
+FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH into_db = 'newdb';
+~~~
+
+After the restore completes, add the `users` to the existing `system.users` table:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v21.1/restore.md
+++ b/v21.1/restore.md
@@ -184,6 +184,20 @@ If initiated correctly, the statement returns when the restore is finished or if
 
 ## Examples
 
+The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="s3">Amazon S3</button>
+  <button class="filter-button" data-scope="azure">Azure Storage</button>
+  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+</div>
+
+<section class="filter-content" markdown="1" data-scope="s3">
+
+{{site.data.alerts.callout_info}}
+The examples in this section use the **default** `AUTH=specified` parameter. For more detail on how to use `implicit` authentication with Amazon S3 buckets, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+{{site.data.alerts.end}}
+
 ### View the backup subdirectories
 
 <span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`]:
@@ -260,7 +274,9 @@ To explicitly point to where your incremental backups are, provide the previous 
 {% include copy-clipboard.html %}
 ~~~ sql
 > RESTORE bank.customers \
-FROM 'gs://acme-co-backup/database-bank-2017-03-27-weekly', 'gs://acme-co-backup/database-bank-2017-03-28-nightly', 'gs://acme-co-backup/database-bank-2017-03-29-nightly';
+FROM 's3://{bucket_name}/database-bank-2017-03-27-weekly?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}', \
+'s3://{bucket_name}/database-bank-2017-03-28-nightly?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}', \
+'s3://{bucket_name}/database-bank-2017-03-29-nightly?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -349,6 +365,356 @@ WITH into_db = 'newdb';
 ~~~ sql
 > DROP TABLE newdb.users;
 ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gcs">
+
+{{site.data.alerts.callout_info}}
+The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+{{site.data.alerts.end}}
+
+### View the backup subdirectories
+
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`]:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW BACKUPS IN 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+~~~
+        path
+------------------------
+2021/03/23-213101.37
+2021/03/24-172553.85
+2021/03/24-210532.53
+(3 rows)
+~~~
+
+When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+
+### Restore a cluster
+
+To restore a full cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+### Restore a database
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE DATABASE bank FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+{{site.data.alerts.callout_info}}
+`RESTORE DATABASE` can only be used if the entire database was backed up.
+{{site.data.alerts.end}}
+
+### Restore a table
+
+To restore a single table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE TABLE bank.customers FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To restore multiple tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE TABLE bank.customers, bank.accounts FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+### Restore from incremental backups
+
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'gs://{bucket name}/database-bank-2017-03-27-weekly?AUTH=specified&CREDENTIALS={encoded key}', \
+'gs://{bucket name}/database-bank-2017-03-28-nightly?AUTH=specified&CREDENTIALS={encoded key}', \
+'gs://{bucket name}/database-bank-2017-03-29-nightly?AUTH=specified&CREDENTIALS={encoded key}';
+~~~
+
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version, but restored from a newer version.
+
+Incremental backups created by v20.2.2 and prior v20.2.x releases or v20.1.4 and prior v20.1.x releases may include incomplete data for indexes that were in the process of being created. Therefore, when incremental backups taken by these versions are restored by v21.1.0+, any indexes created during those incremental backups will be re-validated by `RESTORE`.
+{{site.data.alerts.end}}
+
+### Restore a backup asynchronously
+
+Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH DETACHED;
+~~~
+
+The job ID is returned immediately without waiting for the job to finish:
+
+~~~
+        job_id
+----------------------
+  592786066399264769
+(1 row)
+~~~
+
+**Without** the `DETACHED` option, `RESTORE` will block the SQL connection until the job completes. Once finished, the job status and more detailed job data is returned:
+
+~~~
+job_id             |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+--------
+652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
+(1 row)
+~~~
+
+### Other restore usages
+
+#### Restore tables into a different database
+
+By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH into_db = 'newdb';
+~~~
+
+#### Remove the foreign key before restore
+
+By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.accounts \
+FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH skip_missing_foreign_keys;
+~~~
+
+#### Restoring users from `system.users` backup
+
+The `system.users` table stores your cluster's usernames and their hashed passwords. To restore them, you must restore the `system.users` table into a new database because you cannot drop the existing `system.users` table.
+
+After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE DATABASE newdb;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE system.users \
+FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+WITH into_db = 'newdb';
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO system.users SELECT * FROM newdb.users;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DROP TABLE newdb.users;
+~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="azure">
+
+### View the backup subdirectories
+
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`]:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SHOW BACKUPS IN 'azure://{container name}/{path}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+~~~
+        path
+------------------------
+2021/03/23-213101.37
+2021/03/24-172553.85
+2021/03/24-210532.53
+(3 rows)
+~~~
+
+When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+
+### Restore a cluster
+
+To restore a full cluster:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+### Restore a database
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE DATABASE bank FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+{{site.data.alerts.callout_info}}
+`RESTORE DATABASE` can only be used if the entire database was backed up.
+{{site.data.alerts.end}}
+
+### Restore a table
+
+To restore a single table:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE TABLE bank.customers FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+To restore multiple tables:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE TABLE bank.customers, bank.accounts FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
+
+### Restore from incremental backups
+
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'azure://{container name}/database-bank-2017-03-27-weekly?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}', \
+'azure://{container name}/database-bank-2017-03-28-nightly?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}', \
+'azure://{container name}/database-bank-2017-03-29-nightly?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+~~~
+
+{{site.data.alerts.callout_info}}
+<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version, but restored from a newer version.
+
+Incremental backups created by v20.2.2 and prior v20.2.x releases or v20.1.4 and prior v20.1.x releases may include incomplete data for indexes that were in the process of being created. Therefore, when incremental backups taken by these versions are restored by v21.1.0+, any indexes created during those incremental backups will be re-validated by `RESTORE`.
+{{site.data.alerts.end}}
+
+### Restore a backup asynchronously
+
+Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM \
+'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+WITH DETACHED;
+~~~
+
+The job ID is returned immediately without waiting for the job to finish:
+
+~~~
+        job_id
+----------------------
+  592786066399264769
+(1 row)
+~~~
+
+**Without** the `DETACHED` option, `RESTORE` will block the SQL connection until the job completes. Once finished, the job status and more detailed job data is returned:
+
+~~~
+job_id             |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+--------
+652471804772712449 | succeeded |                  1 |   50 |             0 |  4911
+(1 row)
+~~~
+
+### Other restore usages
+
+#### Restore tables into a different database
+
+By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.customers \
+FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+WITH into_db = 'newdb';
+~~~
+
+#### Remove the foreign key before restore
+
+By default, tables with [Foreign Key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the Foreign Key constraint from the table and then restore it.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE bank.accounts \
+FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+WITH skip_missing_foreign_keys;
+~~~
+
+#### Restoring users from `system.users` backup
+
+The `system.users` table stores your cluster's usernames and their hashed passwords. To restore them, you must restore the `system.users` table into a new database because you cannot drop the existing `system.users` table.
+
+After it's restored into a new database, you can write the restored `users` table data to the cluster's existing `system.users` table.
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE DATABASE newdb;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE system.users \
+FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+WITH into_db = 'newdb';
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> INSERT INTO system.users SELECT * FROM newdb.users;
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+> DROP TABLE newdb.users;
+~~~
+
+</section>
 
 ## See also
 

--- a/v21.1/take-and-restore-encrypted-backups.md
+++ b/v21.1/take-and-restore-encrypted-backups.md
@@ -62,8 +62,8 @@ To take an encrypted backup with AWS KMS, use the `kms` [option](backup.html#opt
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP INTO 's3://test/backups/test_kms?AWS_ACCESS_KEY_ID=123456&AWS_SECRET_ACCESS_KEY=123456'
-    WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID=123456&AWS_SECRET_ACCESS_KEY=123456&REGION=us-east-1';
+> BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+    WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION=us-east-1';
 ~~~
 
 ~~~
@@ -79,7 +79,7 @@ To take a backup with [multi-region encryption](#multi-region), use the `kms` op
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP INTO 's3://test/backups/test_explicit_kms_2?AWS_ACCESS_KEY_ID=123456&AWS_SECRET_ACCESS_KEY=123456'
+> BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH KMS=(
       'aws:///<cmk>?AUTH=implicit&REGION=us-east-1',
       'aws:///<cmk>?AUTH=implict&REGION=us-west-1'
@@ -101,8 +101,8 @@ For example, the encrypted backup created in the [first example](#take-an-encryp
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://test/backups/test_kms?AWS_ACCESS_KEY_ID=123456&AWS_SECRET_ACCESS_KEY=123456'
-    WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID=123456&AWS_SECRET_ACCESS_KEY=123456&REGION=us-east-1';
+> RESTORE FROM 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+    WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION=us-east-1';
 ~~~
 
 ~~~
@@ -121,15 +121,23 @@ For example, the encrypted backup created in the [first example](#take-an-encryp
 - [Take an encrypted backup using a passphrase](#take-an-encrypted-backup-using-a-passphrase)
 - [Restore from an encrypted backup using a passphrase](#restore-from-an-encrypted-backup-using-a-passphrase)
 
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="s3">Amazon S3</button>
+  <button class="filter-button" data-scope="azure">Azure Storage</button>
+  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+</div>
+
+The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+
+<section class="filter-content" markdown="1" data-scope="s3">
+
 #### Take an encrypted backup using a passphrase
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO \
-'gs://acme-co-backup/test-cluster' \
-WITH encryption_passphrase = 'password123';
+> BACKUP TO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -148,9 +156,7 @@ For example, the encrypted backup created in the [previous example](#take-an-enc
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM \
-'gs://acme-co-backup/test-cluster' \
-WITH encryption_passphrase = 'password123';
+> RESTORE FROM 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -158,6 +164,85 @@ WITH encryption_passphrase = 'password123';
   543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
 (1 row)
 ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gcs">
+
+#### Take an encrypted backup using a passphrase
+
+To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543214409874014209 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+To [restore](restore.html), use the same `encryption_passphrase`. See the [example](#restore-from-an-encrypted-backup-using-a-passphrase) below for more details.
+
+#### Restore from an encrypted backup using a passphrase
+
+To decrypt an [encrypted backup](#take-an-encrypted-backup-using-a-passphrase), use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
+
+For example, the encrypted backup created in the [previous example](#take-an-encrypted-backup-using-a-passphrase) can be restored with:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="azure">
+
+#### Take an encrypted backup using a passphrase
+
+To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
+
+{% include copy-clipboard.html %}
+~~~ sql
+> BACKUP TO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543214409874014209 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+To [restore](restore.html), use the same `encryption_passphrase`. See the [example](#restore-from-an-encrypted-backup-using-a-passphrase) below for more details.
+
+#### Restore from an encrypted backup using a passphrase
+
+To decrypt an [encrypted backup](#take-an-encrypted-backup-using-a-passphrase), use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
+
+For example, the encrypted backup created in the [previous example](#take-an-encrypted-backup-using-a-passphrase) can be restored with:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> RESTORE FROM 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
+~~~
+~~~
+        job_id       |  status   | fraction_completed | rows | index_entries | bytes
+---------------------+-----------+--------------------+------+---------------+---------
+  543217488273801217 | succeeded |                  1 | 2597 |          1028 | 467701
+(1 row)
+~~~
+
+</section>
+
 
 ## See also
 

--- a/v21.1/take-and-restore-encrypted-backups.md
+++ b/v21.1/take-and-restore-encrypted-backups.md
@@ -118,16 +118,13 @@ For example, the encrypted backup created in the [first example](#take-an-encryp
 
 ### Examples
 
-- [Take an encrypted backup using a passphrase](#take-an-encrypted-backup-using-a-passphrase)
-- [Restore from an encrypted backup using a passphrase](#restore-from-an-encrypted-backup-using-a-passphrase)
-
 <div class="filters clearfix">
   <button class="filter-button" data-scope="s3">Amazon S3</button>
   <button class="filter-button" data-scope="azure">Azure Storage</button>
   <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
 </div>
 
-The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+{% include {{ page.version.version }}/backups/bulk-auth-options.md %}
 
 <section class="filter-content" markdown="1" data-scope="s3">
 
@@ -150,9 +147,9 @@ To [restore](restore.html), use the same `encryption_passphrase`. See the [examp
 
 #### Restore from an encrypted backup using a passphrase
 
-To decrypt an [encrypted backup](#take-an-encrypted-backup-using-a-passphrase), use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
+To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
 
-For example, the encrypted backup created in the [previous example](#take-an-encrypted-backup-using-a-passphrase) can be restored with:
+For example, the encrypted backup created in the previous example can be restored with:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -188,9 +185,9 @@ To [restore](restore.html), use the same `encryption_passphrase`. See the [examp
 
 #### Restore from an encrypted backup using a passphrase
 
-To decrypt an [encrypted backup](#take-an-encrypted-backup-using-a-passphrase), use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
+To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
 
-For example, the encrypted backup created in the [previous example](#take-an-encrypted-backup-using-a-passphrase) can be restored with:
+For example, the encrypted backup created in the previous example can be restored with:
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -226,9 +223,9 @@ To [restore](restore.html), use the same `encryption_passphrase`. See the [examp
 
 #### Restore from an encrypted backup using a passphrase
 
-To decrypt an [encrypted backup](#take-an-encrypted-backup-using-a-passphrase), use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
+To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase) option and the same passphrase that was used to create the backup.
 
-For example, the encrypted backup created in the [previous example](#take-an-encrypted-backup-using-a-passphrase) can be restored with:
+For example, the encrypted backup created in the previous example can be restored with:
 
 {% include copy-clipboard.html %}
 ~~~ sql

--- a/v21.1/take-and-restore-locality-aware-backups.md
+++ b/v21.1/take-and-restore-locality-aware-backups.md
@@ -46,6 +46,10 @@ can be restored by running:
 
 Note that the first URI in the list has to be the URI specified as the `default` URI when the backup was created. If you have moved your backups to a different location since the backup was originally taken, the first URI must be the new location of the files originally written to the `default` location.
 
+{{site.data.alerts.callout_info}}
+For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
+{{site.data.alerts.end}}
+
 ## Restore from a locality-aware backup
 
 Given a list of URIs that together contain the locations of all of the files for a single [locality-aware backup](#create-a-locality-aware-backup), [`RESTORE`](restore.html) can read in that backup. Note that the list of URIs passed to [`RESTORE`](restore.html) may be different from the URIs originally passed to [`BACKUP`](backup.html). This is because it's possible to move the contents of one of the parts of a locality-aware backup (i.e., the files written to that destination) to a different location, or even to consolidate all the files for a locality-aware backup into a single location.

--- a/v21.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
+++ b/v21.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
@@ -23,10 +23,10 @@ You can configure garbage collection periods using the `ttlseconds` [replication
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> BACKUP INTO \
-'s3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
-AS OF SYSTEM TIME '-10s' WITH revision_history;
+> BACKUP INTO '{destination}' AS OF SYSTEM TIME '-10s' WITH revision_history;
 ~~~
+
+For guidance on connecting to Amazon S3, Google Cloud Storage, Azure Storage, and other storage options, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
 
 ## Point-in-time restore
 
@@ -38,8 +38,7 @@ If you do not specify a point-in-time, the data will be restored to the backup t
 
 {% include copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
-AS OF SYSTEM TIME '2017-02-26 10:00:00';
+> RESTORE FROM '{destination}' AS OF SYSTEM TIME '2017-02-26 10:00:00';
 ~~~
 
 To view the available backup subdirectories you can restore from, use [`SHOW BACKUPS`](restore.html#view-the-backup-subdirectories).

--- a/v21.1/take-full-and-incremental-backups.md
+++ b/v21.1/take-full-and-incremental-backups.md
@@ -129,6 +129,16 @@ To take incremental backups, you need an [enterprise license](enterprise-licensi
 
 ## Examples
 
+<div class="filters clearfix">
+  <button class="filter-button" data-scope="s3">Amazon S3</button>
+  <button class="filter-button" data-scope="azure">Azure Storage</button>
+  <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
+</div>
+
+The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+
+<section class="filter-content" markdown="1" data-scope="s3">
+
 ### Automated full backups
 
 Both core and enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
@@ -136,7 +146,7 @@ Both core and enterprise users can use backup scheduling for full backups of clu
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
-  FOR BACKUP INTO 's3://test/schedule-test-core?AWS_ACCESS_KEY_ID=x&AWS_SECRET_ACCESS_KEY=x'
+  FOR BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     RECURRING '@daily'
     FULL BACKUP ALWAYS
     WITH SCHEDULE OPTIONS first_run = 'now';
@@ -144,9 +154,59 @@ Both core and enterprise users can use backup scheduling for full backups of clu
 ~~~
      schedule_id     |        name         | status |         first_run         | schedule |                                                                                       backup_stmt
 ---------------------+---------------------+--------+---------------------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 's3://test/schedule-test-core?AWS_ACCESS_KEY_ID=x&AWS_SECRET_ACCESS_KEY=x' WITH detached
+  588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH detached
 (1 row)
 ~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="gcs">
+
+### Automated full backups
+
+Both core and enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE SCHEDULE core_schedule_label
+  FOR BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
+    RECURRING '@daily'
+    FULL BACKUP ALWAYS
+    WITH SCHEDULE OPTIONS first_run = 'now';
+~~~
+~~~
+     schedule_id     |        name         | status |         first_run         | schedule |                                                                                       backup_stmt
+---------------------+---------------------+--------+---------------------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH detached
+(1 row)
+~~~
+
+</section>
+
+<section class="filter-content" markdown="1" data-scope="azure">
+
+### Automated full backups
+
+Both core and enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE SCHEDULE core_schedule_label
+  FOR BACKUP INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}'
+    RECURRING '@daily'
+    FULL BACKUP ALWAYS
+    WITH SCHEDULE OPTIONS first_run = 'now';
+~~~
+~~~
+     schedule_id     |        name         | status |         first_run         | schedule |                                                                                       backup_stmt
+---------------------+---------------------+--------+---------------------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH detached
+(1 row)
+~~~
+
+</section>
+
+
 
 For more examples on how to schedule backups that take full and incremental backups, see [`CREATE SCHEDULE FOR BACKUP`](create-schedule-for-backup.html).
 

--- a/v21.1/take-full-and-incremental-backups.md
+++ b/v21.1/take-full-and-incremental-backups.md
@@ -107,9 +107,7 @@ If it's ever necessary, you can then use the [`RESTORE`][restore] command to res
 ~~~
 
 {{site.data.alerts.callout_info}}
-<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when incremental backups are created from an older version, but restored from a newer version.
-
-Incremental backups created by v20.2.2 and prior v20.2.x releases or v20.1.4 and prior v20.1.x releases may include incomplete data for indexes that were in the process of being created. Therefore, when incremental backups taken by these versions are restored by v21.1.0+, any indexes created during those incremental backups will be re-validated by `RESTORE`.
+<span class="version-tag">New in v21.1:</span> `RESTORE` will re-validate [indexes](indexes.html) when [incremental backups](take-full-and-incremental-backups.html) are created from an older version (v20.2.2 and earlier or v20.1.4 and earlier), but restored by a newer version (v21.1.0+). These earlier releases may have included incomplete data for indexes that were in the process of being created.
 {{site.data.alerts.end}}
 
 ## Incremental backups with explicitly specified destinations
@@ -135,7 +133,7 @@ To take incremental backups, you need an [enterprise license](enterprise-licensi
   <button class="filter-button" data-scope="gcs">Google Cloud Storage</button>
 </div>
 
-The examples below provide connection strings to Amazon S3, Google Cloud Storage, and Azure Storage. For guidance on connecting to other storage options or using other authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+{% include {{ page.version.version }}/backups/bulk-auth-options.md %}
 
 <section class="filter-content" markdown="1" data-scope="s3">
 
@@ -155,29 +153,6 @@ Both core and enterprise users can use backup scheduling for full backups of clu
      schedule_id     |        name         | status |         first_run         | schedule |                                                                                       backup_stmt
 ---------------------+---------------------+--------+---------------------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH detached
-(1 row)
-~~~
-
-</section>
-
-<section class="filter-content" markdown="1" data-scope="gcs">
-
-### Automated full backups
-
-Both core and enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
-
-{% include copy-clipboard.html %}
-~~~ sql
-> CREATE SCHEDULE core_schedule_label
-  FOR BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
-    RECURRING '@daily'
-    FULL BACKUP ALWAYS
-    WITH SCHEDULE OPTIONS first_run = 'now';
-~~~
-~~~
-     schedule_id     |        name         | status |         first_run         | schedule |                                                                                       backup_stmt
----------------------+---------------------+--------+---------------------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH detached
 (1 row)
 ~~~
 
@@ -206,7 +181,28 @@ Both core and enterprise users can use backup scheduling for full backups of clu
 
 </section>
 
+<section class="filter-content" markdown="1" data-scope="gcs">
 
+### Automated full backups
+
+Both core and enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> CREATE SCHEDULE core_schedule_label
+  FOR BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
+    RECURRING '@daily'
+    FULL BACKUP ALWAYS
+    WITH SCHEDULE OPTIONS first_run = 'now';
+~~~
+~~~
+     schedule_id     |        name         | status |         first_run         | schedule |                                                                                       backup_stmt
+---------------------+---------------------+--------+---------------------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  588799238330220545 | core_schedule_label | ACTIVE | 2020-09-11 00:00:00+00:00 | @daily   | BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH detached
+(1 row)
+~~~
+
+</section>
 
 For more examples on how to schedule backups that take full and incremental backups, see [`CREATE SCHEDULE FOR BACKUP`](create-schedule-for-backup.html).
 


### PR DESCRIPTION
Closes #10285 

Relates to #10544

Added a toggle to the example sections of `BACKUP` and `RESTORE` (v21.1) for s3, gcs, and azure. This covers some issues and questions around specific URLs for the cloud options. 

Possibility to add further storage options to toggle in future. And gives the opportunity to provide more detail on some of the examples when cloud specific.

This toggle setup will be replicated across all the bulk operations, `IMPORT`, `EXPORT` etc.