### PR TITLE
Added HTTP(S) connections to known limitations

### DIFF
--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -161,6 +161,16 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ## Unresolved limitations
 
+### HTTP(S) connections
+
+CockroachDB does not support database connections across HTTP(S). All database connections must be made via TCP.
+
+As of v21.1, CockroachDB includes the [Cluster API](cluster-api.html), a REST API that accepts HTTP(S) requests for monitoring data.
+
+In a future release, we plan to add support for HTTP(S) proxies, such as [PostgREST](https://postgrest.org/en/v8.0/).
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/69010)
+
 ### `IMPORT` into a `REGIONAL BY ROW` table
 
 CockroachDB does not currently support [`IMPORT`s](import.html) into [`REGIONAL BY ROW`](set-locality.html#regional-by-row) tables that are part of [multi-region databases](multiregion-overview.html).

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -167,9 +167,9 @@ CockroachDB does not support database connections across HTTP(S). All database c
 
 As of v21.1, CockroachDB includes the [Cluster API](cluster-api.html), a REST API that accepts HTTP(S) requests for monitoring data.
 
-In a future release, we plan to add support for HTTP(S) proxies, such as [PostgREST](https://postgrest.org/en/v8.0/).
+In a future release, we may add support for HTTP(S) proxies, such as [PostgREST](https://postgrest.org/en/v8.0/).
 
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/69010)
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/69146)
 
 ### `IMPORT` into a `REGIONAL BY ROW` table
 


### PR DESCRIPTION
Follow-up on https://cockroachlabs.slack.com/archives/CC5CX8EKE/p1629155750071600.

Please let me know if there is a better tracking issue to reference, as this limitation calls out our lack of support for HTTP(S) connections in general (and not just our incompatibility with PostgREST).