### PR TITLE
IMPORT TABLE deprecation

### DIFF
--- a/_includes/v20.2/import-table-deprecate.md
+++ b/_includes/v20.2/import-table-deprecate.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+As of v21.2 `IMPORT TABLE` will be deprecated. We recommend using [`CREATE TABLE`](create-table.html) followed by [`IMPORT INTO`](import-into.html) to import data into a new table. For an example, read [Import into a new table from a CSV file](import-into.html#import-into-a-new-table-from-a-csv-file).
+{{site.data.alerts.end}}

--- a/_includes/v20.2/sql/use-import-into.md
+++ b/_includes/v20.2/sql/use-import-into.md
@@ -1,3 +1,5 @@
 {{site.data.alerts.callout_info}}
+As of v21.2 `IMPORT TABLE` will be deprecated. We recommend using [`CREATE TABLE`](create-table.html) followed by [`IMPORT INTO`](import-into.html) to import data into a new table. For an example, read [Import into a new table from a CSV file](import-into.html#import-into-a-new-table-from-a-csv-file).
+
 To import data into an existing table, use [`IMPORT INTO`](import-into.html).
 {{site.data.alerts.end}}

--- a/_includes/v21.1/import-table-deprecate.md
+++ b/_includes/v21.1/import-table-deprecate.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+As of v21.2 `IMPORT TABLE` will be deprecated. We recommend using [`CREATE TABLE`](create-table.html) followed by [`IMPORT INTO`](import-into.html) to import data into a new table. For an example, read [Import into a new table from a CSV file](import-into.html#import-into-a-new-table-from-a-csv-file).
+{{site.data.alerts.end}}

--- a/_includes/v21.1/sql/use-import-into.md
+++ b/_includes/v21.1/sql/use-import-into.md
@@ -1,3 +1,5 @@
 {{site.data.alerts.callout_info}}
+As of v21.2 `IMPORT TABLE` will be deprecated. We recommend using [`CREATE TABLE`](create-table.html) followed by [`IMPORT INTO`](import-into.html) to import data into a new table. For an example, read [Import into a new table from a CSV file](import-into.html#import-into-a-new-table-from-a-csv-file).
+
 To import data into an existing table, use [`IMPORT INTO`](import-into.html).
 {{site.data.alerts.end}}

--- a/v20.2/import-into.md
+++ b/v20.2/import-into.md
@@ -8,7 +8,7 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimit
 
 ## Considerations
 
-- `IMPORT INTO` only works for existing tables. To import data into new tables, see [`IMPORT`](import.html).
+- `IMPORT INTO` works for existing tables. To import data into new tables, read the following [example](#import-into-a-new-table-from-a-csv-file).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
 - `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` is an insert-only statement; it cannot be used to update existing rows—see [`UPDATE`](update.html). Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
@@ -170,9 +170,38 @@ The following provide connection examples to cloud storage providers. For more i
 
 <section class="filter-content" markdown="1" data-scope="s3">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the **default** `AUTH=specified` parameter. For more detail on how to use `implicit` authentication with Amazon S3 buckets, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+
+### Import into a new table from a CSV file
+
+To import into a new table, use [`CREATE TABLE`](create-table.html) followed by `IMPORT INTO`.
+
+{{site.data.alerts.callout_info}}
+Note that as of v21.2 [`IMPORT TABLE`](import.html) will be deprecated; therefore, we recommend using the following example to import data into a new table.
 {{site.data.alerts.end}}
+
+First, create the new table with the necessary columns and data types:
+
+{% include copy-clipboard.html %}
+~~~sql
+CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        city STRING,
+        name STRING,
+        address STRING,
+        credit_card STRING
+      );
+~~~
+
+Next, use `IMPORT INTO` to import the data into the new table:
+
+{% include copy-clipboard.html %}
+~~~sql
+IMPORT INTO users (id, city, name, address, credit_card)
+     CSV DATA (
+       's3://{BUCKET NAME}/{customers.csv}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+     );
+~~~
 
 ### Import into an existing table from a CSV file
 
@@ -234,6 +263,37 @@ For more detailed information about importing data from Avro and examples, see [
 </section>
 
 <section class="filter-content" markdown="1" data-scope="azure">
+
+### Import into a new table from a CSV file
+
+To import into a new table, use [`CREATE TABLE`](create-table.html) followed by `IMPORT INTO`.
+
+{{site.data.alerts.callout_info}}
+Note that as of v21.2 [`IMPORT TABLE`](import.html) will be deprecated; therefore, we recommend using the following example to import data into a new table.
+{{site.data.alerts.end}}
+
+First, create the new table with the necessary columns and data types:
+
+{% include copy-clipboard.html %}
+~~~sql
+CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        city STRING,
+        name STRING,
+        address STRING,
+        credit_card STRING
+      );
+~~~
+
+Next, use `IMPORT INTO` to import the data into the new table:
+
+{% include copy-clipboard.html %}
+~~~sql
+IMPORT INTO users (id, city, name, address, credit_card)
+     CSV DATA (
+       'azure://{CONTAINER NAME}/{customers.csv}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
+     );
+~~~
 
 ### Import into an existing table from a CSV file
 
@@ -297,9 +357,38 @@ For more detailed information about importing data from Avro and examples, see [
 
 <section class="filter-content" markdown="1" data-scope="gcs">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+
+### Import into a new table from a CSV file
+
+To import into a new table, use [`CREATE TABLE`](create-table.html) followed by `IMPORT INTO`.
+
+{{site.data.alerts.callout_info}}
+Note that as of v21.2 [`IMPORT TABLE`](import.html) will be deprecated; therefore, we recommend using the following example to import data into a new table.
 {{site.data.alerts.end}}
+
+First, create the new table with the necessary columns and data types:
+
+{% include copy-clipboard.html %}
+~~~sql
+CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        city STRING,
+        name STRING,
+        address STRING,
+        credit_card STRING
+      );
+~~~
+
+Next, use `IMPORT INTO` to import the data into the new table:
+
+{% include copy-clipboard.html %}
+~~~sql
+IMPORT INTO users (id, city, name, address, credit_card)
+     CSV DATA (
+       'gs://{BUCKET NAME}/{customers.csv}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
+     );
+~~~
 
 ### Import into an existing table from a CSV file
 

--- a/v20.2/import-performance-best-practices.md
+++ b/v20.2/import-performance-best-practices.md
@@ -65,6 +65,8 @@ However, `MYSQLDUMP` and `PGDUMP` run a single thread to parse their data, and t
 - [Provide the table schema in-line](#provide-the-table-schema-in-line)
 - [Import the schema separately from the data](#import-the-schema-separately-from-the-data)
 
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
 ### Provide the table schema in-line
 
 When importing bundled data formats, it is often faster to provide schema for the imported table in-line. For example, instead of importing both the table schema and data from the same file:

--- a/v20.2/import.md
+++ b/v20.2/import.md
@@ -13,13 +13,15 @@ The `IMPORT` [statement](sql-statements.html) imports the following types of dat
 - [CockroachDB dump files](cockroach-dump.html)
 - [Delimited data files](#delimited-data-files)
 
-{{site.data.alerts.callout_success}}
-`IMPORT` only works for creating new tables. For information on how to import into existing tables, see [`IMPORT INTO`](import-into.html). Also, for instructions and working examples on how to migrate data from other databases, see the [Migration Overview](migration-overview.html).
-{{site.data.alerts.end}}
+## Considerations
 
-{{site.data.alerts.callout_danger}}
-`IMPORT` is a blocking statement and cannot be used within a [transaction](transactions.html). Also, `IMPORT` cannot be used during a [rolling upgrade](upgrade-cockroach-version.html).
-{{site.data.alerts.end}}
+- `IMPORT` only works for creating new tables. For information on how to import into existing tables, see [`IMPORT INTO`](import-into.html). Also, for instructions and working examples on how to migrate data from other databases, see the [Migration Overview](migration-overview.html).
+
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
+- `IMPORT` is a blocking statement and cannot be used within a [transaction](transactions.html).
+- `IMPORT` cannot be used during a [rolling upgrade](upgrade-cockroach-version.html).
+- <span class="version-tag">New in v20.2:</span> `IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead.
 
 ## Required privileges
 
@@ -117,13 +119,13 @@ Before using `IMPORT`, you should have:
 - The schema of the table you want to import.
 - The data you want to import, preferably hosted on cloud storage. This location must be equally accessible to all nodes using the same import file location.  This is necessary because the `IMPORT` statement is issued once by the client, but is executed concurrently across all nodes of the cluster.  For more information, see the [Import file location](#import-file-location) section below.
 
-{{site.data.alerts.callout_info}}
-<span class="version-tag">New in v20.2:</span> `IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead. </span>
-{{site.data.alerts.end}}
+Refer to [Considerations](#considerations) when running an `IMPORT` for further information.
 
 ### Import targets
 
-Imported tables must not exist and must be created in the `IMPORT` statement. If the table you want to import already exists, you must drop it with [`DROP TABLE`](drop-table.html) or use [`IMPORT INTO`](import-into.html).
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
+To use `IMPORT` in v21.1 and prior, imported tables must not exist and must be created in the `IMPORT` statement. If the table you want to import already exists, you must drop it with [`DROP TABLE`](drop-table.html) or use [`IMPORT INTO`](import-into.html).
 
 You can specify the target database in the table name in the `IMPORT` statement. If it's not specified there, the active database in the SQL session is used.
 
@@ -134,6 +136,8 @@ Your `IMPORT` statement must reference a `CREATE TABLE` statement representing t
 - Specify the table's columns explicitly from the [SQL client](cockroach-sql.html). For an example, see [Import a table from a CSV file](#import-a-table-from-a-csv-file) below.
 
 - Load a file that already contains a `CREATE TABLE` statement. For an example, see [Import a Postgres database dump](#import-a-postgres-database-dump) below.
+
+- **Recommended**: Since `IMPORT TABLE` will be deprecated from v21.2, use [`CREATE TABLE`](create-table.html) followed by [`IMPORT INTO`](import-into.html). For an example, see [Import into a new table from a CSV file](import-into.html##import-into-a-new-table-from-a-csv-file).
 
 We also recommend [specifying all secondary indexes you want to use in the `CREATE TABLE` statement](create-table.html#create-a-table-with-secondary-and-inverted-indexes). It is possible to [add secondary indexes later](create-index.html), but it is significantly faster to specify them during import.
 
@@ -183,6 +187,8 @@ If initiated correctly, the statement returns when the import is finished or if 
 
 The following provide connection examples to cloud storage providers. For more information on connecting to different storage options, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
 
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
 <div class="filters clearfix">
   <button class="filter-button" data-scope="s3">Amazon S3</button>
   <button class="filter-button" data-scope="azure">Azure Storage</button>
@@ -191,9 +197,7 @@ The following provide connection examples to cloud storage providers. For more i
 
 <section class="filter-content" markdown="1" data-scope="s3">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the **default** `AUTH=specified` parameter. For more detail on how to use `implicit` authentication with Amazon S3 buckets, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
-{{site.data.alerts.end}}
 
 ### Import a table from a CSV file
 
@@ -837,9 +841,7 @@ For more detailed information about importing data from Avro and examples, see [
 
 <section class="filter-content" markdown="1" data-scope="gcs">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
-{{site.data.alerts.end}}
 
 ### Import a table from a CSV file
 

--- a/v21.1/import-into.md
+++ b/v21.1/import-into.md
@@ -8,7 +8,7 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimit
 
 ## Considerations
 
-- `IMPORT INTO` only works for existing tables. To import data into new tables, use [`IMPORT`](import.html).
+- `IMPORT INTO` works for existing tables. To import data into new tables, read the following [example](#import-into-a-new-table-from-a-csv-file).
 - `IMPORT INTO` cannot be used within a [transaction](transactions.html) or during a [rolling upgrade](upgrade-cockroach-version.html).
 - `IMPORT INTO` invalidates all [foreign keys](foreign-key.html) on the target table. To validate the foreign key(s), use the [`VALIDATE CONSTRAINT`](validate-constraint.html) statement.
 - `IMPORT INTO` is an insert-only statement; it cannot be used to update existing rows—see [`UPDATE`](update.html). Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
@@ -172,9 +172,38 @@ The following provide connection examples to cloud storage providers. For more i
 
 <section class="filter-content" markdown="1" data-scope="s3">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the **default** `AUTH=specified` parameter. For more detail on how to use `implicit` authentication with Amazon S3 buckets, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+
+### Import into a new table from a CSV file
+
+To import into a new table, use [`CREATE TABLE`](create-table.html) followed by `IMPORT INTO`.
+
+{{site.data.alerts.callout_info}}
+Note that as of v21.2 [`IMPORT TABLE`](import.html) will be deprecated; therefore, we recommend using the following example to import data into a new table.
 {{site.data.alerts.end}}
+
+First, create the new table with the necessary columns and data types:
+
+{% include copy-clipboard.html %}
+~~~sql
+CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        city STRING,
+        name STRING,
+        address STRING,
+        credit_card STRING
+      );
+~~~
+
+Next, use `IMPORT INTO` to import the data into the new table:
+
+{% include copy-clipboard.html %}
+~~~sql
+IMPORT INTO users (id, city, name, address, credit_card)
+     CSV DATA (
+       's3://{BUCKET NAME}/{customers.csv}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+     );
+~~~
 
 ### Import into an existing table from a CSV file
 
@@ -236,6 +265,37 @@ For more detailed information about importing data from Avro and examples, see [
 </section>
 
 <section class="filter-content" markdown="1" data-scope="azure">
+
+### Import into a new table from a CSV file
+
+To import into a new table, use [`CREATE TABLE`](create-table.html) followed by `IMPORT INTO`.
+
+{{site.data.alerts.callout_info}}
+Note that as of v21.2 [`IMPORT TABLE`](import.html) will be deprecated; therefore, we recommend using the following example to import data into a new table.
+{{site.data.alerts.end}}
+
+First, create the new table with the necessary columns and data types:
+
+{% include copy-clipboard.html %}
+~~~sql
+CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        city STRING,
+        name STRING,
+        address STRING,
+        credit_card STRING
+      );
+~~~
+
+Next, use `IMPORT INTO` to import the data into the new table:
+
+{% include copy-clipboard.html %}
+~~~sql
+IMPORT INTO users (id, city, name, address, credit_card)
+     CSV DATA (
+       'azure://{CONTAINER NAME}/{customers.csv}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
+     );
+~~~
 
 ### Import into an existing table from a CSV file
 
@@ -299,9 +359,38 @@ For more detailed information about importing data from Avro and examples, see [
 
 <section class="filter-content" markdown="1" data-scope="gcs">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
+
+### Import into a new table from a CSV file
+
+To import into a new table, use [`CREATE TABLE`](create-table.html) followed by `IMPORT INTO`.
+
+{{site.data.alerts.callout_info}}
+Note that as of v21.2 [`IMPORT TABLE`](import.html) will be deprecated; therefore, we recommend using the following example to import data into a new table.
 {{site.data.alerts.end}}
+
+First, create the new table with the necessary columns and data types:
+
+{% include copy-clipboard.html %}
+~~~sql
+CREATE TABLE users (
+        id UUID PRIMARY KEY,
+        city STRING,
+        name STRING,
+        address STRING,
+        credit_card STRING
+      );
+~~~
+
+Next, use `IMPORT INTO` to import the data into the new table:
+
+{% include copy-clipboard.html %}
+~~~sql
+IMPORT INTO users (id, city, name, address, credit_card)
+     CSV DATA (
+       'gs://{BUCKET NAME}/{customers.csv}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
+     );
+~~~
 
 ### Import into an existing table from a CSV file
 

--- a/v21.1/import-performance-best-practices.md
+++ b/v21.1/import-performance-best-practices.md
@@ -65,6 +65,8 @@ However, `MYSQLDUMP` and `PGDUMP` run a single thread to parse their data, and t
 - [Provide the table schema in-line](#provide-the-table-schema-in-line)
 - [Import the schema separately from the data](#import-the-schema-separately-from-the-data)
 
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
 ### Provide the table schema in-line
 
 When importing bundled data formats, it is often faster to provide schema for the imported table in-line. For example, instead of importing both the table schema and data from the same file:

--- a/v21.1/import.md
+++ b/v21.1/import.md
@@ -13,21 +13,16 @@ The `IMPORT` [statement](sql-statements.html) imports the following types of dat
 - [CockroachDB dump files](cockroach-dump.html)
 - [Delimited data files](#delimited-data-files)
 
-{{site.data.alerts.callout_success}}
-`IMPORT` only works for creating new tables. For information on how to import into existing tables, see [`IMPORT INTO`](import-into.html). Also, for instructions and working examples on how to migrate data from other databases, see the [Migration Overview](migration-overview.html).
-{{site.data.alerts.end}}
+## Considerations
 
-{{site.data.alerts.callout_info}}
-`IMPORT` is a blocking statement. To run an import job asynchronously, use the `DETACHED` option. See the [options](#import-options) below.
-{{site.data.alerts.end}}
+- `IMPORT` only works for creating new tables. For information on how to import into existing tables, see [`IMPORT INTO`](import-into.html). Also, for instructions and working examples on how to migrate data from other databases, see the [Migration Overview](migration-overview.html).
 
-{{site.data.alerts.callout_danger}}
-`IMPORT` cannot be used within a [rolling upgrade](upgrade-cockroach-version.html).
-{{site.data.alerts.end}}
+{% include {{ page.version.version }}/import-table-deprecate.md %}
 
-{{site.data.alerts.callout_danger}}
-{% include {{page.version.version}}/sql/import-into-regional-by-row-table.md %}
-{{site.data.alerts.end}}
+- `IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead.
+- `IMPORT` is a blocking statement. To run an import job asynchronously, use the [`DETACHED`](#options-detached) option.
+- `IMPORT` cannot be used within a [rolling upgrade](upgrade-cockroach-version.html).
+- {% include {{page.version.version}}/sql/import-into-regional-by-row-table.md %}
 
 ## Required privileges
 
@@ -114,7 +109,7 @@ Key                 | <div style="width:130px">Context</div> | Value            
 `data_as_json_records` | `AVRO DATA`    | Use when [importing a JSON file containing Avro records](migrate-from-avro.html#import-binary-or-json-records). The schema is not included in the file, so you need to specify the schema with either the `schema` or `schema_uri` option.
 `schema`               | `AVRO DATA`    | The schema of the Avro records included in the binary or JSON file. This is not needed for Avro OCF.
 `schema_uri`           | `AVRO DATA`    | The URI of the file containing the schema of the Avro records include in the binary or JSON file. This is not needed for Avro OCF.
-`DETACHED`             | N/A            | <span class="version-tag">New in v21.1:</span> When an import runs in `DETACHED` mode, it will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. For more on the differences between the returned job data, see the [example](import.html#run-an-import-within-a-transaction) below. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run an import within a [transaction](transactions.html), use the `DETACHED` option.
+<a name="options-detached"></a>`DETACHED`             | N/A            | <span class="version-tag">New in v21.1:</span> When an import runs in `DETACHED` mode, it will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. For more on the differences between the returned job data, see the [example](import.html#run-an-import-within-a-transaction) below. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run an import within a [transaction](transactions.html), use the `DETACHED` option.
 
 For examples showing how to use these options, see the [Examples](#examples) section below.
 
@@ -129,13 +124,13 @@ Before using `IMPORT`, you should have:
 - The schema of the table you want to import.
 - The data you want to import, preferably hosted on cloud storage. This location must be equally accessible to all nodes using the same import file location.  This is necessary because the `IMPORT` statement is issued once by the client, but is executed concurrently across all nodes of the cluster.  For more information, see the [Import file location](#import-file-location) section below.
 
-{{site.data.alerts.callout_info}}
-`IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead. </span>
-{{site.data.alerts.end}}
+Refer to [Considerations](#considerations) when running an `IMPORT` for further information.
 
 ### Import targets
 
-Imported tables must not exist and must be created in the `IMPORT` statement. If the table you want to import already exists, you must drop it with [`DROP TABLE`](drop-table.html) or use [`IMPORT INTO`](import-into.html).
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
+To use `IMPORT` in v21.1 and prior, imported tables must not exist and must be created in the `IMPORT` statement. If the table you want to import already exists, you must drop it with [`DROP TABLE`](drop-table.html) or use [`IMPORT INTO`](import-into.html).
 
 You can specify the target database in the table name in the `IMPORT` statement. If it's not specified there, the active database in the SQL session is used.
 
@@ -146,6 +141,8 @@ Your `IMPORT` statement must reference a `CREATE TABLE` statement representing t
 - Specify the table's columns explicitly from the [SQL client](cockroach-sql.html). For an example, see [Import a table from a CSV file](#import-a-table-from-a-csv-file) below.
 
 - Load a file that already contains a `CREATE TABLE` statement. For an example, see [Import a Postgres database dump](#import-a-postgres-database-dump) below.
+
+- **Recommended**: Since `IMPORT TABLE` will be deprecated from v21.2, use [`CREATE TABLE`](create-table.html) followed by [`IMPORT INTO`](import-into.html). For an example, see [Import into a new table from a CSV file](import-into.html##import-into-a-new-table-from-a-csv-file).
 
 We also recommend [specifying all secondary indexes you want to use in the `CREATE TABLE` statement](create-table.html#create-a-table-with-secondary-and-inverted-indexes). It is possible to [add secondary indexes later](create-index.html), but it is significantly faster to specify them during import.
 
@@ -195,6 +192,8 @@ If initiated correctly, the statement returns when the import is finished or if 
 
 The following provide connection examples to cloud storage providers. For more information on connecting to different storage options, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
 
+{% include {{ page.version.version }}/import-table-deprecate.md %}
+
 <div class="filters clearfix">
   <button class="filter-button" data-scope="s3">Amazon S3</button>
   <button class="filter-button" data-scope="azure">Azure Storage</button>
@@ -203,9 +202,7 @@ The following provide connection examples to cloud storage providers. For more i
 
 <section class="filter-content" markdown="1" data-scope="s3">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the **default** `AUTH=specified` parameter. For more detail on how to use `implicit` authentication with Amazon S3 buckets, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
-{{site.data.alerts.end}}
 
 ### Import a table from a CSV file
 
@@ -887,9 +884,7 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 <section class="filter-content" markdown="1" data-scope="gcs">
 
-{{site.data.alerts.callout_info}}
 The examples in this section use the `AUTH=specified` parameter, which will be the default behavior in v21.2 and beyond for connecting to Google Cloud Storage. For more detail on how to pass your Google Cloud Storage credentials with this parameter, or, how to use `implicit` authentication, read [Use Cloud Storage for Bulk Operations — Authentication](use-cloud-storage-for-bulk-operations.html#authentication).
-{{site.data.alerts.end}}
 
 ### Import a table from a CSV file
 


### PR DESCRIPTION
Closes #10879 

Added a note through the import/import into docs referring to the deprecation and directing users to the recommended workflow. Included a `CREATE TABLE` -> `IMPORT INTO` example on the `IMPORT INTO` doc page and referred to this in the note. Have adjusted language where necessary to encourage readers toward the new workflow. 

There are a _lot_ of `IMPORT TABLE` examples across the docs that will need to be updated in future versions — suggest this overhaul happens in the 21.2 docs coming up. `IMPORT` and `IMPORT INTO` page will need an overhaul or shuffling of the examples.

Also adapted a note that was used across the migration docs referring to `IMPORT INTO` to include this deprecation notice.