### PR TITLE
Replaced SELECT privilege on databases with CONNECT

### DIFF
--- a/_includes/v21.2/sql/privileges.md
+++ b/_includes/v21.2/sql/privileges.md
@@ -5,7 +5,7 @@ Privilege | Levels
 `DROP` | Database, Table
 `GRANT` | Database, Schema, Table, Type
 `CONNECT` | Database
-`SELECT` | Table, Database
+`SELECT` | Table
 `INSERT` | Table
 `DELETE` | Table
 `UPDATE` | Table

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -48,7 +48,7 @@ To backup interleaved data, a `BACKUP` statement must include the [`INCLUDE_DEPR
 ## Required privileges
 
 - [Full cluster backups](take-full-and-incremental-backups.html#full-backups) can only be run by members of the [`admin` role](authorization.html#admin-role). By default, the `root` user belongs to the `admin` role.
-- For all other backups, the user must have [read access](authorization.html#assign-privileges) on all objects being backed up. Database and table backups require `SELECT` privileges. Backups of user-defined schemas, or backups containing user-defined types, require `USAGE` privileges.
+- For all other backups, the user must have [read access](authorization.html#assign-privileges) on all objects being backed up. Database backups require `CONNECT` privileges, and table backups require `SELECT` privileges. Backups of user-defined schemas, or backups containing user-defined types, require `USAGE` privileges.
 - `BACKUP` requires full read and write (including delete and overwrite) permissions to its target destination.
 
 ### Destination privileges

--- a/v21.2/cockroach-userfile-get.md
+++ b/v21.2/cockroach-userfile-get.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Required privileges
 
-The user must have `SELECT` [privileges](authorization.html#assign-privileges) on the target database.
+The user must have `CONNECT` [privileges](authorization.html#assign-privileges) on the target database.
 
 A user can only fetch files from their own user-scoped storage, which is accessed through the [userfile URI](cockroach-userfile-upload.html#file-destination) used during the upload. CockroachDB will revoke all access from every other user in the cluster except users in the `admin` role and users explicitly granted access.
 

--- a/v21.2/show-databases.md
+++ b/v21.2/show-databases.md
@@ -15,7 +15,7 @@ The `SHOW DATABASES` [statement](sql-statements.html) lists all databases in the
 
 ## Required privileges
 
-The user must be granted the `SELECT` [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
+The user must be granted the `CONNECT` [privilege](authorization.html#assign-privileges) to specific databases in order to list those databases in the CockroachDB cluster.
 
 ## Example
 

--- a/v21.2/show-schemas.md
+++ b/v21.2/show-schemas.md
@@ -8,7 +8,7 @@ The `SHOW SCHEMAS` [statement](sql-statements.html) lists all [schemas](sql-name
 
 ## Required privileges
 
-The `SELECT` [privilege](authorization.html#assign-privileges) on the database is required to list the schemas in a database.
+The `CONNECT` [privilege](authorization.html#assign-privileges) on the database is required to list the schemas in a database.
 
 ## Synopsis
 

--- a/v21.2/show-types.md
+++ b/v21.2/show-types.md
@@ -18,7 +18,7 @@ SHOW TYPES
 
 ## Required privileges
 
-The `SELECT` [privilege](authorization.html#assign-privileges) on the database is required to list any user-defined types in the database.
+The `CONNECT` [privilege](authorization.html#assign-privileges) on the database is required to list any user-defined types in the database.
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/11436.
Fixes https://github.com/cockroachdb/docs/issues/11291.

I didn't see any mentions of `INSERT`, `UPDATE`, or `DELETE` as privileges on databases in our docs.