### PR TITLE
Update references for operator v2.2.0

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -91,4 +91,4 @@ release_info:
     version: v21.2.0-beta.3
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com
-operator_version: v2.1.0
+operator_version: v2.2.0

--- a/_includes/v20.2/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v20.2/orchestration/kubernetes-stop-cluster.md
@@ -12,7 +12,7 @@ To shut down the CockroachDB cluster:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/manifests/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
     This will delete the StatefulSet but will not delete the persistent volumes that were attached to the pods. 

--- a/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
@@ -8,7 +8,7 @@ The Operator is currently supported for GKE only.
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
     ~~~
 
     ~~~
@@ -19,7 +19,7 @@ The Operator is currently supported for GKE only.
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/manifests/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
     ~~~

--- a/_includes/v21.1/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v21.1/orchestration/kubernetes-stop-cluster.md
@@ -12,7 +12,7 @@ To shut down the CockroachDB cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/manifests/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
     This will delete the CockroachDB cluster being run by the Operator. It will *not* delete the persistent volumes that were attached to the pods. 

--- a/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
@@ -4,7 +4,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
     ~~~
 
     ~~~
@@ -23,7 +23,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/manifests/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
     ~~~

--- a/_includes/v21.2/orchestration/kubernetes-stop-cluster.md
+++ b/_includes/v21.2/orchestration/kubernetes-stop-cluster.md
@@ -12,7 +12,7 @@ To shut down the CockroachDB cluster:
 
     {% include copy-clipboard.html %}
     ~~~ shell
-    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/manifests/operator.yaml
+    $ kubectl delete -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
     This will delete the CockroachDB cluster being run by the Operator. It will *not* delete the persistent volumes that were attached to the pods. 

--- a/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
@@ -4,7 +4,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/crds.yaml
     ~~~
 
     ~~~
@@ -23,7 +23,7 @@
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/manifests/operator.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
     ~~~


### PR DESCRIPTION
> **NOTE**: This should _**NOT**_ be merged until _after_ we cut the new release. If you'd like to test out the steps, you can swap `v2.2.0` for `v2.2.0-beta.2` which is currently on master.

We've made a few changes for the v2.2.0 release of the public operator including the location of the pre-generated manifests. Both the CRD and the operator yaml files now live in the _install_ directory on master.

This PR updates the version to v2.2.0 and updates the docs to point to the new locations.