### PR TITLE
Fix missing CTA.

### DIFF
--- a/v21.1/install-cockroachdb-mac.html
+++ b/v21.1/install-cockroachdb-mac.html
@@ -124,7 +124,7 @@ true
       </ol>
     <li>
       <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="1" %}
+{% include marketo-install.html uid="2" %}
     </li>
   </ol>
 </div>
@@ -166,7 +166,7 @@ true
     </li>
     <li>
       <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="2" %}
+{% include marketo-install.html uid="3" %}
     </li>
   </ol>
 </div>
@@ -228,7 +228,7 @@ true
     </li>
     <li>
       <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="3" %}
+{% include marketo-install.html uid="4" %}
     </li>
   </ol>
 </div>

--- a/v21.2/install-cockroachdb-mac.html
+++ b/v21.2/install-cockroachdb-mac.html
@@ -124,7 +124,7 @@ true
       </ol>
     <li>
       <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="1" %}
+{% include marketo-install.html uid="2" %}
     </li>
   </ol>
 </div>
@@ -166,7 +166,7 @@ true
     </li>
     <li>
       <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="2" %}
+{% include marketo-install.html uid="3" %}
     </li>
   </ol>
 </div>
@@ -228,7 +228,7 @@ true
     </li>
     <li>
       <p>Keep up-to-date with CockroachDB releases and best practices:</p>
-{% include marketo-install.html uid="3" %}
+{% include marketo-install.html uid="4" %}
     </li>
   </ol>
 </div>


### PR DESCRIPTION
The CTA to provide an email address is missing because the uid value was duplicated in the first two installation methods.
<img width="737" alt="Screen Shot 2021-09-24 at 8 08 40 AM" src="https://user-images.githubusercontent.com/20482960/134699564-56c6e417-b6b8-4fe7-a99b-bba55a505b12.png">

