### PR TITLE
remove 'beta' messaging; add missing filter toggles

### DIFF
--- a/v21.1/deploy-cockroachdb-with-kubernetes.md
+++ b/v21.1/deploy-cockroachdb-with-kubernetes.md
@@ -60,7 +60,7 @@ Feature | Description
 Choose how you want to deploy and maintain the CockroachDB cluster.
 
 {{site.data.alerts.callout_info}}
-The [CockroachDB Kubernetes Operator](https://github.com/cockroachdb/cockroach-operator) eases CockroachDB cluster creation and management on a single Kubernetes cluster. The Operator is currently in **beta** and is not yet production-ready.
+The [CockroachDB Kubernetes Operator](https://github.com/cockroachdb/cockroach-operator) eases CockroachDB cluster creation and management on a single Kubernetes cluster.
 
 Note that the Operator does not provision or apply an enterprise license key. To use [enterprise features](enterprise-licensing.html) with the Operator, [set a license](licensing-faqs.html#set-a-license) in the SQL shell.
 {{site.data.alerts.end}}

--- a/v21.1/monitor-cockroachdb-kubernetes.md
+++ b/v21.1/monitor-cockroachdb-kubernetes.md
@@ -11,6 +11,12 @@ This article assumes you have already [deployed CockroachDB on a single Kubernet
 
 Despite CockroachDB's various [built-in safeguards against failure](architecture/replication-layer.html), it is critical to actively monitor the overall health and performance of a cluster running in production and to create alerting rules that promptly send notifications when there are events that require investigation or intervention.
 
+<div class="filters filters-big clearfix">
+    <button class="filter-button" data-scope="operator">Use Operator</button>
+    <button class="filter-button" data-scope="manual">Use Configs</button>
+    <button class="filter-button" data-scope="helm">Use Helm</button>
+</div>
+
 ## Configure Prometheus
 
 Every node of a CockroachDB cluster exports granular timeseries metrics formatted for easy integration with [Prometheus](https://prometheus.io/), an open source tool for storing, aggregating, and querying timeseries data. This section shows you how to orchestrate Prometheus as part of your Kubernetes cluster and pull these metrics into Prometheus for external monitoring.

--- a/v21.1/operate-cockroachdb-kubernetes.md
+++ b/v21.1/operate-cockroachdb-kubernetes.md
@@ -43,10 +43,6 @@ You can configure, scale, and upgrade a CockroachDB deployment on Kubernetes by 
 </div>
 
 <section class="filter-content" markdown="1" data-scope="operator">
-{{site.data.alerts.callout_info}}
-The Operator is currently in **beta** and is not yet production-ready.
-{{site.data.alerts.end}}
-
 {{site.data.alerts.callout_success}}
 If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html), substitute `kubectl` with `oc` in the following commands.
 {{site.data.alerts.end}}


### PR DESCRIPTION
Removing 'beta' messaging for Operator GA release tomorrow.

Also added missing filter goggles on the Monitoring K8s page.