### PR TITLE
debug backup cli docs added

### DIFF
--- a/_includes/sidebar-data-v21.2.json
+++ b/_includes/sidebar-data-v21.2.json
@@ -2776,6 +2776,12 @@
                 ]
               },
               {
+                "title": "<code>cockroach debug backup</code>",
+                "urls": [
+                  "/${VERSION}/cockroach-debug-backup.html"
+                ]
+              },
+              {
                 "title": "<code>cockroach debug ballast</code>",
                 "urls": [
                   "/${VERSION}/cockroach-debug-ballast.html"

--- a/_includes/v21.2/misc/debug-subcommands.md
+++ b/_includes/v21.2/misc/debug-subcommands.md
@@ -1,3 +1,3 @@
-While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), and [`ballast`](cockroach-debug-ballast.html) subcommands.
+While the `cockroach debug` command has a few subcommands, users are expected to use only the [`zip`](cockroach-debug-zip.html), [`encryption-active-key`](cockroach-debug-encryption-active-key.html), [`merge-logs`](cockroach-debug-merge-logs.html), [`list-files`](cockroach-debug-list-files.html), [`ballast`](cockroach-debug-ballast.html), and [`backup`](cockroach-debug-backup.html) subcommands.
 
 The other `debug` subcommands are useful only to CockroachDB's developers and contributors.

--- a/v21.2/cockroach-commands.md
+++ b/v21.2/cockroach-commands.md
@@ -25,6 +25,7 @@ Command | Usage
 [`cockroach demo`](cockroach-demo.html) | Start a temporary, in-memory CockroachDB cluster, and open an interactive SQL shell to it.
 [`cockroach gen`](cockroach-gen.html) | Generate manpages, a bash completion file, example SQL data, or an HAProxy configuration file for a running cluster.
 [`cockroach version`](cockroach-version.html) | Output CockroachDB version details.
+[`cockroach debug backup`](cockroach-debug-backup.html) | <span class="version-tag">New in v21.2:</span> Inspect backup metadata and table data outside of the SQL shell.
 [`cockroach debug ballast`](cockroach-debug-ballast.html) | Create a large, unused file in a node's storage directory that you can delete if the node runs out of disk space.
 [`cockroach debug encryption-active-key`](cockroach-debug-encryption-active-key.html) | View the encryption algorithm and store key.
 [`cockroach debug zip`](cockroach-debug-zip.html) | Generate a `.zip` file that can help Cockroach Labs troubleshoot issues with your cluster.

--- a/v21.2/cockroach-debug-backup.md
+++ b/v21.2/cockroach-debug-backup.md
@@ -1,0 +1,180 @@
+---
+title: cockroach debug backup
+summary: Display backup metadata outside of the sql shell and perform other backup inspection tasks.
+toc: true
+---
+
+<span class="version-tag">New in v21.2:</span> The `cockroach debug backup` command provides a tool for inspecting a [backup's](take-full-and-incremental-backups.html) metadata and loading single backup files outside of the SQL shell for debugging purposes. With `cockroach debug backup` you can do the following without an active cluster:
+
+- List backups in a collection and incremental backups in a specific storage location.
+- Combine the command with the `--as-of` flag to review historical data at a specific timestamp.
+- Validate and verify backups without having to complete a restore.
+- Export table data from a backup in CSV format.
+
+{{site.data.alerts.callout_info}}
+{% include {{ page.version.version }}/misc/debug-subcommands.md %}
+{{site.data.alerts.end}}
+
+## Synopsis
+
+Use the [subcommands](#subcommands) followed by your storage location to inspect your backups:
+
+~~~shell
+cockroach debug backup {command} {location}
+~~~
+
+Use the `cockroach debug backup` [flags](#flags) to modify the output from the command:
+
+~~~shell
+cockroach debug backup {command} {location} {flag}
+~~~
+
+See [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls) for example file URLs.
+
+## Subcommands
+
+The `cockroach debug backup` command uses the following subcommands to inspect backups offline:
+
+Flag | Description
+-----|-----------
+`show` | Show a backup summary. See the [Show a backup summary](#show-a-backup-summary) example for more detail on the output provided with `show`.
+`list-backups` | List the backups in a collection in your storage location. See [List a backup collection](#list-a-backup-collection) for usage.
+`list-incremental` | List the [incremental backups](take-full-and-incremental-backups.html#incremental-backups) in your storage location.
+<a name="export-sub"></a>`export` | Export table data from a backup. See [Export backup table data](#export-backup-table-data) for usage.
+
+## Flags
+
+Flag | Description
+-----|-----------
+`--as-of` | Use with the [`export`](#export-sub) subcommand to read the data as of the specified timestamp, for example `--as-of='2021-09-24T15:15:32Z'`. See the [`TIMESTAMP`](timestamp.html) type for supported formats.
+<a name="destination-flag"></a>`--destination` | Use with the [`export`](#export-sub) subcommand to specify a destination to export data to. Note that if the `export` format is readable and the `--desination` flag is not specified, `export` defaults to display the data in the terminal output.
+`--external-io-dir` | Specify the file path of the external IO directory to which the `nodelocal` file paths resolve. The `external-io-dir` is the path that remotely initiated operations such as `BACKUP`, `RESTORE`, or `IMPORT` can access. <br></br>For example, to view data outputted to the `external-io-dir`, you could use: <br>`cockroach debug backup export {backup_location} --destination="nodelocal://{node_id}/backup_inspect" --external-io-dir="{location for nodelocal to write}"`. <br>Here, `--external-io-dir` will configure which [directory or NFS drive](use-cloud-storage-for-bulk-operations.html#nfs-local) the data will be written to, and `--destination` determines where in the external IO directory the data will be written. <br></br> See the [`external-io-dir` option at cluster startup](cockroach-start.html#flags-external-io-dir) for further detail on setup.
+`--format` | Use with the [`export`](#export-sub) subcommand to select the format in which to export table rows from backups. **Note**: Currently only CSV is supported. Default: CSV <!--TODO Do we want to include this while this is the only format available? -->
+`-h`, `--help` | Display help text for the `debug backup {command}`.
+`--max-rows` | Use with the [`export`](#export-sub) subcommand to set the maximum number of rows to return. Default: `0` (unlimited rows)
+`--nullas` | Use with the [`export`](#export-sub) subcommand to set the string that should be used to represent `NULL` values. Default: `NULL`
+`--start-key` | Use with the [`export`](#export-sub) subcommand to set the start key and its format as `<format>:<key>`. Supported formats: `raw,` `hex`, `bytekey`.  The `raw` format supports escaped text. For example, `raw:\x01k` is the prefix for range local keys. The `bytekey` format does not require the table-key prefix. See [known limitations](#known-limitations) for more details.
+<a name="table-flag"></a>`--table` | **Required** when using the [`export`](#export-sub) subcommand to specify the backup table to export from. The fully qualified table name must be passed here. For example: `--table=database.schema.table`.
+`--up-to` | [Export](#export-sub) revisions of data from a backup table up to a specific timestamp.
+`--with-revisions` | [Export](#export-sub) revisions of data from a backup table since the last schema change.
+
+## Examples
+
+{{site.data.alerts.callout_info}}
+The following examples use a connection string to Amazon S3 cloud storage for demonstration. For guidance on connecting to other storage options or using alternative authentication parameters, read [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html).
+{{site.data.alerts.end}}
+
+### Show a backup summary
+
+To review a summary of a specific backup, you can run the following `show` command with the storage location of your backup and its path (in this case `/2021/09/24-151532.23`):
+
+~~~shell
+cockroach debug backup show 's3://cockroach-bucket/2021/09/24-151532.23?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+~~~
+
+You'll receive a summary of the backup in JSON format that can be used for debugging. This includes information about the cluster from which the backup was taken, metadata about the data files within the backup, the schema, and tables within the database:
+
+~~~
+{
+	"StartTime": "1970-01-01T00:00:00Z",
+	"EndTime": "2021-09-24T15:15:32Z",
+	"DataSize": "1.1 MiB",
+	"Rows": 11778,
+	"IndexEntries": 1776,
+	"FormatVersion": 1,
+	"ClusterID": "1005bac4-87bf-432c-aa54-ec59627bb4ae",
+	"NodeID": 0,
+	"BuildInfo": "CockroachDB CCL v21.2.0-alpha.00000000-4456-g6994559251 (x86_64-unknown-linux-gnu, built 2021/09/24 10:42:46, go1.16.6)",
+	"Files": [
+		{
+			"Path": "data/696077958550355969.sst",
+			"Span": "/Table/53/1{-/\"amsterdam\"/\"\\xb333333@\\x00\\x80\\x00\\x00\\x00\\x00\\x00\\x00#\"}",
+			"DataSize": "2.0 KiB",
+			"IndexEntries": 0,
+			"Rows": 23
+		},
+		{
+			"Path": "data/696077958545408002.sst",
+			"Span": "/Table/53/1/\"{amsterdam\"/\"\\xb333333@\\x00\\x80\\x00\\x00\\x00\\x00\\x00\\x00#\"-boston\"/\"333333D\\x00\\x80\\x00\\x00\\x00\\x00\\x00\\x00\\n\"}",
+			"DataSize": "2.5 KiB",
+			"IndexEntries": 0,
+			"Rows": 28
+		},
+
+. . .
+
+	],
+	"Spans": "[/Table/53/{1-2} /Table/54/{1-3} /Table/55/{1-4} /Table/56/{1-2} /Table/57/{1-2} /Table/58/{1-2}]",
+	"DatabaseDescriptors": {
+		"52": "movr"
+	},
+	"TableDescriptors": {
+		"53": "movr.public.users",
+		"54": "movr.public.vehicles",
+		"55": "movr.public.rides",
+		"56": "movr.public.vehicle_location_histories",
+		"57": "movr.public.promo_codes",
+		"58": "movr.public.user_promo_codes"
+	},
+	"TypeDescriptors": {},
+	"SchemaDescriptors": {
+		"29": "public"
+	}
+}
+~~~
+
+### List a backup collection
+
+To review all full (and incremental) backups in your storage location, use `list-backups` with the path to your backup collection:
+
+~~~shell
+cockroach debug backup list-backups 's3://cockroach-bucket/backup-path?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+~~~
+
+You'll receive output listing the backup paths by timestamp:
+
+~~~
+path
+./2021/09/24-161940.44
+./2021/09/24-162033.59
+~~~
+
+### Export backup table data
+
+Use the `export` subcommand to review backup table data from the command line. The [`--table`](#table-flag) flag is required to define the table for export:
+
+~~~shell
+cockroach debug backup export 's3://cockroach-bucket/2021/09/24-151532.23?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' --table=movr.public.users
+~~~
+
+Without using the [`--destination`](destination-flag) flag to specify a file for the data, you'll receive the table data on the command line in CSV format:
+
+~~~
+'0781e581-40e2-4ae7-b436-0449fdc139fc','amsterdam','Michael Jimenez','13579 Campbell Camp','9453598890'
+'0f7da338-2bd9-4033-be4c-8523e175a1ab','amsterdam','Kyle Galvan','20606 Cheryl Field','5213315177'
+'11569226-48f7-49d8-9d49-326fa905aa37','amsterdam','Rebecca Maxwell','11907 Stephen Union','3580898555'
+'15175e67-51d7-48ec-b5e4-057c146d03dd','amsterdam','Daniel Turner','37387 Angel Point','1114454946'
+'1aeb46c6-9665-4539-b368-3bb7089d3d8f','amsterdam','Tracy Kirby','83883 Rasmussen Parkways','8046889122'
+'27ffe621-4956-4e0a-89d3-762b816bf242','amsterdam','Robert Williams','93464 Gabriel Village','5231692453'
+'2b79917e-4b5b-4c33-b239-0b4838b3d082','amsterdam','Matthew Gordon','69574 Tricia Alley','6188820427'
+'35af4a5b-8c61-452b-a963-771e2d3d3a2f','amsterdam','Lisa Sandoval','77153 Donald Road Apt. 62','7531160744'
+'393f7a3b-6260-421d-a765-a56685e2f5f7','amsterdam','Ashley Bailey','67445 James Centers','8750129902'
+'39625926-2f65-4696-97fc-a2730bfd476d','amsterdam','Alexis Shelton','60376 Jordan Walk','0202218241'
+'48cfd73a-6c04-446b-be03-f99b237176fc','amsterdam','Emily Baldwin','34649 Cody Mountain','9083704248'
+'599371b8-fd87-4f62-80c1-e086c5266e45','amsterdam','Carolyn Bell','34392 Timothy Squares Suite 84','5215261260'
+'5b024ced-9d89-4ad1-a6e5-3ad35334aa55','amsterdam','Jennifer Davis','31952 Joshua Glen Suite 8','4350108331'
+. . .
+~~~
+
+## Known limitations
+
+- `cockroach debug backup` does not support access to [encrypted backups](take-and-restore-encrypted-backups.html). [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/68283).
+- When using the `--start-key` flag with `cockroach debug backup`, it is necessary to pass the accepted formats (`raw`, `hex`, and `bytekey`). [Tracking GitHub issue](https://github.com/cockroachdb/cockroach/issues/70178).
+
+## See also
+
+- [`BACKUP`](backup.html)
+- [Take Full and Incremental Backups](take-full-and-incremental-backups.html)
+- [`SHOW BACKUP`](show-backup.html)
+- [Cockroach Commands](cockroach-commands.html)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)

--- a/v21.2/disaster-recovery.md
+++ b/v21.2/disaster-recovery.md
@@ -320,6 +320,10 @@ If your cluster is running, you do not have a backup that encapsulates the time 
 
 If you have corrupted data in a database or table, [restore](restore.html) the object from a prior [backup](backup.html). If revision history is in the backup, you can restore from a [point in time](take-backups-with-revision-history-and-restore-from-a-point-in-time.html).
 
+{{site.data.alerts.callout_info}}
+You can use `cockroach debug backup` to inspect a backup's metadata or its table data from the command line without an active cluster. See [`cockroach debug backup`](cockroach-debug-backup.html) for more detail on usage.
+{{site.data.alerts.end}}
+
 Instead of dropping the corrupted table or database, we recommend [renaming the table](rename-table.html) or [renaming the database](rename-database.html) so you have historical data to compare to later. If you drop a database, the database cannot be referenced with `AS OF SYSTEM TIME` queries (see [#51380](https://github.com/cockroachdb/cockroach/issues/51380) for more information), and you will need to take a backup that is backdated to the system time when the database still existed.
 
 {{site.data.alerts.callout_info}}

--- a/v21.2/use-cloud-storage-for-bulk-operations.md
+++ b/v21.2/use-cloud-storage-for-bulk-operations.md
@@ -30,7 +30,7 @@ Amazon                                                      | `s3`        | Buck
 Azure                                                       | `azure`     | Storage container                                | `AZURE_ACCOUNT_KEY`, `AZURE_ACCOUNT_NAME`
 Google Cloud                                                | `gs`        | Bucket name                                      | `AUTH` (optional; can be `default`, `implicit`, or `specified`), `CREDENTIALS` <br><br>**Deprecation notice:** In v21.1, we suggest you do not use the `cloudstorage.gs.default.key` [cluster setting](cluster-settings.html), as the default behavior will be changing in v21.2. For more information, see [Authentication - Google Cloud Storage](#google-cloud-storage).
 HTTP                                                        | `http`      | Remote host                                      | N/A <br><br>For more information, see [Authentication - HTTP](#http).      
-NFS/Local&nbsp;[<sup>1</sup>](#considerations)              | `nodelocal` | `nodeID` or `self` [<sup>2</sup>](#considerations) (see [Example file URLs](#example-file-urls)) | N/A
+<a name="nfs-local"></a>NFS/Local&nbsp;[<sup>1</sup>](#considerations)              | `nodelocal` | `nodeID` or `self` [<sup>2</sup>](#considerations) (see [Example file URLs](#example-file-urls)) | N/A
 S3-compatible services                                     | `s3`        | Bucket name                                      | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`&nbsp;[<sup>3</sup>](#considerations) (optional), `AWS_ENDPOINT`<br><br>For more information, see [Authentication - S3-compatible services](#s3-compatible-services).   
 
 {{site.data.alerts.callout_success}}


### PR DESCRIPTION
Closes #10936 

Added documentation for `cockroach debug backup` cli tool in v21.2. This includes:

- New v21.2 `cockroach debug backup` page with the available subcommands & flags under the cli/reference
- A note in the disaster recovery docs
- Cockroach commands page 

Question on whether `--format` flag should be included yet, since there is only one option available, which is the default.