### PR TITLE
Hide 21.2 docs

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -21,6 +21,7 @@ exclude:
 - archived
 - package.json
 - package-lock.json
+- v21.2
 include:
 - _redirects
 keep_files:

--- a/_config_cockroachdb.yml
+++ b/_config_cockroachdb.yml
@@ -2,5 +2,6 @@ baseurl: /docs
 destination: _site/docs
 homepage_title: CockroachDB Docs
 versions:
-  dev: v21.2
+  # dev: v21.2
+  v21.2: v21.1
   stable: v21.1

--- a/_config_cockroachdb_local.yml
+++ b/_config_cockroachdb_local.yml
@@ -6,7 +6,7 @@ exclude:
 - "v19.1"
 - "v19.2"
 - "v20.1"
+- "v20.2"
 - "ci"
-- "scripts"
 - "vendor"
 - "archived"


### PR DESCRIPTION
Our 21.2 docs are live before the first testing version has been released. The download instructions in the 21.2 docs therefore fail. 

When the 21.2 beta release is blessed and https://github.com/cockroachdb/docs/pull/11722/files is merged, this won't be an issue. In the meantime, if it takes much longer to get that release out, this PR is a temporary way to hide the 21.2 docs without breaking any existing incoming links.  