### PR TITLE
Adjustments to make export/enterprise language clearer

### DIFF
--- a/_includes/sidebar-data-v20.2.json
+++ b/_includes/sidebar-data-v20.2.json
@@ -1569,7 +1569,7 @@
                     ]
                   },
                   {
-                    "title": "<code>EXPORT</code> (Enterprise)",
+                    "title": "<code>EXPORT</code>",
                     "urls": [
                       "/${VERSION}/export.html"
                     ]

--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -1668,7 +1668,7 @@
                     ]
                   },
                   {
-                    "title": "<code>EXPORT</code> (Enterprise)",
+                    "title": "<code>EXPORT</code>",
                     "urls": [
                       "/${VERSION}/export.html"
                     ]

--- a/v20.2/export.md
+++ b/v20.2/export.md
@@ -6,7 +6,7 @@ toc: true
 
 The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to CSV files.
 
-Using the [CockroachDB distributed execution engine](architecture/sql-layer.html#distsql), `EXPORT` parallelizes CSV creation across all nodes in the cluster, making it possible to quickly get large sets of data out of CockroachDB in a format that can be ingested by downstream systems. If you do not need distributed exports, you can use the [non-enterprise feature to export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
+Using the [CockroachDB distributed execution engine](architecture/sql-layer.html#distsql), `EXPORT` parallelizes CSV creation across all nodes in the cluster, making it possible to quickly get large sets of data out of CockroachDB in a format that can be ingested by downstream systems. If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
 <span class="version-tag">New in v20.2:</span>

--- a/v21.1/export.md
+++ b/v21.1/export.md
@@ -6,10 +6,10 @@ toc: true
 
 The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to CSV files.
 
-Using the [CockroachDB distributed execution engine](architecture/sql-layer.html#distsql), `EXPORT` parallelizes CSV creation across all nodes in the cluster, making it possible to quickly get large sets of data out of CockroachDB in a format that can be ingested by downstream systems. If you do not need distributed exports, you can use the [non-enterprise feature to export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
+Using the [CockroachDB distributed execution engine](architecture/sql-layer.html#distsql), `EXPORT` parallelizes CSV creation across all nodes in the cluster, making it possible to quickly get large sets of data out of CockroachDB in a format that can be ingested by downstream systems. If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
- `EXPORT` no longer requires an enterprise license.
+`EXPORT` no longer requires an enterprise license.
 {{site.data.alerts.end}}
 
 ## Cancelling export


### PR DESCRIPTION
Closes #10971 

The main sidebar on the docs page still included `EXPORT (enterprise)`. As of 20.2 `EXPORT` doesn't require an enterprise license. This caused confusion for a customer recently. Also updated a sentence at the top of the page to avoid enterprise-related language while still pointing to the non-distributed examples. 

Made these adjustments to 21.1 & 20.2