### PR TITLE
Add doc comment markup to generate issues from release notes for v21.1.4

### DIFF
--- a/releases/v21.1.4.md
+++ b/releases/v21.1.4.md
@@ -37,30 +37,30 @@ $ docker pull cockroachdb/cockroach:v21.1.4
 ### Security updates
 
 - Previously, all the [logging](../v21.1/logging-overview.html) output to files or network sinks was disabled temporarily while an operator was using the `/debug/logspy` HTTP API, resulting in lost entries and a breach of auditability guarantees. This behavior has been corrected. [#66328][#66328]
-- CockroachDB now configures a maximum number of concurrent password verifications in the server process, across UI and SQL clients. This limit reduces the risk of DoS attacks or accidents due to misbehaving clients. By default, the maximum amount of concurrency is ~12% of the number of allocated CPU cores (as per `GOMAXPROCS`), with a minimum of 1 core. This default can be overridden using the environment variable `COCKROACH_MAX_BCRYPT_CONCURRENCY`. [#66367][#66367]
+- CockroachDB now configures a maximum number of concurrent password verifications in the server process, across UI and SQL clients. This limit reduces the risk of DoS attacks or accidents due to misbehaving clients. By default, the maximum amount of concurrency is ~12% of the number of allocated CPU cores (as per `GOMAXPROCS`), with a minimum of 1 core. This default can be overridden using the environment variable `COCKROACH_MAX_BCRYPT_CONCURRENCY`. [#66367][#66367] {% comment %}doc{% endcomment %}
 
 ### SQL language changes
 
-- Implemented the `ST_HasArc` [builtin function](../v21.1/functions-and-operators.html#spatial-functions). This adds better out-of-the-box support for [GeoServer](../v21.1/geoserver.html). [#66531][#66531]
-- Added a new internal [cluster setting](../v21.1/cluster-settings.html), `jobs.cancel_update_limit`, for controlling how many [jobs](../v21.1/show-jobs.html) are cleaned up concurrently after query cancellation. [#66488][#66488]
+- Implemented the `ST_HasArc` [builtin function](../v21.1/functions-and-operators.html#spatial-functions). This adds better out-of-the-box support for [GeoServer](../v21.1/geoserver.html). [#66531][#66531] {% comment %}doc{% endcomment %}
+- Added a new internal [cluster setting](../v21.1/cluster-settings.html), `jobs.cancel_update_limit`, for controlling how many [jobs](../v21.1/show-jobs.html) are cleaned up concurrently after query cancellation. [#66488][#66488] {% comment %}doc{% endcomment %}
 
 ### Command-line changes
 
-- The [SQL shell](../v21.1/cockroach-sql.html) now formats times with time zones so that the minutes and seconds offsets are only shown if they are non-zero. Also, infinite floating point values are now formatted as `Infinity` rather than `Inf`. [#66130][#66130]
-- When [log entries](../v21.1/logging-overview.html) are written to disk, the first few header lines written at the start of every new file now report the configured [logging format](../v21.1/log-formats.html). [#66328][#66328]
+- The [SQL shell](../v21.1/cockroach-sql.html) now formats times with time zones so that the minutes and seconds offsets are only shown if they are non-zero. Also, infinite floating point values are now formatted as `Infinity` rather than `Inf`. [#66130][#66130] {% comment %}doc{% endcomment %}
+- When [log entries](../v21.1/logging-overview.html) are written to disk, the first few header lines written at the start of every new file now report the configured [logging format](../v21.1/log-formats.html). [#66328][#66328] {% comment %}doc{% endcomment %}
 
 ### API endpoint changes
 
-- The `/debug/logspy` HTTP API has changed. The endpoint now returns JSON data by default. If the previous format is desired, the user can pass the query argument `&flatten=1` to the `logspy` URL to obtain the previous flat text format (`crdb-v1`) instead. [#66328][#66328] This change is motivated as follows:
+- The `/debug/logspy` HTTP API has changed. The endpoint now returns JSON data by default. If the previous format is desired, the user can pass the query argument `&flatten=1` to the `logspy` URL to obtain the previous flat text format (`crdb-v1`) instead. [#66328][#66328] This change is motivated as follows: {% comment %}doc{% endcomment %}
     - The previous format, `crdb-v1`, cannot be parsed reliably.
     - Using JSON entries guarantees that the text of each entry all fits on a single line of output (newline characters inside the messages are escaped). This makes filtering easier and more reliable.
     - Using JSON enables the user to apply `jq` on the output, for example via `curl -s .../debug/logspy | jq ...`.
-- The `/debug/logspy` API no longer enables maximum logging verbosity automatically. To change the verbosity, use the new `/debug/vmodule` endpoint or pass the `&vmodule=` query parameter to the `/debug/logspy` endpoint. [#66328][#66328] For example, suppose you wish to run a 20s logspy session:
+- The `/debug/logspy` API no longer enables maximum logging verbosity automatically. To change the verbosity, use the new `/debug/vmodule` endpoint or pass the `&vmodule=` query parameter to the `/debug/logspy` endpoint. [#66328][#66328] For example, suppose you wish to run a 20s logspy session: {% comment %}doc{% endcomment %}
     - Before: `curl 'https://.../debug/logspy?duration=20s&...'`.
     - Now: `curl 'https://.../debug/logspy?duration=20s&vmodule=...'` OR `curl 'https://.../debug/vmodule?duration=22s&vmodule=...'   curl 'https://.../debug/logspy?duration=20s'`.
     - As for the regular `vmodule` command-line flag, the maximum verbosity across all the source code can be selected with the pattern `*=4`.
     - Note: at most one in-flight HTTP API request is allowed to modify the `vmodule` parameter. This maintains the invariant that the configuration restored at the end of each request is the same as when the request started.
-- The new `/debug/vmodule` API makes it possible for an operator to configure the logging verbosity in a similar way as the SQL [builtin function](../v21.1/functions-and-operators.html) `crdb_internal.set_vmodule()`, or to query the current configuration as in `crdb_internal.get_vmodule()`. Additionally, any configuration change performed via this API can be automatically reverted after a configurable delay. [#66328][#66328] The API forms are:
+- The new `/debug/vmodule` API makes it possible for an operator to configure the logging verbosity in a similar way as the SQL [builtin function](../v21.1/functions-and-operators.html) `crdb_internal.set_vmodule()`, or to query the current configuration as in `crdb_internal.get_vmodule()`. Additionally, any configuration change performed via this API can be automatically reverted after a configurable delay. [#66328][#66328] The API forms are: {% comment %}doc{% endcomment %}
     - `/debug/vmodule`: Retrieve the current configuration
     - `/debug/vmodule?set=[vmodule config]&duration=[duration]`: Change the configuration to `[vmodule config]` . The previous configuration at the time the `/debug/vmodule` request started is restored after `[duration]`. This duration, if not specified, defaults to twice the default duration of a `logspy` request (currently, the `logspy`   default duration is 5s, so the `vmodule` default duration is 10s). If the duration is zero or negative, the previous configuration is never restored.
 


### PR DESCRIPTION
Also reviewed v21.1.5 but no bullets required these for conversion to release notes.