### PR TITLE
Correct foreign key restriction for computed columns

### DIFF
--- a/v21.1/computed-columns.md
+++ b/v21.1/computed-columns.md
@@ -19,8 +19,8 @@ Computed columns are especially useful when used with [`JSONB`](jsonb.html) colu
 Computed columns:
 
 - Cannot be used to generate other computed columns.
-- Behave like any other column, with the exception that they cannot be written to directly.
 - Cannot reference a [foreign key](foreign-key.html).
+- Behave like any other column, with the exception that they cannot be written to directly.
 - Are mutually exclusive with [`DEFAULT`](default-value.html).
 
 Virtual computed columns:

--- a/v21.1/computed-columns.md
+++ b/v21.1/computed-columns.md
@@ -19,8 +19,8 @@ Computed columns are especially useful when used with [`JSONB`](jsonb.html) colu
 Computed columns:
 
 - Cannot be used to generate other computed columns.
-- Cannot be a [foreign key](foreign-key.html) reference.
 - Behave like any other column, with the exception that they cannot be written to directly.
+- Cannot reference a [foreign key](foreign-key.html).
 - Are mutually exclusive with [`DEFAULT`](default-value.html).
 
 Virtual computed columns:
@@ -28,6 +28,7 @@ Virtual computed columns:
 - Are not stored in the table's primary index.
 - Are recomputed as the column data in the expression changes.
 - Cannot be used as part of a primary key, `FAMILY` definition, in `CHECK` constraints, or `FOREIGN KEY` constraints.
+- Cannot be a [foreign key](foreign-key.html) reference.
 - Cannot be stored in indexes.
 - Can be index columns.
 


### PR DESCRIPTION
Stored computed columns can be a foreign key reference. Virtual columns cannot. Neither can reference a foreign key.