### PR TITLE
Assorted log config documentation

### DIFF
--- a/v21.1/configure-logs.md
+++ b/v21.1/configure-logs.md
@@ -447,10 +447,6 @@ When `capture-stray-errors` is disabled, [`redactable`](#redact-logs) cannot be 
 
 The YAML payload below represents the default logging behavior of [`cockroach start`](cockroach-start.html) and [`cockroach start-single-node`](cockroach-start-single-node.html). To retain backward compatibility with v20.2 and earlier, these settings match the [log filenames used in previous versions](logging-overview.html#changes-to-logging-system).
 
-{{site.data.alerts.callout_danger}}
-These `file-groups` defaults will be removed in v21.2.
-{{site.data.alerts.end}}
-
 ~~~ yaml
 file-defaults:
   max-file-size: 10MiB
@@ -477,8 +473,10 @@ sinks:
       channels: [STORAGE]
     sql-audit:
       channels: [SENSITIVE_ACCESS]
+      auditable: true
     sql-auth:
       channels: [SESSIONS]
+      auditable: true
     sql-exec:
       channels: [SQL_EXEC]
     sql-slow:

--- a/v21.1/logging-overview.md
+++ b/v21.1/logging-overview.md
@@ -50,7 +50,7 @@ Logging channels are analogous to [logging facilities in Syslog](https://en.wiki
 
 Prior to v21.1, logs were separated into a general CockroachDB log and secondary SQL and storage logs. These were output to correspondingly named log files.
 
-The events collected by those logs are now directed into the following [logging channels](#logging-channels):
+The events collected by [logging channels](#logging-channels) are now redirected to file sinks as follows:
 
 | Filename (legacy)         | Description             | Channel            |
 |---------------------------|-------------------------|--------------------|
@@ -60,10 +60,6 @@ The events collected by those logs are now directed into the following [logging 
 | `cockroach-sql-exec.log`  | SQL execution log       | `SQL_EXEC`         |
 | `cockroach-auth.log`      | SQL authentication log  | `SESSIONS`         |
 | `cockroach-sql-slow.log`  | Slow query log          | `SQL_PERF`         |
-
-{{site.data.alerts.callout_info}}
-In v21.1, the [default logging configuration](configure-logs.html#default-logging-configuration) keeps the legacy filenames for these channels. Starting in v21.2, you will need to explicitly map the channels to the legacy filenames in order to preserve this configuration. For details on this, see [Configure Logs](configure-logs.html#configure-log-sinks).
-{{site.data.alerts.end}}
 
 Notable events that were previously collected in the general CockroachDB log are now directed into several new logging channels:
 

--- a/v21.2/logging-overview.md
+++ b/v21.2/logging-overview.md
@@ -7,7 +7,7 @@ toc: true
 If you need to monitor your cluster, tune performance, or [troubleshoot](troubleshooting-overview.html) issues, you can check the CockroachDB logs, which include details about notable cluster, node, and range-level events.
 
 {{site.data.alerts.callout_info}}
-This logging system has been introduced in v21.1 and is backward-compatible. For a summary of what has changed, see [Changes to logging system](#changes-to-logging-system).
+The default logging configuration has changed in v21.2. For a summary of what has changed, see [Changes to logging system](#changes-to-logging-system).
 {{site.data.alerts.end}}
 
 ## Details
@@ -29,49 +29,41 @@ Log messages in CockroachDB are directed into logging channels, which can in tur
 
 This allows you to group channels that log related information (e.g., operational, security, or SQL events) into their own sinks. Each sink can output to a predetermined destination where the logs can be collected and parsed. For usage examples, see [Logging Use Cases](logging-use-cases.html).
 
-| Channel                                             | Description                                                                                                                                                                                                                                                                                                                |
-|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`DEV`](logging.html#dev)                           | Uncategorized and debug messages.                                                                                                                                                                                                                                                                                          |
-| [`OPS`](logging.html#ops)                           | Process starts, stops, shutdowns, and crashes (if they can be logged); changes to cluster topology, such as node additions, removals, and decommissions.                                                                                                                                                                   |
-| [`HEALTH`](logging.html#health)                     | Resource usage; node-node connection events, including connection errors; up- and down-replication and range unavailability.                                                                                                                                                                                               |
-| [`STORAGE`](logging.html#storage)                   | Low-level storage logs from Pebble or RocksDB.                                                                                                                                                                                                                                                                             |
-| [`SESSIONS`](logging.html#sessions)                 | Client connections and disconnections (when enabled via the `server.auth_log.sql_connections.enabled` [cluster setting](cluster-settings.html)); SQL authentication logins/attempts and session/query terminations (when enabled via the `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)). |
-| [`SQL_SCHEMA`](logging.html#sql_schema)             | Database, schema, table, sequence, view, and type creation; changes to table columns and sequence parameters.                                                                                                                                                                                                              |
-| [`USER_ADMIN`](logging.html#user_admin)             | Changes to users, roles, and authentication credentials.                                                                                                                                                                                                                                                                   |
-| [`PRIVILEGES`](logging.html#privileges)             | Changes to privileges and object ownership.                                                                                                                                                                                                                                                                                |
-| [`SENSITIVE_ACCESS`](logging.html#sensitive_access) | SQL audit events (when enabled via [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html)).                                                                                                                                                                                                                       |
-| [`SQL_EXEC`](logging.html#sql_exec)                 | SQL statement executions (when enabled via the `sql.trace.log_statement_execute`) [cluster setting](cluster-settings.html) and uncaught Go panic errors during SQL statement execution.                                                                                                                                    |
-| [`SQL_PERF`](logging.html#sql_perf)                 | SQL executions that impact performance, such as slow queries (when enabled via the `sql.log.slow_query.latency_threshold` and/or `sql.log.slow_query.experimental_full_table_scans.enabled` [cluster settings](cluster-settings.html)).                                                                                    |
-
+| Channel                                              | Description                                                                                                                                                                                                                                                                                                                |
+|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`DEV`](logging.html#dev)                            | Uncategorized and debug messages.                                                                                                                                                                                                                                                                                          |
+| [`OPS`](logging.html#ops)                            | Process starts, stops, shutdowns, and crashes (if they can be logged); changes to cluster topology, such as node additions, removals, and decommissions.                                                                                                                                                                   |
+| [`HEALTH`](logging.html#health)                      | Resource usage; node-node connection events, including connection errors; up- and down-replication and range unavailability.                                                                                                                                                                                               |
+| [`STORAGE`](logging.html#storage)                    | Low-level storage logs from Pebble or RocksDB.                                                                                                                                                                                                                                                                             |
+| [`SESSIONS`](logging.html#sessions)                  | Client connections and disconnections (when enabled via the `server.auth_log.sql_connections.enabled` [cluster setting](cluster-settings.html)); SQL authentication logins/attempts and session/query terminations (when enabled via the `server.auth_log.sql_sessions.enabled` [cluster setting](cluster-settings.html)). |
+| [`SQL_SCHEMA`](logging.html#sql_schema)              | Database, schema, table, sequence, view, and type creation; changes to table columns and sequence parameters.                                                                                                                                                                                                              |
+| [`USER_ADMIN`](logging.html#user_admin)              | Changes to users, roles, and authentication credentials.                                                                                                                                                                                                                                                                   |
+| [`PRIVILEGES`](logging.html#privileges)              | Changes to privileges and object ownership.                                                                                                                                                                                                                                                                                |
+| [`SENSITIVE_ACCESS`](logging.html#sensitive_access)  | SQL audit events (when enabled via [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html)).                                                                                                                                                                                                                       |
+| [`SQL_EXEC`](logging.html#sql_exec)                  | SQL statement executions (when enabled via the `sql.trace.log_statement_execute`) [cluster setting](cluster-settings.html) and uncaught Go panic errors during SQL statement execution.                                                                                                                                    |
+| [`SQL_PERF`](logging.html#sql_perf)                  | SQL executions that impact performance, such as slow queries (when enabled via the `sql.log.slow_query.latency_threshold` and/or `sql.log.slow_query.experimental_full_table_scans.enabled` [cluster settings](cluster-settings.html)).                                                                                    |
+| [`TELEMETRY`](logging.html#telemetry) (New in v21.2) | Telemetry events.                                                                                                                                                                                                                                                                                                          |
 
 Logging channels are analogous to [logging facilities in Syslog](https://en.wikipedia.org/wiki/Syslog) or [logging services in Datadog](https://docs.datadoghq.com/logs/log_collection/?tab=http#reserved-attributes). For more details on the contents of each logging channel, see the [Logging reference](logging.html#logging-channels).
 
 ## Changes to logging system
 
-Prior to v21.1, logs were separated into a general CockroachDB log and secondary SQL and storage logs. These were output to correspondingly named log files.
+When using the [default logging configuration](configure-logs.html#default-logging-configuration), the events collected on each
+[logging channel](#logging-channels) are split into log files as
+follows:
 
-The events collected by those logs are now directed into the following [logging channels](#logging-channels):
-
-| Filename (legacy)         | Description             | Channel            |
-|---------------------------|-------------------------|--------------------|
-| `cockroach.log`           | General CockroachDB log | `DEV`              |
-| `cockroach-pebble.log`    | Pebble/RocksDB log      | `STORAGE`          |
-| `cockroach-sql-audit.log` | SQL audit log           | `SENSITIVE_ACCESS` |
-| `cockroach-sql-exec.log`  | SQL execution log       | `SQL_EXEC`         |
-| `cockroach-auth.log`      | SQL authentication log  | `SESSIONS`         |
-| `cockroach-sql-slow.log`  | Slow query log          | `SQL_PERF`         |
-
-{{site.data.alerts.callout_info}}
-In v21.1, the [default logging configuration](configure-logs.html#default-logging-configuration) keeps the legacy filenames for these channels. Starting in v21.2, you will need to explicitly map the channels to the legacy filenames in order to preserve this configuration. For details on this, see [Configure Logs](configure-logs.html#configure-log-sinks).
-{{site.data.alerts.end}}
-
-Notable events that were previously collected in the general CockroachDB log are now directed into several new logging channels:
-
-- `OPS`
-- `HEALTH`
-- `SQL_SCHEMA`
-- `USER_ADMIN`
-- `PRIVILEGES`
+| Filename (legacy)                        | Description             | Channels                    |
+|------------------------------------------|-------------------------|-----------------------------|
+| `cockroach.log`                          | General CockroachDB log | `DEV`                       |
+| `cockroach-health.log`                   | Health log              | `HEALTH`                    |
+| `cockroach-security.log` (New in 21.2)   | SQL security log        | `PRIVILEGES` + `USER_ADMIN` |
+| `cockroach-sql-audit.log`                | SQL access audit log    | `SENSITIVE_ACCESS`          |
+| `cockroach-sql-auth.log`                 | SQL authentication log  | `SESSIONS`                  |
+| `cockroach-sql-exec.log`                 | SQL execution log       | `SQL_EXEC`                  |
+| `cockroach-sql-slow.log`                 | SQL slow query log      | `SQL_PERF`                  |
+| `cockroach-sql-schema.log` (New in 21.2) | SQL schema change log   | `SQL_SCHEMA`                |
+| `cockroach-pebble.log`                   | Pebble/RocksDB log      | `STORAGE`                   |
+| `cockroach-telemetry.log` (New in 21.2)  | Telemetry log           | `TELEMETRY`                 |
 
  Logging is now configurable via YAML. The YAML configuration allows you to customize which kinds of events are output to different logging destinations, along with many other parameters. As a result, the logging flags previously used with `cockroach` commands are now deprecated in favor of the YAML configuration. For details, see [Configure Logs](configure-logs.html).
 


### PR DESCRIPTION
Fixes #11739
Fixes #11740
Fixes #11741
Fixes #10791

Summary of changes:

- remove the deprecation notice about the default log file config.
  We've decided not to deprecate it after all.
- document the new TELEMETRY channel. (https://github.com/cockroachdb/cockroach/pull/66427)
- document the new HTTP sink. (https://github.com/cockroachdb/cockroach/pull/66196)
- document the new channel-file mappings. (https://github.com/cockroachdb/cockroach/pull/70388)
- document the new channel filtering syntax (https://github.com/cockroachdb/cockroach/pull/69715)
- fix the missing `auditable` flag in the 21.1/21.2 default config. 