### PR TITLE
Misc 21.1.1 CLI updates

### DIFF
--- a/_includes/v21.1/app/start-cockroachdb.md
+++ b/_includes/v21.1/app/start-cockroachdb.md
@@ -25,17 +25,17 @@ Choose whether to run a temporary local cluster or a free CockroachDB cluster on
     {% include copy-clipboard.html %}
     ~~~ shell
     $ cockroach demo \
-    --empty
+    --no-example-database
     ~~~
 
     This starts a temporary, in-memory cluster and opens an interactive SQL shell to the cluster. Any changes to the database will not persist after the cluster is stopped.
-1. Take note of the `(sql/tcp)` connection string in the SQL shell welcome text:
+1. Take note of the `(sql)` connection string in the SQL shell welcome text:
 
     ~~~
     # Connection parameters:
-    #   (console) http://127.0.0.1:8080/demologin?password=demo11762&username=demo
-    #   (sql)     postgres://demo:demo11762@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo382139081&port=26257
-    #   (sql/tcp) postgres://demo:demo11762@127.0.0.1:26257?sslmode=require
+    #   (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+    #   (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+    #   (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
     ~~~
 
 </section>

--- a/_includes/v21.1/sql/connection-parameters.md
+++ b/_includes/v21.1/sql/connection-parameters.md
@@ -1,8 +1,8 @@
 Flag | Description
 -----|------------
 `--host` | The server host and port number to connect to. This can be the address of any node in the cluster. <br><br>**Env Variable:** `COCKROACH_HOST`<br>**Default:** `localhost:26257`
-`--port`<br>`-p` | The server port to connect to. Note: The port number can also be specified via `--host`. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
-`--user`<br>`-u` | The [SQL user](create-user.html) that will own the client session.<br><br>**Env Variable:** `COCKROACH_USER`<br>**Default:** `root`
+`--port`<br><br>`-p` | The server port to connect to. Note: The port number can also be specified via `--host`. <br><br>**Env Variable:** `COCKROACH_PORT`<br>**Default:** `26257`
+`--user`<br><br>`-u` | The [SQL user](create-user.html) that will own the client session.<br><br>**Env Variable:** `COCKROACH_USER`<br>**Default:** `root`
 `--insecure` | Use an insecure connection.<br><br>**Env Variable:** `COCKROACH_INSECURE`<br>**Default:** `false`
 `--certs-dir` | The path to the [certificate directory](cockroach-cert.html) containing the CA and client certificates and client key.<br><br>**Env Variable:** `COCKROACH_CERTS_DIR`<br>**Default:** `${HOME}/.cockroach-certs/`
 <a name="sql-flag-url"></a> `--url` | A [connection URL](connection-parameters.html#connect-using-a-url) to use instead of the other arguments.<br><br>**Env Variable:** `COCKROACH_URL`<br>**Default:** no URL

--- a/_includes/v21.1/sql/multiregion-example-setup.md
+++ b/_includes/v21.1/sql/multiregion-example-setup.md
@@ -6,7 +6,7 @@ To follow along with the examples below, start a [demo cluster](cockroach-demo.h
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach demo --global --nodes 9 --empty
+$ cockroach demo --global --nodes 9 --no-example-database
 ~~~
 
 To see the regions available to the databases in the cluster, use a `SHOW REGIONS FROM CLUSTER` statement:

--- a/_includes/v21.1/sql/shell-commands.md
+++ b/_includes/v21.1/sql/shell-commands.md
@@ -2,16 +2,16 @@ The following commands can be used within the interactive SQL shell:
 
 Command | Usage
 --------|------------
-`\?`<br>`help` | View this help within the shell.
-`\q`<br>`quit`<br>`exit`<br>`ctrl-d` | Exit the shell.<br>When no text follows the prompt, `ctrl-c` exits the shell as well; otherwise, `ctrl-c` clears the line.
+`\?`<br><br>`help` | View this help within the shell.
+`\q`<br><br>`quit`<br><br>`exit`<br><br>`ctrl-d` | Exit the shell.<br>When no text follows the prompt, `ctrl-c` exits the shell as well; otherwise, `ctrl-c` clears the line.
 `\!` | Run an external command and print its results to `stdout`. [See an example](cockroach-sql.html#run-external-commands-from-the-sql-shell).
 <code>&#92;&#124;</code> | Run the output of an external command as SQL statements. [See an example](cockroach-sql.html#run-external-commands-from-the-sql-shell).
-`\set <option>`<br>`\unset <option>` | Enable or disable a client-side option. For more details, see [Client-side options](#client-side-options).<br>You can also use the [`--set` flag](#general) to enable or disable client-side options before starting the SQL shell.
-`\show`<br>`\p` | During a multi-line statement or transaction, show the SQL that has been entered but not yet executed.<br><span class="version-tag">New in v21.1:</span>`\show` is deprecated in v21.1. Use `\p` instead.
-`\h <statement>`<br>`\hf <function>` | View help for specific SQL statements or functions. See [SQL shell help](#help) for more details.
-`\c`<br>`\connect` | <span class="version-tag">New in v21.1</span>: Change the current database. This is equivalent to `SET <database>` and `USE <database>`.
+`\set <option>`<br><br>`\unset <option>` | Enable or disable a client-side option. For more details, see [Client-side options](#client-side-options).<br>You can also use the [`--set` flag](#general) to enable or disable client-side options before starting the SQL shell.
+`\show`<br><br>`\p` | During a multi-line statement or transaction, show the SQL that has been entered but not yet executed.<br><span class="version-tag">New in v21.1:</span>`\show` is deprecated in v21.1. Use `\p` instead.
+`\h <statement>`<br><br>`\hf <function>` | View help for specific SQL statements or functions. See [SQL shell help](#help) for more details.
+`\c`<br><br>`\connect` | <span class="version-tag">New in v21.1</span>: Change the current database. This is equivalent to `SET <database>` and `USE <database>`.
 `\l` | List all databases in the CockroachDB cluster. This command is equivalent to [`SHOW DATABASES`](show-databases.html).
-`\dt`<br>`d` | Show the tables of the current schema in the current database. These commands are equivalent to [`SHOW TABLES`](show-tables.html).
+`\dt`<br><br>`d` | Show the tables of the current schema in the current database. These commands are equivalent to [`SHOW TABLES`](show-tables.html).
 `\dT` |  Show the [user-defined types](enum.html) in the current database. This command is equivalent to [`SHOW TYPES`](show-types.html).
 `\du` | List the users for all databases. This command is equivalent to [`SHOW USERS`](show-users.html).
 `\d <table>` | Show details about columns in the specified table. This command is equivalent to [`SHOW COLUMNS`](show-columns.html).
@@ -19,3 +19,4 @@ Command | Usage
 `\i <filename>` |  <span class="version-tag">New in v21.1:</span> Reads and executes input from the file `<filename>`, in the current working directory.
 `\ir <filename>` |  <span class="version-tag">New in v21.1:</span> Reads and executes input from the file `<filename>`.<br>When invoked in the interactive shell, `\i` and `\ir` behave identically (i.e., CockroachDB looks for `<filename>` in the current working directory). When invoked from a script, CockroachDB looks for `<filename>` relative to the directory in which the script is located.
 `\echo <arguments>` |  <span class="version-tag">New in v21.1:</span> Evaluate the `<arguments>` and print the results to the standard output.
+`\x <boolean>` |  <span class="version-tag">New in v21.1:</span> When `true`/`on`/`yes`/`1`, [sets the display format](cockroach-sql.html#sql-flag-format) to `records`. When `false`/`off`/`no`/`0`, sets the session's format to the default (`table`/`tsv`).

--- a/_includes/v21.1/sql/shell-help.md
+++ b/_includes/v21.1/sql/shell-help.md
@@ -2,10 +2,10 @@ Within the SQL shell, you can get interactive help about statements and function
 
 Command | Usage
 --------|------
-`\h`<br>`??` | List all available SQL statements, by category.
+`\h`<br><br>`??` | List all available SQL statements, by category.
 `\hf` | List all available SQL functions, in alphabetical order.
-`\h <statement>`<br>or `<statement> ?` | View help for a specific SQL statement.
-`\hf <function>`<br>or `<function> ?` | View help for a specific SQL function.
+`\h <statement>`<br><br>`<statement> ?` | View help for a specific SQL statement.
+`\hf <function>`<br><br>`<function> ?` | View help for a specific SQL function.
 
 #### Examples
 

--- a/_includes/v21.1/sql/shell-options.md
+++ b/_includes/v21.1/sql/shell-options.md
@@ -2,7 +2,7 @@
 - To enable or disable an option, use `\set <option> <value>` or `\unset <option> <value>`. You can also use the form `<option>=<value>`.
 - If an option accepts a boolean value:
     - `\set <option>` without `<value>` is equivalent to `\set <option> true`, and `\unset <option>` without `<value>` is equivalent to `\set <option> false`.
-    - `on` and `0` are aliases for `true`, and `off` and `1` are aliases for `false`.
+    - `on`, `yes`, and `0` are aliases for `true`, and `off`, `no`, and `1` are aliases for `false`.
 
 Client Options | Description
 ---------------|------------

--- a/_includes/v21.1/sql/start-a-multi-region-demo-cluster.md
+++ b/_includes/v21.1/sql/start-a-multi-region-demo-cluster.md
@@ -2,7 +2,7 @@ Use the [`cockroach demo`](cockroach-demo.html) command shown below to start the
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach demo --global --nodes 9 --empty --insecure
+$ cockroach demo --global --nodes 9 --no-example-database --insecure
 ~~~
 
 When the cluster starts, you'll see a message like the one shown below, followed by a SQL prompt. Note the URLs for:
@@ -11,6 +11,7 @@ When the cluster starts, you'll see a message like the one shown below, followed
 - Connecting to the database from a [SQL shell](cockroach-sql.html) or a [programming language](connect-to-the-database.html): `postgres://root@127.0.0.1:26257?sslmode=disable`.
 
 ~~~
+#
 # Welcome to the CockroachDB demo database!
 #
 # You are connected to a temporary, in-memory CockroachDB cluster of 9 nodes.
@@ -23,11 +24,18 @@ When the cluster starts, you'll see a message like the one shown below, followed
 # Reminder: your changes to data stored in the demo session will not be saved!
 #
 # Connection parameters:
-#   (console) http://127.0.0.1:8080
-#   (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo956443538&port=26257
-#   (sql/tcp) postgres://root@127.0.0.1:26257?sslmode=disable
-# 
+#   (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+#   (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+#   (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
+#
 # To display connection parameters for other nodes, use \demo ls.
-# Server version: CockroachDB CCL v21.1.0-alpha.3-1368-g0ee391c3b9 (x86_64-apple-darwin19.6.0, built 2021/03/18 14:54:44, go1.16) (same version as client)
-# Cluster ID: 063fa964-1f43-4b7f-b1e6-f70afd9ad921
+#
+# The user "demo" with password "demo76950" has been created. Use it to access the Web UI!
+#
+# Server version: CockroachDB CCL v21.1.2 (x86_64-apple-darwin19, built 2021/06/07 18:13:04, go1.15.11) (same version as client)
+# Cluster ID: bfd9fc91-69bd-4417-a2f7-66e556bf2cfd
+# Organization: Cockroach Demo
+#
+# Enter \? for a brief introduction.
+#
 ~~~

--- a/v21.1/build-a-go-app-with-cockroachdb-gorm.md
+++ b/v21.1/build-a-go-app-with-cockroachdb-gorm.md
@@ -54,7 +54,7 @@ Here are the contents of `main.go`:
 Edit the `addr` constant so that:
 
 - `{username}` and `{password}` specify the SQL username and password that you created earlier.
-- `{hostname}` and `{port}` specify the hostname and port in the `(sql/tcp)` connection string from SQL shell welcome text.
+- `{hostname}` and `{port}` specify the hostname and port in the `(sql)` connection string from SQL shell welcome text.
 
 </section>
 

--- a/v21.1/build-a-go-app-with-cockroachdb-pq.md
+++ b/v21.1/build-a-go-app-with-cockroachdb-pq.md
@@ -52,7 +52,7 @@ Here are the contents of `main.go`:
 Edit the connection string passed to `sql.Open()` so that:
 
 - `{username}` and `{password}` specify the SQL username and password that you created earlier.
-- `{hostname}` and `{port}` specify the hostname and port in the `(sql/tcp)` connection string from SQL shell welcome text.
+- `{hostname}` and `{port}` specify the hostname and port in the `(sql)` connection string from SQL shell welcome text.
 
 </section>
 

--- a/v21.1/build-a-go-app-with-cockroachdb.md
+++ b/v21.1/build-a-go-app-with-cockroachdb.md
@@ -76,7 +76,7 @@ Here are the contents of `main.go`:
 Edit the connection string passed to `pgx.ParseConfig()` so that:
 
 - `{username}` and `{password}` specify the SQL username and password that you created earlier.
-- `{hostname}` and `{port}` specify the hostname and port in the `(sql/tcp)` connection string from SQL shell welcome text.
+- `{hostname}` and `{port}` specify the hostname and port in the `(sql)` connection string from SQL shell welcome text.
 
 </section>
 

--- a/v21.1/build-a-python-app-with-cockroachdb-django.md
+++ b/v21.1/build-a-python-app-with-cockroachdb-django.md
@@ -111,7 +111,7 @@ Where:
 
 - `<user>` is the username that you created earlier.
 - `<password>` is the password that you created for the `<user>`.
-- `<port>` is the port listed in the `(sql/tcp)` connection string in the SQL shell welcome text. For example, for the connection string `postgres://demo:demo11762@127.0.0.1:26257?sslmode=require`, the port is `26257`.
+- `<port>` is the port listed in the `(sql)` connection string in the SQL shell welcome text. For example, for the connection string `postgres://demo:demo11762@127.0.0.1:26257?sslmode=require`, the port is `26257`.
 
 </section>
 

--- a/v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -91,7 +91,7 @@ In the `create_engine()` function, update the connection string as follows:
 <section class="filter-content" markdown="1" data-scope="local">
 
 - Replace `<username>` and `<password>` with the SQL username and password that you created earlier.
-- Replace `<hostname>` and `<port>` with the hostname and port in the `(sql/tcp)` connection string from SQL shell welcome text.
+- Replace `<hostname>` and `<port>` with the hostname and port in the `(sql)` connection string from SQL shell welcome text.
 
 </section>
 

--- a/v21.1/build-a-python-app-with-cockroachdb.md
+++ b/v21.1/build-a-python-app-with-cockroachdb.md
@@ -82,7 +82,7 @@ $ python3 example.py \
 Before running the command, update the connection string as follows:
 
 - Replace `<username>` and `<password>` with the SQL username and password that you created earlier.
-- Replace `<hostname>` and `<port>` with the hostname and port in the `(sql/tcp)` connection string from SQL shell welcome text.
+- Replace `<hostname>` and `<port>` with the hostname and port in the `(sql)` connection string from SQL shell welcome text.
 
 </section>
 

--- a/v21.1/cockroach-demo.md
+++ b/v21.1/cockroach-demo.md
@@ -87,7 +87,7 @@ ctrl-d
 ## Datasets
 
 {{site.data.alerts.callout_success}}
-By default, the `movr` dataset is pre-loaded into a demo cluster. To load a different dataset, use [`cockroach demo <dataset>`](#load-a-sample-dataset-into-a-demo-cluster). To start a demo cluster without a pre-loaded dataset, pass the `--empty` flag.
+By default, the `movr` dataset is pre-loaded into a demo cluster. To load a different dataset, use [`cockroach demo <dataset>`](#load-a-sample-dataset-into-a-demo-cluster). To start a demo cluster without a pre-loaded dataset, pass the `--no-example-database` flag.
 {{site.data.alerts.end}}
 
 Workload | Description
@@ -113,8 +113,8 @@ Flag | Description
 `--disable-demo-license` |  Start the demo cluster without loading a temporary [enterprise license](https://www.cockroachlabs.com/get-cockroachdb) that expires after an hour.<br><br>Setting the `COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING` environment variable will also prevent the loading of a temporary license, along with preventing the sharing of anonymized [diagnostic details](diagnostics-reporting.html) with Cockroach Labs.
 `--echo-sql` | Reveal the SQL statements sent implicitly by the command-line utility. This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](#commands).
 `--embedded` | <span class="version-tag">New in v21.1:</span> Minimizes the SQL shell [welcome text](#welcome-text) to be appropriate for embedding in playground-type environments. Specifically, this flag removes details that users in an embedded environment have no control over (e.g., networking information).
-`--empty` | Start the demo cluster without a pre-loaded dataset.
-`--execute`<br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons.<br><br>If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).
+`--no-example-database` | <span class="version-tag">New in v21.1:</span> Start the demo cluster without a pre-loaded dataset.<br>To obtain this behavior automatically in every new `cockroach demo` session, set the `COCKROACH_NO_EXAMPLE_DATABASE` environment variable to `true`.
+`--execute`<br><br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons.<br><br>If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).
 `--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `table`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `table` for sessions that [output on a terminal](cockroach-sql.html#session-and-output-types); `tsv` otherwise<br /><br />This flag corresponds to the `display_format` [client-side option](#client-side-options) for use in interactive sessions.
 `--geo-partitioned-replicas` | Start a 9-node demo cluster with [geo-partitioning](partitioning.html) applied to the [`movr`](movr.html) database.
 `--global` | <a name="global-flag"></a> This experimental flag is used to simulate a [multi-region cluster](simulate-a-multi-region-cluster-on-localhost.html) which sets the [`--locality` flag on node startup](cockroach-start.html#locality) to three different regions. It also simulates the network latency that would occur between them given the specified localities. In order for this to operate as expected, with 3 nodes in each of 3 regions, you must also pass the `--nodes 9` argument.
@@ -158,15 +158,15 @@ When the SQL shell connects to the demo cluster at startup, it prints a welcome 
 # Reminder: your changes to data stored in the demo session will not be saved!
 #
 # Connection parameters:
-#   (console) http://127.0.0.1:8080/demologin?password=demo36965&username=demo
-#   (sql)     postgres://demo:demo36965@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo885159696&port=26257
-#   (sql/tcp) postgres://demo:demo36965@127.0.0.1:26257?sslmode=require
+#   (webui)    http://127.0.0.1:8080/demologin?password=demo76915&username=demo
+#   (sql)      postgres://demo:demo76915@127.0.0.1:26257?sslmode=require
+#   (sql/unix) postgres://demo:demo76915@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo038435782&port=26257
 #
 #
-# The user "demo" with password "demo36965" has been created. Use it to access the Web UI!
+# The user "demo" with password "demo76915" has been created. Use it to access the Web UI!
 #
-# Server version: CockroachDB CCL v21.1.0 (x86_64-apple-darwin19, built 2021/05/17 13:52:51, go1.15.11) (same version as client)
-# Cluster ID: 5448bb81-6d2f-4545-a36c-4236df7e3d7d
+# Server version: CockroachDB CCL v21.1.2 (x86_64-apple-darwin19, built 2021/06/07 18:13:04, go1.15.11) (same version as client)
+# Cluster ID: 9dd61f86-add2-47c0-88a3-eb00525b1a22
 # Organization: Cockroach Demo
 #
 # Enter \? for a brief introduction.
@@ -179,19 +179,19 @@ The SQL shell welcome text includes connection parameters for accessing the DB C
 
 ~~~
 # Connection parameters:
-#   (console) http://127.0.0.1:8080/demologin?password=demo36965&username=demo
-#   (sql)     postgres://demo:demo36965@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo885159696&port=26257
-#   (sql/tcp) postgres://demo:demo36965@127.0.0.1:26257?sslmode=require
+#   (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+#   (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+#   (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 ~~~
 
 Parameter | Description
 ----------|------------
-`console` | Use this link to access a local [DB Console](ui-overview.html) to the demo cluster.
-`sql` | Use this connection URL to establish a [Unix domain socket connection](cockroach-sql.html#connect-to-a-cluster-listening-for-unix-domain-socket-connections) with a client that is installed on the same machine.
-`sql/tcp` | Use this connection URL for standard sql/tcp connections from other SQL clients such as [`cockroach sql`](cockroach-sql.html).<br>The default SQL port for the first node of a demo cluster is `26257`.
+`webui` | Use this link to access a local [DB Console](ui-overview.html) to the demo cluster.
+`sql` | Use this connection URL for standard sql/tcp connections from other SQL clients such as [`cockroach sql`](cockroach-sql.html).<br>The default SQL port for the first node of a demo cluster is `26257`.
+`sql/unix` | Use this connection URL to establish a [Unix domain socket connection](cockroach-sql.html#connect-to-a-cluster-listening-for-unix-domain-socket-connections) with a client that is installed on the same machine.
 
 {{site.data.alerts.callout_info}}
-You do not need to create or specify node and client certificates in `sql` or `sql/tcp` connection URLs. Instead, you can securely connect to the demo cluster with the random password generated for the `demo` user.
+You do not need to create or specify node and client certificates in `sql` or `sql/unix` connection URLs. Instead, you can securely connect to the demo cluster with the random password generated for the `demo` user.
 {{site.data.alerts.end}}
 
 When running a multi-node demo cluster, use the `\demo ls` [shell command](#commands) to list the connection parameters for all nodes:
@@ -203,19 +203,19 @@ When running a multi-node demo cluster, use the `\demo ls` [shell command](#comm
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:8080/demologin?password=demo53628&username=demo
-  (sql)     postgres://demo:demo53628@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo179679939&port=26257
-  (sql/tcp) postgres://demo:demo53628@127.0.0.1:26257?sslmode=require
+  (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 
 node 2:
-  (console) http://127.0.0.1:8081/demologin?password=demo53628&username=demo
-  (sql)     postgres://demo:demo53628@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo179679939&port=26258
-  (sql/tcp) postgres://demo:demo53628@127.0.0.1:26258?sslmode=require
+  (webui)    http://127.0.0.1:8081/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26258?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26258
 
 node 3:
-  (console) http://127.0.0.1:8082/demologin?password=demo53628&username=demo
-  (sql)     postgres://demo:demo53628@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo179679939&port=26259
-  (sql/tcp) postgres://demo:demo53628@127.0.0.1:26259?sslmode=require
+  (webui)    http://127.0.0.1:8082/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26259?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26259
 ~~~
 
 ### Commands
@@ -353,19 +353,19 @@ $ cockroach demo --nodes=3
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:8080/demologin?password=demo37407&username=demo
-  (sql)     postgres://demo:demo37407@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo252870906&port=26257
-  (sql/tcp) postgres://demo:demo37407@127.0.0.1:26257?sslmode=require
+  (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 
 node 2:
-  (console) http://127.0.0.1:8081/demologin?password=demo37407&username=demo
-  (sql)     postgres://demo:demo37407@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo252870906&port=26258
-  (sql/tcp) postgres://demo:demo37407@127.0.0.1:26258?sslmode=require
+  (webui)    http://127.0.0.1:8081/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26258?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26258
 
 node 3:
-  (console) http://127.0.0.1:8082/demologin?password=demo37407&username=demo
-  (sql)     postgres://demo:demo37407@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo252870906&port=26259
-  (sql/tcp) postgres://demo:demo37407@127.0.0.1:26259?sslmode=require
+  (webui)    http://127.0.0.1:8082/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26259?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26259
 ~~~
 
 ### Load a sample dataset into a demo cluster
@@ -439,22 +439,22 @@ First, use `\demo ls` to list the connection parameters for each node in the dem
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:8080/demologin?password=demo53628&username=demo
-  (sql)     postgres://demo:demo53628@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo179679939&port=26257
-  (sql/tcp) postgres://demo:demo53628@127.0.0.1:26257?sslmode=require
+  (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 
 node 2:
-  (console) http://127.0.0.1:8081/demologin?password=demo53628&username=demo
-  (sql)     postgres://demo:demo53628@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo179679939&port=26258
-  (sql/tcp) postgres://demo:demo53628@127.0.0.1:26258?sslmode=require
+  (webui)    http://127.0.0.1:8081/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26258?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26258
 
 node 3:
-  (console) http://127.0.0.1:8082/demologin?password=demo53628&username=demo
-  (sql)     postgres://demo:demo53628@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo179679939&port=26259
-  (sql/tcp) postgres://demo:demo53628@127.0.0.1:26259?sslmode=require
+  (webui)    http://127.0.0.1:8082/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26259?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26259
 ~~~
 
-Then open a new terminal and run [`cockroach sql`](cockroach-sql.html) with the `--url` flag set to the `sql/tcp` connection URL of the node to which you want to connect:
+Then open a new terminal and run [`cockroach sql`](cockroach-sql.html) with the `--url` flag set to the `sql` connection URL of the node to which you want to connect:
 
 {% include copy-clipboard.html %}
 ~~~ shell
@@ -472,6 +472,10 @@ $ cockroach demo --global --nodes 9
 
 This command starts a 9-node demo cluster with the `movr` database preloaded and region and zone localities set at the cluster level.
 
+{{site.data.alerts.callout_info}}
+The `--global` flag is an experimental feature of `cockroach demo`. The interface and output are subject to change.
+{{site.data.alerts.end}}
+
 For a tutorial that uses a demo cluster to demonstrate CockroachDB's multi-region capabilities, see [Low Latency Reads and Writes in a Multi-Region Cluster](demo-low-latency-multi-region-deployment.html).
 
 ### Add, shut down, and restart nodes in a multi-node demo cluster
@@ -484,6 +488,10 @@ In a multi-node demo cluster, you can use `\demo` [shell commands](#commands) to
 ~~~ shell
 $ cockroach demo --nodes=9
 ~~~
+
+{{site.data.alerts.callout_info}}
+`cockroach demo` does not support the `\demo add` and `\demo shutdown` commands in demo clusters started with the `--global` flag.
+{{site.data.alerts.end}}
 
 {% include copy-clipboard.html %}
 ~~~ sql
@@ -506,49 +514,49 @@ $ cockroach demo --nodes=9
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:8080/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26257
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26257?sslmode=require
+  (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 
 node 2:
-  (console) http://127.0.0.1:8081/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26258
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26258?sslmode=require
+  (webui)    http://127.0.0.1:8081/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26258?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26258
 
 node 3:
-  (console) http://127.0.0.1:8082/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26259
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26259?sslmode=require
+  (webui)    http://127.0.0.1:8082/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26259?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26259
 
 node 4:
-  (console) http://127.0.0.1:8083/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26260
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26260?sslmode=require
+  (webui)    http://127.0.0.1:8083/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26260?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26260
 
 node 5:
-  (console) http://127.0.0.1:8084/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26261
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26261?sslmode=require
+  (webui)    http://127.0.0.1:8084/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26261?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26261
 
 node 6:
-  (console) http://127.0.0.1:8085/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26262
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26262?sslmode=require
+  (webui)    http://127.0.0.1:8085/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26262?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26262
 
 node 7:
-  (console) http://127.0.0.1:8086/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26263
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26263?sslmode=require
+  (webui)    http://127.0.0.1:8086/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26263?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26263
 
 node 8:
-  (console) http://127.0.0.1:8087/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26264
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26264?sslmode=require
+  (webui)    http://127.0.0.1:8087/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26264?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26264
 
 node 9:
-  (console) http://127.0.0.1:8088/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26265
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26265?sslmode=require
+  (webui)    http://127.0.0.1:8088/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26265?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26265
 ~~~
 
 You can shut down and restart any node by node id. For example, to shut down the 3rd node and then restart it:
@@ -624,21 +632,21 @@ node 10 has been added with locality "region=us-central1,zone=a"
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:8080/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26257
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26257?sslmode=require
+  (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 
 node 2:
-  (console) http://127.0.0.1:8081/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26258
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26258?sslmode=require
+  (webui)    http://127.0.0.1:8081/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26258?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26258
 
 ...
 
 node 10:
-  (console) http://127.0.0.1:8089/demologin?password=demo37632&username=demo
-  (sql)     postgres://demo:demo37632@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo742364495&port=26266
-  (sql/tcp) postgres://demo:demo37632@127.0.0.1:26266?sslmode=require
+  (webui)    http://127.0.0.1:8089/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26266?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26266
 ~~~
 
 ### Try your own scenario

--- a/v21.1/cockroach-dump.md
+++ b/v21.1/cockroach-dump.md
@@ -358,7 +358,7 @@ INSERT INTO quotes (quote, characters, stardate, episode) VALUES
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ cockroach sql --insecure --database=startrek --user=maxroach < backup.sql
+$ cockroach sql --insecure --database=startrek --user=maxroach -f backup.sql
 ~~~
 
 ~~~

--- a/v21.1/cockroach-sql.md
+++ b/v21.1/cockroach-sql.md
@@ -30,7 +30,7 @@ $ cockroach sql --execute="<sql statement>;<sql statement>" --execute="<sql-stat
 $ echo "<sql statement>;<sql statement>" | cockroach sql <flags>
 ~~~
 ~~~ shell
-$ cockroach sql <flags> < file-containing-statements.sql
+$ cockroach sql <flags> --input-file file-containing-statements.sql
 ~~~
 
 Exit the interactive SQL shell:
@@ -72,14 +72,16 @@ The `sql` command supports the following types of flags:
 
 Flag | Description
 -----|------------
-`--database`<br>`-d` | A database name to use as [current database](sql-name-resolution.html#current-database) in the newly created session.
+`--database`<br><br>`-d` | A database name to use as [current database](sql-name-resolution.html#current-database) in the newly created session.
 `--embedded` | <span class="version-tag">New in v21.1:</span> Minimizes the SQL shell [welcome text](#welcome-message) to be appropriate for embedding in playground-type environments. Specifically, this flag removes details that users in an embedded environment have no control over (e.g., networking information).
 `--echo-sql` | Reveal the SQL statements sent implicitly by the command-line utility. For a demonstration, see the [example](#reveal-the-sql-statements-sent-implicitly-by-the-command-line-utility) below.<br><br>This can also be enabled within the interactive SQL shell via the `\set echo` [shell command](#commands).
-<a name="sql-flag-execute"></a> `--execute`<br />`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
+<a name="sql-flag-execute"></a> `--execute`<br><br>`-e` | Execute SQL statements directly from the command line, without opening a shell. This flag can be set multiple times, and each instance can contain one or more statements separated by semi-colons. If an error occurs in any statement, the command exits with a non-zero status code and further statements are not executed. The results of each statement are printed to the standard output (see `--format` for formatting options).<br><br>For a demonstration of this and other ways to execute SQL from the command line, see the [example](#execute-sql-statements-from-the-command-line) below.
 <a name="sql-flag-format"></a> `--format` | How to display table rows printed to the standard output. Possible values: `tsv`, `csv`, `table`, `raw`, `records`, `sql`, `html`.<br><br>**Default:** `table` for sessions that [output on a terminal](#session-and-output-types); `tsv` otherwise<br /><br />This flag corresponds to the `display_format` [client-side option](#client-side-options).
 `--safe-updates` | Disallow potentially unsafe SQL statements, including `DELETE` without a `WHERE` clause, `UPDATE` without a `WHERE` clause, and `ALTER TABLE ... DROP COLUMN`.<br><br>**Default:** `true` for [interactive sessions](#session-and-output-types); `false` otherwise<br /><br />Potentially unsafe SQL statements can also be allowed/disallowed for an entire session via the `sql_safe_updates` [session variable](set-vars.html).
 `--set` | Set a [client-side option](#client-side-options) before starting the SQL shell or executing SQL statements from the command line via `--execute`. This flag may be specified multiple times, once per option.<br><br>After starting the SQL shell, the `\set` and `unset` commands can be use to enable and disable client-side options as well.  
 `--watch` | Repeat the SQL statements specified with `--execute` or `-e` until a SQL error occurs or the process is terminated. `--watch` applies to all `--execute` or `-e` flags in use.<br />You must also specify an interval at which to repeat the statement, followed by a time unit. For example, to specify an interval of 5 seconds, use `5s`.<br /><br /> Note that this flag is intended for simple monitoring scenarios during development and testing. See the [example](#repeat-a-sql-statement) below.
+`--input-file <filename>`<br><br>`-f <filename>`<br><br>`< <filename>` | <span class="version-tag">New in v21.1:</span> Read SQL statements from `<filename>`.
+
 
 ### Client connection
 
@@ -485,7 +487,7 @@ $ cockroach sql --insecure \
 --user=maxroach \
 --host=12.345.67.89 \
 --database=critterdb \
-< statements.sql
+-f statements.sql
 ~~~
 
 ~~~

--- a/v21.1/copy-from.md
+++ b/v21.1/copy-from.md
@@ -58,12 +58,12 @@ Run [`cockroach demo`](cockroach-demo.html) to start a temporary, in-memory clus
 $ cockroach demo
 ~~~
 
-Take note of the `(sql/tcp)` connection string listed under `Connection parameters` in the welcome message of the demo cluster's SQL shell:
+Take note of the `(sql)` connection string listed under `Connection parameters` in the welcome message of the demo cluster's SQL shell:
 
 ~~~
 # Connection parameters:
 ...
-#   (sql/tcp) postgres://demo:demo11762@127.0.0.1:26257?sslmode=require
+#   (sql) postgres://demo:demo11762@127.0.0.1:26257?sslmode=require
 ~~~
 
 Open a new terminal window, and connect to your demo cluster with `psql`, using the connection string provided for the demo cluster, with the `movr` database specified:

--- a/v21.1/create-database.md
+++ b/v21.1/create-database.md
@@ -106,7 +106,7 @@ For this example, let's use a [demo cluster](cockroach-demo.html), with the [`--
 
 {% include copy-clipboard.html %}
 ~~~ shell
-cockroach211 demo --nodes=6 --demo-locality=region=us-east1,zone=us-east1-a:region=us-east1,zone=us-east1-b:region=us-central1,zone=us-central1-a:region=us-central1,zone=us-central1-b:region=us-west1,zone=us-west1-a:region=us-west1,zone=us-west1-b --empty
+cockroach211 demo --nodes=6 --demo-locality=region=us-east1,zone=us-east1-a:region=us-east1,zone=us-east1-b:region=us-central1,zone=us-central1-a:region=us-central1,zone=us-central1-b:region=us-west1,zone=us-west1-a:region=us-west1,zone=us-west1-b --no-example-database
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v21.1/demo-low-latency-multi-region-deployment.md
+++ b/v21.1/demo-low-latency-multi-region-deployment.md
@@ -73,49 +73,49 @@ Here is the output of `\demo ls` from the SQL shell.
 
 ~~~
 node 1:
-  (console) http://127.0.0.1:8080
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26257
-  (sql/tcp) postgres://root@127.0.0.1:26257?sslmode=disable
-
-node 8:
-  (console) http://127.0.0.1:8081
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26264
-  (sql/tcp) postgres://root@127.0.0.1:26258?sslmode=disable
-
-node 3:
-  (console) http://127.0.0.1:8082
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26259
-  (sql/tcp) postgres://root@127.0.0.1:26259?sslmode=disable
-
-node 6:
-  (console) http://127.0.0.1:8083
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26262
-  (sql/tcp) postgres://root@127.0.0.1:26260?sslmode=disable
-
-node 9:
-  (console) http://127.0.0.1:8084
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26265
-  (sql/tcp) postgres://root@127.0.0.1:26261?sslmode=disable
-
-node 4:
-  (console) http://127.0.0.1:8085
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26260
-  (sql/tcp) postgres://root@127.0.0.1:26262?sslmode=disable
+  (webui)    http://127.0.0.1:8080/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26257?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26257
 
 node 2:
-  (console) http://127.0.0.1:8086
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26258
-  (sql/tcp) postgres://root@127.0.0.1:26263?sslmode=disable
+  (webui)    http://127.0.0.1:8081/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26258?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26258
+
+node 3:
+  (webui)    http://127.0.0.1:8082/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26259?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26259
+
+node 4:
+  (webui)    http://127.0.0.1:8083/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26260?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26260
 
 node 5:
-  (console) http://127.0.0.1:8087
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26261
-  (sql/tcp) postgres://root@127.0.0.1:26264?sslmode=disable
+  (webui)    http://127.0.0.1:8084/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26261?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26261
+
+node 6:
+  (webui)    http://127.0.0.1:8085/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26262?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26262
 
 node 7:
-  (console) http://127.0.0.1:8088
-  (sql)     postgres://root:unused@?host=%2Fvar%2Ffolders%2Fbh%2F_32m6zhj67z534slcg79nm_w0000gp%2FT%2Fdemo731561476&port=26263
-  (sql/tcp) postgres://root@127.0.0.1:26265?sslmode=disable
+  (webui)    http://127.0.0.1:8086/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26263?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26263
+
+node 8:
+  (webui)    http://127.0.0.1:8087/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26264?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26264
+
+node 9:
+  (webui)    http://127.0.0.1:8088/demologin?password=demo76950&username=demo
+  (sql)      postgres://demo:demo76950@127.0.0.1:26265?sslmode=require
+  (sql/unix) postgres://demo:demo76950@?host=%2Fvar%2Ffolders%2Fc8%2Fb_q93vjj0ybfz0fz0z8vy9zc0000gp%2FT%2Fdemo070856957&port=26265
 ~~~
 
 And here is the view on the **Network Latency Page**, which shows which nodes are in which cluster regions:

--- a/v21.1/movr-flask-deployment.md
+++ b/v21.1/movr-flask-deployment.md
@@ -57,7 +57,7 @@ In production, you want to start a secure CockroachDB cluster, with nodes on mac
     e.g.,
 
     ~~~ shell
-    $ cockroach sql --url \ 'postgresql://user:password@region.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full&sslrootcert=certs-dir/movr-app-ca.crt' < dbinit.sql
+    $ cockroach sql --url \ 'postgresql://user:password@region.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full&sslrootcert=certs-dir/movr-app-ca.crt' -f dbinit.sql
     ~~~
 
 {{site.data.alerts.callout_info}}

--- a/v21.1/movr-flask-setup.md
+++ b/v21.1/movr-flask-setup.md
@@ -40,7 +40,7 @@ For debugging and development purposes, you can use the [`cockroach demo`](cockr
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --insecure --url='postgresql://root@127.0.0.1:26257/defaultdb' < dbinit.sql
+    $ cockroach sql --insecure --url='postgresql://root@127.0.0.1:26257/defaultdb' -f dbinit.sql
     ~~~
 
 

--- a/v21.1/movr-flask-setup.md
+++ b/v21.1/movr-flask-setup.md
@@ -40,7 +40,7 @@ For debugging and development purposes, you can use the [`cockroach demo`](cockr
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ cockroach sql --insecure --url='postgresql://root@127.0.0.1:26257/defaultdb' -f dbinit.sql
+    $ cockroach sql --insecure --url='postgres://demo:<demo_password>@127.0.0.1:26257?sslmode=require' -f dbinit.sql
     ~~~
 
 

--- a/v21.1/schema-design-database.md
+++ b/v21.1/schema-design-database.md
@@ -63,7 +63,7 @@ To execute the statement in the `dbinit.sql` file as the `root` user, run the fo
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=root \
-< dbinit.sql
+-f dbinit.sql
 ~~~
 
 To view the database in the cluster, execute a [`SHOW DATABASES`](show-databases.html) statement from the command line:

--- a/v21.1/schema-design-indexes.md
+++ b/v21.1/schema-design-indexes.md
@@ -164,7 +164,7 @@ If you executed this file when following the [Create a Table](schema-design-tabl
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=root \
-< dbinit.sql
+-f dbinit.sql
 ~~~
 
 Then, execute the statements in the `max_init.sql` and `abbey_init.sql` files:
@@ -174,8 +174,8 @@ Then, execute the statements in the `max_init.sql` and `abbey_init.sql` files:
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=max \
---database=movr
-< max_init.sql
+--database=movr \
+-f max_init.sql
 ~~~
 
 {% include copy-clipboard.html %}
@@ -183,8 +183,8 @@ $ cockroach sql \
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=abbey \
---database=movr
-< abbey_init.sql
+--database=movr \
+-f abbey_init.sql
 ~~~
 
 After the statements have been executed, you can see the new index in the [CockroachDB SQL shell](cockroach-sql.html#sql-shell).

--- a/v21.1/schema-design-schema.md
+++ b/v21.1/schema-design-schema.md
@@ -109,7 +109,7 @@ To execute the statements in the `dbinit.sql` file as the `root` user, run the f
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=root \
-< dbinit.sql
+-f dbinit.sql
 ~~~
 
 Before the new users can connect to the cluster and start creating objects, they each need a [user certificate](authentication.html#client-authentication). To create a user certificate for `max`, open a new terminal, and run the following [`cockroach cert`](cockroach-cert.html) command:

--- a/v21.1/schema-design-table.md
+++ b/v21.1/schema-design-table.md
@@ -460,8 +460,8 @@ To execute the statements in the `max_init.sql` file, run the following command:
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=max \
---database=movr
-< max_init.sql
+--database=movr \
+-f max_init.sql
 ~~~
 
 The SQL client will execute any statements in `max_init.sql`, with `movr` as the database and `max` as the user. `max` is now the owner of all objects created by the statements in the `max_init.sql` file.
@@ -535,8 +535,8 @@ To execute the statement in the `abbey_init.sql` file, run the following command
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=abbey \
---database=movr
-< abbey_init.sql
+--database=movr \
+-f abbey_init.sql
 ~~~
 
 After the statements have been executed, you can see the table in the [CockroachDB SQL shell](cockroach-sql.html#sql-shell).

--- a/v21.1/schema-design-update.md
+++ b/v21.1/schema-design-update.md
@@ -141,8 +141,8 @@ To execute the statements in the `update_users_table.sql` file as `max`, run the
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=max \
---database=movr
-< update_users_table.sql
+--database=movr \
+-f update_users_table.sql
 ~~~
 
 To execute the statements in the `update_users_owner.sql` file as `root`, run the following command:
@@ -152,8 +152,8 @@ To execute the statements in the `update_users_owner.sql` file as `root`, run th
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=root \
---database=movr
-< update_users_owner.sql
+--database=movr \
+-f update_users_owner.sql
 ~~~
 
 The `users` table should now have a new column, a different primary key, a different schema, and a different owner.
@@ -306,8 +306,8 @@ To drop the index, execute the file:
 $ cockroach sql \
 --certs-dir={certs-directory} \
 --user=abbey \
---database=movr
-< drop_unique_users_idx.sql
+--database=movr \
+-f drop_unique_users_idx.sql
 ~~~
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/10661.
Fixes https://github.com/cockroachdb/docs/issues/10660.
Fixes https://github.com/cockroachdb/docs/issues/10659.
Fixes https://github.com/cockroachdb/docs/issues/10658.
Fixes https://github.com/cockroachdb/docs/issues/9142.
Fixes https://github.com/cockroachdb/docs/issues/9143.
Fixes https://github.com/cockroachdb/docs/issues/9131.

This PR includes changes to the CLI reference docs for `cockroach sql` and `cockroach demo`, and updates to examples affected by the changes linked in the `cockroach` PRs above.