### PR TITLE
Syntax typo in UPDATE query example

### DIFF
--- a/v21.1/set-locality.md
+++ b/v21.1/set-locality.md
@@ -88,7 +88,7 @@ To update an existing row's home region, use an [`UPDATE`](update.html) statemen
 
 {% include copy-clipboard.html %}
 ~~~ sql
-UPDATE {table} SET crdb_region = "eu-west" WHERE id IN (...)
+UPDATE {table} SET crdb_region = 'eu-west' WHERE id IN (...)
 ~~~
 
 To add a new row to a regional by row table, you must choose one of the following options.


### PR DESCRIPTION
I've testing the UPDATE query and when using double quotes, the command returns the following error:
```sql
ERROR: column "eu-west" does not exist
```
Just changing double quotes by single does the fix.