### PR TITLE
releases/v21.1.2: fix typo mentioning functions as cluster settings

### DIFF
--- a/releases/v21.1.2.md
+++ b/releases/v21.1.2.md
@@ -40,8 +40,8 @@ $ docker pull cockroachdb/cockroach:v21.1.2
 
 ### SQL language changes
 
-- Added the `crdb_internal.lost_descriptors_with_data` [cluster setting](../v21.1/cluster-settings.html) to show descriptors that have no entries but data left behind. [#65462][#65462] {% comment %}doc{% endcomment %}
-- Added the `crdb_internal.force_delete_table_data` [cluster setting](../v21.1/cluster-settings.html) which allows table data to be cleaned up only using a descriptor ID for cases of table descriptor corruption. [#65462][#65462] {% comment %}doc{% endcomment %}
+- Added the `crdb_internal.lost_descriptors_with_data` [function](../v21.1/functions-and-operators.html) to show descriptors that have no entries but data left behind. [#65462][#65462] {% comment %}doc{% endcomment %}
+- Added the `crdb_internal.force_delete_table_data` [function](../v21.1/functions-and-operators.html) which allows table data to be cleaned up only using a descriptor ID for cases of table descriptor corruption. [#65462][#65462] {% comment %}doc{% endcomment %}
 - The statement type ("tag") is now also included alongside the full text of the SQL query in the various structured log entries produced when query execution is being [logged](../v21.1/logging-overview.html). [#65554][#65554] {% comment %}doc{% endcomment %}
 - CockroachDB now returns a SQL Notice if a [`CREATE TABLE IF NOT EXISTS`](../v21.1/create-table.html) command is used to create a `TABLE` and the `TABLE` already exists. [#65636][#65636] {% comment %}doc{% endcomment %}
 - The `SHOW FULL TABLE SCANS` statement was added to CockroachDB. [#65671][#65671] {% comment %}doc{% endcomment %}


### PR DESCRIPTION
The lines replaced here are functions, not cluster settings. Reword as
appropriate.