### PR TITLE
information_schema tables added for pg,mysql compatibility

### DIFF
--- a/v21.2/information-schema.md
+++ b/v21.2/information-schema.md
@@ -229,7 +229,7 @@ Column | Description
 
 ### referential_constraints
 
-`referential_constraints` identifies all referential ([Foreign Key](foreign-key.html)) constraints.
+`referential_constraints` identifies all referential ([foreign key](foreign-key.html)) constraints.
 
 Column | Description
 -------|-----------


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/11353.
Fixes https://github.com/cockroachdb/docs/issues/11367.
Fixes https://github.com/cockroachdb/docs/issues/11370.

In this PR, I've added a list of all of the empty `information_schema` tables introduced in 21.2 for compatibility with postgresql and mysql tooling. 

Note that I've removed the sections dedicated to the two empty tables included in previous versions, as these tables' contents were empty and identical to their postgresql analogs.