### PR TITLE
Added guidance for scaling applications to multiple regions

### DIFF
--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -255,6 +255,12 @@
                     "urls": [
                       "/${VERSION}/spatial-indexes.html"
                     ]
+                  },
+                  {
+                    "title": "Scale to Multi-region",
+                    "urls": [
+                      "/${VERSION}/multiregion-scale-application.html"
+                    ]
                   }
                 ]
               }

--- a/v21.1/multiregion-scale-application.md
+++ b/v21.1/multiregion-scale-application.md
@@ -1,10 +1,10 @@
 ---
 title: Scale to Multiple Regions
-summary: Learn how to scale a single-region application to a multi-region application.
+summary: Learn how to scale a single-region application to multiple regions.
 toc: true
 ---
 
-This page provides guidance for scaling a single-region application to a multi-region application.
+This page provides guidance for scaling a single-region application to multiple regions.
 
 Before reading this page, we recommend reviewing [CockroachDB's multi-region capabilities](multiregion-overview.html).
 
@@ -12,45 +12,56 @@ Before reading this page, we recommend reviewing [CockroachDB's multi-region cap
 
 Scaling an application from a single region to multiple regions consists of:
 
-- [Scaling the database](#scale-the-database), which includes transforming the database schema into a multi-region schema and adding new nodes to a CockroachDB cluster.
+- [Scaling the database](#scale-the-database), which includes adding new nodes to a CockroachDB cluster in different regions, adding regions to the database schema, and optionally transforming the database schema to leverage multi-region table localities.
 
 - [Scaling the application](#scale-the-application), which includes deploying the application in new regions and, if necessary, updating the application code to work with the multi-region database schema.
 
 ## Scale the database
 
-To scale a database from a single region to multiple regions:
+### Step 1. Prep the database schema
 
-1. Use an [`ALTER DATABASE ... SET PRIMARY REGION`](set-primary-region.html) statement to set the database's [primary region](multiregion-overview.html#database-regions) to the single region in which the cluster is deployed. This region must have been specified as a [regional locality](cockroach-start.html#locality) at cluster startup.
+Use an [`ALTER DATABASE ... SET PRIMARY REGION`](set-primary-region.html) statement to set the database's [primary region](multiregion-overview.html#database-regions) to a region in which the cluster is deployed. This region must have been specified as a [regional locality](cockroach-start.html#locality) at cluster startup.
 
-    Setting the primary database region before adding new regional nodes to the cluster prevents CockroachDB from [rebalancing row replications](architecture/replication-layer.html#leaseholder-rebalancing) across all regions each time a node is added in a new region.
+Setting the primary region before adding new regional nodes to the cluster prevents CockroachDB from [rebalancing row replications](architecture/replication-layer.html#leaseholder-rebalancing) across all regions each time a node is added in a new region.
 
-    {{site.data.alerts.callout_info}}
-    Executing `ALTER` statements performs a [schema migration](online-schema-changes.html) on the cluster. If you are using a schema migration tool, you will need to execute these statements as raw SQL, as the [multi-region SQL syntax](multiregion-overview.html) is specific to CockroachDB.
+{{site.data.alerts.callout_info}}
+Executing `ALTER` statements performs a [schema migration](online-schema-changes.html) on the cluster. If you are using a schema migration tool, you will need to execute these statements as raw SQL, as the [multi-region SQL syntax](multiregion-overview.html) is specific to CockroachDB.
 
-    Here are some simple tutorials on executing schema migrations against CockroachDB clusters:
-    - [Migrate CockroachDB Schemas with Liquibase](liquibase.html).
-    - [Migrate CockroachDB Schemas with Flyway](flyway.html).
-    - [Execute SQL statements from a file](cockroach-sql.html#execute-sql-statements-from-a-file) and [Change and Remove Objects in a Database Schema](schema-design-update.html).
-    {{site.data.alerts.end}}
+Here are some simple tutorials on executing schema migrations against CockroachDB clusters:
 
-1. Add nodes to the cluster in new regions.
+- [Migrate CockroachDB Schemas with Liquibase](liquibase.html)
+- [Migrate CockroachDB Schemas with Flyway](flyway.html)
+- [Migrate CockroachDB Schemas with Alembic](alembic.html)
+- [Execute SQL statements from a file](cockroach-sql.html#execute-sql-statements-from-a-file) and [Change and Remove Objects in a Database Schema](schema-design-update.html)
+{{site.data.alerts.end}}
 
-    For instructions on adding nodes to an existing cluster, see one of the following pages:
-    - For managed CockroachCloud deployments, see [Cluster Management](../cockroachcloud/cluster-management.html).
-    - For orchestrated deployments, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html).
-    - For manual deployments, see [`cockroach start`](cockroach-start.html) and [Manual Deployment](manual-deployment.html).
+### Step 2. Scale the cluster deployment
 
-    {{site.data.alerts.callout_info}}
-    You must specify a [regional locality](cockroach-start.html#locality) for each node at startup. These regional localities are represented as [cluster regions](multiregion-overview.html#cluster-regions) in the cluster.
-    {{site.data.alerts.end}}
+Scale the cluster by adding nodes to the cluster in new regions.
 
-1. Use an [`ALTER DATABASE ... ADD REGIONS`](add-region.html) statement to add the new regions to your database. Only cluster regions (i.e., regional localities specified at cluster startup) can be added as [database regions](multiregion-overview.html#database-regions).
+For instructions on adding nodes to an existing cluster, see one of the following pages:
 
-1. Use [`ALTER DATABASE ... SURVIVE ... FAILURE`](survive-failure.html) statements to set your database's [survival goals](multiregion-overview.html#survival-goals).
+- For managed CockroachCloud deployments, see [Cluster Management](../cockroachcloud/cluster-management.html).
+- For orchestrated deployments, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html).
+- For manual deployments, see [`cockroach start`](cockroach-start.html) and [Manual Deployment](manual-deployment.html).
 
-1. Use [`ALTER TABLE ... SET LOCALITY`](set-locality.html) statements to set [table localities](multiregion-overview.html#table-locality) for each table.
+{{site.data.alerts.callout_info}}
+For orchestrated and manual deployments, you must specify a [regional locality](cockroach-start.html#locality) for each node at startup. These regional localities are represented as [cluster regions](multiregion-overview.html#cluster-regions) in the cluster.
+{{site.data.alerts.end}}
+
+### Step 3. Scale the database schema
+
+Use an [`ALTER DATABASE ... ADD REGIONS`](add-region.html) statement to add the new regions to your database. Only cluster regions (i.e., regional localities specified at cluster startup) can be added as [database regions](multiregion-overview.html#database-regions).
+
+After you add new regions to the database schema, you can optionally configure the [survival goals](multiregion-overview.html#survival-goals) and [table localities](multiregion-overview.html#table-locality) of the multi-region database:
+
+- Add [`ALTER DATABASE ... SURVIVE ... FAILURE`](survive-failure.html) statements to set your database's [survival goals](multiregion-overview.html#survival-goals).
+
+- Add [`ALTER TABLE ... SET LOCALITY`](set-locality.html) statements to set [table localities](multiregion-overview.html#table-locality) for each table.
 
 ## Scale the application
+
+### Step 1. Scale application deployments
 
 Scaling application deployments in multiple regions can greatly improve latency for the end-user of the application.
 
@@ -67,54 +78,55 @@ A multi-region application deployment does not require a multi-region database d
 If you do scale the application first, make sure that you reconfigure each application deployment to communicate with the closest database deployment after deploying the database in multiple regions.
 {{site.data.alerts.end}}
 
-### Update the application code for multi-region
+### Step 2. *(Optional)* Update the application code for multi-region
 
 For most table localities, including the default locality `LOCALITY REGIONAL BY TABLE IN PRIMARY REGION`, *you do not need to update your application code after migrating your database schema for multi-region*. CockroachDB automatically optimizes queries against multi-region databases, based on the regional locality of the node executing the query, and on the multi-region configuration of the database. For more details, see [Regional Tables](regional-tables.html#regional-by-row-tables). For an extended example, see [Develop and Deploy a Global Application: Create a Multi-region Database Schema](movr-flask-database.html).
 
 However, there are some scenarios in which you might need to update the SQL operations in your application. For example:
 
 - If a table has a `REGIONAL BY ROW AS <custom_region_column>` table locality, and you want to explicitly insert regional values into a table, as shown in [Low Latency Reads and Writes in a Multi-Region Cluster](demo-low-latency-multi-region-deployment.html#configure-regional-by-row-tables).
-- If a table has a `REGIONAL BY ROW` locality, and you want to update the hidden `crdb_region` column of existing rows in the table based on some other column value, as shown in [Set the table locality to `REGIONAL BY ROW`](set-locality.html#set-the-table-locality-to-regional-by-row).
-- If a table has a `REGIONAL BY ROW` locality, and you want to filter a selection query based on the value of the region-tracking column.
+- If a table has a `REGIONAL BY ROW` locality, and you want to update the `crdb_region` value of existing rows in the table based on some other column value, as shown in [Set the table locality to `REGIONAL BY ROW`](set-locality.html#set-the-table-locality-to-regional-by-row).
+- If a table has a `REGIONAL BY ROW` locality, and you want to filter a [selection query](select-clause.html#filter-rows) based on the `crdb_region` value.
 
 In all of these scenarios, statements reference the column that tracks the region for each row in a `REGIONAL BY ROW` locality. This column can be a custom column of the built-in `ENUM` type `crdb_internal_region`, or it can be the default, hidden [`crdb_region` column](set-locality.html#crdb_region).
 
-#### Representing `crdb_region` in ORMs
+If you need to explicitly reference the region-tracking column in a SQL operation in your application code, you should do the following:
 
-If your application's ORM framework supports enumerated data types, and you need to explicitly reference the `crdb_region` column (or a custom region column) in a SQL operation in your application code, you should do the following:
+- Verify that the region-tracking column is visible to the ORM.
 
-- Using the ORM framework's type library, create an enumerated type, with the type name `crdb_internal_region` and enumerated values for each of the existing regions.
-- Add a new region column to the relevant table mappings, with the new enumerated data type and the column name `crdb_region` (or the name of the custom region column of the table). Note that this column does not persist to the database; it is simply a mapping for the application.
-- Reference the region column in read/write operations as needed.
+    To make a hidden column visible, use an [`ALTER TABLE ... ALTER COLUMN ... SET VISIBLE` statement](alter-column.html). By default, the `crdb_region` column created by CockroachDB is hidden.
+- Using your ORM framework, sync the mapping objects in your application to reflect the latest database schema with the region-tracking column(s).
+- Reference the region-tracking column in read/write operations as needed.
 
-For example, suppose that you have a single-region table that has just been transformed into a multi-region table. In the absence of an explicit, back-filling computed column for the hidden `crdb_region` column, the following code (written in Python, with [SQLAlchemy](https://www.sqlalchemy.org/)) updates the `crdb_region` values in rows that were inserted before the multi-region transformation was executed:
+For example, suppose that you have a single-region table called `users` that has just been transformed into a multi-region table with a `REGIONAL BY ROW` locality. When the application was first deployed, this table had no region-tracking column. During the multi-region database schema transformation, CockroachDB automatically created a hidden `crdb_region` column to track the region of each row.
 
-1. Create the `ENUM` type:
+In the absence of an explicit, back-filling computed column for the hidden `crdb_region` column, there is no way for CockroachDB to determine the region for old rows of data. The following steps update the `crdb_region` values in rows that were inserted before the multi-region transformation, based on the values of a `city` column:
+
+1. Make `crdb_region` visible in the relevant `REGIONAL BY ROW` table(s):
 
     {% include copy-clipboard.html %}
-    ~~~ python
-    from sqlalchemy.types import Enum
-    ...
-
-    region_list = list(tup[0] for tup in session.execute(text('SELECT region FROM [SHOW REGIONS]')).fetchall())
-    region_enum = Enum(*region_list, name='crdb_internal_region', create_type=False, native_enum=False)
+    ~~~ sql
+    ALTER TABLE users ALTER COLUMN crdb_region SET VISIBLE;
     ~~~
 
-2. Update the mapping in the application code:
+1. Update the table mappings in the application code (written in Python, with [SQLAlchemy](https://www.sqlalchemy.org/)):
 
     {% include copy-clipboard.html %}
     ~~~ python
-    crdb_region = Column('crdb_region', region_enum)
-    MyTable.append_column(crdb_region)
+    from models import Base
+
+    ...
+
+    Base.metadata.reflect(bind=self.engine, extend_existing=True, autoload_replace=True)
     ~~~
 
     {{site.data.alerts.callout_info}}
-    SQLAlchemy allows you to append columns to a table-mapped object with the `sqlalchemy.Table` class method [`append_column()`](https://docs.sqlalchemy.org/en/13/core/metadata.html#sqlalchemy.schema.Table.append_column). If your ORM framework does not support updating mapping objects dynamically, you might need to add the column to the table-mapping class definition and reinstantiate the object.
+    SQLAlchemy allows you to update all table mappings to reflect the database with the `sqlalchemy.schema.MetaData` class method [`reflect()`](https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.MetaData.reflect). If your ORM framework does not support updating mapping objects dynamically, you might need to add the column to the table-mapping class definition as a `String`-typed column and reinstantiate the object.
     {{site.data.alerts.end}}
 
-3. Reference the column value as needed.
+1. Reference the column value as needed.
 
-    Here is an example function that updates the region value in a given table, using the values of a `city` column:
+    Here is an example function that updates the region value in a given table, using the values of the `city` column:
 
     {% include copy-clipboard.html %}
     ~~~ python
@@ -124,19 +136,12 @@ For example, suppose that you have a single-region table that has just been tran
     def update_region(engine, table, region, cities):
 
         def update_region_helper(session, table, region, cities):
-            query = table.update().where(column('city').in_(cities)).values({crdb_region: region})
+            query = table.update().where(column('city').in_(cities)).values({'crdb_region': region})
             session.execute(query)
 
         run_transaction(sessionmaker(bind=engine),
                         lambda session: update_region_helper(session, table, region, cities))
     ~~~
-
-If your ORM framework does not support `ENUM` data types, or if you run into type compatibility issues, you can alternatively try the following approach:
-
-- Add `crdb_region` (or the custom region-tracking column) to an existing table object as a *string*-typed column.
-- Validate the string input for `crdb_region` values, using one of the following approaches:
-    - Implement client-side string validation to check if the string input matches one of the allowed enumerated types.
-    - Add some exception handling to catch data errors (e.g., `sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation)` in SQLAlchemy).
 
 ## See also
 

--- a/v21.1/multiregion-scale-application.md
+++ b/v21.1/multiregion-scale-application.md
@@ -18,7 +18,7 @@ Scaling an application from a single region to multiple regions consists of:
 
 ## Scale the database
 
-### Step 1. Prep the database schema
+### Step 1. Prep the database
 
 Use an [`ALTER DATABASE ... SET PRIMARY REGION`](set-primary-region.html) statement to set the database's [primary region](multiregion-overview.html#database-regions) to a region in which the cluster is deployed. This region must have been specified as a [regional locality](cockroach-start.html#locality) at cluster startup.
 

--- a/v21.1/multiregion-scale-application.md
+++ b/v21.1/multiregion-scale-application.md
@@ -12,17 +12,17 @@ Before reading this page, we recommend reviewing [CockroachDB's multi-region cap
 
 To scale to multiple regions:
 
-[1.](#scale-deployments) Scale both the deployment of your database and the deployment of your application to multiple regions.
+[1.](#scale-database-deployments) Scale the deployment of your database to multiple regions.
 
-[2.](#transform-a-single-region-schema-into-a-multi-region-schema) Migrate the database schema from a single-region schema to a multi-region schema, using a schema migration tool.
+[2.](#scale-application-deployments) Scale the deployment of your application to multiple regions.
 
-[3.](#upgrade-read-write-operations) If necessary, upgrade the read/write operations in the application to work with your new database schema.
+[3.](#transform-a-single-region-schema-into-a-multi-region-schema) Migrate the database schema from a single-region schema to a multi-region schema.
 
-## Scale deployments
+[4.](#upgrade-read-write-operations) If necessary, upgrade the read/write operations in the application to work with your new database schema.
 
-### Scale database deployments
+## Scale database deployments
 
-In order to use CockroachDB's [multi-region capabilities](multiregion-overview.html), your CockroachDB cluster must have nodes deployed in multiple regions, with different [regional localities](multiregion-overview.html#cluster-regions).
+In order to use CockroachDB's [multi-region capabilities](multiregion-overview.html), your CockroachDB cluster must have nodes deployed in multiple regions, with different [regional node localities](multiregion-overview.html#cluster-regions).
 
 For instructions on adding nodes to an existing cluster, see one of the following pages:
 
@@ -30,7 +30,7 @@ For instructions on adding nodes to an existing cluster, see one of the followin
 - For orchestrated deployments, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html).
 - For manual deployments, see [`cockroach start`](cockroach-start.html) and [Manual Deployment](manual-deployment.html).
 
-### Scale application deployments
+## Scale application deployments
 
 To take full advantage of the latency and resiliency improvements of a multi-region database deployment, you need to scale the application deployments to multiple regions as well. To limit the latency between the application and the database, each deployment of the application must communicate with the closest database deployment.
 

--- a/v21.1/multiregion-scale-application.md
+++ b/v21.1/multiregion-scale-application.md
@@ -1,0 +1,142 @@
+---
+title: Scale a Single-region Database Schema to Multiple Regions
+summary: Learn how to migrate a single-region application to a multi-region application.
+toc: true
+---
+
+This page provides guidance for scaling an application built on a single-region database schema to multiple regions.
+
+Before reading this page, we recommend reviewing [CockroachDB's multi-region capabilities](multiregion-overview.html).
+
+## Overview
+
+To scale to multiple regions:
+
+[1.](#scale-deployments) Scale both the deployment of your database and the deployment of your application to multiple regions.
+
+[2.](#transform-a-single-region-schema-into-a-multi-region-schema) Migrate the database schema from a single-region schema to a multi-region schema, using a schema migration tool.
+
+[3.](#upgrade-read-write-operations) If necessary, upgrade the read/write operations in the application to work with your new database schema.
+
+## Scale deployments
+
+### Scale database deployments
+
+In order to use CockroachDB's [multi-region capabilities](multiregion-overview.html), your CockroachDB cluster must have nodes deployed in multiple regions, with different [regional localities](multiregion-overview.html#cluster-regions).
+
+For instructions on adding nodes to an existing cluster, see one of the following pages:
+
+- For managed CockroachCloud deployments, see [Cluster Management](../cockroachcloud/cluster-management.html).
+- For orchestrated deployments, see [Orchestrate CockroachDB Across Multiple Kubernetes Clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html).
+- For manual deployments, see [`cockroach start`](cockroach-start.html) and [Manual Deployment](manual-deployment.html).
+
+### Scale application deployments
+
+To take full advantage of the latency and resiliency improvements of a multi-region database deployment, you need to scale the application deployments to multiple regions as well. To limit the latency between the application and the database, each deployment of the application must communicate with the closest database deployment.
+
+For guidance on connecting to CockroachDB from an application deployment, see one of the following pages:
+
+- For connecting to managed, CockroachCloud deployments, see [Connect to Your CockroachCloud Cluster](../cockroachcloud/connect-to-your-cluster.html) and [Connect to the Database (CockroachCloud)](connect-to-the-database-cockroachcloud.html).
+- For connecting to a standard CockroachDB deployment, see [`cockroach sql`](cockroach-sql.html) and [Connect to the Database](connect-to-the-database.html).
+
+For details on configuring database connections for individual application deployments, consult your cloud provider's documentation. For an example using Google Cloud services, see [Multi-region Application Deployment](multi-region-deployment.html).
+
+## Transform a single-region schema into a multi-region schema
+
+To transform a single-region database schema into a multi-region database schema:
+
+- [Choose a multi-region configuration](choosing-a-multi-region-configuration.html).
+- Use `ALTER DATABASE` and `ALTER TABLE` statements to set the [database regions](multiregion-overview.html#database-regions), [survival goals](multiregion-overview.html#survival-goals), and [table localities](multiregion-overview.html#table-locality), accordingly to your selected multi-region configuration.
+
+For SQL syntax reference documentation for the multi-region `ALTER DATABASE` statements, see the following pages:
+
+- [`SET PRIMARY REGION`](set-primary-region.html)
+- [`ADD REGION`](add-region.html)
+- [`SET LOCALITY`](set-locality.html)
+- [`SURVIVE ... FAILURE`](survive-failure.html)
+
+Executing `ALTER` statements performs a [schema migration](online-schema-changes.html) on the cluster. As a best practice, we recommend performing all schema migrations (including multi-region transformations) with a schema migration tool.
+
+Note that, because the `ALTER` statements listed above are specific to CockroachDB syntax, you will have to execute these statements as raw SQL in schema migration tools.
+
+Here are some simple tutorials on executing schema migrations against CockroachDB clusters:
+
+- [Migrate CockroachDB Schemas with Liquibase](liquibase.html).
+- [Migrate CockroachDB Schemas with Flyway](flyway.html).
+- [Execute SQL statements from a file](cockroach-sql.html#execute-sql-statements-from-a-file) and [Change and Remove Objects in a Database Schema](schema-design-update.html).
+
+## Upgrade read/write operations
+
+For most multi-region configurations, including the default configuration (`LOCALITY REGIONAL BY TABLE IN PRIMARY REGION` and `SURVIVE ZONE FAILURE`), you do not need to update any client-side read/write operations after migrating your database schema for multi-region features. CockroachDB automatically optimizes queries against multi-region databases, based on the locality of the node executing the query, and on the multi-region configuration of the database.
+
+However, there are some scenarios in which you might need to update the read/write operations in your application's persistence layer. For example:
+
+- If a table has a `REGIONAL BY ROW AS <custom_region_column>` table locality, and you want to explicitly insert regional values into a table, as shown in [Low Latency Reads and Writes in a Multi-Region Cluster](demo-low-latency-multi-region-deployment.html#configure-regional-by-row-tables).
+- If a table has a `REGIONAL BY ROW` locality, and you want to update the hidden `crdb_region` column of existing rows in the table based on some other column value, as shown in [Set the table locality to `REGIONAL BY ROW`](set-locality.html#set-the-table-locality-to-regional-by-row).
+- If a table has a `REGIONAL BY ROW` locality, and you want to filter a selection query based on the value of the region-tracking column.
+
+In all of these scenarios, statements reference the column that tracks the region for each row in a `REGIONAL BY ROW` locality. This column can be a custom column of the built-in `ENUM` type `crdb_internal_region`, or it can be the default, hidden [`crdb_region` column](set-locality.html#crdb_region).
+
+### Representing `crdb_region` in ORMs
+
+If your application's ORM framework supports enumerated data types, and you need to explicitly reference the `crdb_region` column (or a custom region column) in a read/write operation, you should do the following:
+
+- Using the ORM framework's type library, create an enumerated type, with the type name `crdb_internal_region` and enumerated values for each of the existing regions.
+- Add a new region column to the relevant table mappings, with the new enumerated data type and the column name `crdb_region` (or the name of the custom region column of the table). Note that this column does not persist to the database; it is simply a mapping for the application.
+- Reference the region column in read/write operations as needed.
+
+For example, suppose that you have a single-region table that has just been transformed into a multi-region table. In the absence of an explicit, back-filling computed column for the hidden `crdb_region` column, the following code (written in Python, with [SQLAlchemy](https://www.sqlalchemy.org/)) updates the `crdb_region` values in rows that were inserted before the multi-region transformation was executed:
+
+1. Create the `ENUM` type:
+
+    {% include copy-clipboard.html %}
+    ~~~ python
+    from sqlalchemy.types import Enum
+    ...
+
+    region_list = list(tup[0] for tup in session.execute(text('SELECT region FROM [SHOW REGIONS]')).fetchall())
+    region_enum = Enum(*region_list, name='crdb_internal_region', create_type=False, native_enum=False)
+    ~~~
+
+2. Update the mapping in the application code:
+
+    {% include copy-clipboard.html %}
+    ~~~ python
+    crdb_region = Column('crdb_region', region_enum)
+    MyTable.append_column(crdb_region)
+    ~~~
+
+    {{site.data.alerts.callout_info}}
+    SQLAlchemy allows you to append columns to a table-mapped object with the `sqlalchemy.Table` class method [`append_column()`](https://docs.sqlalchemy.org/en/13/core/metadata.html#sqlalchemy.schema.Table.append_column). If your ORM framework does not support updating mapping objects dynamically, you might need to add the column to the table-mapping class definition and reinstantiate the object.
+    {{site.data.alerts.end}}
+
+3. Reference the column value as needed.
+
+    Here is an example function that updates the region value in a given table, using the values of a `city` column:
+
+    {% include copy-clipboard.html %}
+    ~~~ python
+    from sqlalchemy_cockroachdb import run_transaction
+    ...
+
+    def update_region(engine, table, region, cities):
+
+        def update_region_helper(session, table, region, cities):
+            query = table.update().where(column('city').in_(cities)).values({crdb_region: region})
+            session.execute(query)
+
+        run_transaction(sessionmaker(bind=engine),
+                        lambda session: update_region_helper(session, table, region, cities))
+    ~~~
+
+If your ORM framework does not support `ENUM` data types, or if you run into type compatibility issues, you can alternatively try the following approach:
+
+- Add `crdb_region` (or the custom region-tracking column) to an existing table object as a *string*-typed column.
+- Validate the string input for `crdb_region` values, using one of the following approaches:
+    - Implement client-side string validation to check if the string input matches one of the allowed enumerated types.
+    - Add some exception handling to catch data errors (e.g., `sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation)` in SQLAlchemy).
+
+## See also
+
+- [Multi-region Capabilities Overview](multiregion-overview.html)
+- [Low Latency Reads and Writes in a Multi-Region Cluster](demo-low-latency-multi-region-deployment.html)


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/10455.

This PR introduces a new page with guidance on scaling from single-region to multi-region. 

The page includes some general guidance on representing `crdb_region` columns in an ORM, for DML statements, with an example for SQLAlchemy. We can add other examples (notably, in Hibernate) after publishing this page.