### PR TITLE
Adding DbUp

### DIFF
--- a/v21.1/community-tooling.md
+++ b/v21.1/community-tooling.md
@@ -34,6 +34,7 @@ If you have a tested or developed a third-party tool with CockroachDB, and would
 ## Schema migration tools
 
 - [SchemaHero](https://schemahero.io/databases/cockroachdb/connecting/)
+- [DbUp](https://github.com/DbUp/DbUp/issues/464#issuecomment-895503849)
 
 ## Connection pooling tools
 


### PR DESCRIPTION
DbUp supports crdb vis-a-vis its support of postgres databases using dotnet's `npgsql` driver.  