### PR TITLE
Userfile link to v21.2 migrate doc

### DIFF
--- a/v21.2/migrate-from-csv.md
+++ b/v21.2/migrate-from-csv.md
@@ -33,6 +33,7 @@ You will need to export one CSV file per table, with the following requirements:
 Each node in the CockroachDB cluster needs to have access to the files being imported. There are several ways for the cluster to access the data; for more information on the types of storage [`IMPORT`][import] can pull from, see the following:
 
 - [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
+- [Use Userfile for Bulk Operations](use-userfile-for-bulk-operations.html)
 - [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html)
 
 {{site.data.alerts.callout_success}}


### PR DESCRIPTION
Update to v21.2 docs to add link to userfile docs on migrate CSV (per contributor PR #11671) 