### PR TITLE
specify regional clusters in single-region GKE deployments

### DIFF
--- a/_includes/v20.1/orchestration/start-kubernetes.md
+++ b/_includes/v20.1/orchestration/start-kubernetes.md
@@ -5,6 +5,10 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 - [Manual GCE](#manual-gce)
 - [Manual AWS](#manual-aws)
 
+{{site.data.alerts.callout_info}}
+The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
+{{site.data.alerts.end}}
+
 ### Hosted GKE
 
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.
@@ -12,23 +16,27 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
 
     {{site.data.alerts.callout_success}}
-    Be sure to set a [default compute zone and/or region](https://cloud.google.com/kubernetes-engine/docs/quickstart#defaults) to use with `gcloud`. If no defaults are set, you will need to specify them with the `--zone` and `--region` flags when creating and deleting clusters.
+    The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.
     {{site.data.alerts.end}}
 
-    {{site.data.alerts.callout_success}}The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the CockroachDB Admin UI using the steps in this guide.{{site.data.alerts.end}}
+2. From your local workstation, start the Kubernetes cluster, specifying one of the available [regions](https://cloud.google.com/compute/docs/regions-zones#available) (e.g., `us-east1`):
 
-2. From your local workstation, start the Kubernetes cluster:
+    {{site.data.alerts.callout_success}}
+    Since this region can differ from your default `gcloud` region, be sure to include the `--region` flag to run `gcloud` commands against this cluster.
+    {{site.data.alerts.end}}
 
-    {% include copy-clipboard.html %}
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ gcloud container clusters create cockroachdb --machine-type n2-standard-4
+    $ gcloud container clusters create cockroachdb --machine-type n2-standard-4 --region {region-name} --num-nodes 1
     ~~~
 
     ~~~
     Creating cluster cockroachdb...done.
     ~~~
 
-    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
+    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` and `--num-nodes` flags specify a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) with one node in each zone.
+
+    The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
 
     The process can take a few minutes, so do not move on to the next step until you see a `Creating cluster cockroachdb...done` message and details about your cluster.
 

--- a/_includes/v20.1/orchestration/start-kubernetes.md
+++ b/_includes/v20.1/orchestration/start-kubernetes.md
@@ -34,7 +34,7 @@ The CockroachDB Kubernetes Operator is currently supported for GKE. You can also
     Creating cluster cockroachdb...done.
     ~~~
 
-    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` and `--num-nodes` flags specify a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) with one node in each zone.
+    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` flag specifies a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster), and `--num-nodes` specifies one node in each zone.
 
     The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
 

--- a/_includes/v20.1/orchestration/start-kubernetes.md
+++ b/_includes/v20.1/orchestration/start-kubernetes.md
@@ -6,7 +6,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 - [Manual AWS](#manual-aws)
 
 {{site.data.alerts.callout_info}}
-The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
+The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](../{{site.versions["stable"]}}/deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
 {{site.data.alerts.end}}
 
 ### Hosted GKE

--- a/_includes/v20.2/orchestration/start-kubernetes.md
+++ b/_includes/v20.2/orchestration/start-kubernetes.md
@@ -5,8 +5,8 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 - [Manual GCE](#manual-gce)
 - [Manual AWS](#manual-aws)
 
-{{site.data.alerts.callout_success}}
-You can also orchestrate CockroachDB on platforms such as [Red Hat OpenShift](https://marketplace.redhat.com/en-us/products/cockroachdb-operator) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
+{{site.data.alerts.callout_info}}
+The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
 {{site.data.alerts.end}}
 
 ### Hosted GKE
@@ -16,23 +16,27 @@ You can also orchestrate CockroachDB on platforms such as [Red Hat OpenShift](ht
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
 
     {{site.data.alerts.callout_success}}
-    Be sure to set a [default compute zone and/or region](https://cloud.google.com/kubernetes-engine/docs/quickstart#defaults) to use with `gcloud`. If no defaults are set, you will need to specify them with the `--zone` and `--region` flags when creating and deleting clusters.
+    The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the DB Console using the steps in this guide.
     {{site.data.alerts.end}}
 
-    {{site.data.alerts.callout_success}}The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the DB Console using the steps in this guide.{{site.data.alerts.end}}
+2. From your local workstation, start the Kubernetes cluster, specifying one of the available [regions](https://cloud.google.com/compute/docs/regions-zones#available) (e.g., `us-east1`):
 
-2. From your local workstation, start the Kubernetes cluster:
+    {{site.data.alerts.callout_success}}
+    Since this region can differ from your default `gcloud` region, be sure to include the `--region` flag to run `gcloud` commands against this cluster.
+    {{site.data.alerts.end}}
 
-    {% include copy-clipboard.html %}
+    {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ gcloud container clusters create cockroachdb --machine-type n2-standard-4
+    $ gcloud container clusters create cockroachdb --machine-type n2-standard-4 --region {region-name} --num-nodes 1
     ~~~
 
     ~~~
     Creating cluster cockroachdb...done.
     ~~~
 
-    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
+    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` and `--num-nodes` flags specify a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) with one node in each zone.
+
+    The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
 
     The process can take a few minutes, so do not move on to the next step until you see a `Creating cluster cockroachdb...done` message and details about your cluster.
 

--- a/_includes/v20.2/orchestration/start-kubernetes.md
+++ b/_includes/v20.2/orchestration/start-kubernetes.md
@@ -34,7 +34,7 @@ The CockroachDB Kubernetes Operator is currently supported for GKE. You can also
     Creating cluster cockroachdb...done.
     ~~~
 
-    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` and `--num-nodes` flags specify a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) with one node in each zone.
+    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` flag specifies a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster), and `--num-nodes` specifies one node in each zone.
 
     The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
 

--- a/_includes/v20.2/orchestration/start-kubernetes.md
+++ b/_includes/v20.2/orchestration/start-kubernetes.md
@@ -6,7 +6,7 @@ Choose whether you want to orchestrate CockroachDB with Kubernetes using the hos
 - [Manual AWS](#manual-aws)
 
 {{site.data.alerts.callout_info}}
-The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
+The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](../{{site.versions["stable"]}}/deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
 {{site.data.alerts.end}}
 
 ### Hosted GKE

--- a/_includes/v21.1/orchestration/start-kubernetes.md
+++ b/_includes/v21.1/orchestration/start-kubernetes.md
@@ -34,7 +34,7 @@ The CockroachDB Kubernetes Operator is currently supported for GKE. You can also
     Creating cluster cockroachdb...done.
     ~~~
 
-    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` and `--num-nodes` flags specify a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) with one node in each zone.
+    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` flag specifies a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster), and `--num-nodes` specifies one node in each zone.
 
     The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
 

--- a/_includes/v21.1/orchestration/start-kubernetes.md
+++ b/_includes/v21.1/orchestration/start-kubernetes.md
@@ -16,25 +16,27 @@ The CockroachDB Kubernetes Operator is currently supported for GKE. You can also
     This includes installing `gcloud`, which is used to create and delete Kubernetes Engine clusters, and `kubectl`, which is the command-line tool used to manage Kubernetes from your workstation.
 
     {{site.data.alerts.callout_success}}
-    Be sure to set a [default compute region and zone](https://cloud.google.com/kubernetes-engine/docs/quickstart#defaults) to use with `gcloud`. If no defaults are set, you will need to specify them with the `--region` and `--zone` flags when creating and deleting clusters.
-    {{site.data.alerts.end}}
-
-    {{site.data.alerts.callout_success}}
     The documentation offers the choice of using Google's Cloud Shell product or using a local shell on your machine. Choose to use a local shell if you want to be able to view the DB Console using the steps in this guide.
     {{site.data.alerts.end}}
 
-2. From your local workstation, start the Kubernetes cluster:
+2. From your local workstation, start the Kubernetes cluster, specifying one of the available [regions](https://cloud.google.com/compute/docs/regions-zones#available) (e.g., `us-east1`):
+
+    {{site.data.alerts.callout_success}}
+    Since this region can differ from your default `gcloud` region, be sure to include the `--region` flag to run `gcloud` commands against this cluster.
+    {{site.data.alerts.end}}
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ gcloud container clusters create cockroachdb --machine-type n2-standard-4
+    $ gcloud container clusters create cockroachdb --machine-type n2-standard-4 --region {region-name} --num-nodes 1
     ~~~
 
     ~~~
     Creating cluster cockroachdb...done.
     ~~~
 
-    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
+    This creates GKE instances and joins them into a single Kubernetes cluster named `cockroachdb`. The `--region` and `--num-nodes` flags specify a [regional three-zone cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-regional-cluster) with one node in each zone.
+
+    The `--machine-type` flag tells the node pool to use the [`n2-standard-4`](https://cloud.google.com/compute/docs/machine-types#standard_machine_types) machine type (4 vCPUs, 16 GB memory), which meets our [recommended CPU and memory configuration](recommended-production-settings.html#basic-hardware-recommendations).
 
     The process can take a few minutes, so do not move on to the next step until you see a `Creating cluster cockroachdb...done` message and details about your cluster.
 

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -156,7 +156,7 @@ To shut down the CockroachDB cluster:
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ gcloud container clusters delete cockroachdb
+        $ gcloud container clusters delete cockroachdb --region {region-name}
         ~~~
     - Hosted EKS:
 

--- a/v20.1/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v20.1/orchestrate-cockroachdb-with-kubernetes.md
@@ -471,7 +471,7 @@ To shut down the CockroachDB cluster:
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ gcloud container clusters delete cockroachdb
+        $ gcloud container clusters delete cockroachdb --region {region-name}
         ~~~
     - Hosted EKS:
 

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes-insecure.md
@@ -151,7 +151,7 @@ To shut down the CockroachDB cluster:
 
         {% include copy-clipboard.html %}
         ~~~ shell
-        $ gcloud container clusters delete cockroachdb
+        $ gcloud container clusters delete cockroachdb --region {region-name}
         ~~~
     - Hosted EKS:
 

--- a/v20.2/orchestrate-cockroachdb-with-kubernetes.md
+++ b/v20.2/orchestrate-cockroachdb-with-kubernetes.md
@@ -135,7 +135,7 @@ To delete the Kubernetes cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ gcloud container clusters delete cockroachdb
+    $ gcloud container clusters delete cockroachdb --region {region-name}
     ~~~
 - Hosted EKS:
 

--- a/v21.1/deploy-cockroachdb-with-kubernetes.md
+++ b/v21.1/deploy-cockroachdb-with-kubernetes.md
@@ -108,7 +108,7 @@ To delete the Kubernetes cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ gcloud container clusters delete cockroachdb
+    $ gcloud container clusters delete cockroachdb --region {region-name}
     ~~~
 - Hosted EKS:
 


### PR DESCRIPTION
Addresses #10479 for single-region deployments.

Also removed the callout about defining a default `gcloud` region/zone, since a regional cluster requires an explicit `--region` flag and it would send a mixed message to also define an unrelated default region.

The multi-region GKE doc needs a deeper overhaul. I didn't update it because parts of the Python script used in that doc appear to reference zone values, and I'm not sure whether they would be broken by specifying a regional cluster.