### PR TITLE
Duplicated HTTP(s) connection limitation to 20.1, 20.2, and 21.2 docsets

### DIFF
--- a/v20.1/known-limitations.md
+++ b/v20.1/known-limitations.md
@@ -159,6 +159,14 @@ $ export COCKROACH_SQL_CLI_HISTORY=.cockroachsql_history_shell_2
 
 ## Unresolved limitations
 
+### HTTP(S) connections
+
+CockroachDB does not support database connections across HTTP(S). All database connections must be made via TCP.
+
+In a future release, we may add support for HTTP(S) proxies, such as [PostgREST](https://postgrest.org/en/v8.0/).
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/69146)
+
 ### Collation names that include upper-case or hyphens may cause errors
 
 Using a [collation](collate.html) name with upper-case letters or hyphens may result in errors.

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -97,6 +97,14 @@ CockroachDB supports efficiently storing and querying [spatial data](spatial-dat
 
 ## Unresolved limitations
 
+### HTTP(S) connections
+
+CockroachDB does not support database connections across HTTP(S). All database connections must be made via TCP.
+
+In a future release, we may add support for HTTP(S) proxies, such as [PostgREST](https://postgrest.org/en/v8.0/).
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/69146)
+
 ### Differences in syntax and behavior between CockroachDB and PostgreSQL
 
 CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of its syntax. However, CockroachDB does not support some of the PostgreSQL features or behaves differently from PostgreSQL because not all features can be easily implemented in a distributed system.

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -161,6 +161,16 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ## Unresolved limitations
 
+### HTTP(S) connections
+
+CockroachDB does not support database connections across HTTP(S). All database connections must be made via TCP.
+
+As of v21.1, CockroachDB includes the [Cluster API](cluster-api.html), a REST API that accepts HTTP(S) requests for monitoring data.
+
+In a future release, we may add support for HTTP(S) proxies, such as [PostgREST](https://postgrest.org/en/v8.0/).
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/69146)
+
 ### `IMPORT` into a `REGIONAL BY ROW` table
 
 CockroachDB does not currently support [`IMPORT`s](import.html) into [`REGIONAL BY ROW`](set-locality.html#regional-by-row) tables that are part of [multi-region databases](multiregion-overview.html).


### PR DESCRIPTION
Follow-up of https://github.com/cockroachdb/docs/pull/11083