### PR TITLE
Fix typo in rename-index.md files

### DIFF
--- a/v1.0/rename-index.md
+++ b/v1.0/rename-index.md
@@ -21,7 +21,7 @@ The user must have the `CREATE` [privilege](privileges.html) on the table.
 
 | Parameter | Description |
 |-----------|-------------|
-| `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error. |
+| `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error. |
 | `table_name` | The name of the table with the index you want to use |
 | `index_name` | The current name of the index |
 | `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers). |

--- a/v1.1/rename-index.md
+++ b/v1.1/rename-index.md
@@ -21,7 +21,7 @@ The user must have the `CREATE` [privilege](privileges.html) on the table.
 
 | Parameter | Description |
 |-----------|-------------|
-| `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error. |
+| `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error. |
 | `table_name` | The name of the table with the index you want to use. |
 | `index_name` | The current name of the index. |
 | `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers). |

--- a/v19.1/rename-index.md
+++ b/v19.1/rename-index.md
@@ -24,7 +24,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).

--- a/v19.2/rename-index.md
+++ b/v19.2/rename-index.md
@@ -24,7 +24,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).

--- a/v2.0/rename-index.md
+++ b/v2.0/rename-index.md
@@ -23,7 +23,7 @@ The user must have the `CREATE` [privilege](privileges.html) on the table.
 
 | Parameter | Description |
 |-----------|-------------|
-| `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error. |
+| `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error. |
 | `table_name` | The name of the table with the index you want to use |
 | `index_name` | The current name of the index |
 | `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers). |

--- a/v2.1/rename-index.md
+++ b/v2.1/rename-index.md
@@ -23,7 +23,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).

--- a/v20.1/rename-index.md
+++ b/v20.1/rename-index.md
@@ -24,7 +24,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).

--- a/v20.2/rename-index.md
+++ b/v20.2/rename-index.md
@@ -24,7 +24,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).

--- a/v21.1/rename-index.md
+++ b/v21.1/rename-index.md
@@ -24,7 +24,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).

--- a/v21.2/rename-index.md
+++ b/v21.2/rename-index.md
@@ -24,7 +24,7 @@ The user must have the `CREATE` [privilege](authorization.html#assign-privileges
 
  Parameter | Description
 -----------|-------------
- `IF EXISTS` | Rename the column only if a column of `current_name` exists; if one does not exist, do not return an error.
+ `IF EXISTS` | Rename the index only if an index `current_name` exists; if one does not exist, do not return an error.
  `table_name` | The name of the table with the index you want to use
  `index_name` | The current name of the index
  `name` | The [`name`](sql-grammar.html#name) you want to use for the index, which must be unique to its table and follow these [identifier rules](keywords-and-identifiers.html#identifiers).


### PR DESCRIPTION
IF EXISTS mistakenly referred to columns instead of indexes.