### PR TITLE
Adding docs for securing operator webhooks

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -91,4 +91,4 @@ release_info:
     version: v21.2.0-rc.2
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com
-operator_version: v2.2.0
+operator_version: v2.3.0


### PR DESCRIPTION
We commission both CA and server certificates for securing the webhooks in the operator. By default this is a no-touch process which generates a self-signed CA certificate and uses that to generate a server certificate at startup.

If people want to use their own CA for this, it is possible, but we need to tell them how. This PR addresses that.