### PR TITLE
Removed restore_node_concurrency setting from the release notes

### DIFF
--- a/releases/v21.1.3.md
+++ b/releases/v21.1.3.md
@@ -97,12 +97,10 @@ $ docker pull cockroachdb/cockroach:v21.1.3
 ### Performance improvements
 
 - Fixed an issue in the optimizer that prevented spatial predicates of the form `(column && value) = true` from being index-accelerated. These queries can now use a [spatial index](../v21.1/spatial-indexes.html) if one is available. [#65986][#65986]
-- A new setting `kv.bulk_io_write.restore_node_concurrency` controls the concurrency per restore worker. This enables more concurrent calls to `AddSSTable`, which can be bottlenecked by the cluster setting `kv.bulk_io_write.concurrent_addsstable_requests`. [#66022][#66022] {% comment %}doc{% endcomment %}
 - The optimizer is now more efficient when planning queries on tables that have many columns and indexes. [#66304][#66304]
 - The `COCKROACHDB_REGISTRY` file is no longer rewritten whenever a new unencrypted file is created. [#66423][#66423] {% comment %}doc{% endcomment %}
 - After improvements, queries use up to 1MB less system memory per scan, [lookup join, index join, zigzag join, or inverted join](../v21.1/joins.html) in their query plans. This will result in improved memory performance for workloads with concurrent OLAP-style queries. [#66145][#66145]
 - Made improvements to prevent intra-query leaks during disk spilling that could cause the database to run out of memory, especially on tables with wide rows. [#66145][#66145]
-
 
 ### Contributors
 


### PR DESCRIPTION
Closes #10838 

Removing this cluster setting mention from the release notes as per @pbardea:

"the cluster setting was renamed to kv.bulk_io_write.experimental_restore_node_concurrency and the renaming was missed in the release notes (there’s a GH issue tracking to update the name in the release notes). It’s not a publicly documented cluster setting because increasing it on memory-constrained clusters could OOM the cluster as there aren’t safeguards put in place yet (it was backported for a couple of customers that verified that they had enough memory overhead to use the setting)."

