### PR TITLE
Changing the event type to maybe enable changed files from forks.

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -1,7 +1,7 @@
 name: List files changed as GitHub comment
 
 on:
-  pull_request
+  pull_request_target
 
 jobs:
   list-files-changed:


### PR DESCRIPTION
This is a test to see if changing the event type to `pull_request_target` will trigger the changed files workflows from forked repositories.

See the note under "Action inputs" here: https://github.com/peter-evans/create-or-update-comment