### PR TITLE
remove GKE-exclusive callout for Operator

### DIFF
--- a/_includes/v20.2/orchestration/start-kubernetes.md
+++ b/_includes/v20.2/orchestration/start-kubernetes.md
@@ -8,7 +8,7 @@ GKE or EKS are not required to run CockroachDB on Kubernetes. A manual GCE or AW
 {{site.data.alerts.end}}
 
 {{site.data.alerts.callout_info}}
-The CockroachDB Kubernetes Operator is currently supported for GKE. You can also use the Operator on platforms such as [Red Hat OpenShift](../{{site.versions["stable"]}}/deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
+You can also use the CockroachDB Kubernetes Operator on platforms such as [Red Hat OpenShift](../{{site.versions["stable"]}}/deploy-cockroachdb-with-kubernetes-openshift.html) and [IBM Cloud Pak for Data](https://www.ibm.com/products/cloud-pak-for-data).
 {{site.data.alerts.end}}
 
 ### Hosted GKE

--- a/_includes/v21.1/orchestration/start-kubernetes.md
+++ b/_includes/v21.1/orchestration/start-kubernetes.md
@@ -4,10 +4,6 @@ You can use the hosted [Google Kubernetes Engine (GKE)](#hosted-gke) service or 
 GKE or EKS are not required to run CockroachDB on Kubernetes. A manual GCE or AWS cluster with the [minimum recommended Kubernetes version](#kubernetes-version) and at least 3 pods, each presenting [sufficient resources](#resources) to start a CockroachDB node, can also be used.
 {{site.data.alerts.end}}
 
-{{site.data.alerts.callout_info}}
-The CockroachDB Kubernetes Operator is currently supported for GKE.
-{{site.data.alerts.end}}
-
 ### Hosted GKE
 
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.

--- a/_includes/v21.2/orchestration/start-kubernetes.md
+++ b/_includes/v21.2/orchestration/start-kubernetes.md
@@ -4,10 +4,6 @@ You can use the hosted [Google Kubernetes Engine (GKE)](#hosted-gke) service or 
 GKE or EKS are not required to run CockroachDB on Kubernetes. A manual GCE or AWS cluster with the [minimum recommended Kubernetes version](#kubernetes-version) and at least 3 pods, each presenting [sufficient resources](#resources) to start a CockroachDB node, can also be used.
 {{site.data.alerts.end}}
 
-{{site.data.alerts.callout_info}}
-The CockroachDB Kubernetes Operator is currently supported for GKE.
-{{site.data.alerts.end}}
-
 ### Hosted GKE
 
 1. Complete the **Before You Begin** steps described in the [Google Kubernetes Engine Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart) documentation.


### PR DESCRIPTION
With EKS support being finalized for the Operator, this removes the callouts that stated that the Operator is only supported on GKE.