### PR TITLE
Update contradictory recommendation re: localities

### DIFF
--- a/v21.1/demo-low-latency-multi-region-deployment.md
+++ b/v21.1/demo-low-latency-multi-region-deployment.md
@@ -45,7 +45,7 @@ The workload you'll run against the cluster is our open-source, fictional, peer-
 
 {% include {{ page.version.version }}/misc/movr-schema.md %}
 
-All of the tables except `promo_codes` have a composite primary key of `city` and `id`, in that order. This means that the rows in these tables are ordered by their geography. These tables are read from and written to very frequently. To keep read and write latency low, you'll use the [Regional table locality pattern](multiregion-overview.html#regional-by-row-tables) for these tables.
+All of the tables except `promo_codes` have a composite primary key of `city` and `id`, in that order. This means that the rows in these tables are ordered by their geography. These tables are read from and written to very frequently. To keep read and write latency low, you'll use the [`REGIONAL BY ROW` table locality pattern](multiregion-overview.html#regional-by-row-tables) for these tables.
 
 The data in the `promo_codes` table is different: it is not tied to geography, and it is rarely updated. This type of table is often referred to as a "reference table" or "lookup table". In this case, you'll use the [Global table locality pattern](multiregion-overview.html#global-tables) to keep read latencies low.
 

--- a/v21.2/demo-low-latency-multi-region-deployment.md
+++ b/v21.2/demo-low-latency-multi-region-deployment.md
@@ -45,7 +45,7 @@ The workload you'll run against the cluster is our open-source, fictional, peer-
 
 {% include {{ page.version.version }}/misc/movr-schema.md %}
 
-All of the tables except `promo_codes` have a composite primary key of `city` and `id`, in that order. This means that the rows in these tables are ordered by their geography. These tables are read from and written to very frequently. To keep read and write latency low, you'll use the [Regional table locality pattern](multiregion-overview.html#regional-by-row-tables) for these tables.
+All of the tables except `promo_codes` have a composite primary key of `city` and `id`, in that order. This means that the rows in these tables are ordered by their geography. These tables are read from and written to very frequently. To keep read and write latency low, you'll use the [`REGIONAL BY ROW` table locality pattern](multiregion-overview.html#regional-by-row-tables) for these tables.
 
 The data in the `promo_codes` table is different: it is not tied to geography, and it is rarely updated. This type of table is often referred to as a "reference table" or "lookup table". In this case, you'll use the [Global table locality pattern](multiregion-overview.html#global-tables) to keep read latencies low.
 


### PR DESCRIPTION
Fixes #11786

Summary of changes:

- Instead of referring to "regional tables" generally, we update to say
  `REGIONAL BY ROW` (which is what we meant, and what the doc already
  links to).