### PR TITLE
Updated go-pgx GH repo URLs for repo rename

### DIFF
--- a/v19.2/build-a-go-app-with-cockroachdb.md
+++ b/v19.2/build-a-go-app-with-cockroachdb.md
@@ -57,14 +57,6 @@ The code samples will run with `maxroach` as the user.
 
 Now that you have a database and a user, you'll run code to create a table and insert some rows, and then you'll run code to read and update values as an atomic [transaction](transactions.html).
 
-{{site.data.alerts.callout_success}}
-To clone a version of the code below that connects to insecure clusters, run the following:
-
-`git clone https://github.com/cockroachlabs/hello-world-go-pgx/`
-
-Note that you will need to edit the connection string to use the certificates that you generated when you set up your secure cluster.
-{{site.data.alerts.end}}
-
 ### Basic statements
 
 First, use the following code to connect to the cluster as the `maxroach` user, and then execute some basic SQL statements that create a table, insert some rows, and read and print the rows to the console.
@@ -152,14 +144,6 @@ $ cockroach sql --certs-dir=certs -e 'SELECT id, balance FROM accounts' --databa
 ## Step 4. Run the Go code
 
 Now that you have a database and a user, you'll run code to create a table and insert some rows, and then you'll run code to read and update values as an atomic [transaction](transactions.html).
-
-{{site.data.alerts.callout_success}}
-To clone a version of the code below that connects to insecure clusters, run the following:
-
-`git clone https://github.com/cockroachlabs/hello-world-go-pgx/`
-
-Note that you will need to edit the connection string to use the certificates that you generated when you set up your secure cluster.
-{{site.data.alerts.end}}
 
 ### Basic statements
 

--- a/v20.1/build-a-go-app-with-cockroachdb.md
+++ b/v20.1/build-a-go-app-with-cockroachdb.md
@@ -57,14 +57,6 @@ The code samples will run with `maxroach` as the user.
 
 Now that you have a database and a user, you'll run code to create a table and insert some rows, and then you'll run code to read and update values as an atomic [transaction](transactions.html).
 
-{{site.data.alerts.callout_success}}
-To clone a version of the code below that connects to insecure clusters, run the following:
-
-`git clone https://github.com/cockroachlabs/hello-world-go-pgx/`
-
-Note that you will need to edit the connection string to use the certificates that you generated when you set up your secure cluster.
-{{site.data.alerts.end}}
-
 ### Basic statements
 
 First, use the following code to connect to the cluster as the `maxroach` user, and then execute some basic SQL statements that create a table, insert some rows, and read and print the rows to the console.
@@ -150,14 +142,6 @@ $ cockroach sql --certs-dir=certs -e 'SELECT id, balance FROM accounts' --databa
 ## Step 4. Run the Go code
 
 Now that you have a database and a user, you'll run code to create a table and insert some rows, and then you'll run code to read and update values as an atomic [transaction](transactions.html).
-
-{{site.data.alerts.callout_success}}
-To clone a version of the code below that connects to insecure clusters, run the following:
-
-`git clone https://github.com/cockroachlabs/hello-world-go-pgx/`
-
-Note that you will need to edit the connection string to use the certificates that you generated when you set up your secure cluster.
-{{site.data.alerts.end}}
 
 ### Basic statements
 

--- a/v20.2/build-a-go-app-with-cockroachdb.md
+++ b/v20.2/build-a-go-app-with-cockroachdb.md
@@ -36,7 +36,7 @@ You can now run the code sample (`main.go`) provided in this tutorial to do the 
 
 ### Get the code
 
-Clone [the code's GitHub repository](https://github.com/cockroachlabs/hello-world-go-pgx).
+Clone [the code's GitHub repository](https://github.com/cockroachlabs/example-app-go-pgx).
 
 <div class="filter-content" markdown="1" data-scope="cockroachcloud">
 
@@ -55,7 +55,7 @@ Here are the contents of `main.go`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ go
-{% remote_include https://raw.githubusercontent.com/cockroachlabs/hello-world-go-pgx/master/main.go %}
+{% remote_include https://raw.githubusercontent.com/cockroachlabs/example-app-go-pgx/master/main.go %}
 ~~~
 
 </div>
@@ -64,7 +64,7 @@ Here are the contents of `main.go`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ go
-{% remote_include https://raw.githubusercontent.com/cockroachlabs/hello-world-go-pgx/cockroachcloud/main.go %}
+{% remote_include https://raw.githubusercontent.com/cockroachlabs/example-app-go-pgx/cockroachcloud/main.go %}
 ~~~
 
 </div>

--- a/v21.1/build-a-go-app-with-cockroachdb.md
+++ b/v21.1/build-a-go-app-with-cockroachdb.md
@@ -36,7 +36,7 @@ You can now run the code sample (`main.go`) provided in this tutorial to do the 
 
 ### Get the code
 
-Clone [the code's GitHub repository](https://github.com/cockroachlabs/hello-world-go-pgx).
+Clone [the code's GitHub repository](https://github.com/cockroachlabs/example-app-go-pgx).
 
 <div class="filter-content" markdown="1" data-scope="cockroachcloud">
 
@@ -55,7 +55,7 @@ Here are the contents of `main.go`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ go
-{% remote_include https://raw.githubusercontent.com/cockroachlabs/hello-world-go-pgx/master/main.go %}
+{% remote_include https://raw.githubusercontent.com/cockroachlabs/example-app-go-pgx/master/main.go %}
 ~~~
 
 </div>
@@ -64,7 +64,7 @@ Here are the contents of `main.go`:
 
 {% include_cached copy-clipboard.html %}
 ~~~ go
-{% remote_include https://raw.githubusercontent.com/cockroachlabs/hello-world-go-pgx/cockroachcloud/main.go %}
+{% remote_include https://raw.githubusercontent.com/cockroachlabs/example-app-go-pgx/cockroachcloud/main.go %}
 ~~~
 
 </div>


### PR DESCRIPTION
This PR updates the URLs to the simple crud golang pgx app repo (formerly named `hello-world-go-pgx`)