### PR TITLE
Revert "Changing the event type to maybe enable changed files from forks."

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -1,7 +1,7 @@
 name: List files changed as GitHub comment
 
 on:
-  pull_request_target
+  pull_request
 
 jobs:
   list-files-changed:


### PR DESCRIPTION
Reverts cockroachdb/docs#11238

Using `pull_request_target` resulted in an error.