### PR TITLE
Removed experimental designation from TIMESTAMP, DATE to epoch casting

### DIFF
--- a/v20.2/date.md
+++ b/v20.2/date.md
@@ -84,10 +84,10 @@ String literal implicitly typed as `DATE`:
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
+`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
 `TIMESTAMP` | Sets the time to 00:00 (midnight) in the resulting timestamp.
-`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
 `STRING` | ––
 
 ## See also

--- a/v20.2/int.md
+++ b/v20.2/int.md
@@ -97,8 +97,8 @@ Type | Details
 `FLOAT` | Loses precision if the `INT` value is larger than 2^53 in magnitude.
 `BIT` | Converts to the binary representation of the integer value. If the value is negative, the sign bit is replicated on the left to fill the entire bit array.
 `BOOL` | **0** converts to `false`; all other values convert to `true`.
-`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970).
+`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970).
 `INTERVAL` | Converts to seconds.
 `STRING` | ––
 

--- a/v20.2/timestamp.md
+++ b/v20.2/timestamp.md
@@ -226,10 +226,10 @@ SQLSTATE: 0A000
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
+`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
 `TIME` | Converts to the time portion (HH:MM:SS) of the timestamp.
-`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
 `DATE` | --
 `STRING` | <span class="version-tag">New in v20.2:</span> Converts to the date and time portion (YYYY-MM-DD HH:MM:SS) of the timestamp and omits the time zone offset.
 

--- a/v21.1/date.md
+++ b/v21.1/date.md
@@ -84,10 +84,10 @@ String literal implicitly typed as `DATE`:
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
+`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
 `TIMESTAMP` | Sets the time to 00:00 (midnight) in the resulting timestamp.
-`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
 `STRING` | ––
 
 ## See also

--- a/v21.1/int.md
+++ b/v21.1/int.md
@@ -97,8 +97,8 @@ Type | Details
 `FLOAT` | Loses precision if the `INT` value is larger than 2^53 in magnitude.
 `BIT` | Converts to the binary representation of the integer value. If the value is negative, the sign bit is replicated on the left to fill the entire bit array.
 `BOOL` | **0** converts to `false`; all other values convert to `true`.
-`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970).
+`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970).
 `INTERVAL` | Converts to seconds.
 `STRING` | ––
 

--- a/v21.1/timestamp.md
+++ b/v21.1/timestamp.md
@@ -226,10 +226,10 @@ SQLSTATE: 0A000
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
+`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
 `TIME` | Converts to the time portion (HH:MM:SS) of the timestamp.
-`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
 `DATE` | --
 `STRING` |  Converts to the date and time portion (YYYY-MM-DD HH:MM:SS) of the timestamp and omits the time zone offset.
 

--- a/v21.2/date.md
+++ b/v21.2/date.md
@@ -84,10 +84,10 @@ String literal implicitly typed as `DATE`:
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
+`FLOAT` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
 `TIMESTAMP` | Sets the time to 00:00 (midnight) in the resulting timestamp.
-`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of days since the Unix epoch (Jan. 1, 1970).
 `STRING` | ––
 
 ## See also

--- a/v21.2/int.md
+++ b/v21.2/int.md
@@ -97,8 +97,8 @@ Type | Details
 `FLOAT` | Loses precision if the `INT` value is larger than 2^53 in magnitude.
 `BIT` | Converts to the binary representation of the integer value. If the value is negative, the sign bit is replicated on the left to fill the entire bit array.
 `BOOL` | **0** converts to `false`; all other values convert to `true`.
-`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DATE` | Converts to days since the Unix epoch (Jan. 1, 1970).
+`TIMESTAMP` | Converts to seconds since the Unix epoch (Jan. 1, 1970).
 `INTERVAL` | Converts to seconds.
 `STRING` | ––
 

--- a/v21.2/timestamp.md
+++ b/v21.2/timestamp.md
@@ -226,10 +226,10 @@ SQLSTATE: 0A000
 
 Type | Details
 -----|--------
-`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
-`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`DECIMAL` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
+`FLOAT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
 `TIME` | Converts to the time portion (HH:MM:SS) of the timestamp.
-`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970). This is a CockroachDB experimental feature which may be changed without notice.
+`INT` | Converts to number of seconds since the Unix epoch (Jan. 1, 1970).
 `DATE` | --
 `STRING` |  Converts to the date and time portion (YYYY-MM-DD HH:MM:SS) of the timestamp and omits the time zone offset.
 


### PR DESCRIPTION
Related to https://cockroachlabs.atlassian.net/browse/CRDB-7903.