### PR TITLE
Fix markup in session var table.

### DIFF
--- a/_includes/v21.2/misc/session-vars.html
+++ b/_includes/v21.2/misc/session-vars.html
@@ -2,15 +2,15 @@
  <thead>
 
   <tr>
-   <td>Variable name</td>
-   <td>Description</td>
-   <td>Initial value</td>
-   <td>Modify with <a href="set-vars.html">
+   <th>Variable name</th>
+   <th>Description</th>
+   <th>Initial value</th>
+   <th>Modify with <a href="set-vars.html">
      <code>SET</code>
-    </a>?</td>
-   <td>View with <a href="show-vars.html">
+    </a>?</th>
+   <th>View with <a href="show-vars.html">
      <code>SHOW</code>
-    </a>?</td>
+    </a>?</th>
   </tr>
 
  </thead>
@@ -54,7 +54,7 @@
     <code>crdb_version</code>
    </td>
    <td>The version of CockroachDB.</td>
-   <td>`CockroachDB OSS <i>version</i>`</td>
+   <td><code>CockroachDB OSS <i>version</i></code></td>
    <td>No</td>
    <td>Yes</td>
   </tr>


### PR DESCRIPTION
- Make the header row look like a header.
- Use HTML code markup instead of MD code markup.