### PR TITLE
21.2 cdc docs remove experimental from cloud

### DIFF
--- a/v21.2/create-changefeed.md
+++ b/v21.2/create-changefeed.md
@@ -60,17 +60,17 @@ Example of a Kafka sink URI:
 
 Use a cloud storage sink to deliver changefeed data to OLAP or big data systems without requiring transport via Kafka.
 
-{{site.data.alerts.callout_info}}
-Currently, cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
-{{site.data.alerts.end}}
-
 Example of a cloud storage sink URI with Amazon S3:
 
 ~~~
 's3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456'
 ~~~
 
-The supported cloud schemes are: `s3`, `gs`, `azure`, `http`, and `https`.
+Some considerations when using cloud storage sinks:
+
+- Cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
+- The supported cloud schemes are: `s3`, `gs`, `azure`, `http`, and `https`.
+- Both `http://` and `https://` are cloud storage sinks, **not** webhook sinks. It is necessary to prefix the scheme with `webhook-` for [webhook sinks](#webhook-sink).
 
 [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls) provides more detail on sink URI structure and authentication to cloud storage sinks.
 

--- a/v21.2/create-changefeed.md
+++ b/v21.2/create-changefeed.md
@@ -8,7 +8,7 @@ toc: true
 `CREATE CHANGEFEED` is an [{{ site.data.products.enterprise }}-only](enterprise-licensing.html) feature. For the core version, see [`EXPERIMENTAL CHANGEFEED FOR`](changefeed-for.html).
 {{site.data.alerts.end}}
 
-The `CREATE CHANGEFEED` [statement](sql-statements.html) creates a new {{ site.data.products.enterprise }} changefeed, which targets an allowlist of tables called "watched rows".  Every change to a watched row is emitted as a record in a configurable format (`JSON` or Avro) to a configurable sink ([Kafka](https://kafka.apache.org/) or a [cloud storage sink](#cloud-storage-sink)). You can [create](#create-a-changefeed-connected-to-kafka), [pause](#pause-a-changefeed), [resume](#resume-a-paused-changefeed), or [cancel](#cancel-a-changefeed) an {{ site.data.products.enterprise }} changefeed.
+The `CREATE CHANGEFEED` [statement](sql-statements.html) creates a new {{ site.data.products.enterprise }} changefeed, which targets an allowlist of tables called "watched rows".  Every change to a watched row is emitted as a record in a configurable format (`JSON` or Avro) to a configurable sink ([Kafka](https://kafka.apache.org/), a [cloud storage sink](#cloud-storage-sink), or a [webhook sink](#webhook-sink)). You can [create](#create-a-changefeed-connected-to-kafka), [pause](#pause-a-changefeed), [resume](#resume-a-paused-changefeed), or [cancel](#cancel-a-changefeed) an {{ site.data.products.enterprise }} changefeed.
 
 For more information, see [Stream Data Out of CockroachDB Using Changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html).
 
@@ -64,13 +64,15 @@ Use a cloud storage sink to deliver changefeed data to OLAP or big data systems 
 Currently, cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 
-Example of a cloud storage sink URI:
+Example of a cloud storage sink URI with Amazon S3:
 
 ~~~
-'experimental-s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456'
+'s3://acme-co/employees?AWS_ACCESS_KEY_ID=123&AWS_SECRET_ACCESS_KEY=456'
 ~~~
 
-Cloud storage sink URIs must be pre-pended with `experimental-` when working with changefeeds. For more information on the sink URI structure, see [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls).
+The supported cloud schemes are: `s3`, `gs`, `azure`, `http`, and `https`.
+
+[Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html#example-file-urls) provides more detail on sink URI structure and authentication to cloud storage sinks.
 
 #### Webhook sink
 
@@ -349,14 +351,10 @@ For more information on how to create a changefeed that emits an [Avro](https://
 
 ### Create a changefeed connected to a cloud storage sink
 
-{{site.data.alerts.callout_danger}}
-**This is an experimental feature.** The interface and output are subject to change.
-{{site.data.alerts.end}}
-
 {% include copy-clipboard.html %}
 ~~~ sql
 > CREATE CHANGEFEED FOR TABLE name, name2, name3
-  INTO 'experimental-scheme://host?parameters'
+  INTO 'scheme://host?parameters'
   WITH updated, resolved;
 ~~~
 ~~~

--- a/v21.2/create-changefeed.md
+++ b/v21.2/create-changefeed.md
@@ -68,7 +68,7 @@ Example of a cloud storage sink URI with Amazon S3:
 
 Some considerations when using cloud storage sinks:
 
-- Cloud storage sinks only work with `JSON` and emits newline-delimited `JSON` files.
+- Cloud storage sinks only work with `JSON` and emit newline-delimited `JSON` files.
 - The supported cloud schemes are: `s3`, `gs`, `azure`, `http`, and `https`.
 - Both `http://` and `https://` are cloud storage sinks, **not** webhook sinks. It is necessary to prefix the scheme with `webhook-` for [webhook sinks](#webhook-sink).
 

--- a/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -698,8 +698,6 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 [`CREATE CHANGEFEED`](create-changefeed.html) is an [{{ site.data.products.enterprise }}-only](enterprise-licensing.html) feature. For the core version, see [the `CHANGEFEED FOR` example above](#create-a-core-changefeed).
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
-
 In this example, you'll set up a changefeed for a single-node cluster that is connected to an AWS S3 sink. The changefeed watches two tables. Note that you can set up changefeeds for any of [these cloud storage providers](create-changefeed.html#cloud-storage-sink).
 
 1. If you do not already have one, [request a trial {{ site.data.products.enterprise }} license](enterprise-licensing.html).
@@ -792,7 +790,7 @@ In this example, you'll set up a changefeed for a single-node cluster that is co
 
     {% include copy-clipboard.html %}
     ~~~ sql
-    > CREATE CHANGEFEED FOR TABLE office_dogs, employees INTO 'experimental-s3://example-bucket-name/test?AWS_ACCESS_KEY_ID=enter_key-here&AWS_SECRET_ACCESS_KEY=enter_key_here' with updated, resolved='10s';
+    > CREATE CHANGEFEED FOR TABLE office_dogs, employees INTO 's3://example-bucket-name/test?AWS_ACCESS_KEY_ID=enter_key-here&AWS_SECRET_ACCESS_KEY=enter_key_here' with updated, resolved='10s';
     ~~~
 
     ~~~

--- a/v21.2/use-cloud-storage-for-bulk-operations.md
+++ b/v21.2/use-cloud-storage-for-bulk-operations.md
@@ -51,7 +51,7 @@ You can disable the use of implicit credentials when accessing external cloud st
 
 ### Example file URLs
 
-Example URLs for [`BACKUP`](backup.html), [`RESTORE`](restore.html), [`EXPORT`](export.html), or [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) given a bucket or container name of `acme-co` and an `employees` subdirectory:
+Example URLs for [`BACKUP`](backup.html), [`RESTORE`](restore.html), or [`EXPORT`](export.html) given a bucket or container name of `acme-co` and an `employees` subdirectory:
 
 Location     | Example                                                                          
 -------------+----------------------------------------------------------------------------------
@@ -61,14 +61,10 @@ Google Cloud | `gs://acme-co/employees?AUTH=specified&CREDENTIALS=encoded-123`
 NFS/Local    | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>2</sup>](#considerations)
 
 {{site.data.alerts.callout_info}}
-URLs for [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) should be prepended with `experimental-`.
-{{site.data.alerts.end}}
-
-{{site.data.alerts.callout_info}}
 Currently, cloud storage sinks (for changefeeds) only work with `JSON` and emits newline-delimited `JSON` files.
 {{site.data.alerts.end}}
 
-Example URLs for [`IMPORT`](import.html) given a bucket or container name of `acme-co` and a filename of `employees`:
+Example URLs for [`IMPORT`](import.html) or [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) given a bucket or container name of `acme-co` and a filename of `employees`:
 
 Location     | Example                                                                          
 -------------+----------------------------------------------------------------------------------
@@ -79,7 +75,7 @@ HTTP         | `http://localhost:8080/employees.sql`
 NFS/Local    | `nodelocal://1/path/employees`, `nodelocal://self/nfsmount/backups/employees`&nbsp;[<sup>2</sup>](#considerations)
 
 {{site.data.alerts.callout_info}}
-HTTP storage can only be used for [`IMPORT`](import.html).
+HTTP storage can only be used for [`IMPORT`](import.html) and [`CREATE CHANGEFEED`](create-changefeed.html).
 {{site.data.alerts.end}}
 
 ## Encryption


### PR DESCRIPTION
Closes #11068 

Removed the experimental tag and warning from cloud storage URIs and examples in the 21.2 cdc docs. Updated the information on the Cloud storage bulk operations page. 