### PR TITLE
Update sitemap.xml script and add front matter to exclude pages

### DIFF
--- a/releases/v1.0-rc.1.md
+++ b/releases/v1.0-rc.1.md
@@ -1,7 +1,7 @@
 ---
-title: 'What&#39;s New in v1.0-rc.1'
+title: What&#39;s New in v1.0-rc.1
 toc: true
-summary: 'Additions and changes in CockroachDB version v1.0-rc.1'
+summary: Additions and changes in CockroachDB version v1.0-rc.1
 sitemap: false
 ---
 

--- a/releases/v1.0-rc.1.md
+++ b/releases/v1.0-rc.1.md
@@ -1,7 +1,8 @@
 ---
-title: What&#39;s New in v1.0-rc.1
+title: 'What&#39;s New in v1.0-rc.1'
 toc: true
-summary: Additions and changes in CockroachDB version v1.0-rc.1
+summary: 'Additions and changes in CockroachDB version v1.0-rc.1'
+sitemap: false
 ---
 
 ## May 1, 2017

--- a/releases/v1.0-rc.2.md
+++ b/releases/v1.0-rc.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0-rc.2
 toc: true
 summary: Additions and changes in CockroachDB version v1.0-rc.2
+sitemap: false
 ---
 
 ## May 5, 2017

--- a/releases/v1.0.1.md
+++ b/releases/v1.0.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.1
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.1
+sitemap: false
 ---
 
 ## May 25, 2017

--- a/releases/v1.0.2.md
+++ b/releases/v1.0.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.2
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.2
+sitemap: false
 ---
 
 ## Jun 15, 2017

--- a/releases/v1.0.3.md
+++ b/releases/v1.0.3.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.3
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.3
+sitemap: false
 ---
 
 ## Jul 6, 2017

--- a/releases/v1.0.4.md
+++ b/releases/v1.0.4.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.4
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.4
+sitemap: false
 ---
 
 ## Jul 27, 2017

--- a/releases/v1.0.5.md
+++ b/releases/v1.0.5.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.5
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.5
+sitemap: false
 ---
 
 ## Aug 24, 2017

--- a/releases/v1.0.6.md
+++ b/releases/v1.0.6.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.6
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.6
+sitemap: false
 ---
 
 ## Sep 14, 2017

--- a/releases/v1.0.7.md
+++ b/releases/v1.0.7.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0.7
 toc: true
 summary: Additions and changes in CockroachDB version v1.0.7
+sitemap: false
 ---
 
 ## Feb 13, 2017

--- a/releases/v1.0.md
+++ b/releases/v1.0.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.0
 toc: true
 summary: Additions and changes in CockroachDB version v1.0
+sitemap: false
 ---
 
 ## May 10, 2017

--- a/releases/v1.1-alpha.20170601.md
+++ b/releases/v1.1-alpha.20170601.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170601
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170601
+sitemap: false
 ---
 
 ## Jun 1, 2017

--- a/releases/v1.1-alpha.20170608.md
+++ b/releases/v1.1-alpha.20170608.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170608
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170608
+sitemap: false
 ---
 
 ## Jun 8, 2017

--- a/releases/v1.1-alpha.20170622.md
+++ b/releases/v1.1-alpha.20170622.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170622
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170622
+sitemap: false
 ---
 
 ## Jun 22, 2017

--- a/releases/v1.1-alpha.20170629.md
+++ b/releases/v1.1-alpha.20170629.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170629
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170629
+sitemap: false
 ---
 
 ## Jun 29, 2017

--- a/releases/v1.1-alpha.20170713.md
+++ b/releases/v1.1-alpha.20170713.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170713
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170713
+sitemap: false
 ---
 
 ## Jul 13, 2017

--- a/releases/v1.1-alpha.20170720.md
+++ b/releases/v1.1-alpha.20170720.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170720
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170720
+sitemap: false
 ---
 
 ## Jul 20, 2017

--- a/releases/v1.1-alpha.20170803.md
+++ b/releases/v1.1-alpha.20170803.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170803
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170803
+sitemap: false
 ---
 
 ## Aug 3, 2017

--- a/releases/v1.1-alpha.20170810.md
+++ b/releases/v1.1-alpha.20170810.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170810
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170810
+sitemap: false
 ---
 
 ## Aug 10, 2017

--- a/releases/v1.1-alpha.20170817.md
+++ b/releases/v1.1-alpha.20170817.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-alpha.20170817
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-alpha.20170817
+sitemap: false
 ---
 
 ## Aug 17, 2017

--- a/releases/v1.1-beta.20170907.md
+++ b/releases/v1.1-beta.20170907.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-beta.20170907
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-beta.20170907
+sitemap: false
 ---
 
 ## Sep 7, 2017

--- a/releases/v1.1-beta.20170921.md
+++ b/releases/v1.1-beta.20170921.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-beta.20170921
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-beta.20170921
+sitemap: false
 ---
 
 ## Sep 21, 2017

--- a/releases/v1.1-beta.20170928.md
+++ b/releases/v1.1-beta.20170928.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1-beta.20170928
 toc: true
 summary: Additions and changes in CockroachDB version v1.1-beta.20170928
+sitemap: false
 ---
 
 ## Sep 28, 2017

--- a/releases/v1.1.0-rc.1.md
+++ b/releases/v1.1.0-rc.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.0-rc.1
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.0-rc.1
+sitemap: false
 ---
 
 ## Oct 5, 2017

--- a/releases/v1.1.0.md
+++ b/releases/v1.1.0.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.0
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.0.
+sitemap: false
 ---
 
 ## Oct 12, 2017
@@ -45,6 +46,7 @@ This section summarizes the most significant user-facing changes in v1.1.0. For 
 ### Backwards-Incompatible Changes
 
 Change | Description
+sitemap: false
 -------|------------
 [`DROP DATABASE`](../v1.1/drop-database.html) | This statement no longer drops non-empty databases unless the `CASCADE` modifier is added.
 [`cockroach start`](../v1.1/start-a-node.html) | The `--max-sql-memory` and `--cache` flags now default to 128MiB instead of 25% of physical memory. These new defaults are reasonable for local development clusters. However, for production deployments, they should be increased to 25% or higher. See [Recommended Production Settings](../v1.1/recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details.<br><br>Also, if the server's own hostname cannot be resolved, CockroachDB reports an error at startup instead of starting a node that will be unable to participate in a cluster. Local test clusters may need to pass `--host=localhost` to avoid this error.
@@ -55,6 +57,7 @@ Change | Description
 ### SQL Statements
 
 Statement | Description
+sitemap: false
 ----------|------------
 [`IMPORT`](../v1.1/import.html) | Use this new statement to import an entire table's data into a running cluster by loading CSV files.
 [`SHOW QUERIES`](../v1.1/show-queries.html)<br>[`CANCEL QUERY`](../v1.1/cancel-query.html) | Use these new statements to monitor the progress of active queries, and, if necessary, cancel long-running queries causing unwanted resource consumption.
@@ -72,6 +75,7 @@ Statement | Description
 ### SQL Types
 
 Type | Description
+sitemap: false
 -----|------------
 [`ARRAY`](../v1.1/array.html) | Use this new data type to store 1-dimensional, 1-indexed, homogeneous arrays of any non-array data type.
 [`UUID`](../v1.1/uuid.html) | Use this new data type to store 128-bit values that are globally unique. This type is recommended for [auto-generating unique row IDs](../v1.1/uuid.html#create-a-table-with-auto-generated-unique-row-ids).
@@ -79,6 +83,7 @@ Type | Description
 ### Cockroach Commands
 
 Command | Description
+sitemap: false
 --------|------------
 [`init`](../v1.1/initialize-a-cluster.html) | Use this new command to perform a one-time initialization of a new multi-node cluster. For a full walk-through of the cluster startup and initialization process, see [Manual Deployment](../v1.1/manual-deployment.html) or one of the [Cloud Deployment](../v1.1/manual-deployment.html) tutorials.
 [`node decommission`](../v1.1/view-node-details.html)<br>[`node recommission`](../v1.1/view-node-details.html) | Use these new subcommands of `cockroach node` to decommission nodes for permanent removal or recommission nodes that were accidentally decommissioned. See [Remove Nodes](../v1.1/remove-nodes.html) for more details.
@@ -90,6 +95,7 @@ Command | Description
 ### Admin UI
 
 Area | Description
+sitemap: false
 -----|------------
 [Jobs Page](../v1.1/admin-ui-jobs-page.html) | This new page in the Admin UI shows the user, description, creation time, and status of each backup and restore job, as well as schema changes performed across all nodes in the cluster.
 [Nodes List](../v1.1/admin-ui-access-and-navigate.html#decommissioned-nodes) | Nodes that have been decommissioned for permanent removal are now listed in a separate table.
@@ -97,6 +103,7 @@ Area | Description
 ### Documentation
 
 Topic | Description
+sitemap: false
 ------|------------
 [CockroachDB Architecture](../v1.1/architecture/overview.html) | This new section of the documentation provides an introduction to CockroachDB internals, with detailed explanations of each layer of the software.
 [Admin UI](../v1.1/admin-ui-overview.html) | This new section of the documentation explains how to understand and use the Admin UI to monitor and optimize cluster performance.

--- a/releases/v1.1.0.md
+++ b/releases/v1.1.0.md
@@ -46,7 +46,6 @@ This section summarizes the most significant user-facing changes in v1.1.0. For 
 ### Backwards-Incompatible Changes
 
 Change | Description
-sitemap: false
 -------|------------
 [`DROP DATABASE`](../v1.1/drop-database.html) | This statement no longer drops non-empty databases unless the `CASCADE` modifier is added.
 [`cockroach start`](../v1.1/start-a-node.html) | The `--max-sql-memory` and `--cache` flags now default to 128MiB instead of 25% of physical memory. These new defaults are reasonable for local development clusters. However, for production deployments, they should be increased to 25% or higher. See [Recommended Production Settings](../v1.1/recommended-production-settings.html#cache-and-sql-memory-size-changed-in-v1-1) for more details.<br><br>Also, if the server's own hostname cannot be resolved, CockroachDB reports an error at startup instead of starting a node that will be unable to participate in a cluster. Local test clusters may need to pass `--host=localhost` to avoid this error.
@@ -57,7 +56,6 @@ sitemap: false
 ### SQL Statements
 
 Statement | Description
-sitemap: false
 ----------|------------
 [`IMPORT`](../v1.1/import.html) | Use this new statement to import an entire table's data into a running cluster by loading CSV files.
 [`SHOW QUERIES`](../v1.1/show-queries.html)<br>[`CANCEL QUERY`](../v1.1/cancel-query.html) | Use these new statements to monitor the progress of active queries, and, if necessary, cancel long-running queries causing unwanted resource consumption.
@@ -75,7 +73,6 @@ sitemap: false
 ### SQL Types
 
 Type | Description
-sitemap: false
 -----|------------
 [`ARRAY`](../v1.1/array.html) | Use this new data type to store 1-dimensional, 1-indexed, homogeneous arrays of any non-array data type.
 [`UUID`](../v1.1/uuid.html) | Use this new data type to store 128-bit values that are globally unique. This type is recommended for [auto-generating unique row IDs](../v1.1/uuid.html#create-a-table-with-auto-generated-unique-row-ids).
@@ -83,7 +80,6 @@ sitemap: false
 ### Cockroach Commands
 
 Command | Description
-sitemap: false
 --------|------------
 [`init`](../v1.1/initialize-a-cluster.html) | Use this new command to perform a one-time initialization of a new multi-node cluster. For a full walk-through of the cluster startup and initialization process, see [Manual Deployment](../v1.1/manual-deployment.html) or one of the [Cloud Deployment](../v1.1/manual-deployment.html) tutorials.
 [`node decommission`](../v1.1/view-node-details.html)<br>[`node recommission`](../v1.1/view-node-details.html) | Use these new subcommands of `cockroach node` to decommission nodes for permanent removal or recommission nodes that were accidentally decommissioned. See [Remove Nodes](../v1.1/remove-nodes.html) for more details.
@@ -95,7 +91,6 @@ sitemap: false
 ### Admin UI
 
 Area | Description
-sitemap: false
 -----|------------
 [Jobs Page](../v1.1/admin-ui-jobs-page.html) | This new page in the Admin UI shows the user, description, creation time, and status of each backup and restore job, as well as schema changes performed across all nodes in the cluster.
 [Nodes List](../v1.1/admin-ui-access-and-navigate.html#decommissioned-nodes) | Nodes that have been decommissioned for permanent removal are now listed in a separate table.
@@ -103,7 +98,6 @@ sitemap: false
 ### Documentation
 
 Topic | Description
-sitemap: false
 ------|------------
 [CockroachDB Architecture](../v1.1/architecture/overview.html) | This new section of the documentation provides an introduction to CockroachDB internals, with detailed explanations of each layer of the software.
 [Admin UI](../v1.1/admin-ui-overview.html) | This new section of the documentation explains how to understand and use the Admin UI to monitor and optimize cluster performance.

--- a/releases/v1.1.1.md
+++ b/releases/v1.1.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.1
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.1
+sitemap: false
 ---
 
 ## Oct 19, 2017

--- a/releases/v1.1.2.md
+++ b/releases/v1.1.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.2
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.2
+sitemap: false
 ---
 
 ## Nov 2, 2017

--- a/releases/v1.1.3.md
+++ b/releases/v1.1.3.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.3
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.3
+sitemap: false
 ---
 
 ## Nov 27, 2017

--- a/releases/v1.1.4.md
+++ b/releases/v1.1.4.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.4
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.4
+sitemap: false
 ---
 
 ## Jan 8, 2018

--- a/releases/v1.1.5.md
+++ b/releases/v1.1.5.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.5
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.5 since version v1.1.4.
+sitemap: false
 ---
 
 ## Feb 5, 2018

--- a/releases/v1.1.6.md
+++ b/releases/v1.1.6.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.6
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.6 since version v1.1.5
+sitemap: false
 ---
 
 ## March 12, 2018

--- a/releases/v1.1.7.md
+++ b/releases/v1.1.7.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.7
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.7 since version v1.1.6
+sitemap: false
 ---
 
 ## March 26, 2018

--- a/releases/v1.1.8.md
+++ b/releases/v1.1.8.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.8
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.8 since version v1.1.7
+sitemap: false
 ---
 
 ## April 23, 2018

--- a/releases/v1.1.9.md
+++ b/releases/v1.1.9.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.1.9
 toc: true
 summary: Additions and changes in CockroachDB version v1.1.9 since version v1.1.8
+sitemap: false
 ---
 
 ## October 1, 2018

--- a/releases/v1.2-alpha.20171026.md
+++ b/releases/v1.2-alpha.20171026.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.2-alpha.20171026
 toc: true
 summary: Additions and changes in CockroachDB version v1.2-alpha.20171026
+sitemap: false
 ---
 
 ## Oct 26, 2017

--- a/releases/v1.2-alpha.20171113.md
+++ b/releases/v1.2-alpha.20171113.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.2-alpha.20171113
 toc: true
 summary: Additions and changes in CockroachDB version v1.2-alpha.20171113
+sitemap: false
 ---
 
 ## Nov 13, 2017

--- a/releases/v1.2-alpha.20171204.md
+++ b/releases/v1.2-alpha.20171204.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.2-alpha.20171204
 toc: true
 summary: Additions and changes in CockroachDB version v1.2-alpha.20171204
+sitemap: false
 ---
 
 ## Dec 4, 2017

--- a/releases/v1.2-alpha.20171211.md
+++ b/releases/v1.2-alpha.20171211.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v1.2-alpha.20171211
 toc: true
 summary: Additions and changes in CockroachDB version v1.2-alpha.20171211
+sitemap: false
 ---
 
 ## Dec 11, 2017

--- a/releases/v19.1.0-beta.20190225.md
+++ b/releases/v19.1.0-beta.20190225.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-beta.20190225
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-beta.20190225 since version v2.2.0-alpha.20190211
+sitemap: false
 ---
 
 ## February 25, 2019

--- a/releases/v19.1.0-beta.20190304.md
+++ b/releases/v19.1.0-beta.20190304.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-beta.20190304
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-beta.20190304 since version v19.1.0-beta.20190225
+sitemap: false
 ---
 
 ## March 4, 2019

--- a/releases/v19.1.0-beta.20190318.md
+++ b/releases/v19.1.0-beta.20190318.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-beta.20190318
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-beta.20190318 since version v19.1.0-beta.20190304
+sitemap: false
 ---
 
 ## March 18, 2019

--- a/releases/v19.1.0-rc.1.md
+++ b/releases/v19.1.0-rc.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-rc.1
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-rc.1 since version v19.1.0-beta.20190318
+sitemap: false
 ---
 
 ## April 2, 2019

--- a/releases/v19.1.0-rc.2.md
+++ b/releases/v19.1.0-rc.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-rc.2
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-rc.2 since version v19.1.0-rc.1
+sitemap: false
 ---
 
 ## April 8, 2019

--- a/releases/v19.1.0-rc.3.md
+++ b/releases/v19.1.0-rc.3.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-rc.3
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-rc.3 since version v19.1.0-rc.2
+sitemap: false
 ---
 
 ## April 14, 2019

--- a/releases/v19.1.0-rc.4.md
+++ b/releases/v19.1.0-rc.4.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0-rc.4
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0-rc.4 since version v19.1.0-rc.3
+sitemap: false
 ---
 
 ## April 25, 2019

--- a/releases/v19.1.0.md
+++ b/releases/v19.1.0.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.0
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.0.
+sitemap: false
 ---
 
 ## April 30, 2019
@@ -59,6 +60,7 @@ This section summarizes the most significant user-facing changes in v19.1.0. For
 ### Managed service offering
 
 Feature | Description
+sitemap: false
 --------|------------
 [**Managed CockroachDB Console**](../cockroachcloud/quickstart.html) | Paid managed CockroachDB customers can now sign into their organization's account, view the connection string details, add and edit their list of allowed IPs on the management console.
 
@@ -67,6 +69,7 @@ Feature | Description
 These features require an [enterprise license](../v19.1/enterprise-licensing.html). Register for a 30-day trial license [here](https://www.cockroachlabs.com/get-cockroachdb/).
 
 Feature | Description
+sitemap: false
 --------|------------
 [**Encryption at Rest**](../v19.1/encryption.html#encryption-at-rest-enterprise) | Encryption at rest provides transparent encryption of a node's data on the local disk. This feature was introduced as experimental in v2.1 and is now ready for production use.
 [**GSSAPI with Kerberos Authentication**](../v19.1/gssapi_authentication.html) | CockroachDB now supports the Generic Security Services API (GSSAPI) with Kerberos authentication, which lets you use an external enterprise directory system that supports Kerberos, such as Active Directory.
@@ -79,6 +82,7 @@ Feature | Description
 These features are freely available in the core version and do not require an enterprise license.
 
 Feature | Description
+sitemap: false
 --------|------------
 [**Load-Based Splitting**](../v19.1/load-based-splitting.html) | CockroachDB now automatically splits frequently accessed keys into smaller ranges to optimize your cluster’s performance.
 [**Query Optimizer Hints**](../v19.1/cost-based-optimizer.html#join-hints) | The cost-based optimizer now supports hint syntax to force the use of merge, hash, or lookup joins. This let you override the cost-based optimizer's join algorithm selection in cases where you have information about your data that the cost-based optimizer does not yet have.
@@ -112,6 +116,7 @@ For information about limitations we've identified in CockroachDB v19.1, with su
 ### Documentation
 
 Topic | Description
+sitemap: false
 ------|------------
 **Geo-Partitioning** | Added a [video and tutorial on using geo-partitioning](../v19.1/demo-geo-partitioning.html) to get very fast reads and writes in a broadly distributed cluster.
 **Security** | Added an [overview of CockroachDB security](../v19.1/security-overview.html), with a dedicated page on [authentication](../v19.1/authentication.html), [encryption](../v19.1/encryption.html), [authorization](../v19.1/authorization.html), and [SQL audit logging](../v19.1/sql-audit-logging.html).

--- a/releases/v19.1.0.md
+++ b/releases/v19.1.0.md
@@ -60,7 +60,6 @@ This section summarizes the most significant user-facing changes in v19.1.0. For
 ### Managed service offering
 
 Feature | Description
-sitemap: false
 --------|------------
 [**Managed CockroachDB Console**](../cockroachcloud/quickstart.html) | Paid managed CockroachDB customers can now sign into their organization's account, view the connection string details, add and edit their list of allowed IPs on the management console.
 
@@ -69,7 +68,6 @@ sitemap: false
 These features require an [enterprise license](../v19.1/enterprise-licensing.html). Register for a 30-day trial license [here](https://www.cockroachlabs.com/get-cockroachdb/).
 
 Feature | Description
-sitemap: false
 --------|------------
 [**Encryption at Rest**](../v19.1/encryption.html#encryption-at-rest-enterprise) | Encryption at rest provides transparent encryption of a node's data on the local disk. This feature was introduced as experimental in v2.1 and is now ready for production use.
 [**GSSAPI with Kerberos Authentication**](../v19.1/gssapi_authentication.html) | CockroachDB now supports the Generic Security Services API (GSSAPI) with Kerberos authentication, which lets you use an external enterprise directory system that supports Kerberos, such as Active Directory.
@@ -82,7 +80,6 @@ sitemap: false
 These features are freely available in the core version and do not require an enterprise license.
 
 Feature | Description
-sitemap: false
 --------|------------
 [**Load-Based Splitting**](../v19.1/load-based-splitting.html) | CockroachDB now automatically splits frequently accessed keys into smaller ranges to optimize your cluster’s performance.
 [**Query Optimizer Hints**](../v19.1/cost-based-optimizer.html#join-hints) | The cost-based optimizer now supports hint syntax to force the use of merge, hash, or lookup joins. This let you override the cost-based optimizer's join algorithm selection in cases where you have information about your data that the cost-based optimizer does not yet have.
@@ -116,7 +113,6 @@ For information about limitations we've identified in CockroachDB v19.1, with su
 ### Documentation
 
 Topic | Description
-sitemap: false
 ------|------------
 **Geo-Partitioning** | Added a [video and tutorial on using geo-partitioning](../v19.1/demo-geo-partitioning.html) to get very fast reads and writes in a broadly distributed cluster.
 **Security** | Added an [overview of CockroachDB security](../v19.1/security-overview.html), with a dedicated page on [authentication](../v19.1/authentication.html), [encryption](../v19.1/encryption.html), [authorization](../v19.1/authorization.html), and [SQL audit logging](../v19.1/sql-audit-logging.html).

--- a/releases/v19.1.1.md
+++ b/releases/v19.1.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.1
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.1 since version v19.1.0
+sitemap: false
 ---
 
 ## May 20, 2019

--- a/releases/v19.1.10.md
+++ b/releases/v19.1.10.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.10
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.10 since version v19.1.9
+sitemap: false
 ---
 
 ## June 29, 2020

--- a/releases/v19.1.11.md
+++ b/releases/v19.1.11.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.11
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.11 since version v19.1.10
+sitemap: false
 ---
 
 ## July 7, 2020

--- a/releases/v19.1.2.md
+++ b/releases/v19.1.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.2
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.2 since version v19.1.1
+sitemap: false
 ---
 
 ## June 17, 2019

--- a/releases/v19.1.3.md
+++ b/releases/v19.1.3.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.3
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.3 since version v19.1.2
+sitemap: false
 ---
 
 ## July 15, 2019

--- a/releases/v19.1.4.md
+++ b/releases/v19.1.4.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.4
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.4 since version v19.1.3
+sitemap: false
 ---
 
 ## August 13, 2019

--- a/releases/v19.1.5.md
+++ b/releases/v19.1.5.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.5
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.5 since version v19.1.4
+sitemap: false
 ---
 
 ## September 30, 2019

--- a/releases/v19.1.6.md
+++ b/releases/v19.1.6.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.6
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.6 since version v19.1.5
+sitemap: false
 ---
 
 ## December 16, 2019

--- a/releases/v19.1.7.md
+++ b/releases/v19.1.7.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.7
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.7 since version v19.1.6
+sitemap: false
 ---
 
 ## January 27, 2020

--- a/releases/v19.1.8.md
+++ b/releases/v19.1.8.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.8
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.8 since version v19.1.7
+sitemap: false
 ---
 
 ## February 11, 2020

--- a/releases/v19.1.9.md
+++ b/releases/v19.1.9.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v19.1.9
 toc: true
 summary: Additions and changes in CockroachDB version v19.1.9 since version v19.1.8
+sitemap: false
 ---
 
 ## May 12, 2020

--- a/releases/v2.0-alpha.20171218.md
+++ b/releases/v2.0-alpha.20171218.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-alpha.20171218
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-alpha.20171218
+sitemap: false
 ---
 
 ## Dec 18, 2017

--- a/releases/v2.0-alpha.20180116.md
+++ b/releases/v2.0-alpha.20180116.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-alpha.20180116
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-alpha.20180116
+sitemap: false
 ---
 
 ## Jan 16, 2018

--- a/releases/v2.0-alpha.20180122.md
+++ b/releases/v2.0-alpha.20180122.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-alpha.20180122
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-alpha.20180122
+sitemap: false
 ---
 
 ## January 22, 2018

--- a/releases/v2.0-alpha.20180129.md
+++ b/releases/v2.0-alpha.20180129.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-alpha.20180129
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-alpha.20180129
+sitemap: false
 ---
 
 ## January 29, 2018

--- a/releases/v2.0-alpha.20180212.md
+++ b/releases/v2.0-alpha.20180212.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-alpha.20180212
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-alpha.20180212 since version v2.0-alpha.20180129
+sitemap: false
 ---
 
 ## February 12, 2018

--- a/releases/v2.0-beta.20180305.md
+++ b/releases/v2.0-beta.20180305.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-beta.20180305
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-beta.20180305
+sitemap: false
 ---
 
 ## March 05, 2018

--- a/releases/v2.0-beta.20180312.md
+++ b/releases/v2.0-beta.20180312.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-beta.20180312
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-beta.20180312 since version v2.0-beta.20180305
+sitemap: false
 ---
 
 ## March 12, 2018

--- a/releases/v2.0-beta.20180319.md
+++ b/releases/v2.0-beta.20180319.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-beta.20180319
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-beta.20180319 since version v2.0-beta.20180312
+sitemap: false
 ---
 
 ## March 19, 2018

--- a/releases/v2.0-beta.20180326.md
+++ b/releases/v2.0-beta.20180326.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-beta.20180326
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-beta.20180326 since version v2.0-beta.20180319
+sitemap: false
 ---
 
 ## March 26, 2018

--- a/releases/v2.0-rc.1.md
+++ b/releases/v2.0-rc.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0-rc.1
 toc: true
 summary: Additions and changes in CockroachDB version v2.0-rc.1 since version v2.0-beta.20180326.
+sitemap: false
 ---
 
 ## April 2, 2018

--- a/releases/v2.0.0.md
+++ b/releases/v2.0.0.md
@@ -46,7 +46,6 @@ This section summarizes the most significant user-facing changes in v2.0.0. For 
 These new features require an [enterprise license](../v2.0/enterprise-licensing.html). Register for a 30-day trial license [here](https://www.cockroachlabs.com/pricing/start-trial/).
 
 Feature | Description
-sitemap: false
 --------|------------
 [Table Partitioning](../v2.0/partitioning.html) | Table partitioning gives you row-level control of how and where your data is stored. This feature can be used to keep data close to users, thereby reducing latency, or to store infrequently-accessed data on slower and cheaper storage, thereby reducing costs.
 [Node Map](../v2.0/enable-node-map.html) | The **Node Map** in the Admin UI visualizes the geographical configuration of a multi-region cluster by plotting the node localities on a world map. This feature provides real-time cluster metrics, with the ability to drill down to individual nodes to monitor and troubleshoot cluster health and performance.
@@ -60,7 +59,6 @@ These new features are freely available in the core version and do not require a
 ### SQL
 
 Feature | Description
-sitemap: false
 --------|------------
 [JSON Support](../v2.0/demo-json-support.html) | The [`JSONB`](../v2.0/jsonb.html) data type and [inverted indexes](../v2.0/inverted-indexes.html) give you the flexibility to store and efficiently query  semi-structured data.
 [Sequences](../v2.0/create-sequence.html) | Sequences generate sequential integers according to defined rules. They are generally used for creating numeric primary keys.   
@@ -76,7 +74,6 @@ sitemap: false
 ### Operations
 
 Feature | Description
-sitemap: false
 --------|------------
 [Node Readiness Endpoint](../v2.0/monitoring-and-alerting.html#health-ready-1) | The new `/health?ready=1` endpoint returns an `HTTP 503 Service Unavailable` status response code with an error when a node is being decommissioned or is in the process of shutting down and is therefore not able to accept SQL connections and execute queries. This is especially useful for making sure [load balancers](../v2.0/recommended-production-settings.html#load-balancing) do not direct traffic to nodes that are live but not "ready", which is a necessary check during [rolling upgrades](../v2.0/upgrade-cockroach-version.html).
 [Node Decommissioning](../v2.0/remove-nodes.html) | Nodes that have been decommissioned and stopped no longer appear in Admin UI and command-line interface metrics.
@@ -87,7 +84,6 @@ sitemap: false
 ## Backward-Incompatible Changes
 
 Change | Description
-sitemap: false
 -------|------------
 Replication Zones | [Positive replication zone constraints](../v2.0/configure-replication-zones.html#replication-constraints) no longer work. Any existing positive constraints will be ignored. This change should not impact existing deployments since positive constraints have not been documented or supported for some time.
 Casts from `BYTES` to `STRING` | Casting between these types now works the same way as in PostgreSQL. New functions `encode()` and `decode()` are available to replace the former functionality.
@@ -105,7 +101,6 @@ For information about limitations we've identified in CockroachDB v2.0, with sug
 ## Documentation Updates
 
 Topic | Description
-sitemap: false
 ------|------------
 [Production Checklist](../v2.0/recommended-production-settings.html) | This topic now provides cloud-specific hardware, security, load balancing, monitoring and alerting, and clock synchronization recommendations as well as expanded cluster topology guidance. Related [deployment tutorials](../v2.0/manual-deployment.html) have been enhanced with much of this information as well.
 [Monitoring and Alerting](../v2.0/monitoring-and-alerting.html) | This new topic explains available tools for monitoring the overall health and performance of a cluster and critical events and metrics to alert on.

--- a/releases/v2.0.0.md
+++ b/releases/v2.0.0.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.0
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.0.
+sitemap: false
 ---
 
 ## April 4, 2018
@@ -45,6 +46,7 @@ This section summarizes the most significant user-facing changes in v2.0.0. For 
 These new features require an [enterprise license](../v2.0/enterprise-licensing.html). Register for a 30-day trial license [here](https://www.cockroachlabs.com/pricing/start-trial/).
 
 Feature | Description
+sitemap: false
 --------|------------
 [Table Partitioning](../v2.0/partitioning.html) | Table partitioning gives you row-level control of how and where your data is stored. This feature can be used to keep data close to users, thereby reducing latency, or to store infrequently-accessed data on slower and cheaper storage, thereby reducing costs.
 [Node Map](../v2.0/enable-node-map.html) | The **Node Map** in the Admin UI visualizes the geographical configuration of a multi-region cluster by plotting the node localities on a world map. This feature provides real-time cluster metrics, with the ability to drill down to individual nodes to monitor and troubleshoot cluster health and performance.
@@ -58,6 +60,7 @@ These new features are freely available in the core version and do not require a
 ### SQL
 
 Feature | Description
+sitemap: false
 --------|------------
 [JSON Support](../v2.0/demo-json-support.html) | The [`JSONB`](../v2.0/jsonb.html) data type and [inverted indexes](../v2.0/inverted-indexes.html) give you the flexibility to store and efficiently query  semi-structured data.
 [Sequences](../v2.0/create-sequence.html) | Sequences generate sequential integers according to defined rules. They are generally used for creating numeric primary keys.   
@@ -73,6 +76,7 @@ Feature | Description
 ### Operations
 
 Feature | Description
+sitemap: false
 --------|------------
 [Node Readiness Endpoint](../v2.0/monitoring-and-alerting.html#health-ready-1) | The new `/health?ready=1` endpoint returns an `HTTP 503 Service Unavailable` status response code with an error when a node is being decommissioned or is in the process of shutting down and is therefore not able to accept SQL connections and execute queries. This is especially useful for making sure [load balancers](../v2.0/recommended-production-settings.html#load-balancing) do not direct traffic to nodes that are live but not "ready", which is a necessary check during [rolling upgrades](../v2.0/upgrade-cockroach-version.html).
 [Node Decommissioning](../v2.0/remove-nodes.html) | Nodes that have been decommissioned and stopped no longer appear in Admin UI and command-line interface metrics.
@@ -83,6 +87,7 @@ Feature | Description
 ## Backward-Incompatible Changes
 
 Change | Description
+sitemap: false
 -------|------------
 Replication Zones | [Positive replication zone constraints](../v2.0/configure-replication-zones.html#replication-constraints) no longer work. Any existing positive constraints will be ignored. This change should not impact existing deployments since positive constraints have not been documented or supported for some time.
 Casts from `BYTES` to `STRING` | Casting between these types now works the same way as in PostgreSQL. New functions `encode()` and `decode()` are available to replace the former functionality.
@@ -100,6 +105,7 @@ For information about limitations we've identified in CockroachDB v2.0, with sug
 ## Documentation Updates
 
 Topic | Description
+sitemap: false
 ------|------------
 [Production Checklist](../v2.0/recommended-production-settings.html) | This topic now provides cloud-specific hardware, security, load balancing, monitoring and alerting, and clock synchronization recommendations as well as expanded cluster topology guidance. Related [deployment tutorials](../v2.0/manual-deployment.html) have been enhanced with much of this information as well.
 [Monitoring and Alerting](../v2.0/monitoring-and-alerting.html) | This new topic explains available tools for monitoring the overall health and performance of a cluster and critical events and metrics to alert on.

--- a/releases/v2.0.1.md
+++ b/releases/v2.0.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.1
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.1 since version v2.0.0
+sitemap: false
 ---
 
 ## April 23, 2018

--- a/releases/v2.0.2.md
+++ b/releases/v2.0.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.2
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.2 since version v2.0.1
+sitemap: false
 ---
 
 ## May 21, 2018

--- a/releases/v2.0.3.md
+++ b/releases/v2.0.3.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.3
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.3 since version v2.0.2
+sitemap: false
 ---
 
 ## June 18, 2018

--- a/releases/v2.0.4.md
+++ b/releases/v2.0.4.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.4
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.4 since version v2.0.3
+sitemap: false
 ---
 
 ## July 16, 2018

--- a/releases/v2.0.5.md
+++ b/releases/v2.0.5.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.5
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.5 since version v2.0.4
+sitemap: false
 ---
 
 ## August 13, 2018

--- a/releases/v2.0.6.md
+++ b/releases/v2.0.6.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.6
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.6 since version v2.0.5
+sitemap: false
 ---
 
 ## October 1, 2018

--- a/releases/v2.0.7.md
+++ b/releases/v2.0.7.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.0.7
 toc: true
 summary: Additions and changes in CockroachDB version v2.0.7 since version v2.0.6
+sitemap: false
 ---
 
 ## December 10, 2018

--- a/releases/v2.1.0-alpha.20180416.md
+++ b/releases/v2.1.0-alpha.20180416.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-alpha.20180416
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-alpha.20180416 since version v2.0.0
+sitemap: false
 ---
 
 ## April 16, 2018

--- a/releases/v2.1.0-alpha.20180507.md
+++ b/releases/v2.1.0-alpha.20180507.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-alpha.20180507
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-alpha.20180507 since version v2.1.0-alpha.20180416
+sitemap: false
 ---
 
 ## May 7, 2018

--- a/releases/v2.1.0-alpha.20180604.md
+++ b/releases/v2.1.0-alpha.20180604.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1-alpha.20180604
 toc: true
 summary: Additions and changes in CockroachDB version v2.1-alpha.20180604 since version v2.1-alpha.20180507
+sitemap: false
 ---
 
 ## June 4, 2018

--- a/releases/v2.1.0-alpha.20180702.md
+++ b/releases/v2.1.0-alpha.20180702.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-alpha.20180702
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-alpha.20180702 since version v2.1-alpha.20180604
+sitemap: false
 ---
 
 ## July 2, 2018

--- a/releases/v2.1.0-alpha.20180730.md
+++ b/releases/v2.1.0-alpha.20180730.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-alpha.20180730
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-alpha.20180730 since version v2.1.0-alpha.20180702
+sitemap: false
 ---
 
 ## July 25, 2018

--- a/releases/v2.1.0-beta.20180827.md
+++ b/releases/v2.1.0-beta.20180827.md
@@ -3,6 +3,7 @@ title: What&#39;s New in v2.1.0-beta.20180827
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20180827 since version v2.1.0-alpha.20180730
 toc: true
+sitemap: false
 ---
 
 ## August 27, 2018

--- a/releases/v2.1.0-beta.20180904.md
+++ b/releases/v2.1.0-beta.20180904.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20180904
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20180904 since version v2.1.0-beta.20180827
+sitemap: false
 ---
 
 ## September 4, 2018

--- a/releases/v2.1.0-beta.20180910.md
+++ b/releases/v2.1.0-beta.20180910.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20180910
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20180910 since version v2.1.0-beta.20180904
+sitemap: false
 ---
 
 ## September 10, 2018

--- a/releases/v2.1.0-beta.20180917.md
+++ b/releases/v2.1.0-beta.20180917.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20180917
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20180917 since version v2.1.0-beta.20180910
+sitemap: false
 ---
 
 ## September 17, 2018

--- a/releases/v2.1.0-beta.20180924.md
+++ b/releases/v2.1.0-beta.20180924.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20180924
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20180924 since version v2.1.0-beta.20180917
+sitemap: false
 ---
 
 ## September 24, 2018

--- a/releases/v2.1.0-beta.20181001.md
+++ b/releases/v2.1.0-beta.20181001.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20181001
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20181001 since version v2.1.0-beta.20180924
+sitemap: false
 ---
 
 ## October 1, 2018

--- a/releases/v2.1.0-beta.20181008.md
+++ b/releases/v2.1.0-beta.20181008.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20181008
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20181008 since version v2.1.0-beta.20181001
+sitemap: false
 ---
 
 ## October 8, 2018

--- a/releases/v2.1.0-beta.20181015.md
+++ b/releases/v2.1.0-beta.20181015.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-beta.20181015
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-beta.20181015 since version v2.1.0-beta.20181008
+sitemap: false
 ---
 
 ## October 15, 2018

--- a/releases/v2.1.0-rc.1.md
+++ b/releases/v2.1.0-rc.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-rc.1
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-rc.1 since version v2.1.0-beta.20181015
+sitemap: false
 ---
 
 ## October 22, 2018

--- a/releases/v2.1.0-rc.2.md
+++ b/releases/v2.1.0-rc.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0-rc.2
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0-rc.2 since version v2.1.0-rc.1
+sitemap: false
 ---
 
 ## October 25, 2018

--- a/releases/v2.1.0.md
+++ b/releases/v2.1.0.md
@@ -63,7 +63,6 @@ For more details, see the [Managed CockroachDB](../cockroachcloud/quickstart.htm
 These new features require an [enterprise license](../v2.1/enterprise-licensing.html). Register for a 30-day trial license [here](https://www.cockroachlabs.com/get-cockroachdb/).
 
 Feature | Description
-sitemap: false
 --------|------------
 [Change Data Capture](../v2.1/change-data-capture.html) (Beta)|  Change data capture (CDC) provides efficient, distributed, row-level change feeds into Apache Kafka for downstream processing such as reporting, caching, or full-text indexing. Use the [`CREATE CHANGEFEED`](../v2.1/create-changefeed.html) statement to create a new changefeed, which provides row-level change subscriptions.
 [Encryption at Rest](../v2.1/encryption.html) (Experimental) | Encryption at Rest provides transparent encryption of a node's data on the local disk.
@@ -76,7 +75,6 @@ These new features are freely available in the core version and do not require a
 #### SQL
 
 Feature | Description
-sitemap: false
 --------|------------
 [`ALTER TABLE ... ALTER TYPE`](../v2.1/alter-type.html) | The `ALTER TABLE ... ALTER TYPE` statement changes a column's [data type](../v2.1/data-types.html). Only type changes that neither require data checks nor data conversion are supported at this time.
 [`ALTER COLUMN ... DROP STORED`](../v2.1/alter-column.html#convert-a-computed-column-into-a-regular-column) | The `ALTER TABLE ... ALTER COLUMN ... DROP STORED` statement converts a stored, [computed column](../v2.1/computed-columns.html) into a regular column.
@@ -98,7 +96,6 @@ sitemap: false
 #### CLI
 
 Feature | Description
-sitemap: false
 --------|------------
 [`cockroach demo`](../v2.1/cockroach-demo.html) | The `cockroach demo` command starts a temporary, in-memory, single-node CockroachDB cluster and opens an [interactive SQL shell](../v2.1/use-the-built-in-sql-client.html) to it.
 [`cockroach start`](../v2.1/start-a-node.html) | The new `--advertise-addr` flag recognizes both a hostname/address and port and replaces the `--advertise-host` and `--advertise-port` flags, which are now deprecated.<br><br>The new `--listen-addr` flag recognizes both a hostname/address and port and replaces the `--host` and `--port` flags, which are now deprecated for `cockroach start` but remain valid for other client commands.<br><br>The new `--http-addr` flag recognizes both a hostname/address and port and replaces the `--http-host` flag, which is now deprecated.
@@ -108,7 +105,6 @@ sitemap: false
 #### Operations
 
 Feature | Description
-sitemap: false
 --------|------------
 [Controlling Leaseholder Location](../v2.1/configure-replication-zones.html#constrain-leaseholders-to-specific-datacenters) | Using replication zones, you can now specify preferences for where a range's leaseholders should be placed to increase performance in some scenarios.
 [DBeaver Support](../v2.1/third-party-database-tools.html) | DBeaver, a cross-platform database GUI, has been thoroughly vetted and tested with CockroachDB v2.1.
@@ -124,7 +120,6 @@ sitemap: false
 #### Admin UI
 
 Feature | Description
-sitemap: false
 --------|------------
 [Advanced Debugging Page](../v2.1/admin-ui-debug-pages.html) (Experimental) | The **Advanced Debugging** page provides links to advanced monitoring and troubleshooting reports and cluster configuration details.
 [Hardware Dashboard](../v2.1/admin-ui-hardware-dashboard.html) | The **Hardware** dashboard lets you monitor CPU usage, disk throughput, network traffic, storage capacity, and memory.
@@ -138,7 +133,6 @@ For information about limitations we've identified in CockroachDB v2.1, with sug
 ### Documentation
 
 Topic | Description
-sitemap: false
 ------|------------
 [Experimental Features](../v2.1/experimental-features.html) | This new page lists the experimental features that are available in CockroachDB v2.1.
 [Client Connection Parameters](../v2.1/connection-parameters.html) | This new page describes the parameters used to establish a client connection. The client connection parameters determine which CockroachDB cluster they connect to, and how to establish this network connection.

--- a/releases/v2.1.0.md
+++ b/releases/v2.1.0.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.0
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.0.
+sitemap: false
 ---
 
 ## October 30, 2018
@@ -62,6 +63,7 @@ For more details, see the [Managed CockroachDB](../cockroachcloud/quickstart.htm
 These new features require an [enterprise license](../v2.1/enterprise-licensing.html). Register for a 30-day trial license [here](https://www.cockroachlabs.com/get-cockroachdb/).
 
 Feature | Description
+sitemap: false
 --------|------------
 [Change Data Capture](../v2.1/change-data-capture.html) (Beta)|  Change data capture (CDC) provides efficient, distributed, row-level change feeds into Apache Kafka for downstream processing such as reporting, caching, or full-text indexing. Use the [`CREATE CHANGEFEED`](../v2.1/create-changefeed.html) statement to create a new changefeed, which provides row-level change subscriptions.
 [Encryption at Rest](../v2.1/encryption.html) (Experimental) | Encryption at Rest provides transparent encryption of a node's data on the local disk.
@@ -74,6 +76,7 @@ These new features are freely available in the core version and do not require a
 #### SQL
 
 Feature | Description
+sitemap: false
 --------|------------
 [`ALTER TABLE ... ALTER TYPE`](../v2.1/alter-type.html) | The `ALTER TABLE ... ALTER TYPE` statement changes a column's [data type](../v2.1/data-types.html). Only type changes that neither require data checks nor data conversion are supported at this time.
 [`ALTER COLUMN ... DROP STORED`](../v2.1/alter-column.html#convert-a-computed-column-into-a-regular-column) | The `ALTER TABLE ... ALTER COLUMN ... DROP STORED` statement converts a stored, [computed column](../v2.1/computed-columns.html) into a regular column.
@@ -95,6 +98,7 @@ Feature | Description
 #### CLI
 
 Feature | Description
+sitemap: false
 --------|------------
 [`cockroach demo`](../v2.1/cockroach-demo.html) | The `cockroach demo` command starts a temporary, in-memory, single-node CockroachDB cluster and opens an [interactive SQL shell](../v2.1/use-the-built-in-sql-client.html) to it.
 [`cockroach start`](../v2.1/start-a-node.html) | The new `--advertise-addr` flag recognizes both a hostname/address and port and replaces the `--advertise-host` and `--advertise-port` flags, which are now deprecated.<br><br>The new `--listen-addr` flag recognizes both a hostname/address and port and replaces the `--host` and `--port` flags, which are now deprecated for `cockroach start` but remain valid for other client commands.<br><br>The new `--http-addr` flag recognizes both a hostname/address and port and replaces the `--http-host` flag, which is now deprecated.
@@ -104,6 +108,7 @@ Feature | Description
 #### Operations
 
 Feature | Description
+sitemap: false
 --------|------------
 [Controlling Leaseholder Location](../v2.1/configure-replication-zones.html#constrain-leaseholders-to-specific-datacenters) | Using replication zones, you can now specify preferences for where a range's leaseholders should be placed to increase performance in some scenarios.
 [DBeaver Support](../v2.1/third-party-database-tools.html) | DBeaver, a cross-platform database GUI, has been thoroughly vetted and tested with CockroachDB v2.1.
@@ -119,6 +124,7 @@ Feature | Description
 #### Admin UI
 
 Feature | Description
+sitemap: false
 --------|------------
 [Advanced Debugging Page](../v2.1/admin-ui-debug-pages.html) (Experimental) | The **Advanced Debugging** page provides links to advanced monitoring and troubleshooting reports and cluster configuration details.
 [Hardware Dashboard](../v2.1/admin-ui-hardware-dashboard.html) | The **Hardware** dashboard lets you monitor CPU usage, disk throughput, network traffic, storage capacity, and memory.
@@ -132,6 +138,7 @@ For information about limitations we've identified in CockroachDB v2.1, with sug
 ### Documentation
 
 Topic | Description
+sitemap: false
 ------|------------
 [Experimental Features](../v2.1/experimental-features.html) | This new page lists the experimental features that are available in CockroachDB v2.1.
 [Client Connection Parameters](../v2.1/connection-parameters.html) | This new page describes the parameters used to establish a client connection. The client connection parameters determine which CockroachDB cluster they connect to, and how to establish this network connection.

--- a/releases/v2.1.1.md
+++ b/releases/v2.1.1.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.1
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.1 since version v2.1.0
+sitemap: false
 ---
 
 ## November 19, 2018

--- a/releases/v2.1.10.md
+++ b/releases/v2.1.10.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.10
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.10 since version v2.1.9
+sitemap: false
 ---
 
 ## December 16, 2019

--- a/releases/v2.1.11.md
+++ b/releases/v2.1.11.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.11
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.11 since version v2.1.10
+sitemap: false
 ---
 
 ## January 29, 2020

--- a/releases/v2.1.2.md
+++ b/releases/v2.1.2.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.2
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.2 since version v2.1.1
+sitemap: false
 ---
 
 ## December 10, 2018

--- a/releases/v2.1.3.md
+++ b/releases/v2.1.3.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.3
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.3 since version v2.1.2
+sitemap: false
 ---
 
 ## December 17, 2018

--- a/releases/v2.1.4.md
+++ b/releases/v2.1.4.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.4
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.4 since version v2.1.3
+sitemap: false
 ---
 
 ## January 22, 2019

--- a/releases/v2.1.5.md
+++ b/releases/v2.1.5.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.5
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.5 since version v2.1.4
+sitemap: false
 ---
 
 ## February 19, 2019

--- a/releases/v2.1.6.md
+++ b/releases/v2.1.6.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.6
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.6 since version v2.1.5
+sitemap: false
 ---
 
 ## March 11, 2019

--- a/releases/v2.1.7.md
+++ b/releases/v2.1.7.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.7
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.7 since version v2.1.6
+sitemap: false
 ---
 
 ## May 14, 2019

--- a/releases/v2.1.8.md
+++ b/releases/v2.1.8.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.8
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.8 since version v2.1.7
+sitemap: false
 ---
 
 ## July 15, 2019

--- a/releases/v2.1.9.md
+++ b/releases/v2.1.9.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.1.9
 toc: true
 summary: Additions and changes in CockroachDB version v2.1.9 since version v2.1.8
+sitemap: false
 ---
 
 ## September 23, 2019

--- a/releases/v2.2.0-alpha.20181119.md
+++ b/releases/v2.2.0-alpha.20181119.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.2.0-alpha.20181118
 toc: true
 summary: Additions and changes in CockroachDB version v2.2.0-alpha.20181118 since v2.1.0
+sitemap: false
 ---
 
 ## November 19, 2018

--- a/releases/v2.2.0-alpha.20181217.md
+++ b/releases/v2.2.0-alpha.20181217.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.2.0-alpha.20181217
 toc: true
 summary: Additions and changes in CockroachDB version v2.2.0-alpha.20181217 since version v2.2.0-alpha.20181119
+sitemap: false
 ---
 
 ## December 17, 2018

--- a/releases/v2.2.0-alpha.20190114.md
+++ b/releases/v2.2.0-alpha.20190114.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.2.0-alpha.20190114
 toc: true
 summary: Additions and changes in CockroachDB version v2.2.0-alpha.20190114 since version v2.2.0-alpha.20181217
+sitemap: false
 ---
 
 ## January 14, 2019

--- a/releases/v2.2.0-alpha.20190211.md
+++ b/releases/v2.2.0-alpha.20190211.md
@@ -2,6 +2,7 @@
 title: What&#39;s New in v2.2.0-alpha.20190211
 toc: true
 summary: Additions and changes in CockroachDB version v2.2.0-alpha.20190211 since version v2.2.0-alpha.20190114
+sitemap: false
 ---
 
 ## February 11, 2019

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -5,7 +5,7 @@ layout: null
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- for page in site.pages -%}
     {%- if page.url contains site.versions["stable"] or page.url contains 'cockroachcloud/' or page.url contains 'releases/' or page.url contains 'advisories/' -%}
-      {%- unless page.url contains '404' %}
+      {%- unless page.url contains '404' or page.sitemap == false %}
   <url>
     <loc>{{ page.canonical | absolute_url }}</loc>
   </url>

--- a/v20.2/install-cockroachdb-spatial.md
+++ b/v20.2/install-cockroachdb-spatial.md
@@ -2,4 +2,5 @@
 title: Install CockroachDB Spatial
 summary: Install CockroachDB with spatial libraries for efficiently storing and querying spatial data.
 toc: true
+sitemap: false
 ---

--- a/v21.1/install-cockroachdb-spatial.md
+++ b/v21.1/install-cockroachdb-spatial.md
@@ -2,4 +2,5 @@
 title: Install CockroachDB Spatial
 summary: Install CockroachDB with spatial libraries for efficiently storing and querying spatial data.
 toc: true
+sitemap: false
 ---


### PR DESCRIPTION
Closes https://cockroachlabs.atlassian.net/browse/DO-42

- [Modifies sitemap.xml](https://github.com/cockroachdb/docs/pull/10950/files#diff-ab0948979d8a429a3b73069f8d557801277b33d41cdec22352c1aadc1460266d) to exclude pages with `sitemap: false` front matter from `sitemap.xml`.
- Adds `sitemap: false` to all md files listed in the sheet linked from the issue.

Note that paths including `*/releases/v1.0*` and others to exclude are no longer present in 
https://deploy-preview-10950--cockroachdb-docs.netlify.app/docs/sitemap.xml
vs. the current live site https://www.cockroachlabs.com/docs/sitemap.xml where they are present.

Note: @rmloveland plans to remove the two largely empty `install-cockroach-spatial.md` files after this is merged.