### PR TITLE
Release notes v21.2.0 beta.1 and v21.2.0-beta.2

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -84,11 +84,11 @@ release_info:
     start_time: 2021-9-20 11:01:26.34274101 +0000 UTC
     version: v21.1.9
   v21.2:
-    build_time: 2021/08/12 11:00:26 (go1.13.4)
+    build_time: 2021/09/27 11:00:26 (go1.13.4)
     docker_image: cockroachdb/cockroach-unstable
     name: v21.2
-    start_time: 2021-08-12 11:01:26.34274101 +0000 UTC
-    version: v21.2.0-alpha.1
+    start_time: 2021-09-27 11:01:26.34274101 +0000 UTC
+    version: v21.2.0-beta.2
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com
 operator_version: v2.1.0

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -270,6 +270,10 @@
       no_windows: true
 - title: Testing releases
   releases:
+    - date: Sep 27, 2021
+      version: v21.2.0-beta.2
+    - date: Sep 24, 2021
+      version: v21.2.0-beta.1
     - date: May 10, 2021
       version: v21.1.0-rc.2
     - date: May 5, 2021

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -99,7 +99,9 @@
         "/releases/v21.1.0-beta.4.html",
         "/releases/v21.1.0-beta.5.html",
         "/releases/v21.1.0-rc.1.html",
-        "/releases/v21.1.0-rc.2.html"
+        "/releases/v21.1.0-rc.2.html",
+        "/releases/v21.2.0-beta.1.html",
+        "/releases/v21.2.0-beta.2.html"        
       ]
     },
     {

--- a/releases/v21.2.0-beta.1.md
+++ b/releases/v21.2.0-beta.1.md
@@ -1,0 +1,1223 @@
+---
+title: What&#39;s New in v21.2.0-beta.1
+toc: true
+summary: Additions and changes to CockroachDB version 21.2.0-beta.1.
+---
+
+## September 24, 2021
+
+{{site.data.alerts.callout_danger}}
+This testing release includes a known bug. We do **not** recommend upgrading to this release. The [v21.2.0-beta.2 release](v21.2.0-beta.2.html) includes a fix for the bug.
+{{site.data.alerts.end}}
+
+Get future release notes emailed to you:
+
+{% include marketo.html %}
+
+### Downloads
+
+{{site.data.alerts.callout_danger}}
+This release includes a known bug. We do **not** recommend upgrading to this release.
+{{site.data.alerts.end}}
+
+<div id="os-tabs" class="filters clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.1.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.1.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.1.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.1.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+<section class="filter-content" data-scope="windows">
+{% include windows_warning.md %}
+</section>
+
+### Docker image
+
+{% include copy-clipboard.html %}
+~~~shell
+$ docker pull cockroachdb/cockroach-unstable:v21.2.0-beta.1
+~~~
+
+### Backward-incompatible changes
+
+- Previously, CockroachDB only supported the YMD format for parsing timestamps from strings. It now also supports the MDY format to better align with PostgreSQL. A timestamp such as `1-1-18`, which was previously interpreted as `2001-01-18`, will now be interpreted as `2018-01-01`. To continue interpreting the timestamp in the YMD format, the first number can be represented with 4 digits, `2001-1-18`. [#64381][#64381]
+- The deprecated setting `cloudstorage.gs.default.key` has been removed, and the behavior of the `AUTH` parameter in Google Cloud Storage [`BACKUP`](../v21.2/backup.html) and `IMPORT` URIs has been changed. The default behavior is now that of `AUTH=specified`, which uses the credentials passed in the `CREDENTIALS` parameter, and the previous default behavior of using the node's implicit access (via its machine account or role) now requires explicitly passing `AUTH=implicit`. [#64737][#64737]
+- Switched types from `TEXT` to `"char"` for compatibility with postgres in the following columns: `pg_constraint` (`confdeltype`, `confmatchtype`, `confudptype`, `contype`) `pg_operator` (`oprkind`), `pg_prog` (`proargmodes`), `pg_rewrite` (`ev_enabled`, `ev_type`), `pg_trigger` (`tgenabled`) [#65101][#65101]
+
+### Security updates
+
+- Certain HTTP debug endpoints reserved to [`admin`](../v21.2/authorization.html#admin-role) users now return more details about range start/end keys, such as the "hot ranges" report. [#63748][#63748]
+- The [cluster setting](../v21.2/cluster-settings.html) `server.remote_debugging.mode` has been removed. The debug endpoints are now available to every client with access to the HTTP port. All the HTTP URLs previously affected by this setting already have user authentication and require a user to be logged in as a member of the [`admin`](../v21.2/authorization.html#admin-role) role, so there was no need for an additional layer of security. [#63748][#63748]
+- There is now a cache for per-user authentication-related information. The data in the cache is always kept up-to-date because it checks if any change to the underlying authentication tables has been made since the last time the cache was updated. The cached data includes the user's hashed password, the [`NOLOGIN`](../v21.2/authorization.html#roles) role option, and the [`VALID UNTIL`](../v21.2/authorization.html#roles) role option. [#66919][#66919]
+- The `--cert-principal-map` flag now allows the certificate principal name to contain colons. [#67703][#67703]
+- Added the [`admin`](../v21.2/authorization.html#admin-role)-only debugging [builtin](../v21.2/functions-and-operators.html#built-in-functions) functions `crdb_internal.read_file` and `crdb_internal.write_file` to read/write bytes from/to external storage URIs used by [`BACKUP`](../v21.2/backup.html) or [`IMPORT`](../v21.2/import.html). [#67427][#67427]
+- The certificate loader now allows the loading of [`root`](../v21.2/authorization.html#root-user)-owned private keys, provided the owning group matches the group of the (non-`root`) user running CockroachDB. [#68182][#68182]
+- Old authentication web session rows in the `system.web_sessions` table no longer accumulate indefinitely in the long run. These rows are periodically deleted. Refer to the documentation for details about the new [cluster settings](../v21.2/cluster-settings.html) for `system.web_sessions`. [#67547][#67547]
+- The error returned during a failed authentication attempt will now include the `InvalidAuthorizationSpecification` PostgreSQL error code (`28000`). [#69106][#69106]
+
+### General changes
+
+- CockroachDB now supports new [debug endpoints](../v21.2/monitoring-and-alerting.html#raw-status-endpoints) to help users with troubleshooting. [#69594][#69594]
+- The `kv.closed_timestamp.closed_fraction` and `kv.follower_read.target_multiple` [settings](../v21.2/cluster-settings.html) are now deprecated and turned into no-ops. They had already stopped controlling the closing of timestamps in v21.1, but were still influencing the [`follower_read_timestamp()`](../v21.2/functions-and-operators.html) computation for a timestamp that's likely to be closed on all followers. To replace them, a simpler `kv.closed_timestamp.propagation_slack` setting is introduced, modeling the delay between when a leaseholder closes a timestamp and when all the followers become aware of it (defaults conservatively to 1s). `follower_read_timestamp()` is now computed as `kv.closed_timestamp.target_duration` + `kv.closed_timestamp.side_transport_interval` + `kv.closed_timestamp.propagation_slack`, which defaults to 4.2s (instead of the previous default of 4.8s). [#69775][#69775]
+- Added documentation for [Cluster API](../v21.2/cluster-api.html) v2 endpoints. [#62560][#62560]
+- Added `crdb_internal.create_join_token()` SQL [builtin](../v21.2/functions-and-operators.html#built-in-functions) function to create join tokens for use when joining new nodes to a secure cluster. This functionality is hidden behind a feature flag. [#62053][#62053]
+- Added [Cluster API](../v21.2/cluster-api.html) v2 endpoints for querying databases, tables, users, and events in a database. [#63000][#63000]
+- All SQL-level [cluster settings](../v21.2/cluster-settings.html) have been made public. [#66688][#66688]
+- The setting `kv.transaction.write_pipelining_max_outstanding_size` is now a no-op. Its function is folded into the `kv.transaction.max_intents_bytes` setting. [#66915][#66915]
+- Introduced a `/_status/regions` endpoint which returns all regions along with their availability zones. [#67098][#67098]
+- `crdb_internal.regions` is now accessible from a tenant. [#67098][#67098]
+- The behavior for retrying jobs, which fail due to a retriable error or due to job coordinator failure, is now delayed using exponential backoff. Before this change, jobs that failed in a retriable manner would be resumed immediately on a different coordinator. This change reduces the impact of recurrently failing jobs on the cluster. This change adds two new [cluster settings](../v21.2/cluster-settings.html) that control this behavior: `jobs.registry.retry.initial_delay` and `jobs.registry.retry.max_delay`, which respectively control initial delay and maximum delay between resumptions. [#66889][#66889]
+- Previously, non-cancelable jobs, such as schema-change jobs, could fail while reverting due to transient errors, leading to unexpected results. Now, non-cancelable reverting jobs are retried instead of failing when transient errors are encountered. This mitigates the impact of temporary failures on non-cancelable reverting jobs. [#69087][#69087]
+- Added new columns in the `crdb_internal.jobs` table that show the current backoff state of a job and its execution log. The execution log consists of a sequence of job start and end events and any associated errors that were encountered during each job's execution. Now users can query the internal `crdb_internal.jobs` table to get more insights about jobs through the following columns: `last_run` shows the last execution time of a job; `next_run` shows the next execution time of a job based on exponential-backoff delay; `num_runs` shows the number of times the job has been executed; and `execution_log` provides a set of events that are generated when a job starts and ends its execution. [#68995][#68995]
+- When jobs encounter retriable errors during execution, they will now record these errors into their state. The errors, as well as metadata about the execution, can be inspected via the newly added `execution_errors` field of `crdb_internal.jobs`, which is a `STRING[]` column. [#69370][#69370]
+
+### Enterprise edition changes
+
+- Added new `DEBUG_PAUSE_ON` option to [`RESTORE`](../v21.2/functions-and-operators.html) jobs to allow for self pause on errors. [#69422][#69422]
+- [Changefeed option](../v21.2/create-changefeed.html#options) values are now case insensitive. [#69217][#69217]
+- Performance for [changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) during some range-split operations is now improved. [#66312][#66312]
+- [Cloud storage sinks for enterprise changefeeds](../v21.2/create-changefeed.html#cloud-storage-sink) are no longer experimental. [#69787][#69787]
+- Kafka sink URIs now accept the `topic_name` parameter to override per-table topic names. [#62377][#62377]
+- [`SHOW BACKUP`](../v21.2/show-backup.html) now shows whether the backup is full or incremental under the `backup_type` column. [#63832][#63832]
+- Previously, if a restore cluster mismatched the regions in backup cluster, the data would be restored as if the zone configuration did not exist. CockroachDB now checks the regions before restore, making users aware of mismatched regions between backup and restore clusters. If there is a mismatched region, users can either update cluster localities or restore with the `--skip-localities-check` option to continue. [#64758][#64758]
+- Added `ca_cert` as a query parameter to the Confluent registry schema URL to trust custom certs on connection. [#65431][#65431]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) will now report more schema registry connection problems immediately at job creation time. [#65775][#65775]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) can now be started with the `mvcc_timestamp` option to emit the MVCC timestamp of each row being emitted. This option is similar to the `updated` option, but the `mvcc_timestamp` will always contain the row's MVCC timestamp, even during the changefeed's initial backfill. [#65661][#65661]
+- Introduced a new webhook sink (prefix `webhook-https`) to send individual changefeed messages as webhook events. [#66497][#66497]
+- [`RESTORE`](../v21.2/restore.html) now supports restoring individual tables into a multi-region database. If the table being restored is also multi-region, `REGIONAL BY ROW` tables cannot be restored, and `REGIONAL BY TABLE` tables can only be restored if their localities match those of the database they're being restored into. [#65015][#65015]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) don't attempt to use protected timestamps when running in a multi-tenant environment. [#67285][#67285]
+- New 'on_error' option to pause on non-retryable errors instead of failing. [#68176][#68176]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) no longer fail when started on `REGIONAL BY ROW` tables. Note that in `REGION BY ROW` tables, the `crdb_region` column becomes part of the primary index. Thus, changing an existing table to `REGIONAL BY ROW` will trigger a changefeed backfill with new messages emitted using the new composite primary key. [#68229][#68229]
+- Descriptor IDs of every object are now visible in [`SHOW BACKUP`](../v21.2/show-backup.html), along with the descriptor IDs of the object's database and parent schema. `SHOW BACKUP` will display these IDs if the `WITH debug_ids` option is specified. [#68540][#68540]
+- The changefeed Avro format is no longer marked as experimental. [#68818][#68818]
+- [Changefeed](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) statements now error if the provided sink URL does not contain a scheme. Such URLs are typically a mistake and will result in non-functional changefeeds. [#68978][#68978]
+- Added `WITH REASON = <reason>` to [`PAUSE JOB`](../v21.2/pause-job.html) to gain visibility into why a job was paused by allowing pauses to be attached to a reason string. This reason is then persisted in the payload of the job and can be queried later. [#68909][#68909]
+- Because the [`SELECT`](../v21.2/authorization.html#privileges) database privilege is being deprecated, CockroachDB now additionally checks for the [`CONNECT`](../v21.2/authorization.html#privileges) privilege on the database to allow for backing up the database. Existing users with `SELECT` on the database can still back up the database, but it is now recommended to [`GRANT`](../v21.2/grant.html) `CONNECT` on the database. [#68391][#68391]
+- Added a `webhook_sink_config` JSON option to configure batching and flushing behavior, along with retry behavior for webhook sink [changefeed](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) messages. [#68633][#68633]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) will now error if an option is used with an incompatible sink. [#69173][#69173]
+- Fixed a bug where [changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) would fail to correctly handle a primary key change. [#69234][#69234]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) now correctly account for memory during backfills and "pushback" under memory pressure—that is, slow down backfills. [#69388][#69388]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) will now slow down correctly whenever there is a slow-down in the system (i.e. downstream sink is slow). [#68288][#68288]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) will now flush the sink only when frontier advances. This eliminates unnecessary sink flushes. [#67988][#67988]
+- Improved [changefeed](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) scalability, particularly when running against large tables, by reducing the rate of job progress updates. [#67815][#67815]
+- [Changefeeds](../v21.2/stream-data-out-of-cockroachdb-using-changefeeds.html) can resume during backfill without losing too much progress. [#66013][#66013]
+
+### SQL language changes
+
+- To perform [`REASSIGN OWNED BY`](../v21.2/reassign-owned.html), the current user running the command must now be a member of both the old and new [roles](../v21.2/authorization.html#roles). Previously the new owner would need: to be a member of the `CREATEDB` role if the object being changed was a database, [`CREATE` privileges](../v21.2/grant.html#supported-privileges) for the database if the object being changed was a schema, or `CREATE` privileges for the schema if object being changed was a table or type. [#69382][#69382]
+- The [SQL stats compaction job](../v21.2/cost-based-optimizer.html#table-statistics) now only shows up in the output of [`SHOW AUTOMATIC JOBS`](../v21.2/show-jobs.html). [#69641][#69641]
+- `DROP`s, `RENAME`s, and other light schema changes are no longer user cancelable to avoid scenarios that do not properly rollback. [#69328][#69328]
+- Users can now opt to disable auto-rehoming for a session by setting `on_update_rehome_row_enabled = false`. This can be permanently unset by default using the [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.on_update_rehome_row.enabled`. [#69626][#69626]
+- It is now possible to alter the owner of the [`crdb_internal_region` type](../v21.2/set-locality.html#crdb_region), which is created by initiating a [multi-region database](../v21.2/multiregion-overview.html). [#69722][#69722]
+- Added more detail to the error message users receive when they call [`SHOW BACKUP`](../v21.2/show-backup.html) with a path pointing to the root of the collection, rather than a specific [backup](../v21.2/backup.html) in the collection. [#69638][#69638]
+- Introduced a new cluster setting `sql.stats.persisted_rows.max ` and increased its default value to `1000000` (1,000,000 rows). [#69667][#69667]
+- Previously, users had no way of determining which objects in their database utilized deprecated features like interleaved indexes/tables or cross-database references. Added crdb_internal tables `cross_db_references`, `interleaved_indexes`, and `interleaved_tables` for detecting these deprecated features within a given database. [#61629][#61629]
+- The `sql.defaults.vectorize_row_count_threshold` [cluster setting](../v21.2/cluster-settings.html), as well as the corresponding `vectorize_row_count_threshold` session variable, have been removed. From now on, CockroachDB will behave exactly as if these were set to `0` (last default value). [#62164][#62164]
+- Updated `crdb_internal.interleaved` to add the `parent_table_name` column replacing the `parent_index_name` column. [#62076][#62076]
+- CockroachDB now references sequences used in views by their IDs to allow these sequences to be renamed. [#61439][#61439]
+- Added `SQLType` to classify `DDL`, `DML`, `DCL`, or `TCL` statement types. [#62989][#62989]
+- Implemented the geometry-based [builtin](../v21.2/functions-and-operators.html#built-in-functions) `ST_IsValidTrajectory`. [#63072][#63072]
+- CockroachDB now accepts UUID inputs that have a hyphen after any group of four digits. This aligns with the UUID format used by PostgreSQL. For example, `a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11` is now considered a valid UUID. [#63137][#63137]
+- The `gen_ulid` and `uuid_ulid_to_string` [builtins](../v21.2/functions-and-operators.html#built-in-functions) are now available for use. [#62440][#62440]
+- Single-key spans in [`EXPLAIN`](../v21.2/explain.html) and `EXPLAIN (DISTSQL)` are now shown without a misleading dash after them. [#61583][#61583]
+- Enabled locality-optimized search in the row execution engine. [#63384][#63384]
+- CockroachDB now should be more stable when executing queries with subqueries producing many rows (previously it could OOM crash; it wil now use the temporary disk storage). [#63900][#63900]
+- Correlated common table expressions (CTEs) can now be used. [#63956][#63956]
+- Introduced a new session variable `distsql_workmem` that determines how much RAM a single operation of a single query can take before the operation must spill to disk. This is identical to the `sql.distsql.temp_storage.workmem` [cluster setting](../v21.2/cluster-settings.html) but has the session-level scope. [#63959][#63959]
+- `crdb_internal.node_statement_statistics` now stores `statement_id`. [#64076][#64076]
+- Added line to the [`EXPLAIN ANALYZE`](../v21.2/explain-analyze.html) output to show disk spill usage to make it clear when disk spilling occurs executing a query. This output is only shown when the disk usage is greater than zero. The verbiage in the DistSQL `EXPLAIN` diagrams changed from `max scratch disk allocated` to `max sql temp disk usage` for consistency and to match the way we talk about SQL spill disk usage elsewhere. [#64137][#64137]
+- Previously, committing a transaction when a portal was suspended would cause a "multiple active portals not supported" error. Now, the portal is automatically destroyed. [#63677][#63677]
+- Bulk IO operations are no longer included in service latency metrics. [#64442][#64442]
+- Collated strings may now have a locale that is a language tag, followed by a `-u-` suffix, followed by anything else. For example, any locale with a prefix of `en-US-u-` is now considered valid. [#64695][#64695]
+- Added new tables to `pg_catalog`: `pg_partitioned_table`, `pg_replication_origin_status`, `pg_init_privs`, `pg_replication_slots`, `pg_policy`, `pg_sequences`, `pg_subscription_rel`, `pg_largeobject_metadata`. [#64035][#64035]
+- Added new columns to `pg_catalog` tables: `pg_class` (`relminmxid`), `pg_constraint` (`conparentid`). [#64035][#64035]
+- Using the table name as a projection now works, e.g., `SELECT table_name FROM table_name` or `SELECT row_to_json(table_name) FROM table_name`. [#64748][#64748]
+- Added `generate_series` for `TIMESTAMPTZ` values. [#64887][#64887]
+- Added the `sql.defaults.require_explicit_primary_keys.enabled` [cluster setting](../v21.2/cluster-settings.html) for requiring explicit primary keys in [`CREATE TABLE`](../v21.2/create-table.html) statements. [#64951][#64951]
+- SQL service latency now only includes metrics from DML statements. [#64893][#64893]
+- Added support for using `OPERATOR(operator)` for binary expressions. This only works for in-built CockroachDB operators. [#64701][#64701]
+- Introduced the `OPERATOR` syntax for unary operators. This only works for unary operators usable in CockroachDB. [#64701][#64701]
+- Implemented the geometry [builtin](../v21.2/functions-and-operators.html#built-in-functions) function `ST_LineCrossingDirection`. [#64997][#64997]
+- Added the `pg_relation_is_updatable` and `pg_column_is_updatable` [builtin](../v21.2/functions-and-operators.html#built-in-functions) functions [#64788][#64788]
+- `information_schema.columns.data_type` now returns "`USER-DEFINED`" when the column is a user-defined type (e.g., [`ENUM`](../v21.2/enum.html)) [#65154][#65154]
+- CockroachDB now supports the scalar functions `get_byte()` and `set_byte()` as in PostgreSQL. [#65189][#65189]
+- CockroachDB now supports converting strings of hexadecimal digits prefixed by `x` or `X` to a BIT value, in the same way as PostgreSQL. Note that only the conversion via casts is supported (e.g., `'XAB'::BIT(8)`); PostgreSQL's literal constant syntax (e.g., `X'AB'::BIT(8)`) continues to have different meaning in CockroachDB (byte array) due to historical reasons. [#65188][#65188]
+- [`SHOW JOBS`](../v21.2/show-jobs.html) now shows the `trace_id` of the trace that is associated with the current execution of the job. This allows pulling inflight traces for a job for debugging purposes. [#65322][#65322]
+- The [vectorized execution engine](../v21.2/vectorized-execution.html) now supports the ntile window function. [#64977][#64977]
+- Pg_sequences table was implemented on pg_catalog [#65420][#65420]
+- A constant can now be cast to regclass without first converting the constant to an OID. E.g., 52::regclass can now be done instead of 52::oid::regclass. [#65432][#65432]
+- References to WITH expressions from correlated subqueries are now always supported. [#65550][#65550]
+- Added new [`SHOW CHANGEFEED JOBS`](../v21.2/show-jobs.html) command with additional information about changefeeds for improved user visibility. [#64956][#64956]
+- This is strictly a change for docgen and sql grammar. Now all sql.y statements (excluding those that are unimplemented or specified to be skipped) will have automatically have a stmtSpec defined for them and thus will have a bnf and svg file automatically generated in cockroachdb/generated-diagrams. [#65278][#65278]
+- The [vectorized execution engine](../v21.2/vectorized-execution.html) now supports the `lag` and `lead` window functions. [#65634][#65634]
+- The total number of statement/transaction fingerprints stored in-memory can now be limited using the [cluster settings](../v21.2/cluster-settings.html) `sql.metrics.max_mem_stmt_fingerprints` and `sql.metrics.max_mem_txn_fingerprints`. [#65902][#65902]
+- Previously, SQL commands that were sent during the PostgreSQL extended protocol that were too big would error opaquely. This is now resolved by returning a friendlier error message. [#57590][#57590]
+- Namespace entries may no longer be queried via `system.namespace2`. [#65340][#65340]
+- [`EXPLAIN ANALYZE`](../v21.2/explain-analyze.html) output now includes, for each plan step, the total time spent waiting for KV requests as well as the total time those KV requests spent contending with other transactions. [#66157][#66157]
+- Added the [`SHOW CREATE DATABASE`](../v21.2/show-create.html) command to get database metadata. [#66033][#66033]
+- Added `sample_plan`, `database_name`, and `exec_node_ids` columns to the `crdb_internal.node_statement_statistics` table. This allows for third-party and partner consumption of this data. [#65782][#65782]
+- Implemented `pg_rewrite` for table-view dependencies. Table-view dependencies are no longer stored directly in `pg_depend`. [#65495][#65495]
+- Added some virtual tables `crdb_internal.(node|cluster)_distsql_flows` that expose the information about the flows of the DistSQL execution scheduled on remote nodes. These tables do not include information about the non-distributed queries or about local flows (from the perspective of the gateway node of the query). [#65727][#65727]
+- The use order of columns in a foreign key no longer needs to match the order the columns were defined for the reference table's unique constraint. [#65209][#65209]
+- Previously, in some special cases ([`UPSERT`](../v21.2/upsert.html)s, as documented in [this issue](https://github.com/cockroachdb/docs/issues/9922)), the support of the distinct operations was missing in the [vectorized execution engine](../v21.2/vectorized-execution.html). This has been added, and such operations will be able to spill to disk if necessary. However, in case the distinct operator does, in fact, spill to disk, there is a slight complication. The order in which rows are inserted can be non-deterministic: for example, for a query such as `INSERT INTO t VALUES (1, 1), (1, 2), (1, 3) ON CONFLICT DO NOTHING`, with `t` having the schema `a INT PRIMARY KEY, b INT`, it is possible that any of the three rows are actually inserted. PostgreSQL appears to have the same behavior. [#61582][#61582]
+- Added three new views to the `crdb_internal schema` to support developers investigating contention events: `cluster_contended_{tables, indexes, keys}`. [#66370][#66370]
+- Implemented `similar_escape` and made `similar_to_escape` compatible with PostgreSQL. [#66578][#66578]
+- The `"char"` column type will now truncate long values, in line with PostgreSQL. [#66422][#66422]
+- The contents of the statistics table in the information schema have changed; therefore, so have the results of [`SHOW INDEX`](../v21.2/show-index.html) and [`SHOW COLUMNS`](../v21.2/show-columns.html). A column that is not in the primary key will now be listed as belonging to the primary index as a stored column. Previously, it was simply not listed as belonging to the primary index. [#66599][#66599]
+- Adding empty missing tables on `information_schema` for compatibility: `attributes`, `check_constraint_routine_usage`, `column_column_usage`, `column_domain_usage`, `column_options`, `constraint_table_usage`, `data_type_privileges`, `domain_constraints`, `domain_udt_usage`, `domains`, `element_types`, `foreign_data_wrapper_options`, `foreign_data_wrappers`, `foreign_server_options`, `foreign_servers`, `foreign_table_options`, `foreign_tables`, `information_schema_catalog_name`, `role_column_grants`, `role_routine_grants`, `role_udt_grants`, `role_usage_grants`, `routine_privileges`, `sql_features`, `sql_implementation_info`, `sql_parts`, `sql_sizing`, `transforms`, `triggered_update_columns`, `triggers`, `udt_privileges`, `usage_privileges`, `user_defined_types`, `user_mapping_options`, `user_mappings`, `view_column_usage`, `view_routine_usage`, `view_table_usage`. [#65854][#65854]
+- The [`SHOW QUERIES`](../v21.2/show-statements.html) command was extended for prepared statements to show the actual values in use at query time, rather than the previous `$1`, `$2`, etc. placeholders. We expect showing these values will greatly improve the experience of debugging slow queries. [#66689][#66689]
+- Populated the `pg_type` table with entries for each table. Also populated `pg_class.reltypid` with the corresponding `oid` in the `pg_type` table. [#66815][#66815]
+- Added a virtual table `crdb_internal.cluster_inflight_traces` which surfaces cluster-wide inflight traces for the `trace_id` specified via an index constraint. The output of this table is not appropriate to consume over a SQL connection; follow-up changes will add CLI wrappers to make the interaction more user-friendly. [#66679][#66679]
+- Added support for `iso_8601` and `sql_standard` as usable session variables in `IntervalStyle`. Also added a `sql.defaults.intervalstyle` [cluster setting](../v21.2/cluster-settings.html) to be used as the default interval style. [#67000][#67000]
+- Added a [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.primary_region`, which assigns a `PRIMARY REGION` to a database by default. [#67168][#67168]
+- Introduced a [cluster setting](../v21.2/cluster-settings.html) `sql.allow_drop_final_region.enabled` which disallows dropping of a `PRIMARY REGION` (the final region of a database). [#67168][#67168]
+- [`IMPORT TABLE`](../v21.2/import.html) will be deprecated in v21.2 and removed in a future release. Users should create a table using [`CREATE TABLE`](../v21.2/create-table.html) and then [`IMPORT INTO`](../v21.2/import-into.html) the newly created table. [#67275][#67275]
+- CockroachDB now uses `JSONB` instead of `BYTES` to store statement plans in `system.statement_statistics`. [#67331][#67331]
+- Reduced instantaneous memory usage during scans by up to 2x. [#66376][#66376]
+- Added the session variable `backslash_quote` for PostgreSQL compatibility. Setting this does a no-op, and only `safe_encoding` is supported. [#67343][#67343]
+- Introduced a `crdb_internal.regions` table which contains data on all regions in the cluster. [#67098][#67098]
+- When parsing intervals, `IntervalStyle` is now taken into account. In particular, `IntervalStyle = 'sql_standard'` will make all interval fields negative if there is a negative symbol at the front, e.g., `-3 years 1 day` would be `-(3 years 1 day)` in `sql_standard` and `-3 days, 1 day` in PostgreSQL `DateStyle`. [#67210][#67210]
+- `ROLLBACK TO SAVEPOINT` can now be used to recover from `LockNotAvailable` errors (`pgcode` `55P03`), which are returned when performing a [`FOR UPDATE SELECT`](../v21.2/select-for-update.html) with a `NOWAIT` wait policy. [#67514][#67514]
+- Added tables to `information_schema` that are present on MySQL. The tables are not populated and are entirely empty. `column_statistics`, `columns_extensions`, `engines`, `events`, `files`, `keywords`, `optimizer_trace`, `partitions`, `plugins`, `processlist`, `profiling`, `resource_groups`, `schemata_extensions`, `st_geometry_columns`, `st_spatial_reference_systems`, `st_units_of_measure`, `table_constraints_extensions`, `tables_extensions`, `tablespaces`, `tablespaces_extensions`, `user_attributes`. [#66795][#66795]
+- Added new [builtins](../v21.2/functions-and-operators.html#built-in-functions) `compress(data, codec)` and `decompress(data, codec)` which can compress and decompress bytes with the specified codec. `Gzip` is the only currently supported codec. [#67426][#67426]
+- The column types of the results of `SHOW LAST QUERY STATISTICS` (an undocumented statement meant mostly for internal use by CockroachDB's SQL shell) has been changed from `INTERVAL` to `STRING`. They are populated by the durations of the various phases of executions as if the duration, as an `INTERVAL`, was converted to `STRING` using the '`postgres`' `IntervalStyle`. This ensures that the server-side execution timings are always available regardless of the value of the `IntervalStyle` session variable. [#67654][#67654]
+- Changed `information_schema.routines` data types at columns `interval_precision`, `result_cast_char_octet_length` and `result_cast_datetime_precision` to `INT`. [#67641][#67641]
+- Added syntax for granting and revoking privileges for all the tables in the specified schemas. New supported syntax: [`GRANT {privileges...} ON ALL TABLES IN SCHEMA {schema_names...} TO {roles...}`](../v21.2/grant.html); [`REVOKE {privileges...} ON ALL TABLES IN SCHEMA {schema_names...} TO {roles...}`](../v21.2/revoke.html). This command is added for PostgreSQL compatibility. [#67509][#67509]
+- Added `pg_stat_database` and `pg_stat_database_conflicts` to `pg_catalog`. [#66687][#66687]
+- A database that is restored with the [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.primary_region` will now have the `PRIMARY REGION` from the cluster setting assigned to the database. [#67581][#67581]
+- The [vectorized execution engine](../v21.2/vectorized-execution.html) now supports `CASE` expressions that output `BYTES`-like types. [#66399][#66399]
+- Introduced the `with_min_timestamp` and `with_max_staleness` [builtin](../v21.2/functions-and-operators.html#built-in-functions) functions. In a `SELECT` clause, they return the same timestamp and `(now() - interval)`, but are intended for use in `AS OF SYSTEM TIME`, which will appear in an upcoming update. [#67697][#67697]
+- `first_value`, `last_value`, and `nth_value` window functions can now be executed in the [vectorized execution engine](../v21.2/vectorized-execution.html). This allows for faster execution time, and also removes the need for conversions to and from row format. [#67764][#67764]
+- Improved performance of lookup joins in some cases. If join inequality conditions can be matched to index columns, CockroachDB now includes the conditions in the index lookup spans and removes them from the runtime filters. [#66002][#66002]
+- Added support for `ALTER DEFAULT PRIVILEGES` and default [privileges](../v21.2/authorization.html#privileges) stored on databases. All objects created in a database will have the privilege set defined by the default privileges for that type of object on the database. The types of objects are `TABLES`, `SEQUENCES`, `SCHEMAS`, `TYPES`. Example: `ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO foo` makes it such that all tables created by the user that executed the `ALTER DEFAULT PRIVILEGES` command will have [`SELECT` privilege](../v21.2/authorization.html#privileges) on the table for user `foo`. Additionally, one can specify a [role](../v21.2/authorization.html#roles). Example: `ALTER DEFAULT PRIVILEGES FOR ROLE bar GRANT SELECT ON TABLES TO foo`. All tables created by bar will have [`SELECT` privilege](../v21.2/authorization.html#privileges) for `foo`. If a role is not specified, it uses the current user. For further context, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html). Currently, default privileges are not supported on the schema. Specifying a schema like `ALTER DEFAULT PRIVILEGES IN SCHEMA s` will error. `WITH GRANT OPTION` is ignored. `GRANT OPTION FOR` is also ignored. [#66785][#66785]
+- Introduced a `nearest_only` argument for `with_min_timestamp`/`with_max_staleness`, which enforces that bounded staleness reads only talk to the nearest replica. [#67837][#67837]
+- [`CREATE TABLE LIKE`](../v21.2/create-table.html) now copies hidden columns over. [#67799][#67799]
+- Populated `pg_catalog.pg_default_acl`. This is important for tracking which default [privileges](../v21.2/authorization.html#privileges) are defined in the database. `pg_catalog.pg_default_acl` has 5 columns: <ul><li>`oid` (`oid`): row identifier </li><li>`defaclrole` (`oid`): `oid` of the role the default privileges are defined for</li><li>`defaclnamespace` (`oid`): `oid` of the schema the default privileges are defined in</li><li>`defaclobjtype` (`char`): `r` = relation (`table`, `view`), `S` = sequence, `f` = function, `T` = type, `n` = schema</li><li>`defaclacl` (`aclitem[]`): string representation of default privileges, following the format "`$1`=`$2`/`$3`" where `$1` is the grantee's username, `$2` is a list of characters representing the privileges, and `$3` is the grantor (which is currently always an empty string in CockroachDB).</li></ul> Privileges are represented by chars in the `aclitem[]` representation.<ul><li>`CREATE` = '`C`' <li>`SELECT` = '`r`'</li><li>`INSERT` = '`a`'</li><li>`DELETE` = '`d`'</li><li>`UPDATE` = '`w`'</li><li>`USAGE` = '`U`'</li><li>`CONNECT` = '`c`'</li></ul> See the PostgreSQL documentation for the [table of PostgreSQL-supported privileges and their `char` representations](https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGES-SUMMARY-TABLE) and the [PostgreSQL definition of `pg_catalog.pg_default_acl`](https://www.postgresql.org/docs/13/catalog-pg-default-acl.html). [#67872][#67872]
+- An earlier commit changed CockroachDB to use the value of the `IntervalStyle` session var when interpreting interval to string conversions. However, this made `string::interval` and `interval::string` casts have a volatility of "stable" instead of "immutable". This has ramifications for items such as computed columns and check clauses, which cannot use immutable expressions. This means that the particular results returned by these queries can become incoherent when `IntervalStyle` is customized to a different value from its default, `postgres`. In order to provide guardrails against this incoherence, CockroachDB now provides a new, separate configuration knob called `intervalstyle_enabled` that applications can use to "opt in" the ability to customize IntervalStyle:<ul><li>By default, this knob is false and applications cannot customize `IntervalStyle`. Interval to string conversions that are already stored in the schema are unaffected and continue to produce results as per the default style `postgres`.</li><li>When the knob is true, these things happen:</li><ul><li>Apps can start customizing `IntervalStyle` in SQL sessions.</li><li>A SQL session that has a custom `IntervalStyle` will start observing *incoherent results* when accessing tables that already contain a conversion from interval to string.</li></ul></ul>The knob works as follows: The *primary* configuration mechanism is a new [cluster setting](../v21.2/cluster-settings.html) called `sql.defaults.intervalstyle.enabled`. This is the knob that operators and DBAs should customize manually. Then, as a *secondary* configuration mechanism, the value of the [cluster setting](../v21.2/cluster-settings.html) is also copied to each SQL session as a new session var `intervalstyle_enabled`. This is a performance optimization. SQL apps should not modify this session var directly, except for temporary testing purposes. In v22.1, upgrades will be disabled if these stable expressions are found in computed columns, check clauses, etc. [#67792][#67792]
+- Previously, `OPERATOR(+)int` would simplify to `+int` when parsed, which would lead to re-reproducibility issues when considering order of operators. This is now fixed by leaving `OPERATOR(+)` in the tree. [#68041][#68041]
+- Previously, pretty printing could fold some `OPERATOR` expressions based on the order of operations of the operator inside the `OPERATOR`. This can lead to a different order of operations when reparsing, so this is fixed by never folding `OPERATOR` expressions. [#68041][#68041]
+- Added the `SHOW CREATE SCHEDULE` command to view SQL statements used to create existing schedules. [#66782][#66782]
+- Created a [builtin](../v21.2/functions-and-operators.html#built-in-functions) to reset the zone configurations of multi-region tables. This builtin can be helpful in cases where the user has overridden the [zone configuration](../v21.2/configure-replication-zones.html) for a given table and wishes to revert back to the original system-specified state. [#67985][#67985]
+- Implemented the `parse_interval` and `to_char_with_style` [builtins](../v21.2/functions-and-operators.html#built-in-functions), which convert strings from/to intervals with immutable volatility. [#67970][#67970]
+- Casting from interval to string or vice-versa is now blocked for computed columns, partial indexes, and partitions when the `intervalstyle_enabled` session setting is enabled. Instead, using `to_char_with_style(interval, style)` or `parse_interval(interval, intervalstyle)` is available as a substitute. This is enforced in v22.1, but is opt-in for v21.2. It is recommended to set the [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.intervalstyle_enabled` to `true` to avoid surprises when upgrading to v22.1. [#67970][#67970]
+- Common aggregate functions can now be executed in the [vectorized execution engine](../v21.2/vectorized-execution.html). This allows for better memory accounting and faster execution in some cases. [#68081][#68081]
+- Retry information has been added to the statement trace under the `exec stmt` operation. The trace message is in the format: "executing after <int> retries, last retry reason: <err>". This message will appear in any operations that show the statement trace, which is included in operations such as `SHOW TRACE FOR SESSION` and is also exported in the [statement diagnostics bundle](../v21.2/ui-statements-page.html#diagnostics). [#67941][#67941]
+- Added empty `pg_stat*` tables on `pg_catalog`: `pg_stat_all_indexes`, `pg_stat_all_tables`, `pg_stat_archiver`, `pg_stat_bgwriter`, `pg_stat_gssapi`, `pg_stat_progress_analyze`, `pg_stat_progress_basebackup`, `pg_stat_progress_cluster`, `pg_stat_progress_create_index`, `pg_stat_progress_vacuum`, `pg_stat_replication`, `pg_stat_slru`, `pg_stat_ssl`, `pg_stat_subscription`, `pg_stat_sys_indexes`, `pg_stat_sys_tables`, `pg_stat_user_functions`, `pg_stat_user_indexes`, `pg_stat_user_tables`, `pg_stat_wal_receiver`, `pg_stat_xact_all_tables`, `pg_stat_xact_sys_tables`, `pg_stat_xact_user_functions`, `pg_stat_xact_user_tables`, `pg_statio_all_indexes`, `pg_statio_all_sequences`, `pg_statio_all_tables`, `pg_statio_sys_indexes`, `pg_statio_sys_sequences`, `pg_statio_sys_tables`, `pg_statio_user_indexes`, `pg_statio_user_sequences`, `pg_statio_user_tables`. [#67947][#67947]
+- Added syntax for [`ALTER ROLE ... SET`](../v21.2/alter-role.html) statements. The business logic for these statements is not yet implemented, but will be added in a later commit. The following forms are supported: `ALTER ROLE { name | ALL } [ IN DATABASE database_name ] SET var { TO | = } { value | DEFAULT }`, `ALTER ROLE { name | ALL } [ IN DATABASE database_name ] RESET var`, `ALTER ROLE { name | ALL } [ IN DATABASE database_name ] RESET ALL`. As with other statements, the keywords `ROLE` and `USER` are interchangeable. This matches the [PostgreSQL syntax](https://www.postgresql.org/docs/13/sql-alterrole.html). [#68001][#68001]
+- [`BACKUP`](../v21.2/backup.html) now supports backing up tables in a specified schema (e.g., `BACKUP my_schema.*`, or `my_db.my_schema.*`). Schemas will be resolved before databases, so `my_object.*` will resolve to a schema of that name in the current database before matching a database with that name. [#67649][#67649]
+- Added support for a new index hint, `NO_ZIGZAG_JOIN`, which will prevent the optimizer from planning a zigzag join for the specified table. The hint can be used in the same way as other existing index hints. For example, `SELECT * FROM table_name@{NO_ZIGZAG_JOIN};`. [#68141][#68141]
+- Added a `cardinality` [builtin](../v21.2/functions-and-operators.html#built-in-functions) function that returns the total number of elements in a given array. [#68263][#68263]
+- Introduced a new [cluster setting](../v21.2/cluster-settings.html) `jobs.trace.force_dump_mode` that allows users to configure Traceable jobs to dump their traces:
+ - `never`: Job will never dump its traces.
+ - `onFail`: Job will dump its trace after transitioning to the `failed` state.
+ - `onStatusChange`: Job will dump its trace whenever it transitions from paused, canceled, succeeded or failed state. [#67386][#67386]
+- DMY and YMD `DateStyles` are now supported. [#68093][#68093]
+- When the date value is out of range, a hint now suggests that the user try a different `DateStyle`. [#68093][#68093]
+- When `DateStyle` and `IntervalStyle` are updated, this will now send a `ParamStatusUpdate` over the wire protocol. [#68093][#68093]
+- Added support to alter default [privileges](../v21.2/authorization.html#privileges) for all roles. The syntax supported is `ALTER DEFAULT PRIVILEGES FOR ALL ROLES grant_default_privs_stmt/revoke_default_privs_stmt.` Only [`admin`](../v21.2/authorization.html#admin-role) users are able to execute this. This allows adding default privileges for objects that are created by ANY role, as opposed to having to specify a creator role to which the default privileges will apply when creating an object. Example: `ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT SELECT ON TABLES TO foo;`. Regardless of whichever user now creates a table in the current database, `foo` will have `SELECT`. [#68076][#68076]
+- Added a `crdb_internal.reset_multi_region_zone_configs_for_database` [builtin](../v21.2/functions-and-operators.html#built-in-functions) to reset the zone configuration of a multi-region database. This builtin can be helpful in cases where the user has overridden the zone configuration for a given database and wishes to revert back to the original system-specified state. [#68280][#68280]
+- The session setting `optimizer_improve_disjunction_selectivity` and its associated [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.optimizer_improve_disjunction_selectivity.enabled` are no longer supported. They were added in v21.1.7 to enable better optimizer selectivity calculations for disjunctions. This logic is now always enabled. [#68349][#68349]
+- Running [`ALTER ROLE`](../v21.2/alter-role.html) on any role that is a member of [`admin`](../v21.2/authorization.html#admin-role) now requires the `admin` role. Previously, any user with the `CREATEROLE` option could `ALTER` an `admin`. [#68187][#68187]
+- Introduced an `hlc_to_timestamp` [builtin](../v21.2/functions-and-operators.html#built-in-functions), which converts a CockroachDB HLC to a `TIMESTAMPTZ`. This is useful for pretty printing `crdb_internal_mvcc_timestamp` or `cluster_logical_timestamp()`, but is not useful for accuracy. [#68360][#68360]
+- Added a `crdb_internal.default_privileges` table that is useful for getting a human-readable way of examining default [privileges](../v21.2/authorization.html#privileges). [#67997][#67997]
+- Added support for `SHOW DEFAULT PRIVILEGES` and `SHOW DEFAULT PRIVILEGES FOR ROLE ...`. If a [role(s)](../v21.2/authorization.html#roles) is not specified, default [privileges](../v21.2/authorization.html#privileges) are shown for the current role. `SHOW DEFAULT PRIVILEGES` returns the following columns: `schema_name`, `role`, `object_type`, `grantee`, `privilege_type`. [#67997][#67997]
+- The `pg_db_role_setting` table of the `pg_catalog` is now implemented. When [`ALTER ROLE ... SET var`](../v21.2/alter-role.html) is used to configure per-role defaults, these default settings will be populated in `pg_db_role_setting`. This table contains the same data no matter which database the current session is using. For more context, see the [PostgreSQL documentation](https://www.postgresql.org/docs/13/catalog-pg-db-role-setting.html). [#68245][#68245]
+- Removed the `count` column from the `system.statement_statistics` and `system.transaction_statistics` tables. [#67866][#67866]
+- Introduced the `crdb_internal.index_usage_statistics` virtual table to surface index usage statistics. The `sql.metrics.index_usage_stats.enabled` [cluster setting](../v21.2/cluster-settings.html) can be used to turn on/off the subsystem. It defaults to `true`. [#66640][#66640]
+- The `bulkio.backup.proxy_file_writes.enabled` [cluster setting](../v21.2/cluster-settings.html) is no longer needed to enable proxied writes, which are now the default. [#68468][#68468]
+- Default session variable settings configured by [`ALTER ROLE ... SET`](../v21.2/alter-role.html) are now supported. The following order of precedence is used for variable settings:<ol><li>Settings specified in the connection URL as a query parameter</li><li>Per-role and per-database settings configured by `ALTER ROLE`</li><li>Per-role and all-database settings configured by `ALTER ROLE`</li><li>All-role and per-database settings configured by `ALTER ROLE`</li><li>All-role and all-database settings configured by `ALTER ROLE`</li></ol>`RESET` does not validate the setting name. `SET` validates both the name and the proposed default value. Note that the default settings for a role are not inherited if one role is a member of another role that has default settings. Also, the defaults _only_ apply during session initialization. Using `SET DATABASE` to change databases does not apply default settings for that database. The `public`, `admin`, and `root` [roles](../v21.2/authorization.html#roles) cannot have default session variables configured. The `root` role also will never use the "all-role" default settings. This is so that `root` has fewer dependencies during session initialization and to make it less likely for `root` authentication to become unavailable during the loss of a node. Changing the default settings for a role requires the role running the `ALTER` command to either be an `ADMIN` or to have the `CREATEROLE` role option. Only `ADMIN`s can edit the default settings for another admin. Futhermore, changing the default settings for `ALL` roles is _only_ allowed for `ADMIN`s. Roles without `ADMIN` or `CREATEROLE` _cannot_ change the default settings for themselves. [#68128][#68128]
+- An earlier commit changed CockroachDB to use the value of the `DateStyle` session var when interpreting date to string conversions (and vice-versa). However, this made `string::{date,timestamp}` and `{date,timetz,time,timestamp}::string` casts have a volatility of "stable" instead of "immutable". This has ramifications for items such as computed columns and check clauses, which cannot use immutable expressions. This means that the particular results returned by these queries can become incoherent when `DateStyle` is customized to a different value from its default, `ISO,MDY`. In order to provide guardrails against this incoherence, CockroachDB now provides a new, separate configuration knob called `datestyle_enabled` that applications can use to "opt in" the ability to customize DateStyle:<ul><li>By default, this knob is false and applications cannot customize  `DateStyle`. Invalid conversions that are already stored in the schema are unaffected and continue to produce  results as per the default style `postgres`.</li><li>When the knob is true, these things happen:<ul><li>Apps can start customizing `DateStyle` in SQL sessions.</li><li>A SQL session that has a custom `DateStyle` will start observing *incoherent results* when accessing tables that already contain the aforementioned casts.</li><li>New schemas cannot have the above casts.</li></ul></ul>The knob works as follows: The *primary* configuration mechanism is a new [cluster setting](../v21.2/cluster-settings.html) called `sql.defaults.datestyle.enabled`. This is the knob that operators and DBAs should customize manually. Then as a *secondary* configuration mechanism, the value of the [cluster setting](../v21.2/cluster-settings.html) is also copied to each SQL session as a new session var `datestyle_enabled`. This is a performance optimization. SQL apps should not modify this session var directly, except for temporary testing purposes. In v22.1, upgrades will be disabled if these stable expressions are found in computed columns, check clauses, etc. [#68352][#68352]
+- Introduced `parse_interval` and `to_char`, which takes in 1 string or interval and assumes the PostgreSQL `IntervalStyle` to make its output. [#68351][#68351]
+- `parse_timestamp` now has a two-argument variant, which takes in a `DateStyle` and parses timestamps according to that `DateStyle`. The one argument version assumes MDY. These [builtins](../v21.2/functions-and-operators.html#built-in-functions) have an immutable volatility. [#68351][#68351]
+- Introduced a `timestamp,DateStyle` variant to `to_char_with_style`, which converts timestamps to a string with an immutable volatility. There is also a 1 arg `to_char` for timestamp values which assumes the `ISO,MDY` output style. [#68351][#68351]
+- Introduced a `parse_date` [builtin](../v21.2/functions-and-operators.html#built-in-functions) with two variants. The single-argument variant parses a date and assumes `ISO,MDY` datestyle, and the two-argument variant parses a date assuming the `DateStyle` variant on the second argument. This provides an immutable way of casting strings to dates. [#68351][#68351]
+- Introduced `to_char(date)`, which assumes a `DateStyle` of `ISO,MDY` and outputs date in that format. There is also a `to_char_with_style(date, DateStyle)` variant which outputs the date in the chosen `DateStyle`. This provides an immutable way of casting dates to strings. [#68351][#68351]
+- Implemented the `parse_time` and `parse_timetz` [builtins](../v21.2/functions-and-operators.html#built-in-functions), which parses a [`TIME` or `TIMETZ`](../v21.2/time.html) with immutable volatility. [#68351][#68351]
+- Some queries with lookup joins and/or top K sorts are now more likely to be executed in "local" manner with the `distsql=auto` session variable. [#68524][#68524]
+- SQL stats now can be persisted into `system.statement_statistics` and `system.transaction_statistics` tables by enabling the `sql.stats.flush.enable` [cluster setting](../v21.2/cluster-settings.html). The interval of persistence is determined by the new `sql.stats.flush.interval` [cluster setting](../v21.2/cluster-settings.html), which defaults to 1 hour. [#67090][#67090]
+- The `lock_timeout` session variable is now supported. The configuration can be used to abort a query with an error if it waits longer than the configured duration while blocking on a single row-level lock acquisition. [#68042][#68042]
+- Added support for `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` syntax in a column definition. This will automatically create a sequence for the given column. This matches PostgreSQL syntax and functionality. For more context, see the [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-createtable.html). [#68711][#68711]
+- The [vectorized execution engine](../v21.2/vectorized-execution.html) can now perform a scan over an index, and then join on the primary index to retrieve the required columns. [#67450][#67450]
+- `SHOW DEFAULT PRIVILEGES FOR ALL ROLES` is now supported as a syntax. Show default privileges returns a second column `for_all_roles` (`bool`) which indicates whether or not the default [privileges](../v21.2/authorization.html#privileges) shown are for all roles. [#68607][#68607]
+- `SHOW DEFAULT PRIVILEGES` now only shows default privileges for the current user. [#68607][#68607]
+- If a user has a default [privilege](../v21.2/authorization.html#privileges) defined for, they cannot be dropped until the default privilege is removed. Example: `ALTER DEFAULT PRIVILEGES FOR ROLE test1 GRANT SELECT ON TABLES TO test2;`. Neither `test1` nor `test2` can be dropped until performing `ALTER DEFAULT PRIVILEGES FOR ROLE test1 REVOKE SELECT ON TABLES FROM test2;`. [#67950][#67950]
+- Added new metrics to track schema job failure: `sql.schema_changer.errors.all`, `sql.schema_changer.errors.constraint_violation`, `sql.schema_changer.errors.uncategorized`; errors inside the `crdb_internal.feature_usage` table. [#68252][#68252]
+- Indexes on expressions can now be created. These indexes can be used to satisfy queries that contain filters with identical expressions. For example, `SELECT * FROM t WHERE a + b = 10` can utilize an index like `CREATE INDEX i ON t ((a + b))`. [#68807][#68807]
+- Roles with the name `none` and starting with `pg_` or `crdb_internal` can no longer be created. Any existing roles with these names may continue to work, but they may be broken when new features (e.g., `SET ROLE`) are introduced. [#68972][#68972]
+- Implemented the geometry-based [builtin](../v21.2/functions-and-operators.html#built-in-functions) `ST_Translate` on arguments `{geometry, float8,float8,float8}`. [#68959][#68959]
+- Errors involving `MinTimestampBoundUnsatisfiableError` during a bounded staleness read now get a custom `pgcode` (`54C01`). [#68967][#68967]
+- Table statistics are no longer collected for views. [#68997][#68997]
+- Added support for `SCHEMA` comments using PostgreSQL's `COMMENT ON SCHEMA` syntax. [#68606][#68606]
+- `SET ROLE user` now parses without an equal between `ROLE` and `=`. This functionality is not yet implemented. [#68750][#68750]
+- Allowed `RESET ROLE` to be parsed. This is not yet implemented. [#68750][#68750]
+- Added a `session_user()` [builtin](../v21.2/functions-and-operators.html#built-in-functions) function, which currently returns the same thing as `current_user()`, as we do not implement `SET ROLE`. [#68749][#68749]
+- Introduced new `crdb_internal.statement_statistics` virtual table that surfaces both cluster-wide in-memory statement statistics as well as persisted statement statistics. [#68715][#68715]
+- The regrole `OID` alias type is now supported, which is a PostgreSQL-compatible object identifier alias that references the `pg_catalog.pg_authid` table. [#68877][#68877]
+- CockroachDB now correctly sends the `RESET` tag instead of the `SET` tag when a `RESET` statement is run. [#69053][#69053]
+- Bounded staleness reads now retry transactions when `nearest_only=True` and a schema change is detected which may prevent a [follower read](../v21.2/follower-reads.html) from being served. [#68969][#68969]
+- Granting `SELECT`, `UPDATE`, `INSERT`, `DELETE` on databases is being deprecated. The syntax is still supported, but is automatically converted to the equivalent `ALTER DEFAULT PRIVILEGES FOR ALL ROLES` command. The user is given a notice that the privilege is incompatible and automatically being converted to an `ALTER DEFAULT PRIVILEGE FOR ALL ROLES` command. [#68391][#68391]
+- The syntax for setting database placement is now `ALTER DATABASE db PLACEMENT ...`. (The `SET` keyword is no longer allowed before the `PLACEMENT` keyword.) [#69067][#69067]
+- The `ALTER DATABASE db SET var ...` syntax is now supported. It is a syntax alias for `ALTER ROLE ALL IN DATABASE db SET var ...`, since it is identical to that functionality: it configures the default value to use for a session variable when a user connects to the given database. [#69067][#69067]
+- Implemented the `crdb_internal.serialize_session()` and `crdb_internal.deserialize_session(bytes)` [builtins](../v21.2/functions-and-operators.html#built-in-functions). The former outputs the session settings in a string that can be deserialized into another session by the latter. [#68792][#68792]
+- Added a [cluster setting](../v21.2/cluster-settings.html) `schedules.backup.gc_protection_enabled` that defaults to `true` and enables chaining of GC protection across backups run as part of a schedule. [#68446][#68446]
+- `crdb_internal.pb_to_json` now does not emit default values by default. [#69185][#69185]
+- Implemented `pg_shdepend` with shared dependencies with tables, databases and pinned user/roles. [#68018][#68018]
+- Added a [builtin](../v21.2/functions-and-operators.html#built-in-functions) function `crdb_internal.datums_to_bytes`, which can encode any data type which can be used in an forward index key into bytes in an immutable way. This function is now used in the expression for [hash-sharded indexes](../v21.2/hash-sharded-indexes.html). [#67865][#67865]
+- Introduced a new `crdb_internal.transaction_statistics` virtual table that surfaces both cluster-wide in-memory transaction statistics as well as persisted transaction statistics. [#69049][#69049]
+- Introduced `SET ROLE`, which allows users with certain permissions to assume the identity of another user. It is worth noting that due to cross-version compatibility, `session_user` will always return the same as `current_user` until v22.1. Instead, use `session_user()` if you require this information. [#68973][#68973]
+- An `ON UPDATE` expression can now be added to a column. Whenever a row is updated without modifying the `ON UPDATE` column, the column's `ON UPDATE` expression is re-evaluated, and the column is updated to the result. [#69091][#69091]
+- [Roles](../v21.2/authorization.html#roles) have a default set of default [privileges](../v21.2/authorization.html#privileges). For example, a role has `ALL` privileges on all objects as its default privileges when it creates the object. Additionally, the `public` role has `Usage` is a default privilege. This matches PostgreSQL's behavior such that the creator role and `public` role have the same set of default privileges in the default state. Now, when a user creates a table, sequence, type, or schema, it will automatically have `ALL` privileges on it, and `public` will have `USAGE` on types. This can be altered: `ALTER DEFAULT PRIVILEGE FOR ROLE rolea REVOKE ALL ON ... FROM rolea` will remove the default set of default privileges on the specified object from the role. [#68500][#68500]
+- `SHOW DEFAULT PRIVILEGES` shows implicit privileges. Implicit privileges are "default" default [privileges](../v21.2/authorization.html#privileges). For example, the creator should have all privileges on any object that it creates. This is now reflected in `SHOW DEFAULT PRIVILEGES`. [#69377][#69377]
+- Added a `system.span_configurations` table. This will later be used to store authoritative span configs. [#69047][#69047]
+- Added support for `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY (seq_option)` syntax under [`CREATE TABLE`](../v21.2/create-table.html). An `IDENTITY` column is an auto-incremented column based on an automatically created sequence, with the same performance considerations as the [`CREATE SEQUENCE` syntax](../v21.2/create-sequence.html#considerations). The `seq_option` is consistent with the sequence option syntax in `CREATE SEQUENCE`, and we also support [`CACHE` in `seq_option`](../v21.2/create-sequence.html#cache-sequence-values-in-memory) for better performance. Hence, such a column can only be of `integer` type, and is implicitly `NOT NULL`. It is essentially the same as `SERIAL` with `serial_normalization=sql_sequence`, except for user access to override it. A `GENERATED ALWAYS AS IDENTITY` column cannot be overridden without specifying `OVERRIDING SYSTEM VALUE` in an `INSERT`/`UPSERT`/`UPDATE` statement. This overriding issue cannot be resolved by the `ON CONFLICT` syntax. Such a column can only be updated to `DEFAULT`. A `GENERATED BY DEFAULT AS IDENTITY` column allows being overridden without specifying any extra syntax, and users are allowed to add repeated values to such a column. It can also be updated to customized expression, but only accepts `integer` type expression result. `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` is also supported under `ALTER TABLE ... ADD COLUMN ...` syntax. This matches the [PostgreSQL syntax](https://www.postgresql.org/docs/current/sql-createtable.html). [#69107][#69107]
+- Added `transaction_fingerprint_id` to `system.statement_statistics` primary key. [#69320][#69320]
+- Introduced `crdb_internal.schedule_sql_stats_compaction()` to manually create SQL Stats compaction schedule. Extended the `SHOW SCHEDULES` command to support `SHOW SCHEDULES FOR SQL STATISTICS`. [#68401][#68401]
+- The [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.experimental_auto_rehoming.enabled` and session setting `experimental_enable_auto_rehoming` were added to enable auto-rehoming on [`UPDATE`](../v21.2/update.html) for `REGIONAL BY ROW` tables. [#69381][#69381]
+- `SHOW is_superuser` now works, and is set to true if the user has `root` privileges. [#69224][#69224]
+- Introduced `SET LOCAL`, which sets a session variable for the duration of the transaction. `SET LOCAL` is a no-op outside the transaction. [#69224][#69224]
+- `SET LOCAL` now works for `SAVEPOINT`s. `ROLLBACK` will rollback any variables set during `SET LOCAL`. `RELEASE TO SAVEPOINT` will continue to use the variables set by `SET LOCAL` in the transaction. [#69224][#69224]
+- Interleaved syntax for `CREATE TABLE`/`INDEX` is now a no-op, since support has been removed. [#69304][#69304]
+- `crdb_internal.reset_sql_stats()` now resets persisted SQL Stats. [#69273][#69273]
+- Changed the `plan_hash` column in both `system.statement_statistics` and `crdb_internal.statement_statistics` from `Int` to `Bytes`. [#69502][#69502]
+- Added the optional `IF NOT EXISTS` clause to the `CREATE SCHEDULE` statement, making the statement idempotent. [#69152][#69152]
+- `SHOW is_superuser` now works, and is set to true if the user has [`admin`](../v21.2/authorization.html#admin-role) privileges. [#69355][#69355]
+- The `set_config` [builtin](../v21.2/functions-and-operators.html#built-in-functions) function now allows the `local` parameter to be true. This is the same as using `SET LOCAL`. [#69480][#69480]
+- Added a new `as_json` option to [`SHOW BACKUP`](../v21.2/show-backup.html) which renders the backup manifest as JSON value. [#62628][#62628]
+
+### Operational changes
+
+- [New session variable](../v21.2/set-vars.html#supported-variables) `large_full_scan_rows`, as well as the corresponding cluster setting `sql.defaults.large_full_scan_rows`, are now available. This setting determines which tables are considered "large" for the purposes of enabling `disallow_full_table_scans` feature to reject full table/index scans only of "large" table. The default value for the new setting is `1000`, and in order to reject all full table/index scans (the previous behavior) one can set the new setting to `0`. Internally issued queries aren't affected, and the new setting has no impact when `disallow_full_table_scans` feature is not enabled. [#69371][#69371]
+- Introduced new metric called `txn.restarts.commitdeadlineexceeded` that tracks the number of transactions that were forced to restart because their commit deadline was exceeded (`COMMIT_DEADLINE_EXCEEDED`). [#69671][#69671]
+- The default value of the `storage.transaction.separated_intents.enabled` [cluster setting](../v21.2/cluster-settings.html) was changed to `true`. [#64831][#64831]
+- Node-level admission control that considers the CPU resource was introduced for KV request processing, and response processing (in SQL) for KV responses. This admission control can be enabled using `admission.kv.enabled` and `admission.sql_kv_response.enabled`. [#65614][#65614]
+- The new [cluster setting](../v21.2/cluster-settings.html) `bulkio.backup.merge_file_size` allows [`BACKUP`](../v21.2/backup.html) to buffer and merge smaller files to reduce the number of small individual files created by `BACKUP`. [#66856][#66856]
+- Increased the timeout for range MVCC garbage collection from 1 minute to 10 minutes, to allow larger jobs to run to completion. [#65001][#65001]
+- MVCC and intent garbage collection now triggers when the average intent age is 8 hours, down from 10 days. [#65001][#65001]
+- Added a `server.authentication_cache.enabled` [cluster setting](../v21.2/cluster-settings.html) that defaults to `true`. When enabled, this cache stores authentication-related data and will improve the latency of authentication attempts. Keeping the cache up to date adds additional overhead when using the [`CREATE`](../v21.2/create-role.html), [`ALTER`](../v21.2/alter-role.html), and [`DROP ROLE`](../v21.2/drop-role.html) commands. To minimize the overhead, any bulk `ROLE` operations should be run inside of a transaction. To make the cache more effective, any regularly-scheduled `ROLE` updates should be done all together, rather than occurring throughout the day at all times. [#66919][#66919]
+- Introduced a new metric `exportrequest.delay.total` to track how long `ExportRequests` (issued by [`BACKUP`](../v21.2/backup.html)) are delayed by throttling mechansisms. [#67310][#67310]
+- Enabling `admission.kv.enabled` may provide better inter-tenant isolation for multi-tenant KV nodes. [#67533][#67533]
+- [`debug.zip`](../v21.2/cockroach-debug-zip.html) files no longer contain the file `threads.txt`, which was previously used to list RocksDB background threads. [#67389][#67389]
+- DistSQL response admission control can now be enabled using the [cluster setting](../v21.2/cluster-settings.html) `admission.sql_sql_response.enabled`. [#67531][#67531]
+- Added the `kv.bulk_sst.target_size` and `kv.bulk_sst.max_allowed_overage` [cluster settings](../v21.2/cluster-settings.html) that control the batch size used by export requests during [`BACKUP`](../v21.2/backup.html). [#67705][#67705]
+- [`RESTORE`](../v21.2/restore.html) no longer dynamically reads from the `kv.bulk_ingest.batch_size` [cluster setting](../v21.2/cluster-settings.html) to determine its batch size. If the value is updated, [`RESTORE`](../v21.2/restore.html) jobs need to be `PAUSE`d and `RESUME`d to adopt the updated setting. [#68105][#68105]
+- The memory pool used for SQL is now also used to cover KV memory used for scans. [#66362][#66362]
+- CockroachDB now records a log event and counter increment when removing an expired session. [#68476][#68476]
+- Added an automatically created, on by default, emergency ballast file. This new ballast defaults to the minimum of 1% total disk capacity or 1GiB. The size of the ballast may be configured via the `--store` flag with a `ballast-size` field, accepting the same value formats as the `size` field. Also, added a new `Disk Full (10)` exit code that indicates that the node exited because disk space on at least one store is exhausted. On node start, if any store has less than half the ballast's size bytes available, the node immediately exits with the `Disk Full (10)` exit code. The operator may manually remove the configured ballast (assuming they haven't already) to allow the node to start, and they can take action to remedy the disk space exhaustion. The ballast will automatically be recreated when available disk space is 4x the ballast size, or at least 10 GiB is available after the ballast is created. [#66893][#66893]
+- Added a new [cluster setting](../v21.2/cluster-settings.html), `sql.mutations.max_row_size.log`, which controls large row logging. Whenever a row larger than this size is written (or a single column family if multiple column families are in use) a `LargeRow` event is logged to the [`SQL_PERF`](../v21.2/logging.html#sql_perf) channel (or a `LargeRowInternal` event is logged to [`SQL_INTERNAL_PERF`](../v21.2/logging.html#sql_internal_perf) if the row was added by an internal query). This could occur for [`INSERT`](../v21.2/insert.html), [`UPSERT`](../v21.2/upsert.html), [`UPDATE`](../v21.2/update.html), [`CREATE TABLE AS`](../v21.2/create-table.html), [`CREATE INDEX`](../v21.2/create-index.html), [`ALTER TABLE`](../v21.2/alter-table.html), [`ALTER INDEX`](../v21.2/alter-index.html), [`IMPORT`](../v21.2/import.html), or [`RESTORE`](../v21.2/restore.html) statements. [`SELECT`](../v21.2/select-clause.html), [`DELETE`](../v21.2/delete.html), [`TRUNCATE`](../v21.2/truncate.html), and [`DROP`](../v21.2/drop-table.html) are not affected by this setting. [#67953][#67953]
+- Added a new [cluster setting](../v21.2/cluster-settings.html), `sql.mutations.max_row_size.err`, which limits the size of rows written to the database (or individual column families, if multiple column families are in use). Statements trying to write a row larger than this will fail with a code `54000 (program_limit_exceeded)` error. (Internal queries writing a row larger than this will not fail, but will log a `LargeRowInternal` event to the SQL_INTERNAL_PERF channel.) This limit is enforced for INSERT, UPSERT, and UPDATE statements. [`CREATE TABLE`](../v21.2/create-table.html) AS, CREATE INDEX, ALTER TABLE, ALTER INDEX, IMPORT, and [`RESTORE`](../v21.2/restore.html) will not fail with an error, but will log LargeRowInternal events to the [`SQL_INTERNAL_PERF`](../v21.2/logging.html#sql_internal_perf) channel. [`SELECT`](../v21.2/select-clause.html), [`DELETE`](../v21.2/delete.html), [`TRUNCATE`](../v21.2/truncate.html), and [`DROP`](../v21.2/drop-table.html) are not affected by this limit. Note that existing rows violating the limit **cannot** be updated, unless the update shrinks the size of the row below the limit, but *can* be selected, deleted, altered, backed-up, and restored. For this reason we recommend using the accompanying setting `sql.mutations.max_row_size.log` in conjunction with `SELECT pg_column_size()` queries to detect and fix any existing large rows before lowering `sql.mutations.max_row_size.err`. [#67953][#67953]
+- The new [cluster settings](../v21.2/cluster-settings.html) `admission.l0_sub_level_count_overload_threshold` and `admission.l0_file_count_overload_threshold` can be used to tune admission control. [#69311][#69311]
+- The new [cluster settings](../v21.2/cluster-settings.html) `sql.defaults.transaction_rows_written_log`, `sql.defaults.transaction_rows_written_err`, `sql.defaults.transaction_rows_read_log`, and `sql.defaults.transaction_rows_read_err` (as well as the corresponding session variables) have been introduced. These settings determine the "size" of the transactions in written and read rows upon reaching of which the transactions are logged or rejected. The logging will go into the [`SQL_PERF`](../v21.2/logging.html#sql_perf) logging channel. Note that the internal queries (i.e., those issued by CockroachDB internally) cannot error out but can be logged instead into [`SQL_INTERNAL_PERF`](../v21.2/logging.html#sql_internal_perf) logging channel. The "written" limits apply to [`INSERT`](../v21.2/insert.html), [`INSERT INTO SELECT FROM`](../v21.2/insert.html), [`INSERT ON CONFLICT`](../v21.2/insert.html), [`UPSERT`](../v21.2/upsert.html), [`UPDATE`](../v21.2/update.html), and [`DELETE`](../v21.2/delete.html) whereas the "read" limits apply to [`SELECT`](../v21.2/select-clause.html) statement in addition to all of these. These limits will not apply to [`CREATE TABLE AS`](../v21.2/create-table.html), [`SELECT`](../v21.2/select-clause.html), [`IMPORT`](../v21.2/import.html), [`TRUNCATE`](../v21.2/truncate.html), [`DROP`](../v21.2/drop-table.html), [`ALTER TABLE`](../v21.2/alter-table.html), [`BACKUP`](../v21.2/backup.html), [`RESTORE`](../v21.2/restore.html), or [`CREATE STATISTICS`](../v21.2/create-statistics.html) statements. Note that enabling `transaction_rows_read_err` guardrail comes at the cost of disabling the usage of the auto commit optimization for the mutation statements in implicit transactions. [#69202][#69202]
+- The `cockroach debug tsdump` command now downloads histogram timeseries it silently omitted previously. [#69469][#69469]
+- New variables `sql.mutations.max_row_size.{log|err}` were renamed to `sql.guardrails.max_row_size_{log|err}` for consistency with other variables and metrics. [#69457][#69457]
+- Improved range feed observability by adding a `crdb_internal.active_range_feeds` virtual table which lists all currently executing range feeds on the node. [#69055][#69055]
+- Upgrading to the next version will be blocked if interleaved tables/indexes exist. Users should convert existing interleaved tables/indexes to non-interleaved ones or drop any interleaved tables/indexes before upgrading to the next version. [#68074][#68074]
+- Added support for the DataDog tracer. Set the `trace.datadog.agent` [cluster setting](../v21.2/cluster-settings.html) to enable it if you have got the DataDog collector service running. [#61602][#61602]
+- Upgraded the Lightstep tracer version, resulting in better observability for Lightstep users. [#61593][#61593]
+- Added four new metrics, `sql.guardrails.max_row_size_{log|err}.count{.internal}`, which are incremented whenever a large row violates the corresponding `sql.guardrails.max_row_size_{log|err}` limit. [#69457][#69457]
+
+### Command-line changes
+
+- Added `load show` args to display subset of backup metadata. Users can display subsets of metadata of a single manifest by using `load show files/descriptors/metadata/spans <backup_url>`. [#61131][#61131]
+- Updated `load show` with `summary` subcommand to display meta information of an individual backup. Users are now able to inspect backup metadata, files, spans, and descriptors with the CLI command `cockroach load show summary <backup_url>` without a running cluster. [#61131][#61131]
+- Updated `load show` with `incremental` subcommand to display incremental backups. Users can list incremental backup paths of a full backup by running `cockroach load show incremental <backup_url>.` [#61862][#61862]
+- Added `load show backups` to display backup collection. Previously, users could list backups created by [`BACKUP INTO`](../v21.2/backup.html) via [`SHOW BACKUP IN`](../v21.2/show-backup.html) in a SQL session. But this listing task can be also done offline without a running cluster. Now, users are able to list backups in a collection with `cockroach load show backups <collection_url>`. [#61862][#61862]
+- The command `cockroach sysbench` has been removed. Users who depend on this command can use a copy of a `cockroachdb` executable binary from a previous version. [#62305][#62305]
+- The number of connection retries and connection timeouts for configurations generated by `cockroach gen haproxy` have been tweaked. [#62308][#62308]
+- Extended `load show` with `load show data` subcommand to display backup table data. By running `cockroach load show data <table> <backup_url>`, users are able to inspect data of a table in backup. Also, added `--as-of` flag to `load show data` command. Users are able to show backup snapshot data at a specified timestamp by running `cockroach load show data <table> <backup_url> --as-of='-1s'` [#62662][#62662]
+- Updated `load show data` command to display backup data in CSV format. Users can either pipe the output to a file or specify the destination by a `--destination` flag. [#62662][#62662]
+- Previously, `load show summary` would output results in an unstructured way, which made it harder to filter information. `load show summary` now outputs the information in JSON format, which is easier to handle and can be filtered through another command-line JSON processor. [#63100][#63100]
+- Previously, `--as-of` of `load show data` had the restriction that users could only inspect data at an exact backup timestamp. The flag has improved to work with [backups with revision history](../v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.html) so that users can inspect data at an arbitrary timestamp. [#63181][#63181]
+- Certain errors caused by invalid command-line arguments are now printed on the process' standard error stream, instead of standard output. [#63839][#63839]
+- The `cockroach gen autocomplete` command has been updated and can now produce autocompletion definitions for the `fish` shell. [#63839][#63839]
+- Previously, backup inspection was done via `cockroach load show ..`, which could confuse users with ambiguous verbs in the command chain. The syntax is now more clear and indicative for users debugging backups. The changes are: `load show summary <backup_url>` -> `debug backup show <backup_url>`; `load show incremental <backup_url>` -> `debug backup list-incremental <backup_url>`; `load show backups <collection_url>` -> `debug backup list-backups <collection_url>`; `load show data <table_name> <backup_url>` -> `debug backup export <backup_url> --table=<table_name>`. [#63309][#63309]
+- Previously, `\demo shutdown <node_idx>` would error if `--global` was set. This will now error gracefully as an unsupported behavior. [#62435][#62435]
+- The `--global` flag for [`cockroach demo`](../v21.2/cockroach-demo.html) is now advertised. This flag simulates latencies in multi-node demo clusters when the nodes are set in different regions to simulate real-life global latencies. [#62435][#62435]
+- There will now be a message upon start-up on [`cockroach demo --global`](../v21.2/cockroach-demo.html) indicating that latencies between nodes will simulate real-world latencies. [#62435][#62435]
+- Added `--max-rows` and `--start-key` of `cockroach backup debug` tool for users to specify on export row number and start key when inspecting data from backup. [#64157][#64157]
+- Added `--with-revisions` on `debug export` to allow users to export revisions of table data. If `--with-revisions` is specified, revisions of data are returned to users, with an extra column displaying the revision time of that record. This is an experimenal/beta feature of the `cockroach backup debug` tool to allow users to export revisions of data from backup. [#64285][#64285]
+- Renamed `connect` to `connect init`, and added `connect join` command to retrieve certificates from an existing secure cluster and setup a new node to connect with it. [#63492][#63492]
+- The `cockroach debug keys` command recognizes a new flag `--type` that constrains types of displayed entries. This enables more efficient introspection of storage in certain troubleshooting scenarios. [#64879][#64879]
+- Server health metrics are now a structured event sent to the [`HEALTH`](../v21.2/logging.html#health) logging channel. For details about the event payload, refer to the [reference documentation](../v21.2/eventlog.html#runtime_stats). [#65024][#65024]
+- Server health metrics are now optimized for machine readability by being sent as a structured event to the [`HEALTH`](../v21.2/logging.html#health) logging channel. For details about the event payload, refer to the [reference documentation](../v21.2/eventlog.html#runtime_stats). [#65024][#65024]
+- The `cockroach debug pebble` tool can now be used with encrypted stores. [#64908][#64908]
+- Added a `cockroach debug job-trace` command that takes 2 arguments: `<jobID>` and file destination, along with a `--url` pointing to the node on which to execute this command against. The command pulls information about inflight trace spans associated with the job and dumps it to the file destination. [#65324][#65324]
+- The new subcommand `cockroach convert-url` converts a connection URL, such as those printed out by [`cockroach start`](../v21.2/cockroach-start.html) or included in the online documentation, to the syntax recognized by various client drivers. For example:
+
+    ~~~
+    $ ./cockroach convert-url --url "postgres://foo/bar"
+    Connection URL for libpq (C/C++), psycopg (Python), lib/pq & pgx (Go),
+    node-postgres (JS) and most pq-compatible drivers:
+       postgresql://root@foo:26257/bar
+    Connection DSN (Data Source Name) for Postgres drivers that accept
+    DSNs - most drivers and also ODBC:
+       database=bar user=root host=foo port=26257
+    Connection URL for JDBC (Java and JVM-based languages):
+       jdbc:postgresql://foo:26257/bar?user=root
+    ~~~
+    [#65460][#65460]
+- The URLs spelled out by [`cockroach start`](../v21.2/cockroach-start.html), [`cockroach start-single-node`](../v21.2/cockroach-start-single-node.html), and [`cockroach demo`](../v21.2/cockroach-demo.html) in various outputs now always contain a target database for the connection; for example, `defaultdb` for regular servers. Certain drivers previously automatically filled in the name "postgres" if the database name field was empty. [#65460][#65460]
+- The connection URLs spelled out by [`cockroach start`](../v21.2/cockroach-start.html), [`cockroach start-single-node`](../v21.2/cockroach-start-single-node.html), and [`cockroach demo`](../v21.2/cockroach-demo.html) in various outputs now include a variant suitable for use with JDBC client apps. [#65460][#65460]
+- [`cockroach sql`](../v21.2/cockroach-sql.html) and [`cockroach demo`](../v21.2/cockroach-demo.html) now support the client-side parameter `border` like `psql`. [#66253][#66253]
+- Added support for [`cockroach debug ballast`](../v21.2/cockroach-debug-ballast.html) on Windows. [#66793][#66793]
+- The [`cockroach import pgdump`](../v21.2/cockroach-import.html) command now recognizes custom target database names inside the URL passed via `--url`. Additionally, the command now also accepts a `--database` parameter. Using this parameter is equivalent to customizing the database inside the `--url` flag. [#66375][#66375]
+- `cockroach debug job-trace` now creates a `job-trace.zip` which contains trace information for each node executing the job. [#66914][#66914]
+- Added the `--recursive` or `-r` flag to the [`cockroach userfile upload`](../v21.2/cockroach-userfile-upload.html) CLI command allowing users to upload the entire subtree rooted at a specified directory to user-scoped file storage: `userfile upload -r path/to/source/dir destination`. The destination can be expressed one of four ways:<ul><li>Empty (not specified)</li><li>A relative path, such as `path/to/dir`</li><li>A well-formed URI with no host, such as `userfile:///path/to/dir/`</li><li>A full well-formed URI, such as `userfile://db.schema.tablename_prefix/path/to/dir`</li></ul>If a destination is not specified, the default URI scheme and host will be used, and the basename from the source will be used as the destination directory. For example: `userfile://defaultdb.public.userfiles_root/yourdirectory`. If the destination is a relative path such as `path/to/dir`, the default userfile URI schema and host will be used (`userfile://defaultdb.public.userfiles_$user/`), and the relative path will be appended to it. For example: `userfile://defaultdb.public.userfiles_root/path/to/dir`. If the destination is a well-formed URI with no host, such as `userfile:///path/to/dir/`, the default userfile URI schema and host will be used (`userfile://defaultdb.public.userfiles_$user/`). For example: `userfile://defaultdb.public.userfiles_root/path/to/dir`. If the destination is a full well-formed URI, such as `userfile://db.schema.tablename_prefix/path/to/dir`, then it will be used verbatim. For example: `userfile://foo.bar.baz_root/path/to/dir`. [#65307][#65307]
+- Previously, the `crdb-v2` log file format lacked a parser. This has now changed. [#65633][#65633]
+- The [`cockroach debug merge-logs`](../v21.2/cockroach-debug-merge-logs.html) command now renders in color by default. [#66629][#66629]
+- CockroachDB now supports a new [logging channel](../v21.2/logging.html) called `TELEMETRY`. This will be used in later versions to report diagnostic events useful to Cockroach Labs for product analytics. (At the time of this writing, no events are defined for the `TELEMETRY` channel yet.) When no logging configuration is specified, this channel is connected to file output, with a maximum retention of 1MiB. To also produce the diagnostic output elsewhere, one can [define a new sink](../v21.2/configure-logs.html) that captures this channel. For example, to see diagnostics reports on the standard error, one can use: `--log='sinks: {stderr: {channels: TELEMETRY, filter: INFO}}'` When configuring file output, the operator should be careful to apply a separate maximum retention for the `TELEMETRY` channel from other file outputs, as telemetry data can be verbose and outcrowd other logging messages. For example: `--log='sinks: {file-groups: {telemetry: {channels: TELEMETRY, max-group-size: 1MB}, ...}}`. [#66427][#66427]
+- Added the `cockroach debug statement-bundle recreate <zipdir>` command, which allows users to load a statement bundle into an in-memory database for inspection. [#67979][#67979]
+- CockroachDB server nodes now report more environment variables in logs upon startup. Only certain environment variables that may have an influence on the server's behavior are reported. [#66842][#66842]
+- [`cockroach sql`](../v21.2/cockroach-sql.html) and [`cockroach demo`](../v21.2/cockroach-demo.html) now support the `\c` / `\connect` client-side command, in a way similar to `psql`:<ul><li>`\c` without arguments: display the current connection parameters.</li><li>`\c [DB] [USER] [HOST] [PORT]` connect using the specified parameters. Specify '-' to omit one parameter.</li><li>`\c URL` connect using the specified URL. For example: `\c - myuser` to reconnect to the same server/db as `myuser`.</li></ul>This feature is intended to ease switching across simulated nodes in `cockroach demo`. Note: `\c <dbname>` reuses the existing server connection to change the current database, using a `SET` statement. To force a network reconnect, use `\c -` then `\c <dbname>`, or use `\c <dbname> -`. Note: When using the syntax with discrete parameters, the generated URL reuses the same TLS parameters as the original connection, including the CA certificate used to validate the server. To use different TLS settings, use `\c <URL>` instead. [#66258][#66258]
+- Added a new `HTTP` sink to the logging system. This can be [configured similarly to other log sinks](../v21.2/configure-logs.html) with the new `http-servers` and `http-defaults` sections of the logging config passed via the `--log` or `--log-config-file` command-line flags. [#66196][#66196]
+- The `\c` client-side command in [`cockroach sql`](../v21.2/cockroach-sql.html) and [`cockroach demo`](../v21.2/cockroach-demo.html) now always reconnects to the server even when only changing the current database. (This negates a part of a previous release note.) [#68326][#68326]
+- [`cockroach demo`](../v21.2/cockroach-demo.html) now recognizes the command-line flag `--listening-url-file` like [`cockroach start`](../v21.2/cockroach-start.html) and [`cockroach start-single-node`](../v21.2/cockroach-start-single-node.html). When specified, the `demo` utility will write a valid connection URL to that file after the test cluster has been initialized. This facility also makes it possible to automatically wait until the demo cluster has been initialized in automation; for example, by passing the name of a unix named `FIFO` via the new flag. [#68706][#68706]
+- `cockroach mt start-sql` now supports `--advertise-addr` in the same fashion as [`cockroach start`](../v21.2/cockroach-start.html). [#69113][#69113]
+- `cockroach debug decode-proto` now does not emit default values by default. [#69185][#69185]
+- The `cockroach debug tsdump` command now accepts `--from` and `--to` flags that limit for which dates timeseries are exported. [#69491][#69491]
+- Log file read and write permissions may now be set via the new `file-permissions` key in the `--log` flag or `--log-config-file` file. [#69243][#69243]
+- Updated the output of `--locality` and `--locality-addr` flags to use terms that match cloud provider names for things such as 'region' and 'zone'. [#62381][#62381]
+
+### API endpoint changes
+
+- A list of node IDs representing the nodes that store data for the database has been added to the stats field in the database details endpoint under `nodeIds`. Database details must be requested with `include_stats` set to `true`, e.g. `/_admin/v1/databases/{database}?include_stats=true`. Similarly, `nodeIds` has also been added to the table stats endpoint, which is an ordered list of node ids that stores the table data: `/_admin/v1/databases/{database}/tables/{table}/stats` [#69788][#69788]
+- The `changefeed.poll_request_nanos` metric is no longer reported by the node status API, the `crdb_internal.metrics` table, or the [Prometheus endpoint](../v21.2/monitoring-and-alerting.html#prometheus-endpoint). [#63935][#63935]
+- The transaction abort error reason `ABORT_REASON_ALREADY_COMMITTED_OR_ROLLED_BACK_POSSIBLE_REPLAY` has been renamed to `ABORT_REASON_RECORD_ALREADY_WRITTEN_POSSIBLE_REPLAY`. [#67215][#67215]
+- A Stats message was added to the `admin` `DatabaseDetails` response, providing `RangeCount` and `ApproximateDiskBytes` in support of upcoming UI changes to the DB console. [#67986][#67986]
+- Tenant pods now expose the Statements API at `/_status/statements` on their HTTP port. [#66675][#66675]
+- Tenant pods now expose the ListSessions API at `/_status/sessions` on their HTTP port. [#69376][#69376]
+- Added a new endpoint `/_status/combinedstmts` to retrieve persisted and in-memory statements from `crdb_internal.statement_statistics` and `crdb_internal.transaction_statistics` by aggregated_ts range. The request supports optional query string parameters `start` and `end`, which are the date range in unix time. The response returned is currently the response expected from `/_status/statements`. `/_status/statements` has also been updated to support the parameters `combined`, `start`, and `end`. If `combined` is `true`, then the statements endpoint will use `/_status/combinedstmts` with the optional parameters `start` and `end`. [#69238][#69238]
+
+### DB Console changes
+
+- A new column on the [Database Page](../v21.2/ui-databases-page.html) now shows the node and region information for each database. The [Tables view](../v21.2/ui-databases-page.html#tables-view) now displays a summary section of the nodes and regions where the table data is stored. The new table columns and region/node sections are only displayed if there is more than one node. [#69804][#69804]
+- Fixed duplicates of statements on the [Transaction Details Page](../v21.2/ui-transactions-page.html#transaction-details-page) for multi-node clusters. [#61771][#61771]
+- Changed copy that previously referred to the app as "Admin UI" to "DB Console" instead. [#62452][#62452]
+- Users can now reset SQL stats from the [DB Console](../v21.2/ui-overview.html). [#63342][#63342]
+- Created new routes for statements. A database name can be passed on statements routes, so only statements executed on that particular database are displayed. Added a new function returning all databases that had at least one statement executed during the current statistics collection period. [#64087][#64087]
+- The lease history section on the range report [debug page](../v21.2/ui-debug-pages.html) now shows the type of lease acquisition event that resulted in a given lease. [#63822][#63822]
+- Updated the DB Console to show information about the database on the [Statements Page](../v21.2/ui-statements-page.html) and ability to choose which columns to display. [#64614][#64614]
+- The DB Console now shows information about the region of a node on the [Transactions Page](../v21.2/ui-transactions-page.html). [#64996][#64996]
+- Added missing formatting for some event types displayed in the DB Console. [#65717][#65717]
+- Changed the default event formatting to appear less alarming to users. [#65717][#65717]
+- The [Statement Details Page](../v21.2/ui-statements-page.html#statement-details-page) now displays information about nodes and regions a statement was executed on. [#65126][#65126]
+- The [Statements](../v21.2/ui-statements-page.html) and [Transactions](../v21.2/ui-transactions-page.html) pages now display information about nodes and regions a statement was executed on. [#65126][#65126]
+- Changed time format on metrics events to 24-hour UTC time. [#66277][#66277]
+- Removed styling width calculation from multiple bars. [#66734][#66734]
+- Added a new chart showing the latency of establishing a new SQL connection, including the time spent on authentication. [#66625][#66625]
+- The KV transaction restarts chart was moved from the Distributed metrics to the [SQL Dashboard](../v21.2/ui-sql-dashboard.html) to be close to the Open SQL Transactions chart for more prominent visibility. [#66973][#66973]
+- Fixed mislabelled tooltips on the [Transactions](../v21.2/ui-transactions-page.html) and [Transaction Details](../v21.2/ui-transactions-page.html#transaction-details-page) pages in DB console. [#66605][#66605]
+- The DB Console now uses dotted underline on text that contains a tooltip. The 'i' icon was removed. [#67023][#67023]
+- Added `""` to whitespace application names on filter selection on the [Statements](../v21.2/ui-statements-page.html) and [Transactions](../v21.2/ui-transactions-page.html) pages. [#66967][#66967]
+- Added a new Overload dashboard that groups metrics that are useful for admission control. [#66595][#66595]
+- The SQL Statement Contention Time chart is surfaced more prominently on the [SQL Dashboard](../v21.2/ui-sql-dashboard.html). [#66969][#66969]
+- Added a Full Table/Index Scans time series chart on the [SQL Dashboard](../v21.2/ui-sql-dashboard.html). [#66972][#66972]
+- The 'threads' debugging page, previously used to inspect RocksDB threads, has been removed. [#67389][#67389]
+- Fixed a color mismatch ont he node status badge on the [Cluster Overview](../v21.2/ui-cluster-overview-page.html) page. [#68049][#68049]
+- Added a CES survey link component to support being able to get client feedback. [#68429][#68429]
+- The [Transaction Details Page](../v21.2/ui-transactions-page.html#transaction-details-page)'s SQL box now shows all of a transaction's statements in the order that they were executed. The Transaction Details Page also no longer displays statement statistics. [#68447][#68447]
+- Updated the [Databases Page](../v21.2/ui-databases-page.html) in the DB Console to bring them into alignment with our modern UX. [#68390][#68390]
+- The "Logical Plan" tab in the DB Console has been renamed "Explain Plan", and the displayed plan format has been updated to match the output of the [`EXPLAIN`](../v21.2/explain.html) command in the SQL shell. Global `EXPLAIN` properties have been added to the logical plan in the DB Console which were previously missing. The `EXPLAIN` format shown below should now be reflected in the DB Console:
+
+    ~~~
+      distribution: full
+      vectorized: true
+      • hash join
+      │ estimated row count: 503
+      │ equality: (rider_id) = (id)
+      │
+      ├── • scan
+      │     estimated row count: 513 (100% of the table; stats collected 9 seconds ago)
+      │     table: rides@primary
+      │     spans: FULL SCAN
+      │
+      └── • scan
+            estimated row count: 50 (100% of the table; stats collected 1 minute ago)
+            table: users@primary
+            spans: FULL SCAN
+    ~~~
+    [#68566][#68566]
+- Changed date times on the [Jobs Page](../v21.2/ui-jobs-page.html) to use 24-hour UTC. [#68916][#68916]
+- Added admission control metrics to the Overload dashboard. [#68595][#68595]
+- Hid node and region information on the new tenant plan (serverless/free tier). [#69444][#69444]
+- Added a new date range selector component to the DB Console's [Statements](../v21.2/ui-statements-page.html) and [Transactions](../v21.2/ui-transactions-page.html) pages with the ability to show historical data. The default date range is set to 1 hour ago, and is used as the value when users reset the date range. [#68831][#68831]
+- Fixed tooltip text on the [Statements](../v21.2/ui-statements-page.html) and [Transactions](../v21.2/ui-transactions-page.html) pages to use the correct setting `diagnostics.sql_stat_reset.interval` instead of the previous value, `diagnostics.reporting.interval`. [#69577][#69577]
+
+
+### Bug fixes
+
+- Fixed a bug where [cluster backups with revision history](../v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.html#create-a-backup-with-revision-history) may have included dropped descriptors in the "current" snapshot of descriptors on the cluster. [#68983][#68983]
+- Users can now only scroll in the content section of the [Transactions Page](../v21.2/ui-transactions-page.html), [Statements Page](../v21.2/ui-statements-page.html), and [Sessions Page](../v21.2/ui-sessions-page.html). [#69620][#69620]
+- Previously, when using [`ALTER PRIMARY KEY`](../v21.2/alter-primary-key.html) on a [regional by row](../v21.2/multiregion-overview.html#regional-by-row-tables) table, the copied unique index from the old primary key would not have the correct zone configurations applied. This is now resolved, but users who encountered this bug should re-create the index. [#69681][#69681]
+- Fixed a bug that caused incorrect evaluation of the [`IN` operator](../v21.2/functions-and-operators.html#supported-operations) when the tuple on the right-hand side of the operator included a subquery, like `a IN ('foo', (SELECT s FROM t), 'bar')`. [#69651][#69651]
+- Fixed a bug where previously an internal error or a crash could occur when some [`crdb_internal` builtin functions](../v21.2/functions-and-operators.html) took string-like type arguments (e.g. `name`). [#69698][#69698]
+- Previously, users would receive a panic message when the log parser failed to extract [log file formats](../v21.2/log-formats.html). This has been replaced with a helpful error message. [#69018][#69018]
+- Fixed a bug to ensure that auxiliary tables used during [cluster restore](../v21.2/restore.html) are garbage collected quickly afterwards. [#67936][#67936]
+- [`RESTORE`](../v21.2/restore.html) will now correctly ignore dropped databases that may have been included in [cluster backups with revision history](../v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.html#create-a-backup-with-revision-history). [#68551][#68551]
+- Fixed a bug that can cause prolonged unavailability due to lease transfer to a replica that may be in need of a [raft snapshot](../v21.2/architecture/replication-layer.html#snapshots). [#69696][#69696]
+- Fixed a bug where resuming an active schedule would always reset its next run time. This was sometimes undesirable with schedules that had a [`first_run` option](../v21.2/create-schedule-for-backup.html#schedule-options) specified. [#69571][#69571]
+- Fixed a regression in statistics estimation in the [optimizer](../v21.2/cost-based-optimizer.html) for very large tables. The bug, which has been present since v20.2.14 and v21.1.7, could cause the optimizer to severely underestimate the number of rows returned by an expression. [#69711][#69711]
+- The [`raft.commandsapplied`](../v21.2/ui-custom-chart-debug-page.html#available-metrics) metric is now populated again. [#69857][#69857]
+- Fixed a bug where previously the store rebalancer was unable to rebalance leases for hot ranges that received a disproportionate amount of traffic relative to the rest of the cluster. This often led to prolonged single node hotspots in certain workloads that led to hot ranges. [#65379][#65379]
+- Added protection to [`IMPORT INTO`](../v21.2/import-into.html) to guard against concurrent type changes on [user-defined types](../v21.2/enum.html) referenced by the target table. [#69674][#69674]
+-  DNS unavailability during range 1 leaseholder loss will no longer cause significant latency increases for queries and other operations. [b6fb0e626][b6fb0e626]
+- Previously, using [`SET`](../v21.2/set-vars.html) in a transaction and having the transaction retry internally could result in the previous session variable being unused. For example:
+
+    ~~~sql
+    SET intervalstyle = 'postgres';
+    BEGIN;
+    do something with interval -- (1) SET intervalstyle = 'iso_8601';
+    do something with interval -- (2) COMMIT;
+    ~~~
+
+    If the transaction retries at `COMMIT`, when attempting to re-run (1), we would have an interval style `'iso_8601'` instead of the original `'postgres'` value. This has now been resolved. [#69554][#69554]
+
+- Envelope schema in Avro registry now honors `schema_prefix` and `full_table_name`. [#60946][#60946]
+- Previously, a drop column would cause check constraints that are currently validating to become active on a table. This has been fixed. [#62257][#62257]
+- OpenTracing traces now work correctly across nodes. The client and server spans for RPCs are once again part of the same trace instead of the server erroneously being a root span. [#62703][#62703]
+- Fixed a bug which prevented `cockroach debug doctor zipdir` from validating foreign key information represented in the un-upgraded deprecated format. [#62829][#62829]
+- Schema changes that include both a column addition and primary key change in the same transaction no longer result in a failed changefeed. [#63217][#63217]
+- Fixed a bug whereby transient clock synchronization errors could result in permanent schema change failures. [#63671][#63671]
+- Fixed a bug of `debug backup export` caused by inspecting table with multiple ranges. [#63678][#63678]
+- Fixed a performance regression for very simple queries. [#64225][#64225]
+- Fixed a bug that prevented transactions which lasted longer than 5 minutes and then performed writes from committing. [#63725][#63725]
+- Added a fix to prevent a rare crash that could occur when reading data from interleaved tables. [#64374][#64374]
+- Fixed an "index out of range" internal error with certain simple queries. [#65018][#65018]
+- Hosts listed with the `connect --join` command-line flag now default to port `26257` (was `443`). This matches the existing behavior of `start --join`. [#65014][#65014]
+- CockroachDB now shows a correct error message if it tries to parse an interval that is out of range. [#65377][#65377]
+- Fixed a bug where `NaN` coordinates could make `ShortestLine`/`LongestLine` panic. [#65445][#65445]
+- Fixed a bug whereby using an `enum` value as a placeholder in an `AS OF SYSTEM TIME` query preceding a recent change to that `enum` could result in a fatal error. [#65620][#65620]
+- Fixed a race condition where transaction cleanup would fail to take into account ongoing writes and clean up their intents. [#65592][#65592]
+- The [Transactions Page](../v21.2/ui-transactions-page.html) now shows the correct value for implicit transactions. [#65126][#65126]
+- Fixed a bug where `TIMETZ` values would not display appopriately in the CLI. [#65321][#65321]
+- Fixed a bug which prevented adding self-referencing `FOREIGN KEY` constraints in the `NOT VALID` state. [#65871][#65871]
+- The `cockroach mt start-sql` command with a nonexistent tenant ID now returns an error. Previously, it would crash and poison the tenant ID for future usage. [#65683][#65683]
+- CockroachDB now correctly handles errors during the `pgwire` extended protocol. Specifically, when an error is detected while processing any extended protocol message, an `ErrorResponse` is returned; then the server reads and discards messages until a `Sync` command is received from the client. This matches the [PostgreSQL behavior](https://www.postgresql.org/docs/13/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY). [#57590][#57590]
+- Fixed a bug where owners of a table have privileges to `SELECT` from it, but would return false on `has_*_privilege`-related functions. [#65766][#65766]
+- Added a more accurate error message for restoring AOST before GC TTL. [#66025][#66025]
+- When a non-SQL CLI command (e.g., [`cockroach init`](../v21.2/cockroach-init.html)) was invoked with the `--url` flag and the URL did not contain a `sslmode` parameter, the command was incorrecting defaulting to operate as if `--insecure` was specified. This has been corrected. [#65460][#65460]
+- The URLs printed out by the client-side command `\demo ls` in [`cockroach demo`](../v21.2/cockroach-demo.html) now properly include the workload database name, if any was created. [#65460][#65460]
+- Fixed a bug where a superfluous unique constraint would be added to a table during a primary key change when the primary key change specified a new primary key constraint that involved the same columns in the same directions. [#66225][#66225]
+- Properly populated `crdb_internal.job`'s `coordinator_id` field, which had not been properly populated since v20.2. [#61417][#61417]
+- Fixed a bug in [`SHOW ZONE CONFIGURATIONS`](../v21.2/show-zone-configurations.html) where long constraints fields may show `\n` characters.  [#69470][#69470]
+- CockroachDB could previously error out when a query involving tuples with collated strings and NULLs was executed in a distributed manner. This is now fixed. [#66337][#66337]
+- Fixed a bug with PostgreSQL compatibility where dividing an interval by a number would round to the nearest Microsecond instead of always rounding down. [#66345][#66345]
+- Previously, rows treated as tuples in functions such as `row_to_json` may have had their keys normalized to lowercase, instead of being preserved in the original casing as per PostgreSQL. This is now fixed. [#66535][#66535]
+- CockroachDB could previously crash when executing `EXPLAIN (VEC)` on some mutations. This is now fixed. [#66569][#66569]
+- Fixed a bug that caused a panic for window functions operating in `GROUPS` mode with `OFFSET PRECEDING` start and end bounds. [#66582][#66582]
+- Fixed a bug on the chart catalog admin API. [#66645][#66645]
+- Fixed a deadlock during `adminVerifyProtectedTimestamp`. [#66760][#66760]
+- Fixed a bug where a substring of a linestring with the same points would return `EMPTY` instead of a `POINT` with the repeated point. [#66738][#66738]
+- Fixed a bug where it was possible for a linestring returned from `ST_LineSubString` to have repeated points. [#66738][#66738]
+- Fixed an error occurring when executing `OPERATOR(pg_catalog.~)`. [#66865][#66865]
+- Fixed `ST_LineSubstring` for `LINESTRING EMPTY` panicking instead of returning `null`. [#66936][#66936]
+- A migration will be run when users upgrade to v21.2 (specifically v21.2.14). This migration fixes any privilege descriptors that were corrupted from the fallout of the `ZONECONFIG`/`USAGE` bug on tables and databases after upgrading from v20.1 to v20.2 ([#65010](https://github.com/cockroachdb/cockroach/pull/65010)) and those that were corrupted after converting a database to a schema ([#65697](https://github.com/cockroachdb/cockroach/issues/65697)). [#66495][#66495]
+- Fixed a bug where job leases might be revoked due to a transient network error. [#67075][#67075]
+- Fixed a case where [`IMPORT`](../v21.2/import.html) would panic when parsing geospacial schemas with spacial index tuning parameters. In particular, this bug could be triggered by specifying the `fillfactor` option, or setting the `autovacuum_enabled` option to `false`. [#66899][#66899]
+- Intent garbage collection no longer waits for or aborts running transactions. [#65001][#65001]
+- The [Statements Page](../v21.2/ui-statements-page.html) now properly displays the Statement Time label on the column selector. [#67327][#67327]
+- Avro feeds now support special decimals like Infinity [#66870][#66870]
+- Fixed a typo on the Network tooltip on the [Statements Page](../v21.2/ui-statements-page.html). [#65126][#65126]
+- PostgreSQL-style intervals now print a `+` sign for day units if the year/month unit preceding was negative (e.g., `-1 year -2 months 2 days` will now print as `-1 year -2 months +2 days`). [#67210][#67210]
+- SQL Standard intervals will omit the day value if the day value is `0`. [#67210][#67210]
+- Added partial redactability to log SQL statements. This change provides greater visibility to SQL usage in the logs, enabling greater ability to troubleshoot. [#66359][#66359]
+- Fixed a bug in jobs where failures to write to the jobs table could prevent subsequent adoption of a job until the previous node dies or the job is paused. [#67671][#67671]
+- Fixed a minor resource leak that occurs when a [`RESTORE`](../v21.2/restore.html) is run. [#67478][#67478]
+- Previously, an unavailable node that started draining or [decommissioning](../v21.2/remove-nodes.html) would be treated as live and thus could receive a lease transfer, leading to the range becoming unavailable. This has been fixed. [#67319][#67319]
+- [`INSERT`](../v21.2/insert.html) and [`UPDATE`](../v21.2/update.html) statements which operate on larger rows are split into batches using the sql.mutations.mutation_batch_byte_size setting [#67537][#67537]
+- Fixed a bug that could cause the `min` window function to incorrectly return `null` when executed with a non-default `EXCLUDE` clause, because `min` and `max` did not ignore `null` input values. [#68025][#68025]
+- Fixed a bug that could cause a panic when a window function was executed in `RANGE` mode with `OFFSET PRECEDING` or `OFFSET FOLLOWING` on a datetime column. [#68013][#68013]
+- `SHOW` search_path will now properly quote `$user`. [#68034][#68034]
+- Fixed a bug where restores of data with multiple column families could be split illegally (within a single SQL row). This could result in temporary data unavailability until the ranges on either side of the invalid split were merged. [#67497][#67497]
+- Fixed a bug that was introduced in v21.1.5, which prevented nodes from decommissioning in a cluster if there were multiple nodes intermittently missing their liveness heartbeats. [#67714][#67714]
+- Fixed a bug where the `schedules.backup.succeeded` and `schedules.backup.failed` metrics would sometimes not be updated. [#67855][#67855]
+- Previously, a `SHOW GRANTS ON TYPE db.public.typ` command would not correctly show the grants if the current database was not `db`. This is now fixed. [#68137][#68137]
+- Fixed a bug which permitted the dropping of `enum` values which were in use in index predicates or partitioning values. [#68257][#68257]
+- Fixed a bug that could cause the `min` and `max` window functions to return incorrect results when the window frame for a row was smaller than the frame for the previous row. [#68314][#68314]
+- Previously, parsing a date from a string would incorrectly assuming YMD format instead of the MDY format if the date was formatted using the two digit format for year: "YY-MM-DD" instead of "MM-DD-YY". This has been resolved. However, if you relied on having two-digit years as YY-MM-DD, prepend `0`s at the front until it is at least 3 digits; e.g., "15-10-15" for the year 15 should read "015-10-15". [#68093][#68093]
+- Fixed a bug where migration jobs might run and update a cluster version before the cluster was ready for the upgrade. The bug could result in many extra failed migration jobs. [#67281][#67281]
+- `IMPORT PGDUMP` with a `UDT` would result in a nil pointer exception. It now fails gracefully. [#67994][#67994]
+- Cascaded drop of views could run into '`table ...is already being dropped`' errors incorrectly. This is now fixed. [#68601][#68601]
+- Fixed a bug in which an [`ENUM`](../v21.2/enum.html)-type value could be dropped despite it being referenced in a table's `CHECK` expression. [#68666][#68666]
+- Fixed an oversight in the data generator for TPC-H which was causing a smaller number of distinct values to be generated for `p_type` and `p_container` in the part table than the spec called for. [#68699][#68699]
+- Fixed a bug that created non-partial unique constraints when a user attempted to create a partial unique constraint in [`ALTER TABLE`](../v21.2/alter-table.html) statements. [#68629][#68629]
+- Fixed a bug where encryption-at-rest registry would accumulate nonexistent file entries forever, contributing to the filesystem operation's latency on the store. [#68394][#68394]
+- Fixed a bug where [`IMPORT`](../v21.2/import.html) would incorrectly reset its progress upon resumption. [#68337][#68337]
+- Previously, given a table with [hash-sharded indexes](../v21.2/hash-sharded-indexes.html), the output of `SHOW CREATE TABLE` was not round-trippable: executing the output would not create an identical table. This has been fixed by showing `CHECK` constraints that are automatically created for these indexes in the output of `SHOW CREATE TABLE`. The bug had existed since v21.1. [#69001][#69001]
+- Importing tables via `IMPORT PGDUMP` or `IMPORT MYSQL` should now honor [cluster setting](../v21.2/cluster-settings.html) `sql.defaults.default_int_size` and session variable `default_int_size`. [#68902][#68902]
+- Fixed a bug with cardinality estimation in the optimizer that was introduced in v21.1.0. This bug could cause inaccurate row count estimates in queries involving tables with a large number of null values. As a result, it was possible that the optimizer could choose a suboptimal plan. This issue has now been fixed. [#69070][#69070]
+- Fixed internal or "invalid cast" errors in some cases involving cascading updates. [#69126][#69126]
+- Previously, CockroachDB could return an internal error when performing the streaming aggregation in some edge cases, and this is now fixed. The bug had been present since v21.1. [#69122][#69122]
+- Introduced checks on [Statements](../v21.2/ui-statements-page.html) and [Transactions](../v21.2/ui-transactions-page.html) pages so that the managed repo can update the cluster-ui version. [#69205][#69205]
+- When using `COPY FROM .. BINARY`, the correct format code will now be returned. [#69066][#69066]
+- Previously, `COPY FROM ... BINARY` would return an error if the input data was split across different messages. This is now fixed. [#69066][#69066]
+- Previously, `COPY FROM ... CSV` would require each `CopyData` message to be split at the boundary of a record. This was a bug since the `COPY` protocol would allow messages to be split at arbitrary points. This is now fixed. [#69066][#69066]
+- Previously, `COPY FROM ... CSV` did not correctly handle octal byte escape sequences such as `\011` when using a `BYTEA` column. This is now fixed. [#69066][#69066]
+- Fixed a bug that caused internal errors with set operations, like `UNION`, and columns with tuple types that contained constant `NULL` values. This bug was introduced in v20.2. [#68627][#68627]
+- Fixed a crash when using the `cockroach backup debug` tool. [#69251][#69251]
+- Previously, after a temporary node outage, other nodes in the cluster could fail to connect to the restarted node due to their circuit breakers not resetting. This would manifest in the logs via messages "unable to dial nXX: breaker open", where `XX` is the ID of the restarted node. (Note that such errors are expected for nodes that are truly unreachable, and may still occur around the time of the restart, but for no longer than a few seconds). This is now fixed. [#69405][#69405]
+- Previously, table stats collection issued via an `ANALYZE` or [`CREATE STATISTICS`](../v21.2/create-statistics.html) statement without specifying `AS OF SYSTEM TIME` option could run into `flow: memory budget exceeded`. This has been fixed. [#69483][#69483]
+- Fixed a bug where [`IMPORT`](../v21.2/import.html) internal retries (i.e., due to node failures) might not pick up the latest progress updates. [#68218][#68218]
+- Fixed a bug where the summary displayed after an [`IMPORT`](../v21.2/import.html) command would sometimes be inaccurate due to retries. [#68218][#68218]
+- Long-running `ANALYZE` statements will no longer result in GC TTL errors. [#68929][#68929]
+
+### Performance improvements
+
+-  Intent resolution for transactions that write many intents such that we track intent ranges, for the purpose of intent resolution, is much faster (potentially 100x) when using the separated lock table. [#66268][#66268]
+- Updated the [optimizer cost model](../v21.2/cost-based-optimizer.html) so that all else being equal, the optimizer prefers plans in which `LIMIT `operators are pushed as far down the tree as possible. This can reduce the number of rows that need to be processed by higher operators in the plan tree, thus improving performance. [#69688][#69688]
+- QPS-based replica rebalancing is now aware of different constraints placed on different [replication zones](../v21.2/configure-replication-zones.html). This means that heterogeneously loaded replication zones (for instance, regions) will achieve a more even distribution of QPS within the stores inside each of these zone. [#65379][#65379]
+- Some additional expressions using the `<@` (contained by) and `@>` (contains) operators now support index-acceleration with the indexed column on either side of the expression. [#61219][#61219]
+- Some additional expressions using the `<@` (contained by) and `@>` (contains) operators now support index-acceleration with the indexed column on either side of the expression. [#61817][#61817]
+- Columns that are held constant in partial index predicates can now be produced when scanning the partial index. This eliminates unnecessary primary index joins to retrieve those constant columns in some queries, resulting in lower latency. [#62406][#62406]
+- Inverted joins using `<@` (contained by) and `@>` (contains) operators are now supported with the indexed column on either side of the expression. [#62626][#62626]
+- The optimizer now folds functions to `NULL` when the function does not allow `NULL` arguments and one of the arguments is a `NULL` constant. As a result, more efficient query plans will be produced for queries with these types of function calls. [#62924][#62924]
+- Expressions with the `->` (fetch val) operator on the left side of either `<@` (contained by) or `@>` (contains) now support index-acceleration. [#63048][#63048]
+- SQL will now emit `GetRequests` when possible to KV instead of always emitting `ScanRequests`. This manifests as a modest performance improvement for some workloads. [#61583][#61583]
+- Set operations (`UNION`, `UNION ALL`, `INTERSECT`, `INTERSECT ALL`, `EXCEPT`, and `EXCEPT ALL`) can now maintain ordering if both inputs are ordered on the desired output ordering. This can eliminate unnecessary sort operations and improve performance. [#63805][#63805]
+- Reduced memory usage in some write-heavy workloads. [#64222][#64222]
+- Increased the intelligence of the optimizer around the ability of a scan to provide certain requested orderings when some of the columns are held constant. This can eliminate unneeded sort operations in some cases, resulting in improved performance. [#64254][#64254]
+- Increased the intelligence of the optimizer around orderings that can be provided by certain relational expressions when some columns are constant or there are equalities between columns. This can allow the optimizer to plan merge joins, streaming group bys, and streaming set operations in more cases, resulting in improved performance. [#64501][#64501]
+- Increased the intelligence of the optimizer around orderings that can be provided by certain relational expressions when there are equalities between columns. This can allow the optimizer to remove unnecessary sort operations in some cases, thus improving performance. [#64593][#64593]
+- Improved the performance for distributed queries that need to send a lot of data of certain datatypes across the network. [#64169][#64169]
+- Peak memory usage in the lock table is now significantly reduced. Runaway CPU usage due to wasted quadratic time complexity in clearing unclearable locks is addressed. [#64102][#64102]
+- The selectivity of query filters with `OR` expressions is now calculated more accurately during query optimization, improving query plans in some cases. [#64886][#64886]
+- Validation of a new `UNIQUE` index in a `REGIONAL BY ROW` table no longer requires an inefficient and memory-intensive hash aggregation query. The optimizer can now plans the validation query so that it uses all streaming operations, which are much more efficient. [#65355][#65355]
+- A limited scan now checks for conflicting locks in an optimistic manner, which means it will not conflict with locks (typically unreplicated locks) that were held in the scan's full spans, but were not in the spans that were scanned until the limit was reached. This behavior can be turned off by changing the value of the [cluster setting](../v21.2/cluster-settings.html) `kv.concurrency.optimistic_eval_limited_scans.enabled` to `false`. [#58670][#58670]
+- Queries that produce a lot of rows in the result usually will now run faster when executed via the [vectorized execution engine](../v21.2/vectorized-execution.html). [#65289][#65289]
+- Inner, Left, and Semi joins involving `REGIONAL BY ROW` tables can now take advantage of locality-optimized search. This optimization allows lookup joins to avoid communicating with remote nodes if a lookup is known to produce at most one match per input row, and all matches are found locally. This can reduce query latency. [#65784][#65784]
+- Improved the performance of `has_table_privilege` by using an internal cache for performing privilege lookups. [#65766][#65766]
+- Improved the performance of `has_any_column_privilege` by removing some internal queries. [#65766][#65766]
+- Improved the performance of `has_column_privilege` by removing excessive queries. [#65766][#65766]
+- When admission control is enabled, work sent to the KV layer is subject to admission control that takes into account write overload in the storage engines. [#65850][#65850]
+- Regexp expressions that restrict values to a prefix (e.g., `x ^ '^foo'`) now result in better plans if there is a suitable index. [#66441][#66441]
+- The optimizer can now create query plans that use streaming set operations, even when no ordering is required by the query. Streaming set operations are more efficient than the alternative hash set operations, because they avoid the overhead of building a hash table. This can result in improved performance for queries containing the set operations `UNION`, `INTERSECT`, `INTERSECT ALL`, `EXCEPT`, and `EXCEPT ALL`. (`UNION ALL` does not benefit from this optimization.) [#64953][#64953]
+- A limited scan now checks for conflicting latches in an optimistic manner, which means it will not conflict with latches that were held in the scan's full spans, but were not in the spans that were scanned until the limit was reached. This behavior can be turned off (along with optimistic locking) by changing the value of the [cluster setting](../v21.2/cluster-settings.html) `kv.concurrency.optimistic_eval_limited_scans.enabled` to `false`. [#66059][#66059]
+- The optimizer is now less likely to create query plans that require buffering a large number of rows in memory. This can improve performance by reducing memory pressure and reducing the likelihood that execution operators will need to spill to disk. [#66559][#66559]
+- Validation of a new partial `UNIQUE` index in a `REGIONAL BY ROW` table no longer requires an inefficient and memory-intensive hash aggregation query. The optimizer can now plan the validation query so that it uses all streaming operations, which are much more efficient. [#66565][#66565]
+- Fixed a performance regression that made the in-memory vectorized sorter slower than the row-engine sorter when the input had decimal columns. [#66807][#66807]
+- Increased the default value for the `kv.transaction.max_intents_bytes` [cluster setting](../v21.2/cluster-settings.html) from 256KB to 4MB to improve transaction performance for large transactions at the expense of increased memory usage. Transactions above this size limit use slower cleanup mode for commits and aborts. [#66859][#66859]
+- Adjusted optimizer cost to include CPU cost of `lookupExprs` when used by lookup joins.  When a lookup join is chosen we can use two strategies: a simple 1-column lookup or a more involved multi-column lookup that makes more efficient use of indexes but has higher CPU cost. This change makes the cost model reflect that extra cost. [#66786][#66786]
+- Improved the efficiency of validation for some partial unique indexes in REGIONAL BY ROW tables by improving the query plan to use all streaming operations. [#67263][#67263]
+- The latency of authenticating a user has been improved by adding a cache for lookups of authentication related information. [#66919][#66919]
+- Improved the optimizer's cardinality estimations for `enum` columns, including the `crdb_region` column in `REGIONAL BY ROW` tables, as well as all other columns with user-defined types. This may result in the optimizer choosing a better query plan in some cases. [#67374][#67374]
+- Eliminated a round-trip when running most jobs. [#67671][#67671]
+- The performance of queries returning many arrays has been improved. [#66941][#66941]
+- Improved concurrency control for heavily contended write queries outside of transactions that touch multiple ranges, reducing excessive aborts and retries. [#67215][#67215]
+- The optimizer can now decorrelate queries that have a limit on the right (uncorrelated) input of a lateral join when the limit is greater than one. [#68299][#68299]
+- Sort performance has been improved when sorting columns of type `STRING`, `BYTES`, or `UUID`. [#67451][#67451]
+- Lookup joins on partial indexes with virtual columns are no considered by the optimizer, resulting in more efficient query plans in some cases. [#68568][#68568]
+- The `COCKROACHDB_REGISTRY` file used for encryption-at-rest will be replaced with a `COCKROACHDB_ENCRYPTION_REGISTRY`, which can be written to in a more efficient manner. [#67320][#67320]
+- Reduce memory usage slightly during `ANALYZE` or [`CREATE STATISTICS`](../v21.2/create-statistics.html) statements. [#69051][#69051]
+- The optimizer more accurately costs streaming group-by operators. As a result, more efficient query plans should be chosen in some cases. [#68922][#68922]
+- If the query is executed locally and needs to perform reads from multiple remote leaseholders, those remote reads might now be done faster. This is especially likely for the case of locality optimized search when there is a local region miss. [#68679][#68679]
+- Improved the histogram construction logic so that histograms for columns with a large number of distinct values are more accurate. This can result in better cardinality estimates in the optimizer and enable the optimizer to choose better query plans. [#68698][#68698]
+- Locality-optimized search is now supported for scans that are guaranteed to return 100,000 keys or less. This optimization allows the execution engine to avoid visiting remote regions if all requested keys are found in the local region, thus reducing the latency of the query. [#69395][#69395]
+
+### Build changes
+
+- Added go-swagger dependency. Updated Makefile to call it to rebuild spec in `docs/generated/swagger/`, which will eventually be used for API docs. [#62560][#62560]
+
+### Contributors
+
+This release includes 2750 merged PRs by 229 authors.
+We would like to thank the following contributors from the CockroachDB community:
+
+- AJ (first-time contributor)
+- Alan Acosta (first-time contributor)
+- Aleksandr Fedorov (first-time contributor)
+- Callum Neenan (first-time contributor)
+- Catherine J (first-time contributor)
+- David López
+- Eugene Kalinin
+- Ganeshprasad Biradar (first-time contributor)
+- Jane Xing (first-time contributor)
+- Janusz Marcinkiewicz (first-time contributor)
+- Jonathan Albrecht (first-time contributor)
+- Julien Levesy (first-time contributor)
+- Justin Lowery (first-time contributor)
+- K Rain Leander (first-time contributor)
+- Keith McClellan (first-time contributor)
+- Kumar Akshay
+- Lakshmi Kannan (first-time contributor)
+- Lauren Barker (first-time contributor)
+- Masahiro Ikeda (first-time contributor)
+- Max Neverov
+- Miguel Novelo (first-time contributor)
+- Mohammad Aziz (first-time contributor)
+- Mohit Agarwal (first-time contributor)
+- Nikola N (first-time contributor)
+- OrlovM (first-time contributor)
+- Rupesh Harode (first-time contributor)
+- Sam X Smith (first-time contributor)
+- Shivam Agrawal (first-time contributor)
+- Sumit Tembe (first-time contributor)
+- Tharun
+- Wilson Meng (first-time contributor)
+- Zhou Xing (first-time contributor)
+- Zijie Lu (first-time contributor)
+- aayush (first-time contributor)
+- ajstorm (first-time contributor)
+- auxten (first-time contributor)
+- e-mbrown (first-time contributor)
+- joesankey (first-time contributor)
+- kurokochin (first-time contributor)
+- linyimin (first-time contributor)
+- oeph (first-time contributor)
+- rharding6373 (first-time contributor)
+- seekingua (first-time contributor)
+- snyk-bot (first-time contributor)
+- yangxuan (first-time contributor)
+- zhangwei.95 (first-time contributor)
+
+
+[#65379]: https://github.com/cockroachdb/cockroach/pull/65379
+[#66268]: https://github.com/cockroachdb/cockroach/pull/66268
+[#66312]: https://github.com/cockroachdb/cockroach/pull/66312
+[#66901]: https://github.com/cockroachdb/cockroach/pull/66901
+[#67936]: https://github.com/cockroachdb/cockroach/pull/67936
+[#68551]: https://github.com/cockroachdb/cockroach/pull/68551
+[#68983]: https://github.com/cockroachdb/cockroach/pull/68983
+[#69018]: https://github.com/cockroachdb/cockroach/pull/69018
+[#69167]: https://github.com/cockroachdb/cockroach/pull/69167
+[#69217]: https://github.com/cockroachdb/cockroach/pull/69217
+[#69328]: https://github.com/cockroachdb/cockroach/pull/69328
+[#69371]: https://github.com/cockroachdb/cockroach/pull/69371
+[#69382]: https://github.com/cockroachdb/cockroach/pull/69382
+[#69422]: https://github.com/cockroachdb/cockroach/pull/69422
+[#69554]: https://github.com/cockroachdb/cockroach/pull/69554
+[#69571]: https://github.com/cockroachdb/cockroach/pull/69571
+[#69594]: https://github.com/cockroachdb/cockroach/pull/69594
+[#69620]: https://github.com/cockroachdb/cockroach/pull/69620
+[#69626]: https://github.com/cockroachdb/cockroach/pull/69626
+[#69638]: https://github.com/cockroachdb/cockroach/pull/69638
+[#69641]: https://github.com/cockroachdb/cockroach/pull/69641
+[#69651]: https://github.com/cockroachdb/cockroach/pull/69651
+[#69667]: https://github.com/cockroachdb/cockroach/pull/69667
+[#69671]: https://github.com/cockroachdb/cockroach/pull/69671
+[#69674]: https://github.com/cockroachdb/cockroach/pull/69674
+[#69681]: https://github.com/cockroachdb/cockroach/pull/69681
+[#69688]: https://github.com/cockroachdb/cockroach/pull/69688
+[#69696]: https://github.com/cockroachdb/cockroach/pull/69696
+[#69698]: https://github.com/cockroachdb/cockroach/pull/69698
+[#69711]: https://github.com/cockroachdb/cockroach/pull/69711
+[#69722]: https://github.com/cockroachdb/cockroach/pull/69722
+[#69727]: https://github.com/cockroachdb/cockroach/pull/69727
+[#69730]: https://github.com/cockroachdb/cockroach/pull/69730
+[#69775]: https://github.com/cockroachdb/cockroach/pull/69775
+[#69787]: https://github.com/cockroachdb/cockroach/pull/69787
+[#69788]: https://github.com/cockroachdb/cockroach/pull/69788
+[#69804]: https://github.com/cockroachdb/cockroach/pull/69804
+[#69812]: https://github.com/cockroachdb/cockroach/pull/69812
+[#69813]: https://github.com/cockroachdb/cockroach/pull/69813
+[#69814]: https://github.com/cockroachdb/cockroach/pull/69814
+[#69857]: https://github.com/cockroachdb/cockroach/pull/69857
+[0cb53f31d]: https://github.com/cockroachdb/cockroach/commit/0cb53f31d
+[10d10e84a]: https://github.com/cockroachdb/cockroach/commit/10d10e84a
+[247332bc1]: https://github.com/cockroachdb/cockroach/commit/247332bc1
+[5effb91f6]: https://github.com/cockroachdb/cockroach/commit/5effb91f6
+[683f4c592]: https://github.com/cockroachdb/cockroach/commit/683f4c592
+[99157d973]: https://github.com/cockroachdb/cockroach/commit/99157d973
+[b3a9b702b]: https://github.com/cockroachdb/cockroach/commit/b3a9b702b
+[b6fb0e626]: https://github.com/cockroachdb/cockroach/commit/b6fb0e626
+[#57590]: https://github.com/cockroachdb/cockroach/pull/57590
+[#58670]: https://github.com/cockroachdb/cockroach/pull/58670
+[#59079]: https://github.com/cockroachdb/cockroach/pull/59079
+[#60835]: https://github.com/cockroachdb/cockroach/pull/60835
+[#60946]: https://github.com/cockroachdb/cockroach/pull/60946
+[#61131]: https://github.com/cockroachdb/cockroach/pull/61131
+[#61219]: https://github.com/cockroachdb/cockroach/pull/61219
+[#61417]: https://github.com/cockroachdb/cockroach/pull/61417
+[#61439]: https://github.com/cockroachdb/cockroach/pull/61439
+[#61582]: https://github.com/cockroachdb/cockroach/pull/61582
+[#61583]: https://github.com/cockroachdb/cockroach/pull/61583
+[#61593]: https://github.com/cockroachdb/cockroach/pull/61593
+[#61602]: https://github.com/cockroachdb/cockroach/pull/61602
+[#61610]: https://github.com/cockroachdb/cockroach/pull/61610
+[#61629]: https://github.com/cockroachdb/cockroach/pull/61629
+[#61740]: https://github.com/cockroachdb/cockroach/pull/61740
+[#61771]: https://github.com/cockroachdb/cockroach/pull/61771
+[#61817]: https://github.com/cockroachdb/cockroach/pull/61817
+[#61862]: https://github.com/cockroachdb/cockroach/pull/61862
+[#61968]: https://github.com/cockroachdb/cockroach/pull/61968
+[#62053]: https://github.com/cockroachdb/cockroach/pull/62053
+[#62076]: https://github.com/cockroachdb/cockroach/pull/62076
+[#62164]: https://github.com/cockroachdb/cockroach/pull/62164
+[#62257]: https://github.com/cockroachdb/cockroach/pull/62257
+[#62294]: https://github.com/cockroachdb/cockroach/pull/62294
+[#62305]: https://github.com/cockroachdb/cockroach/pull/62305
+[#62308]: https://github.com/cockroachdb/cockroach/pull/62308
+[#62377]: https://github.com/cockroachdb/cockroach/pull/62377
+[#62381]: https://github.com/cockroachdb/cockroach/pull/62381
+[#62406]: https://github.com/cockroachdb/cockroach/pull/62406
+[#62411]: https://github.com/cockroachdb/cockroach/pull/62411
+[#62435]: https://github.com/cockroachdb/cockroach/pull/62435
+[#62440]: https://github.com/cockroachdb/cockroach/pull/62440
+[#62448]: https://github.com/cockroachdb/cockroach/pull/62448
+[#62452]: https://github.com/cockroachdb/cockroach/pull/62452
+[#62465]: https://github.com/cockroachdb/cockroach/pull/62465
+[#62483]: https://github.com/cockroachdb/cockroach/pull/62483
+[#62496]: https://github.com/cockroachdb/cockroach/pull/62496
+[#62560]: https://github.com/cockroachdb/cockroach/pull/62560
+[#62570]: https://github.com/cockroachdb/cockroach/pull/62570
+[#62580]: https://github.com/cockroachdb/cockroach/pull/62580
+[#62626]: https://github.com/cockroachdb/cockroach/pull/62626
+[#62628]: https://github.com/cockroachdb/cockroach/pull/62628
+[#62661]: https://github.com/cockroachdb/cockroach/pull/62661
+[#62662]: https://github.com/cockroachdb/cockroach/pull/62662
+[#62695]: https://github.com/cockroachdb/cockroach/pull/62695
+[#62703]: https://github.com/cockroachdb/cockroach/pull/62703
+[#62744]: https://github.com/cockroachdb/cockroach/pull/62744
+[#62764]: https://github.com/cockroachdb/cockroach/pull/62764
+[#62819]: https://github.com/cockroachdb/cockroach/pull/62819
+[#62829]: https://github.com/cockroachdb/cockroach/pull/62829
+[#62836]: https://github.com/cockroachdb/cockroach/pull/62836
+[#62924]: https://github.com/cockroachdb/cockroach/pull/62924
+[#62980]: https://github.com/cockroachdb/cockroach/pull/62980
+[#62989]: https://github.com/cockroachdb/cockroach/pull/62989
+[#63000]: https://github.com/cockroachdb/cockroach/pull/63000
+[#63048]: https://github.com/cockroachdb/cockroach/pull/63048
+[#63072]: https://github.com/cockroachdb/cockroach/pull/63072
+[#63100]: https://github.com/cockroachdb/cockroach/pull/63100
+[#63137]: https://github.com/cockroachdb/cockroach/pull/63137
+[#63173]: https://github.com/cockroachdb/cockroach/pull/63173
+[#63181]: https://github.com/cockroachdb/cockroach/pull/63181
+[#63217]: https://github.com/cockroachdb/cockroach/pull/63217
+[#63309]: https://github.com/cockroachdb/cockroach/pull/63309
+[#63319]: https://github.com/cockroachdb/cockroach/pull/63319
+[#63342]: https://github.com/cockroachdb/cockroach/pull/63342
+[#63343]: https://github.com/cockroachdb/cockroach/pull/63343
+[#63351]: https://github.com/cockroachdb/cockroach/pull/63351
+[#63353]: https://github.com/cockroachdb/cockroach/pull/63353
+[#63384]: https://github.com/cockroachdb/cockroach/pull/63384
+[#63412]: https://github.com/cockroachdb/cockroach/pull/63412
+[#63488]: https://github.com/cockroachdb/cockroach/pull/63488
+[#63492]: https://github.com/cockroachdb/cockroach/pull/63492
+[#63671]: https://github.com/cockroachdb/cockroach/pull/63671
+[#63677]: https://github.com/cockroachdb/cockroach/pull/63677
+[#63678]: https://github.com/cockroachdb/cockroach/pull/63678
+[#63725]: https://github.com/cockroachdb/cockroach/pull/63725
+[#63747]: https://github.com/cockroachdb/cockroach/pull/63747
+[#63748]: https://github.com/cockroachdb/cockroach/pull/63748
+[#63770]: https://github.com/cockroachdb/cockroach/pull/63770
+[#63799]: https://github.com/cockroachdb/cockroach/pull/63799
+[#63805]: https://github.com/cockroachdb/cockroach/pull/63805
+[#63822]: https://github.com/cockroachdb/cockroach/pull/63822
+[#63832]: https://github.com/cockroachdb/cockroach/pull/63832
+[#63839]: https://github.com/cockroachdb/cockroach/pull/63839
+[#63897]: https://github.com/cockroachdb/cockroach/pull/63897
+[#63900]: https://github.com/cockroachdb/cockroach/pull/63900
+[#63935]: https://github.com/cockroachdb/cockroach/pull/63935
+[#63953]: https://github.com/cockroachdb/cockroach/pull/63953
+[#63956]: https://github.com/cockroachdb/cockroach/pull/63956
+[#63959]: https://github.com/cockroachdb/cockroach/pull/63959
+[#64032]: https://github.com/cockroachdb/cockroach/pull/64032
+[#64035]: https://github.com/cockroachdb/cockroach/pull/64035
+[#64076]: https://github.com/cockroachdb/cockroach/pull/64076
+[#64087]: https://github.com/cockroachdb/cockroach/pull/64087
+[#64102]: https://github.com/cockroachdb/cockroach/pull/64102
+[#64137]: https://github.com/cockroachdb/cockroach/pull/64137
+[#64157]: https://github.com/cockroachdb/cockroach/pull/64157
+[#64169]: https://github.com/cockroachdb/cockroach/pull/64169
+[#64183]: https://github.com/cockroachdb/cockroach/pull/64183
+[#64199]: https://github.com/cockroachdb/cockroach/pull/64199
+[#64222]: https://github.com/cockroachdb/cockroach/pull/64222
+[#64225]: https://github.com/cockroachdb/cockroach/pull/64225
+[#64239]: https://github.com/cockroachdb/cockroach/pull/64239
+[#64254]: https://github.com/cockroachdb/cockroach/pull/64254
+[#64260]: https://github.com/cockroachdb/cockroach/pull/64260
+[#64285]: https://github.com/cockroachdb/cockroach/pull/64285
+[#64374]: https://github.com/cockroachdb/cockroach/pull/64374
+[#64381]: https://github.com/cockroachdb/cockroach/pull/64381
+[#64442]: https://github.com/cockroachdb/cockroach/pull/64442
+[#64501]: https://github.com/cockroachdb/cockroach/pull/64501
+[#64593]: https://github.com/cockroachdb/cockroach/pull/64593
+[#64605]: https://github.com/cockroachdb/cockroach/pull/64605
+[#64614]: https://github.com/cockroachdb/cockroach/pull/64614
+[#64672]: https://github.com/cockroachdb/cockroach/pull/64672
+[#64695]: https://github.com/cockroachdb/cockroach/pull/64695
+[#64701]: https://github.com/cockroachdb/cockroach/pull/64701
+[#64731]: https://github.com/cockroachdb/cockroach/pull/64731
+[#64737]: https://github.com/cockroachdb/cockroach/pull/64737
+[#64748]: https://github.com/cockroachdb/cockroach/pull/64748
+[#64758]: https://github.com/cockroachdb/cockroach/pull/64758
+[#64785]: https://github.com/cockroachdb/cockroach/pull/64785
+[#64788]: https://github.com/cockroachdb/cockroach/pull/64788
+[#64831]: https://github.com/cockroachdb/cockroach/pull/64831
+[#64879]: https://github.com/cockroachdb/cockroach/pull/64879
+[#64886]: https://github.com/cockroachdb/cockroach/pull/64886
+[#64887]: https://github.com/cockroachdb/cockroach/pull/64887
+[#64893]: https://github.com/cockroachdb/cockroach/pull/64893
+[#64908]: https://github.com/cockroachdb/cockroach/pull/64908
+[#64951]: https://github.com/cockroachdb/cockroach/pull/64951
+[#64953]: https://github.com/cockroachdb/cockroach/pull/64953
+[#64956]: https://github.com/cockroachdb/cockroach/pull/64956
+[#64977]: https://github.com/cockroachdb/cockroach/pull/64977
+[#64996]: https://github.com/cockroachdb/cockroach/pull/64996
+[#64997]: https://github.com/cockroachdb/cockroach/pull/64997
+[#65001]: https://github.com/cockroachdb/cockroach/pull/65001
+[#65014]: https://github.com/cockroachdb/cockroach/pull/65014
+[#65015]: https://github.com/cockroachdb/cockroach/pull/65015
+[#65018]: https://github.com/cockroachdb/cockroach/pull/65018
+[#65024]: https://github.com/cockroachdb/cockroach/pull/65024
+[#65099]: https://github.com/cockroachdb/cockroach/pull/65099
+[#65101]: https://github.com/cockroachdb/cockroach/pull/65101
+[#65126]: https://github.com/cockroachdb/cockroach/pull/65126
+[#65154]: https://github.com/cockroachdb/cockroach/pull/65154
+[#65188]: https://github.com/cockroachdb/cockroach/pull/65188
+[#65189]: https://github.com/cockroachdb/cockroach/pull/65189
+[#65209]: https://github.com/cockroachdb/cockroach/pull/65209
+[#65278]: https://github.com/cockroachdb/cockroach/pull/65278
+[#65289]: https://github.com/cockroachdb/cockroach/pull/65289
+[#65307]: https://github.com/cockroachdb/cockroach/pull/65307
+[#65321]: https://github.com/cockroachdb/cockroach/pull/65321
+[#65322]: https://github.com/cockroachdb/cockroach/pull/65322
+[#65324]: https://github.com/cockroachdb/cockroach/pull/65324
+[#65340]: https://github.com/cockroachdb/cockroach/pull/65340
+[#65355]: https://github.com/cockroachdb/cockroach/pull/65355
+[#65377]: https://github.com/cockroachdb/cockroach/pull/65377
+[#65396]: https://github.com/cockroachdb/cockroach/pull/65396
+[#65397]: https://github.com/cockroachdb/cockroach/pull/65397
+[#65413]: https://github.com/cockroachdb/cockroach/pull/65413
+[#65420]: https://github.com/cockroachdb/cockroach/pull/65420
+[#65431]: https://github.com/cockroachdb/cockroach/pull/65431
+[#65432]: https://github.com/cockroachdb/cockroach/pull/65432
+[#65445]: https://github.com/cockroachdb/cockroach/pull/65445
+[#65460]: https://github.com/cockroachdb/cockroach/pull/65460
+[#65495]: https://github.com/cockroachdb/cockroach/pull/65495
+[#65550]: https://github.com/cockroachdb/cockroach/pull/65550
+[#65592]: https://github.com/cockroachdb/cockroach/pull/65592
+[#65614]: https://github.com/cockroachdb/cockroach/pull/65614
+[#65620]: https://github.com/cockroachdb/cockroach/pull/65620
+[#65633]: https://github.com/cockroachdb/cockroach/pull/65633
+[#65634]: https://github.com/cockroachdb/cockroach/pull/65634
+[#65653]: https://github.com/cockroachdb/cockroach/pull/65653
+[#65661]: https://github.com/cockroachdb/cockroach/pull/65661
+[#65683]: https://github.com/cockroachdb/cockroach/pull/65683
+[#65717]: https://github.com/cockroachdb/cockroach/pull/65717
+[#65727]: https://github.com/cockroachdb/cockroach/pull/65727
+[#65766]: https://github.com/cockroachdb/cockroach/pull/65766
+[#65768]: https://github.com/cockroachdb/cockroach/pull/65768
+[#65775]: https://github.com/cockroachdb/cockroach/pull/65775
+[#65782]: https://github.com/cockroachdb/cockroach/pull/65782
+[#65784]: https://github.com/cockroachdb/cockroach/pull/65784
+[#65850]: https://github.com/cockroachdb/cockroach/pull/65850
+[#65854]: https://github.com/cockroachdb/cockroach/pull/65854
+[#65871]: https://github.com/cockroachdb/cockroach/pull/65871
+[#65902]: https://github.com/cockroachdb/cockroach/pull/65902
+[#65909]: https://github.com/cockroachdb/cockroach/pull/65909
+[#65914]: https://github.com/cockroachdb/cockroach/pull/65914
+[#65950]: https://github.com/cockroachdb/cockroach/pull/65950
+[#65953]: https://github.com/cockroachdb/cockroach/pull/65953
+[#65956]: https://github.com/cockroachdb/cockroach/pull/65956
+[#66002]: https://github.com/cockroachdb/cockroach/pull/66002
+[#66013]: https://github.com/cockroachdb/cockroach/pull/66013
+[#66020]: https://github.com/cockroachdb/cockroach/pull/66020
+[#66025]: https://github.com/cockroachdb/cockroach/pull/66025
+[#66033]: https://github.com/cockroachdb/cockroach/pull/66033
+[#66059]: https://github.com/cockroachdb/cockroach/pull/66059
+[#66065]: https://github.com/cockroachdb/cockroach/pull/66065
+[#66146]: https://github.com/cockroachdb/cockroach/pull/66146
+[#66147]: https://github.com/cockroachdb/cockroach/pull/66147
+[#66157]: https://github.com/cockroachdb/cockroach/pull/66157
+[#66196]: https://github.com/cockroachdb/cockroach/pull/66196
+[#66221]: https://github.com/cockroachdb/cockroach/pull/66221
+[#66225]: https://github.com/cockroachdb/cockroach/pull/66225
+[#66253]: https://github.com/cockroachdb/cockroach/pull/66253
+[#66258]: https://github.com/cockroachdb/cockroach/pull/66258
+[#66264]: https://github.com/cockroachdb/cockroach/pull/66264
+[#66277]: https://github.com/cockroachdb/cockroach/pull/66277
+[#66337]: https://github.com/cockroachdb/cockroach/pull/66337
+[#66345]: https://github.com/cockroachdb/cockroach/pull/66345
+[#66359]: https://github.com/cockroachdb/cockroach/pull/66359
+[#66362]: https://github.com/cockroachdb/cockroach/pull/66362
+[#66366]: https://github.com/cockroachdb/cockroach/pull/66366
+[#66370]: https://github.com/cockroachdb/cockroach/pull/66370
+[#66374]: https://github.com/cockroachdb/cockroach/pull/66374
+[#66375]: https://github.com/cockroachdb/cockroach/pull/66375
+[#66376]: https://github.com/cockroachdb/cockroach/pull/66376
+[#66399]: https://github.com/cockroachdb/cockroach/pull/66399
+[#66417]: https://github.com/cockroachdb/cockroach/pull/66417
+[#66422]: https://github.com/cockroachdb/cockroach/pull/66422
+[#66427]: https://github.com/cockroachdb/cockroach/pull/66427
+[#66441]: https://github.com/cockroachdb/cockroach/pull/66441
+[#66464]: https://github.com/cockroachdb/cockroach/pull/66464
+[#66495]: https://github.com/cockroachdb/cockroach/pull/66495
+[#66497]: https://github.com/cockroachdb/cockroach/pull/66497
+[#66535]: https://github.com/cockroachdb/cockroach/pull/66535
+[#66559]: https://github.com/cockroachdb/cockroach/pull/66559
+[#66565]: https://github.com/cockroachdb/cockroach/pull/66565
+[#66569]: https://github.com/cockroachdb/cockroach/pull/66569
+[#66578]: https://github.com/cockroachdb/cockroach/pull/66578
+[#66582]: https://github.com/cockroachdb/cockroach/pull/66582
+[#66595]: https://github.com/cockroachdb/cockroach/pull/66595
+[#66599]: https://github.com/cockroachdb/cockroach/pull/66599
+[#66605]: https://github.com/cockroachdb/cockroach/pull/66605
+[#66625]: https://github.com/cockroachdb/cockroach/pull/66625
+[#66629]: https://github.com/cockroachdb/cockroach/pull/66629
+[#66640]: https://github.com/cockroachdb/cockroach/pull/66640
+[#66645]: https://github.com/cockroachdb/cockroach/pull/66645
+[#66675]: https://github.com/cockroachdb/cockroach/pull/66675
+[#66679]: https://github.com/cockroachdb/cockroach/pull/66679
+[#66687]: https://github.com/cockroachdb/cockroach/pull/66687
+[#66688]: https://github.com/cockroachdb/cockroach/pull/66688
+[#66689]: https://github.com/cockroachdb/cockroach/pull/66689
+[#66734]: https://github.com/cockroachdb/cockroach/pull/66734
+[#66738]: https://github.com/cockroachdb/cockroach/pull/66738
+[#66760]: https://github.com/cockroachdb/cockroach/pull/66760
+[#66782]: https://github.com/cockroachdb/cockroach/pull/66782
+[#66785]: https://github.com/cockroachdb/cockroach/pull/66785
+[#66786]: https://github.com/cockroachdb/cockroach/pull/66786
+[#66793]: https://github.com/cockroachdb/cockroach/pull/66793
+[#66795]: https://github.com/cockroachdb/cockroach/pull/66795
+[#66807]: https://github.com/cockroachdb/cockroach/pull/66807
+[#66815]: https://github.com/cockroachdb/cockroach/pull/66815
+[#66842]: https://github.com/cockroachdb/cockroach/pull/66842
+[#66856]: https://github.com/cockroachdb/cockroach/pull/66856
+[#66859]: https://github.com/cockroachdb/cockroach/pull/66859
+[#66865]: https://github.com/cockroachdb/cockroach/pull/66865
+[#66870]: https://github.com/cockroachdb/cockroach/pull/66870
+[#66889]: https://github.com/cockroachdb/cockroach/pull/66889
+[#66893]: https://github.com/cockroachdb/cockroach/pull/66893
+[#66899]: https://github.com/cockroachdb/cockroach/pull/66899
+[#66914]: https://github.com/cockroachdb/cockroach/pull/66914
+[#66915]: https://github.com/cockroachdb/cockroach/pull/66915
+[#66919]: https://github.com/cockroachdb/cockroach/pull/66919
+[#66936]: https://github.com/cockroachdb/cockroach/pull/66936
+[#66941]: https://github.com/cockroachdb/cockroach/pull/66941
+[#66967]: https://github.com/cockroachdb/cockroach/pull/66967
+[#66969]: https://github.com/cockroachdb/cockroach/pull/66969
+[#66972]: https://github.com/cockroachdb/cockroach/pull/66972
+[#66973]: https://github.com/cockroachdb/cockroach/pull/66973
+[#67000]: https://github.com/cockroachdb/cockroach/pull/67000
+[#67011]: https://github.com/cockroachdb/cockroach/pull/67011
+[#67017]: https://github.com/cockroachdb/cockroach/pull/67017
+[#67022]: https://github.com/cockroachdb/cockroach/pull/67022
+[#67023]: https://github.com/cockroachdb/cockroach/pull/67023
+[#67075]: https://github.com/cockroachdb/cockroach/pull/67075
+[#67080]: https://github.com/cockroachdb/cockroach/pull/67080
+[#67090]: https://github.com/cockroachdb/cockroach/pull/67090
+[#67093]: https://github.com/cockroachdb/cockroach/pull/67093
+[#67094]: https://github.com/cockroachdb/cockroach/pull/67094
+[#67098]: https://github.com/cockroachdb/cockroach/pull/67098
+[#67121]: https://github.com/cockroachdb/cockroach/pull/67121
+[#67168]: https://github.com/cockroachdb/cockroach/pull/67168
+[#67175]: https://github.com/cockroachdb/cockroach/pull/67175
+[#67210]: https://github.com/cockroachdb/cockroach/pull/67210
+[#67215]: https://github.com/cockroachdb/cockroach/pull/67215
+[#67263]: https://github.com/cockroachdb/cockroach/pull/67263
+[#67275]: https://github.com/cockroachdb/cockroach/pull/67275
+[#67281]: https://github.com/cockroachdb/cockroach/pull/67281
+[#67285]: https://github.com/cockroachdb/cockroach/pull/67285
+[#67310]: https://github.com/cockroachdb/cockroach/pull/67310
+[#67319]: https://github.com/cockroachdb/cockroach/pull/67319
+[#67320]: https://github.com/cockroachdb/cockroach/pull/67320
+[#67327]: https://github.com/cockroachdb/cockroach/pull/67327
+[#67331]: https://github.com/cockroachdb/cockroach/pull/67331
+[#67343]: https://github.com/cockroachdb/cockroach/pull/67343
+[#67350]: https://github.com/cockroachdb/cockroach/pull/67350
+[#67355]: https://github.com/cockroachdb/cockroach/pull/67355
+[#67374]: https://github.com/cockroachdb/cockroach/pull/67374
+[#67386]: https://github.com/cockroachdb/cockroach/pull/67386
+[#67389]: https://github.com/cockroachdb/cockroach/pull/67389
+[#67426]: https://github.com/cockroachdb/cockroach/pull/67426
+[#67427]: https://github.com/cockroachdb/cockroach/pull/67427
+[#67431]: https://github.com/cockroachdb/cockroach/pull/67431
+[#67450]: https://github.com/cockroachdb/cockroach/pull/67450
+[#67451]: https://github.com/cockroachdb/cockroach/pull/67451
+[#67478]: https://github.com/cockroachdb/cockroach/pull/67478
+[#67486]: https://github.com/cockroachdb/cockroach/pull/67486
+[#67497]: https://github.com/cockroachdb/cockroach/pull/67497
+[#67509]: https://github.com/cockroachdb/cockroach/pull/67509
+[#67514]: https://github.com/cockroachdb/cockroach/pull/67514
+[#67531]: https://github.com/cockroachdb/cockroach/pull/67531
+[#67533]: https://github.com/cockroachdb/cockroach/pull/67533
+[#67537]: https://github.com/cockroachdb/cockroach/pull/67537
+[#67541]: https://github.com/cockroachdb/cockroach/pull/67541
+[#67547]: https://github.com/cockroachdb/cockroach/pull/67547
+[#67581]: https://github.com/cockroachdb/cockroach/pull/67581
+[#67641]: https://github.com/cockroachdb/cockroach/pull/67641
+[#67649]: https://github.com/cockroachdb/cockroach/pull/67649
+[#67652]: https://github.com/cockroachdb/cockroach/pull/67652
+[#67654]: https://github.com/cockroachdb/cockroach/pull/67654
+[#67671]: https://github.com/cockroachdb/cockroach/pull/67671
+[#67697]: https://github.com/cockroachdb/cockroach/pull/67697
+[#67703]: https://github.com/cockroachdb/cockroach/pull/67703
+[#67705]: https://github.com/cockroachdb/cockroach/pull/67705
+[#67714]: https://github.com/cockroachdb/cockroach/pull/67714
+[#67725]: https://github.com/cockroachdb/cockroach/pull/67725
+[#67764]: https://github.com/cockroachdb/cockroach/pull/67764
+[#67792]: https://github.com/cockroachdb/cockroach/pull/67792
+[#67799]: https://github.com/cockroachdb/cockroach/pull/67799
+[#67813]: https://github.com/cockroachdb/cockroach/pull/67813
+[#67814]: https://github.com/cockroachdb/cockroach/pull/67814
+[#67815]: https://github.com/cockroachdb/cockroach/pull/67815
+[#67837]: https://github.com/cockroachdb/cockroach/pull/67837
+[#67855]: https://github.com/cockroachdb/cockroach/pull/67855
+[#67865]: https://github.com/cockroachdb/cockroach/pull/67865
+[#67866]: https://github.com/cockroachdb/cockroach/pull/67866
+[#67872]: https://github.com/cockroachdb/cockroach/pull/67872
+[#67941]: https://github.com/cockroachdb/cockroach/pull/67941
+[#67947]: https://github.com/cockroachdb/cockroach/pull/67947
+[#67950]: https://github.com/cockroachdb/cockroach/pull/67950
+[#67953]: https://github.com/cockroachdb/cockroach/pull/67953
+[#67970]: https://github.com/cockroachdb/cockroach/pull/67970
+[#67979]: https://github.com/cockroachdb/cockroach/pull/67979
+[#67985]: https://github.com/cockroachdb/cockroach/pull/67985
+[#67986]: https://github.com/cockroachdb/cockroach/pull/67986
+[#67988]: https://github.com/cockroachdb/cockroach/pull/67988
+[#67994]: https://github.com/cockroachdb/cockroach/pull/67994
+[#67997]: https://github.com/cockroachdb/cockroach/pull/67997
+[#68001]: https://github.com/cockroachdb/cockroach/pull/68001
+[#68013]: https://github.com/cockroachdb/cockroach/pull/68013
+[#68018]: https://github.com/cockroachdb/cockroach/pull/68018
+[#68025]: https://github.com/cockroachdb/cockroach/pull/68025
+[#68026]: https://github.com/cockroachdb/cockroach/pull/68026
+[#68034]: https://github.com/cockroachdb/cockroach/pull/68034
+[#68041]: https://github.com/cockroachdb/cockroach/pull/68041
+[#68042]: https://github.com/cockroachdb/cockroach/pull/68042
+[#68045]: https://github.com/cockroachdb/cockroach/pull/68045
+[#68049]: https://github.com/cockroachdb/cockroach/pull/68049
+[#68074]: https://github.com/cockroachdb/cockroach/pull/68074
+[#68076]: https://github.com/cockroachdb/cockroach/pull/68076
+[#68079]: https://github.com/cockroachdb/cockroach/pull/68079
+[#68081]: https://github.com/cockroachdb/cockroach/pull/68081
+[#68093]: https://github.com/cockroachdb/cockroach/pull/68093
+[#68105]: https://github.com/cockroachdb/cockroach/pull/68105
+[#68128]: https://github.com/cockroachdb/cockroach/pull/68128
+[#68137]: https://github.com/cockroachdb/cockroach/pull/68137
+[#68141]: https://github.com/cockroachdb/cockroach/pull/68141
+[#68176]: https://github.com/cockroachdb/cockroach/pull/68176
+[#68182]: https://github.com/cockroachdb/cockroach/pull/68182
+[#68187]: https://github.com/cockroachdb/cockroach/pull/68187
+[#68191]: https://github.com/cockroachdb/cockroach/pull/68191
+[#68192]: https://github.com/cockroachdb/cockroach/pull/68192
+[#68194]: https://github.com/cockroachdb/cockroach/pull/68194
+[#68217]: https://github.com/cockroachdb/cockroach/pull/68217
+[#68218]: https://github.com/cockroachdb/cockroach/pull/68218
+[#68229]: https://github.com/cockroachdb/cockroach/pull/68229
+[#68245]: https://github.com/cockroachdb/cockroach/pull/68245
+[#68252]: https://github.com/cockroachdb/cockroach/pull/68252
+[#68257]: https://github.com/cockroachdb/cockroach/pull/68257
+[#68263]: https://github.com/cockroachdb/cockroach/pull/68263
+[#68280]: https://github.com/cockroachdb/cockroach/pull/68280
+[#68288]: https://github.com/cockroachdb/cockroach/pull/68288
+[#68299]: https://github.com/cockroachdb/cockroach/pull/68299
+[#68313]: https://github.com/cockroachdb/cockroach/pull/68313
+[#68314]: https://github.com/cockroachdb/cockroach/pull/68314
+[#68326]: https://github.com/cockroachdb/cockroach/pull/68326
+[#68337]: https://github.com/cockroachdb/cockroach/pull/68337
+[#68349]: https://github.com/cockroachdb/cockroach/pull/68349
+[#68351]: https://github.com/cockroachdb/cockroach/pull/68351
+[#68352]: https://github.com/cockroachdb/cockroach/pull/68352
+[#68360]: https://github.com/cockroachdb/cockroach/pull/68360
+[#68390]: https://github.com/cockroachdb/cockroach/pull/68390
+[#68391]: https://github.com/cockroachdb/cockroach/pull/68391
+[#68394]: https://github.com/cockroachdb/cockroach/pull/68394
+[#68401]: https://github.com/cockroachdb/cockroach/pull/68401
+[#68426]: https://github.com/cockroachdb/cockroach/pull/68426
+[#68429]: https://github.com/cockroachdb/cockroach/pull/68429
+[#68442]: https://github.com/cockroachdb/cockroach/pull/68442
+[#68446]: https://github.com/cockroachdb/cockroach/pull/68446
+[#68447]: https://github.com/cockroachdb/cockroach/pull/68447
+[#68456]: https://github.com/cockroachdb/cockroach/pull/68456
+[#68468]: https://github.com/cockroachdb/cockroach/pull/68468
+[#68476]: https://github.com/cockroachdb/cockroach/pull/68476
+[#68497]: https://github.com/cockroachdb/cockroach/pull/68497
+[#68500]: https://github.com/cockroachdb/cockroach/pull/68500
+[#68506]: https://github.com/cockroachdb/cockroach/pull/68506
+[#68524]: https://github.com/cockroachdb/cockroach/pull/68524
+[#68540]: https://github.com/cockroachdb/cockroach/pull/68540
+[#68566]: https://github.com/cockroachdb/cockroach/pull/68566
+[#68568]: https://github.com/cockroachdb/cockroach/pull/68568
+[#68595]: https://github.com/cockroachdb/cockroach/pull/68595
+[#68601]: https://github.com/cockroachdb/cockroach/pull/68601
+[#68606]: https://github.com/cockroachdb/cockroach/pull/68606
+[#68607]: https://github.com/cockroachdb/cockroach/pull/68607
+[#68627]: https://github.com/cockroachdb/cockroach/pull/68627
+[#68629]: https://github.com/cockroachdb/cockroach/pull/68629
+[#68633]: https://github.com/cockroachdb/cockroach/pull/68633
+[#68666]: https://github.com/cockroachdb/cockroach/pull/68666
+[#68679]: https://github.com/cockroachdb/cockroach/pull/68679
+[#68698]: https://github.com/cockroachdb/cockroach/pull/68698
+[#68699]: https://github.com/cockroachdb/cockroach/pull/68699
+[#68700]: https://github.com/cockroachdb/cockroach/pull/68700
+[#68706]: https://github.com/cockroachdb/cockroach/pull/68706
+[#68711]: https://github.com/cockroachdb/cockroach/pull/68711
+[#68715]: https://github.com/cockroachdb/cockroach/pull/68715
+[#68749]: https://github.com/cockroachdb/cockroach/pull/68749
+[#68750]: https://github.com/cockroachdb/cockroach/pull/68750
+[#68792]: https://github.com/cockroachdb/cockroach/pull/68792
+[#68807]: https://github.com/cockroachdb/cockroach/pull/68807
+[#68808]: https://github.com/cockroachdb/cockroach/pull/68808
+[#68818]: https://github.com/cockroachdb/cockroach/pull/68818
+[#68831]: https://github.com/cockroachdb/cockroach/pull/68831
+[#68877]: https://github.com/cockroachdb/cockroach/pull/68877
+[#68902]: https://github.com/cockroachdb/cockroach/pull/68902
+[#68909]: https://github.com/cockroachdb/cockroach/pull/68909
+[#68916]: https://github.com/cockroachdb/cockroach/pull/68916
+[#68918]: https://github.com/cockroachdb/cockroach/pull/68918
+[#68922]: https://github.com/cockroachdb/cockroach/pull/68922
+[#68929]: https://github.com/cockroachdb/cockroach/pull/68929
+[#68959]: https://github.com/cockroachdb/cockroach/pull/68959
+[#68967]: https://github.com/cockroachdb/cockroach/pull/68967
+[#68969]: https://github.com/cockroachdb/cockroach/pull/68969
+[#68972]: https://github.com/cockroachdb/cockroach/pull/68972
+[#68973]: https://github.com/cockroachdb/cockroach/pull/68973
+[#68978]: https://github.com/cockroachdb/cockroach/pull/68978
+[#68995]: https://github.com/cockroachdb/cockroach/pull/68995
+[#68997]: https://github.com/cockroachdb/cockroach/pull/68997
+[#69001]: https://github.com/cockroachdb/cockroach/pull/69001
+[#69019]: https://github.com/cockroachdb/cockroach/pull/69019
+[#69046]: https://github.com/cockroachdb/cockroach/pull/69046
+[#69047]: https://github.com/cockroachdb/cockroach/pull/69047
+[#69049]: https://github.com/cockroachdb/cockroach/pull/69049
+[#69051]: https://github.com/cockroachdb/cockroach/pull/69051
+[#69053]: https://github.com/cockroachdb/cockroach/pull/69053
+[#69055]: https://github.com/cockroachdb/cockroach/pull/69055
+[#69066]: https://github.com/cockroachdb/cockroach/pull/69066
+[#69067]: https://github.com/cockroachdb/cockroach/pull/69067
+[#69070]: https://github.com/cockroachdb/cockroach/pull/69070
+[#69087]: https://github.com/cockroachdb/cockroach/pull/69087
+[#69091]: https://github.com/cockroachdb/cockroach/pull/69091
+[#69092]: https://github.com/cockroachdb/cockroach/pull/69092
+[#69106]: https://github.com/cockroachdb/cockroach/pull/69106
+[#69107]: https://github.com/cockroachdb/cockroach/pull/69107
+[#69113]: https://github.com/cockroachdb/cockroach/pull/69113
+[#69114]: https://github.com/cockroachdb/cockroach/pull/69114
+[#69122]: https://github.com/cockroachdb/cockroach/pull/69122
+[#69126]: https://github.com/cockroachdb/cockroach/pull/69126
+[#69152]: https://github.com/cockroachdb/cockroach/pull/69152
+[#69164]: https://github.com/cockroachdb/cockroach/pull/69164
+[#69173]: https://github.com/cockroachdb/cockroach/pull/69173
+[#69185]: https://github.com/cockroachdb/cockroach/pull/69185
+[#69202]: https://github.com/cockroachdb/cockroach/pull/69202
+[#69205]: https://github.com/cockroachdb/cockroach/pull/69205
+[#69224]: https://github.com/cockroachdb/cockroach/pull/69224
+[#69234]: https://github.com/cockroachdb/cockroach/pull/69234
+[#69238]: https://github.com/cockroachdb/cockroach/pull/69238
+[#69243]: https://github.com/cockroachdb/cockroach/pull/69243
+[#69251]: https://github.com/cockroachdb/cockroach/pull/69251
+[#69262]: https://github.com/cockroachdb/cockroach/pull/69262
+[#69273]: https://github.com/cockroachdb/cockroach/pull/69273
+[#69304]: https://github.com/cockroachdb/cockroach/pull/69304
+[#69311]: https://github.com/cockroachdb/cockroach/pull/69311
+[#69318]: https://github.com/cockroachdb/cockroach/pull/69318
+[#69320]: https://github.com/cockroachdb/cockroach/pull/69320
+[#69355]: https://github.com/cockroachdb/cockroach/pull/69355
+[#69370]: https://github.com/cockroachdb/cockroach/pull/69370
+[#69376]: https://github.com/cockroachdb/cockroach/pull/69376
+[#69377]: https://github.com/cockroachdb/cockroach/pull/69377
+[#69381]: https://github.com/cockroachdb/cockroach/pull/69381
+[#69388]: https://github.com/cockroachdb/cockroach/pull/69388
+[#69395]: https://github.com/cockroachdb/cockroach/pull/69395
+[#69405]: https://github.com/cockroachdb/cockroach/pull/69405
+[#69444]: https://github.com/cockroachdb/cockroach/pull/69444
+[#69457]: https://github.com/cockroachdb/cockroach/pull/69457
+[#69469]: https://github.com/cockroachdb/cockroach/pull/69469
+[#69470]: https://github.com/cockroachdb/cockroach/pull/69470
+[#69478]: https://github.com/cockroachdb/cockroach/pull/69478
+[#69480]: https://github.com/cockroachdb/cockroach/pull/69480
+[#69481]: https://github.com/cockroachdb/cockroach/pull/69481
+[#69483]: https://github.com/cockroachdb/cockroach/pull/69483
+[#69491]: https://github.com/cockroachdb/cockroach/pull/69491
+[#69502]: https://github.com/cockroachdb/cockroach/pull/69502
+[#69577]: https://github.com/cockroachdb/cockroach/pull/69577

--- a/releases/v21.2.0-beta.2.md
+++ b/releases/v21.2.0-beta.2.md
@@ -1,0 +1,106 @@
+---
+title: What&#39;s New in v21.2.0-beta.2
+toc: true
+summary: Additions and changes to CockroachDB version 21.2.0-beta.2.
+---
+
+## September 27, 2021
+
+Get future release notes emailed to you:
+
+{% include marketo.html %}
+
+### Downloads
+
+<div id="os-tabs" class="filters clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.2.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.2.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.2.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v21.2.0-beta.2.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+<section class="filter-content" data-scope="windows">
+{% include windows_warning.md %}
+</section>
+
+### Docker image
+
+{% include copy-clipboard.html %}
+~~~shell
+$ docker pull cockroachdb/cockroach-unstable:v21.2.0-beta.2
+~~~
+
+### Security updates
+
+- SQL tenant servers will now use a TLS certificate for their HTTP server when it's present. Previously this server never used TLS. [#70056][#70056]
+
+### SQL language changes
+
+- The query logging enabled by `sql.telemetry.query_sampling.enabled` now avoids considering SQL statements issued internally by CockroachDB itself. [#70358][#70358]
+- [`IMPORT INTO`](../v21.2/import-into.html) now supports UDT for default and computed columns. [#70270][#70270]
+- [`IMPORT INTO`](../v21.2/import-into.html) [regional by row](../v21.2/multiregion-overview.html#regional-by-row-tables) tables is now supported. [#70270][#70270]
+
+### Operational changes
+
+- The meaning of the recently introduced `transaction_rows_written_err` and `transaction_rows_read_err` (as well as the corresponding `_log` variables) have been adjusted to indicate the largest number of rows that is still allowed. In other words, originally reaching the limit would result in an error, and now only exceeding the limit would. [#70014][#70014]
+
+### Command-line changes
+
+- It is now possible to mix and match severity filters for different channels on a single log sink. For example:
+
+    ~~~
+    file-groups:    monitoring:      channels: {WARNING: [OPS, STORAGE], INFO: HEALTH}
+    ~~~
+
+    This defines a single file sink "monitoring" which captures all messages from the `HEALTH` channel, and only messages at severity `WARNING` or higher from the `OPS` and `STORAGE` channels.
+
+    Another example:
+
+    ~~~
+    file-groups:    default:       channels: {INFO: all except STORAGE, WARNING: STORAGE}
+    ~~~
+
+    This captures all messages on all channels except the `STORAGE` channel, plus the messages at severity `WARNING` or higher from `STORAGE`.  Note: the previous syntax remains supported. When `channel` is specified without explicit severities, the `filter` attribute is used as the default (like previously). [#70411][#70411]
+
+- The default logging configuration now redirects the `HEALTH` logging channel to a distinct log file (`cockroach-health.log`). [#70411][#70411]
+- The default logging configuration now redirects the output on the `SQL_SCHEMA` channel to a new separate file group `sql-schema` (`cockroach-sql-schema.log`), and the `PRIVILEGES` and `USER_ADMIN` channels to a new separate file group `security` (`cockroach-security.log`). The new `security` group has the `auditable` flag set. As previously, the administrator can inspect the default configuration with `cockroach debug check-log-config`. [#70411][#70411]
+- The server logging configuration now also includes a copy of messages from all logging channels at severity `WARNING` or higher into the default log file. This ensures that severe messages from all channels are also included in the main log file used during troubleshooting. [#70411][#70411]
+
+### DB Console changes
+
+- Added tooltips on the [**Databases** page](../v21.2/ui-databases-page.html) and made the SQL box scrollable. [#70070][#70070]
+- Added a column selector to the [**Transactions** page](../v21.2/ui-transactions-page.html). [#70286][#70286]
+- Updated the [Jobs table](../v21.2/ui-jobs-page.html#jobs-list) style to match all other tables on the Console and also updated the column name from `Users` to `User`. [#70449][#70449]
+
+### Bug fixes
+
+- Columns that were hidden by default were not being displayed when selected. This commit fixes the behavior. [#70054][#70054]
+- Fixed all broken links to documentation. [#70063][#70063]
+- Temporary tables were not properly cleaned up for tenants. This is now fixed. [#70129][#70129]
+- DNS unavailability during range 1 leaseholder loss will no longer cause significant latency increases for queries and other operations. [#70135][#70135]
+- Last Execution Timestamp is now properly updating. [#70297][#70297]
+- Fixed a bug in full cluster restores where dropped descriptor revisions would cause the [restore](../v21.2/restore.html) to fail. [#70368][#70368]
+- Default columns were displayed on the [**Statements** page](../cockroachcloud/statements-page.html) on the CockroachCloud console when the user never made any selection. This is now fixed. [#70206][#70206]
+- `cockroach mt start-proxy` now appropriately sets the .ServerName member of outgoing TLS connections. This allows the proxy to function appropriately when the `--insecure` and `--skip-verify` CLI flags are omitted. [#70290][#70290]
+
+### Contributors
+
+This release includes 44 merged PRs by 22 authors.
+
+[#70014]: https://github.com/cockroachdb/cockroach/pull/70014
+[#70054]: https://github.com/cockroachdb/cockroach/pull/70054
+[#70056]: https://github.com/cockroachdb/cockroach/pull/70056
+[#70063]: https://github.com/cockroachdb/cockroach/pull/70063
+[#70070]: https://github.com/cockroachdb/cockroach/pull/70070
+[#70129]: https://github.com/cockroachdb/cockroach/pull/70129
+[#70135]: https://github.com/cockroachdb/cockroach/pull/70135
+[#70206]: https://github.com/cockroachdb/cockroach/pull/70206
+[#70270]: https://github.com/cockroachdb/cockroach/pull/70270
+[#70286]: https://github.com/cockroachdb/cockroach/pull/70286
+[#70290]: https://github.com/cockroachdb/cockroach/pull/70290
+[#70297]: https://github.com/cockroachdb/cockroach/pull/70297
+[#70341]: https://github.com/cockroachdb/cockroach/pull/70341
+[#70358]: https://github.com/cockroachdb/cockroach/pull/70358
+[#70368]: https://github.com/cockroachdb/cockroach/pull/70368
+[#70411]: https://github.com/cockroachdb/cockroach/pull/70411
+[#70449]: https://github.com/cockroachdb/cockroach/pull/70449


### PR DESCRIPTION
Closes #10715, #10716

Release notes for v21.2.0-beta.1 and beta.2

For review: Note that this includes **already edited** notes from the alpha that were never released. Markdown comments show the items that do not need review