### PR TITLE
Regional by row tables on changefeeds section added to docs

### DIFF
--- a/_includes/v21.1/known-limitations/cdc.md
+++ b/_includes/v21.1/known-limitations/cdc.md
@@ -1,4 +1,3 @@
-- When a table's locality is set to [`REGIONAL BY ROW`](set-locality.html), changefeed jobs targeting that table will fail.
 - Changefeeds only work on tables with a single [column family](column-families.html) (which is the default for new tables).
 - Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
 - Many DDL queries (including [`TRUNCATE`](truncate.html) and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. You will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).

--- a/_includes/v21.2/known-limitations/cdc.md
+++ b/_includes/v21.2/known-limitations/cdc.md
@@ -1,4 +1,3 @@
-- When a table's locality is set to [`REGIONAL BY ROW`](set-locality.html), changefeed jobs targeting that table will fail.
 - Changefeeds only work on tables with a single [column family](column-families.html) (which is the default for new tables).
 - Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
 - Many DDL queries (including [`TRUNCATE`](truncate.html) and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. You will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).

--- a/v21.1/set-locality.md
+++ b/v21.1/set-locality.md
@@ -65,7 +65,7 @@ For more information about how table localities work, see [Regional tables](mult
 ### Set the table locality to `REGIONAL BY ROW`
 
 {{site.data.alerts.callout_info}}
-[Changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) are not currently supported on regional by row tables. When a table's locality is set to `REGIONAL BY ROW`, any changefeed jobs targeting that that table will fail.
+Changefeeds are supported on regional by row tables from v21.1 onward. Before setting the locality to `REGIONAL BY ROW` on a table targeted by a changefeed, read the considerations in [Changefeeds on regional by row tables](stream-data-out-of-cockroachdb-using-changefeeds.html#changefeeds-on-regional-by-row-tables).
 {{site.data.alerts.end}}
 
 To make an existing table a _regional by row_ table, use the following statement:

--- a/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -15,7 +15,7 @@ The main feature of CDC is the changefeed, which targets an allowlist of tables,
 | [Core changefeeds](#create-a-core-changefeed)   | [{{ site.data.products.enterprise }} changefeeds](#configure-a-changefeed-enterprise) |
 --------------------------------------------------|-----------------------------------------------------------------|
 | Useful for prototyping or quick testing. | Recommended for production use. |
-| Available in all products. | Available in {{ site.data.products.dedicated }} and {{ site.data.products.dedicated }} or with an [{{ site.data.products.enterprise }} license](enterprise-licensing.html) in CockroachDB. |
+| Available in all products. | Available in {{ site.data.products.dedicated }} or with an [{{ site.data.products.enterprise }} license](enterprise-licensing.html) in CockroachDB. |
 | Streams indefinitely until underlying SQL connection is closed. | Maintains connection to configured sink. |
 | Create with [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html). | Create with [`CREATE CHANGEFEED`](create-changefeed.html). |
 | Watches one or multiple tables in a comma-separated list. Emits every change to a "watched" row as a record. | Watches one or multiple tables in a comma-separated list. Emits every change to a "watched" row as a record in a <br> configurable format (`JSON` or Avro) to a configurable sink  ([Kafka](https://kafka.apache.org/)). |
@@ -149,6 +149,40 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 [2]	{"id": 2, "likes_treats": true, "name": "Carl"}
 [3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
 ~~~
+
+## Changefeeds on regional by row tables
+
+Changefeeds are supported on [regional by row tables](multiregion-overview.html#regional-by-row-tables). When working with changefeeds on regional by row tables, it is necessary to consider the following:
+
+- Setting a table's locality to [`REGIONAL BY ROW`](set-locality.html#regional-by-row) is equivalent to a schema change as the [`crdb_region` column](set-locality.html#crdb_region) becomes a hidden column for each of the rows in the table. Therefore, when existing tables targeted by changefeeds are made regional by row, it will trigger a backfill of the table through the changefeed. (See [Schema changes with a column backfill](stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) for more details on the effects of schema changes on changefeeds.)
+
+{{site.data.alerts.callout_info}}
+If the [`schema_change_policy`](create-changefeed.html#options) changefeed option is configured to `stop`, the backfill will cause the changefeed to fail.
+{{site.data.alerts.end}}
+
+- Setting a table to `REGIONAL BY ROW` will have an impact on the changefeed's output as a result of the schema change. The backfill and future updated or inserted rows will emit output that includes the `crdb_region` column as part of the schema. Therefore, it is necessary to ensure that programs consuming the changefeed can manage the new format of the primary keys.
+
+- Changing a row's region will appear as an insert and delete in the emitted changefeed output. For example, in the following output in which the region has been updated to `us-east1`, the insert and then delete messages are emitted followed by the [resolved timestamps](create-changefeed.html#resolved-option)
+
+    ~~~
+    ...
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "52372 Katherine Plains", "ext": {"color": "black"}, "id": "54a69217-35ee-4000-8000-0000000001f0", "owner_id": "3dcc63f1-4120-4c00-8000-0000000004b7", "status": "in_use", "type": "scooter"}, "updated": "1632241564629087669.0000000000"}
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "75024 Patrick Bridge", "ext": {"color": "black"}, "id": "54d242e6-bdc8-4400-8000-0000000001f1", "owner_id": "3ab9f559-b3d0-4c00-8000-00000000047b", "status": "in_use", "type": "scooter"}, "updated": "1632241564629087669.0000000000"}
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "45597 Jackson Inlet", "ext": {"brand": "Schwinn", "color": "red"}, "id": "54fdf3b6-45a1-4c00-8000-0000000001f2", "owner_id": "4339c0eb-edfa-4400-8000-000000000521", "status": "in_use", "type": "bike"}, "updated": "1632241564629087669.0000000000"}
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "18336 Katherine Port", "ext": {"color": "yellow"}, "id": "5529a485-cd7b-4000-8000-0000000001f3", "owner_id": "452bd3c3-6113-4000-8000-000000000547", "status": "in_use", "type": "scooter"}, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    ...
+    {"resolved":"1632240281204175739.0000000000"}
+    {"resolved":"1632240286020225233.0000000000"}
+    {"resolved":"1632240286221336549.0000000000"}
+    {"resolved":"1632240291038235308.0000000000"}
+    ...
+    ~~~
+
+See the changefeed [responses](create-changefeed.html#responses) section for more general information on the messages emitted from a changefeed.
 
 ## Create a changefeed (Core)
 

--- a/v21.2/set-locality.md
+++ b/v21.2/set-locality.md
@@ -65,7 +65,7 @@ For more information about how table localities work, see [Regional tables](mult
 ### Set the table locality to `REGIONAL BY ROW`
 
 {{site.data.alerts.callout_info}}
-[Changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) are not currently supported on regional by row tables. When a table's locality is set to `REGIONAL BY ROW`, any changefeed jobs targeting that that table will fail.
+Changefeeds are supported on regional by row tables from v21.1 onward. Before setting the locality to `REGIONAL BY ROW` on a table targeted by a changefeed, read the considerations in [Changefeeds on regional by row tables](stream-data-out-of-cockroachdb-using-changefeeds.html#changefeeds-on-regional-by-row-tables).
 {{site.data.alerts.end}}
 
 To make an existing table a _regional by row_ table, use the following statement:

--- a/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -154,8 +154,9 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 
 <span class="version-tag">New in v21.2:</span> When working with changefeeds on regional by row tables, it is necessary to consider the following:
 
-- Setting a table's locality to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) is equivalent to a schema change. Therefore, when existing tables targeted by changefeeds are made regional by row, it will cause a backfill of the table through the changefeed. The backfill will cause the changefeed to fail if `fail_on_schema_change` (is this [`schema_change_policy=stop`]?) is set to `stop`. (See [Schema changes with a column backfill](stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) for more details on the effects of schema changes on changefeeds.)
--
+- Setting a table's locality to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) is equivalent to a schema change. Therefore, when existing tables targeted by changefeeds are made regional by row, it will trigger a backfill of the table through the changefeed. The backfill will cause the changefeed to fail if [`schema_change_policy`](create-changefeed.html#options) to `stop`. (See [Schema changes with a column backfill](stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) for more details on the effects of schema changes on changefeeds.)
+- The primary key
+- The [`crdb_region`](set-locality.html#crdb_region) hidden column will be present in changefeed output.
 
 - primary key may look different... may need to change how you ingest
 - regional change of a row may look like an insert/delete in the changefeed

--- a/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -150,6 +150,16 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 [3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
 ~~~
 
+## Changefeeds on regional by row tables
+
+<span class="version-tag">New in v21.2:</span> When working with changefeeds on regional by row tables, it is necessary to consider the following:
+
+- Setting a table's locality to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) is equivalent to a schema change. Therefore, when existing tables targeted by changefeeds are made regional by row, it will cause a backfill of the table through the changefeed. The backfill will cause the changefeed to fail if `fail_on_schema_change` (is this [`schema_change_policy=stop`]?) is set to `stop`. (See [Schema changes with a column backfill](stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) for more details on the effects of schema changes on changefeeds.)
+-
+
+- primary key may look different... may need to change how you ingest
+- regional change of a row may look like an insert/delete in the changefeed
+
 ## Create a changefeed (Core)
 
 A core changefeed streams row-level changes to the client indefinitely until the underlying connection is closed or the changefeed is canceled.

--- a/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -152,14 +152,37 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 
 ## Changefeeds on regional by row tables
 
-<span class="version-tag">New in v21.2:</span> When working with changefeeds on regional by row tables, it is necessary to consider the following:
+<span class="version-tag">New in v21.2:</span> Changefeeds are supported on [regional by row tables](multiregion-overview.html#regional-by-row-tables). When working with changefeeds on regional by row tables, it is necessary to consider the following:
 
-- Setting a table's locality to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) is equivalent to a schema change. Therefore, when existing tables targeted by changefeeds are made regional by row, it will trigger a backfill of the table through the changefeed. The backfill will cause the changefeed to fail if [`schema_change_policy`](create-changefeed.html#options) to `stop`. (See [Schema changes with a column backfill](stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) for more details on the effects of schema changes on changefeeds.)
-- The primary key
-- The [`crdb_region`](set-locality.html#crdb_region) hidden column will be present in changefeed output.
+- Setting a table's locality to [`REGIONAL BY ROW`](set-locality.html#regional-by-row) is equivalent to a schema change as the [`crdb_region` column](set-locality.html#crdb_region) becomes a hidden column for each of the rows in the table. Therefore, when existing tables targeted by changefeeds are made regional by row, it will trigger a backfill of the table through the changefeed. (See [Schema changes with a column backfill](stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) for more details on the effects of schema changes on changefeeds.)
 
-- primary key may look different... may need to change how you ingest
-- regional change of a row may look like an insert/delete in the changefeed
+{{site.data.alerts.callout_info}}
+If the [`schema_change_policy`](create-changefeed.html#options) changefeed option is configured to `stop`, the backfill will cause the changefeed to fail.
+{{site.data.alerts.end}}
+
+- Setting a table to `REGIONAL BY ROW` will have an impact on the changefeed's output as a result of the schema change. The backfill and future updated or inserted rows will emit output that includes the `crdb_region` column as part of the schema. Therefore, it is necessary to ensure that programs consuming the changefeed can manage the new format of the primary keys.
+
+- Changing a row's region will appear as an insert and delete in the emitted changefeed output. For example, in the following output in which the region has been updated to `us-east1`, the insert and then delete messages are emitted followed by the [resolved timestamps](create-changefeed.html#resolved-option)
+
+    ~~~
+    ...
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "52372 Katherine Plains", "ext": {"color": "black"}, "id": "54a69217-35ee-4000-8000-0000000001f0", "owner_id": "3dcc63f1-4120-4c00-8000-0000000004b7", "status": "in_use", "type": "scooter"}, "updated": "1632241564629087669.0000000000"}
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "75024 Patrick Bridge", "ext": {"color": "black"}, "id": "54d242e6-bdc8-4400-8000-0000000001f1", "owner_id": "3ab9f559-b3d0-4c00-8000-00000000047b", "status": "in_use", "type": "scooter"}, "updated": "1632241564629087669.0000000000"}
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "45597 Jackson Inlet", "ext": {"brand": "Schwinn", "color": "red"}, "id": "54fdf3b6-45a1-4c00-8000-0000000001f2", "owner_id": "4339c0eb-edfa-4400-8000-000000000521", "status": "in_use", "type": "bike"}, "updated": "1632241564629087669.0000000000"}
+    {"after": {"city": "washington dc", "crdb_region": "us-east1", "creation_time": "2019-01-02T03:04:05", "current_location": "18336 Katherine Port", "ext": {"color": "yellow"}, "id": "5529a485-cd7b-4000-8000-0000000001f3", "owner_id": "452bd3c3-6113-4000-8000-000000000547", "status": "in_use", "type": "scooter"}, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    {"after": null, "updated": "1632241564629087669.0000000000"}
+    ...
+    {"resolved":"1632240281204175739.0000000000"}
+    {"resolved":"1632240286020225233.0000000000"}
+    {"resolved":"1632240286221336549.0000000000"}
+    {"resolved":"1632240291038235308.0000000000"}
+    ...
+    ~~~
+
+See the changefeed [responses](create-changefeed.html#responses) section for more general information on the messages emitted from a changefeed.
 
 ## Create a changefeed (Core)
 


### PR DESCRIPTION
Closes #10940 

Changefeeds now enabled for RBR tables. Docs changes include:

- Changefeeds on regional by row tables section added to main CDC page (v21.1 + v21.2) includes considerations when setting RBR on table targeted by changefeeds
- Removed known limitation from main CDC page for v21.1 + v21.2
- Updated the note at top of RBR section on `SET LOCALITY` page