### PR TITLE
Updated URLs for simple-crud-python-sqlalchemy repo

### DIFF
--- a/v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v19.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -80,7 +80,7 @@ Copy the code below or
 {{site.data.alerts.callout_success}}
 To clone a version of the code below that connects to insecure clusters, run the command below. Note that you will need to edit the connection string to use the certificates that you generated when you set up your secure cluster.
 
-`git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/`
+`git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/`
 {{site.data.alerts.end}}
 
 {% include copy-clipboard.html %}
@@ -181,11 +181,11 @@ It does all of the above using the practices we recommend for using SQLAlchemy w
 You must use the `cockroachdb://` prefix in the URL passed to [`sqlalchemy.create_engine`](https://docs.sqlalchemy.org/en/latest/core/engines.html?highlight=create_engine#sqlalchemy.create_engine) to make sure the [`cockroachdb`](https://github.com/cockroachdb/sqlalchemy-cockroachdb) dialect is used. Using the `postgres://` URL prefix to connect to your CockroachDB cluster will not work.
 {{site.data.alerts.end}}
 
-To get the code below, clone the `hello-world-python-sqlalchemy` repo to your machine:
+To get the code below, clone the `simple-crud-python-sqlalchemy` repo to your machine:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/
+git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v19.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v19.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -81,7 +81,7 @@ Copy the code below or
 {{site.data.alerts.callout_success}}
 To clone a version of the code below that connects to insecure clusters, run the command below. Note that you will need to edit the connection string to use the certificates that you generated when you set up your secure cluster.
 
-`git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/`
+`git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/`
 {{site.data.alerts.end}}
 
 {% include copy-clipboard.html %}
@@ -182,11 +182,11 @@ It does all of the above using the practices we recommend for using SQLAlchemy w
 You must use the `cockroachdb://` prefix in the URL passed to [`sqlalchemy.create_engine`](https://docs.sqlalchemy.org/en/latest/core/engines.html?highlight=create_engine#sqlalchemy.create_engine) to make sure the [`cockroachdb`](https://github.com/cockroachdb/sqlalchemy-cockroachdb) dialect is used. Using the `postgres://` URL prefix to connect to your CockroachDB cluster will not work.
 {{site.data.alerts.end}}
 
-To get the code below, clone the `hello-world-python-sqlalchemy` repo to your machine:
+To get the code below, clone the `simple-crud-python-sqlalchemy` repo to your machine:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/
+git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v20.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -75,7 +75,7 @@ If you prefer, you can also clone a version of the code:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/
+$ git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v20.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v20.2/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -76,7 +76,7 @@ If you prefer, you can also clone a version of the code:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/
+$ git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/
 ~~~
 
 {% include copy-clipboard.html %}

--- a/v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
+++ b/v21.1/build-a-python-app-with-cockroachdb-sqlalchemy.md
@@ -76,7 +76,7 @@ If you prefer, you can also clone a version of the code:
 
 {% include copy-clipboard.html %}
 ~~~ shell
-$ git clone https://github.com/cockroachlabs/hello-world-python-sqlalchemy/
+$ git clone https://github.com/cockroachlabs/simple-crud-python-sqlalchemy/
 ~~~
 
 {% include copy-clipboard.html %}


### PR DESCRIPTION
Updating the external links to the https://github.com/cockroachlabs/simple-crud-python-sqlalchemy repo (the original repo has been renamed).

I'll add remote-includes and the relevant docs updates in a forthcoming PR.