### PR TITLE
document network logging use case

### DIFF
--- a/v21.1/configure-logs.md
+++ b/v21.1/configure-logs.md
@@ -34,24 +34,24 @@ All log settings for a `cockroach` command are specified with a YAML payload in 
 
 - Block format, where each parameter is written on a separate line. For example, after creating a file `logs.yaml`, pass the YAML values with either `--log-config-file` or `--log`:
 
-  {% include_cached copy-clipboard.html %}
-  ~~~ shell
-  $ cockroach start-single-node --certs-dir=certs --log-config-file=logs.yaml
-  ~~~
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ cockroach start-single-node --certs-dir=certs --log-config-file=logs.yaml
+    ~~~
 
-  {% include_cached copy-clipboard.html %}
-	~~~ shell
-	$ cockroach start-single-node --certs-dir=certs --log="$(cat logs.yaml)"
-	~~~
+    {% include_cached copy-clipboard.html %}
+  	~~~ shell
+  	$ cockroach start-single-node --certs-dir=certs --log="$(cat logs.yaml)"
+  	~~~
 
 - Inline format, where all parameters are specified on one line. For example, to generate an `ops` log file that collects the `OPS` and `HEALTH` channels (overriding the file groups defined for those channels in the [default configuration](#default-logging-configuration)):
 
-  {% include_cached copy-clipboard.html %}
-	~~~ shell
-	$ cockroach start-single-node --certs-dir=certs --log="sinks: {file-groups: {ops: {channels: [OPS, HEALTH]}}}"
-	~~~
+    {% include_cached copy-clipboard.html %}
+  	~~~ shell
+  	$ cockroach start-single-node --certs-dir=certs --log="sinks: {file-groups: {ops: {channels: [OPS, HEALTH]}}}"
+  	~~~
 
-	Note that the inline spaces must be preserved.
+  	Note that the inline spaces must be preserved.
 
 For clarity, this article uses the block format to describe the YAML payload, which has the overall structure:
 
@@ -179,6 +179,10 @@ sinks:
     ...
 ~~~
 
+{{site.data.alerts.callout_info}}
+A network sink can be listed more than once with different `address` values. This routes the same logs to different Fluentd servers.
+{{site.data.alerts.end}}
+
 Fluentd servers accept the following parameters along with the [common sink parameters](#common-sink-parameters).
 
 | Parameter | Description                                                                                                        |
@@ -188,6 +192,8 @@ Fluentd servers accept the following parameters along with the [common sink para
 | `net`     | Network protocol to use. Can be `tcp`, `tcp4`, `tcp6`, `udp`, `udp4`, `udp6`, or `unix`.<br><br>**Default:** `tcp` |
 
 Further details about the network implementation are in [log sinks](log-sinks.html#output-to-fluentd-compatible-log-collectors).
+
+For an example network logging configuration, see [Logging use cases](logging-use-cases.html#network-logging).
 
 ### Output to `stderr`
 

--- a/v21.1/logging-use-cases.md
+++ b/v21.1/logging-use-cases.md
@@ -420,11 +420,15 @@ sinks:
       channels: [SESSIONS, USER_ADMIN, PRIVILEGES, SENSITIVE_ACCESS]
       address: 127.0.0.1:5170 
       net: tcp
-      redact: false
       auditable: true
 ~~~
 
-In this case, defining separate `ops` and `security` network sinks allows us to [enable redaction](configure-logs.html#redact-logs) on the `ops` logs. Otherwise, it is generally more flexible to [configure Fluentd to route logs](https://docs.fluentd.org/configuration/routing-examples) to different destinations.
+In this case, defining separate `ops` and `security` network sinks allows us to:
+
+ - [Enable redaction](configure-logs.html#redact-logs) on the `ops` logs.
+ - Configure the `security` logs as [`auditable`](#security-and-audit-monitoring).
+
+Otherwise, it is generally more flexible to [configure Fluentd to route logs](https://docs.fluentd.org/configuration/routing-examples) to different destinations.
 
 By default, `fluent-servers` log messages use the [`json-fluent-compact`](log-formats.html#format-json-fluent-compact) format for ease of processing over a stream.
 


### PR DESCRIPTION
Enhanced the network logging docs. (Couldn't find an issue on this, though the task was outstanding.)

This was originally planned to be a tutorial on sending logs to a Fluentd server and collecting them with an external tool. After discussion with @thtruo, it seems that adding a section to the Logging Use Cases doc should be sufficient to cover the CRDB functionality. Instructing the user on their Fluentd configuration is beyond the scope of our docs.

Also fixes #10898.