### PR TITLE
Adding a condition to not run list-changed-file workflow for PRs from forks.

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   list-files-changed:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Although we'd like to list the changed files in PRs from forked repos, GitHub can't use security tokens across forks when posting the comment with the changed file output. Until we can find a solution to this, we should just turn off this workflow in PRs from forked repos.