### PR TITLE
Add clarification message to v20.2.14 RNs per customer feedback.

### DIFF
--- a/releases/v20.2.14.md
+++ b/releases/v20.2.14.md
@@ -38,7 +38,7 @@ $ docker pull cockroachdb/cockroach:v20.2.14
 ### Security updates
 
 - The `cert-principal-map` flag passed to [`cockroach` commands](../v20.2/cockroach-commands.html) now allows the certificate principal name to contain colons. [#67811][#67811]
-- The [node status retrieval endpoints over HTTP](../v20.2/monitoring-and-alerting.html) [`/_status/nodes`, `/_status/nodes/<N>` and the [DB Console](../v20.2/ui-overview.html) `/#/reports/nodes`) now require the [`admin` role](../v20.2/authorization.html) from the requesting user. This ensures that operational details such as network addresses and command-line flags do not leak to unprivileged users. This change means that the [Overview page](../v20.2/ui-overview.html) and [Hardware dashboard](../v20.2/ui-hardware-dashboard.html) of the DB Console will not show all details for non-admin users. [#67069][#67069]
+- The [node status retrieval endpoints over HTTP](../v20.2/monitoring-and-alerting.html) [`/_status/nodes`, `/_status/nodes/<N>` and the [DB Console](../v20.2/ui-overview.html) `/#/reports/nodes`) now require the [`admin` role](../v20.2/authorization.html) from the requesting user. This ensures that operational details such as network addresses and command-line flags do not leak to unprivileged users. This change means that the [Overview page](../v20.2/ui-overview.html) and [Hardware dashboard](../v20.2/ui-hardware-dashboard.html) of the DB Console will not show all details for non-`admin` users. [#67069][#67069]
 
 ### Enterprise edition changes
 

--- a/releases/v20.2.14.md
+++ b/releases/v20.2.14.md
@@ -38,7 +38,7 @@ $ docker pull cockroachdb/cockroach:v20.2.14
 ### Security updates
 
 - The `cert-principal-map` flag passed to [`cockroach` commands](../v20.2/cockroach-commands.html) now allows the certificate principal name to contain colons. [#67811][#67811]
-- The [node status retrieval endpoints over HTTP](../v20.2/monitoring-and-alerting.html) [`/_status/nodes`, `/_status/nodes/<N>` and the (DB Console](../v20.2/ui-overview.html) `/#/reports/nodes`) now require the [`admin` role](../v20.2/authorization.html) from the requesting user. This ensures that operational details such as network addresses and command-line flags do not leak to unprivileged users. [#67069][#67069]
+- The [node status retrieval endpoints over HTTP](../v20.2/monitoring-and-alerting.html) [`/_status/nodes`, `/_status/nodes/<N>` and the [DB Console](../v20.2/ui-overview.html) `/#/reports/nodes`) now require the [`admin` role](../v20.2/authorization.html) from the requesting user. This ensures that operational details such as network addresses and command-line flags do not leak to unprivileged users. This change means that the [Overview page](../v20.2/ui-overview.html) and [Hardware dashboard](../v20.2/ui-hardware-dashboard.html) of the DB Console will not show all details for non-admin users. [#67069][#67069]
 
 ### Enterprise edition changes
 


### PR DESCRIPTION
Based on Slack convo, explicitly call out that the Overview page and Hardware dashboard will no longer show all details for non-admin users.

Fixes #11084.