### PR TITLE
`RESTORE` and `IMPORT INTO` multi-region functionality docs

### DIFF
--- a/_includes/v21.2/backups/no-multiregion-table-backups.md
+++ b/_includes/v21.2/backups/no-multiregion-table-backups.md
@@ -2,4 +2,4 @@ CockroachDB does not currently support [`BACKUP`s](backup.html) of individual ta
 
 To work around this limitation, you must [back up the database](backup.html#backup-a-database) or [the entire cluster](backup.html#backup-a-cluster).
 
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/61133)
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71180)

--- a/_includes/v21.2/known-limitations/rbr-restore-no-support.md
+++ b/_includes/v21.2/known-limitations/rbr-restore-no-support.md
@@ -1,0 +1,1 @@
+Restoring [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) tables is currently not supported. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67269)

--- a/_includes/v21.2/known-limitations/restore-multiregion-match.md
+++ b/_includes/v21.2/known-limitations/restore-multiregion-match.md
@@ -1,0 +1,50 @@
+[`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) tables can be restored **only** if the [table locality](multiregion-overview.html#table-locality) matches that of the target database.
+
+    The following must also be true for `RESTORE` to be successful:
+
+    * The regions of the source database and the regions of the destination database have the same set of regions.
+    * The regions were added to each of the databases in the same order.
+    * The databases have the same primary region.
+
+    The following example would be considered as having **mismatched** regions because the database regions were not added in the same order and the primary regions do not match.
+
+    Running on the source database:
+
+    ~~~ sql
+    > ALTER DATABASE source_database SET PRIMARY REGION "us-east1";
+    ~~~
+    ~~~ sql
+    > ALTER DATABASE source_database ADD region "us-west1";  
+    ~~~
+
+    Running on the destination database:
+
+    ~~~ sql
+    > ALTER DATABASE destination_database SET PRIMARY REGION "us-west1";
+    ~~~
+    ~~~ sql
+    > ALTER DATABASE destination_database ADD region "us-east1";  
+    ~~~
+
+    Furthermore, this scenario has mismatched regions between the databases since the regions were not added to the database in the same order.
+
+    Running on the source database:
+
+    ~~~ sql
+    > ALTER DATABASE source_database SET PRIMARY REGION "us-east1";
+    ~~~
+    ~~~ sql
+    > ALTER DATABASE source_database ADD region "us-west1";  
+    ~~~
+
+    Running on the destination database:
+
+    ~~~ sql
+    > ALTER DATABASE destination_database SET PRIMARY REGION "us-west1";
+    ~~~
+    ~~~ sql
+    > ALTER DATABASE destination_database ADD region "us-east1";
+    ~~~
+    ~~~ sql  
+    > ALTER DATABASE destination_database SET PRIMARY REGION "us-east1";    
+    ~~~

--- a/_includes/v21.2/known-limitations/restore-multiregion-match.md
+++ b/_includes/v21.2/known-limitations/restore-multiregion-match.md
@@ -2,9 +2,9 @@
 
     The following must also be true for `RESTORE` to be successful:
 
-    * The regions of the source database and the regions of the destination database have the same set of regions.
+    * The [regions](multiregion-overview.html#database-regions) of the source database and the regions of the destination database have the same set of regions.
     * The regions were added to each of the databases in the same order.
-    * The databases have the same primary region.
+    * The databases have the same [primary region](set-primary-region.html).
 
     The following example would be considered as having **mismatched** regions because the database regions were not added in the same order and the primary regions do not match.
 
@@ -26,7 +26,7 @@
     > ALTER DATABASE destination_database ADD region "us-east1";  
     ~~~
 
-    Furthermore, this scenario has mismatched regions between the databases since the regions were not added to the database in the same order.
+    In addition, the following scenario has mismatched regions between the databases since the regions were not added to the database in the same order.
 
     Running on the source database:
 

--- a/_includes/v21.2/known-limitations/restore-tables-non-multi-reg.md
+++ b/_includes/v21.2/known-limitations/restore-tables-non-multi-reg.md
@@ -1,0 +1,1 @@
+Restoring [`GLOBAL`](multiregion-overview.html#global-tables) and [`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) tables into a **non**-multi-region database is not supported. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71502)

--- a/v21.2/import-into.md
+++ b/v21.2/import-into.md
@@ -14,7 +14,8 @@ The `IMPORT INTO` [statement](sql-statements.html) imports CSV, Avro, or delimit
 - `IMPORT INTO` is an insert-only statement; it cannot be used to update existing rows—see [`UPDATE`](update.html). Imported rows cannot conflict with primary keys in the existing table, or any other [`UNIQUE`](unique.html) constraint on the table.
 - `IMPORT INTO` does not offer `SELECT` or `WHERE` clauses to specify subsets of rows. To do this, use [`INSERT`](insert.html#insert-from-a-select-statement).
 - `IMPORT INTO` will cause any [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) running on the targeted table to fail.
-- {% include {{page.version.version}}/sql/import-into-regional-by-row-table.md %}
+
+<span class="version-tag">New in v21.2:</span> `IMPORT INTO` now supports importing into [`REGIONAL BY ROW`](set-locality.html#regional-by-row) tables.
 
 ## Required privileges
 
@@ -107,7 +108,9 @@ Before using `IMPORT INTO`, you should have:
 
 #### Supported `DEFAULT` expressions
 
- `IMPORT INTO` supports [computed columns](computed-columns.html) and the following [`DEFAULT`](default-value.html) expressions:
+`IMPORT INTO` supports [computed columns](computed-columns.html) and the following [`DEFAULT`](default-value.html) expressions:
+
+- `DEFAULT` expressions with [user-defined types](enum.html).
 
 - Constant `DEFAULT` expressions, which are expressions that return the same value in different statements. Examples include:
 

--- a/v21.2/import.md
+++ b/v21.2/import.md
@@ -22,7 +22,7 @@ The `IMPORT` [statement](sql-statements.html) imports the following types of dat
 - `IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead.
 - `IMPORT` is a blocking statement. To run an import job asynchronously, use the [`DETACHED`](#options-detached) option.
 - `IMPORT` cannot be used within a [rolling upgrade](upgrade-cockroach-version.html).
-- {% include {{page.version.version}}/sql/import-into-regional-by-row-table.md %}
+- `IMPORT` cannot directly import data to `REGIONAL BY ROW` tables that are part of [multi-region databases](multiregion-overview.html). Instead, use [`IMPORT INTO`](import-into.html) which now supports importing into `REGIONAL BY ROW` tables.
 
 ## Required privileges
 

--- a/v21.2/import.md
+++ b/v21.2/import.md
@@ -22,7 +22,7 @@ The `IMPORT` [statement](sql-statements.html) imports the following types of dat
 - `IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead.
 - `IMPORT` is a blocking statement. To run an import job asynchronously, use the [`DETACHED`](#options-detached) option.
 - `IMPORT` cannot be used within a [rolling upgrade](upgrade-cockroach-version.html).
-- `IMPORT` cannot directly import data to `REGIONAL BY ROW` tables that are part of [multi-region databases](multiregion-overview.html). Instead, use [`IMPORT INTO`](import-into.html) which now supports importing into `REGIONAL BY ROW` tables.
+- `IMPORT` cannot directly import data to `REGIONAL BY ROW` tables that are part of [multi-region databases](multiregion-overview.html). <span class="version-tag">New in v21.2:</span> Instead, use [`IMPORT INTO`](import-into.html) which supports importing into `REGIONAL BY ROW` tables.
 
 ## Required privileges
 

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -159,50 +159,17 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/59649)
 
+### Using `RESTORE` with multi-region table localities
+
+* {% include {{ page.version.version }}/known-limitations/rbr-restore-no-support.md %}
+
+* {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
+
+* {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
+
 ## Unresolved limitations
-
-### `IMPORT` into a `REGIONAL BY ROW` table
-
-CockroachDB does not currently support [`IMPORT`s](import.html) into [`REGIONAL BY ROW`](set-locality.html#regional-by-row) tables that are part of [multi-region databases](multiregion-overview.html).
-
-[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/61133)
-
-To work around this limitation, you will need to take the following steps:
-
-1. In the source database, export the [`crdb_region` column](set-locality.html#crdb_region) separately when exporting your data.
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    EXPORT INTO CSV 'nodelocal://0/src_rbr' FROM SELECT crdb_region, i from src_rbr;
-    ~~~
-
-    For more information about the syntax, see [`EXPORT`](export.html).
-
-1. In the destination database, create a table that has a `crdb_region` column of the right type as shown below.
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    CREATE TABLE dest_rbr (crdb_region public.crdb_internal_region NOT NULL, i INT);
-    ~~~
-
-1. Import the data (including the `crdb_region` column explicitly) using [`IMPORT INTO`](import-into.html):
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    IMPORT INTO dest_rbr (crdb_region, i) CSV DATA ('nodelocal://0/src_rbr/export*.csv')
-    ~~~
-
-1. Convert the destination table to `REGIONAL BY ROW` using [`ALTER TABLE ... ALTER COLUMN`](alter-column.html) and [`ALTER TABLE ... SET LOCALITY`](set-locality.html):
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    ALTER TABLE dest_rbr ALTER COLUMN crdb_region SET DEFAULT default_to_database_primary_region(gateway_region())::public.crdb_internal_region;
-    ~~~
-
-    {% include copy-clipboard.html %}
-    ~~~ sql
-    ALTER TABLE dest_rbr SET LOCALITY REGIONAL BY ROW AS crdb_region;
-    ~~~
 
 ### `BACKUP` of multi-region tables
 
@@ -627,4 +594,3 @@ SELECT * FROM mytable WHERE j @> '{"a": {"b": "c"}}'
 ~~~
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/55318)
-

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -63,6 +63,7 @@ You can include the following options as key-value pairs in the `kv_option_list`
 <a name="skip_missing_sequences"></a>`skip_missing_sequences`       | N/A                                         | Use to ignore [sequence](show-sequences.html) dependencies (i.e., the `DEFAULT` expression that uses the sequence).<br><br>Example: `WITH skip_missing_sequences`
 `skip_missing_sequence_owners`                                      | N/A                                         | Must be used when restoring either a table that was previously a [sequence owner](create-sequence.html#owned-by) or a sequence that was previously owned by a table.<br><br>Example: `WITH skip_missing_sequence_owners`
 `skip_missing_views`                                                | N/A                                         | Use to skip restoring [views](views.html) that cannot be restored because their dependencies are not being restored at the same time.<br><br>Example: `WITH skip_missing_views`
+<a name="skip-localities-check"></a>`skip_localities_check`         | N/A                                         | <span class="version-tag">New in v21.2:</span> Use to skip checking localities of a cluster before a restore when there are mismatched regions between the backup's cluster and the target cluster. <br><br>Example: `WITH skip_localities_check`
 `encryption_passphrase`                                             | Passphrase used to create the [encrypted backup](take-and-restore-encrypted-backups.html) |  The passphrase used to decrypt the file(s) that were encrypted by the [`BACKUP`](take-and-restore-encrypted-backups.html) statement.
 `DETACHED`                                                          | N/A                                         |  When `RESTORE` runs with `DETACHED`, the job will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. For more on the differences between the returned job data, see the [example](restore.html#restore-a-backup-asynchronously) below. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run a restore within a [transaction](transactions.html), use the `DETACHED` option.
 `debug_pause_on`                                                    | `"error" `                                    | <span class="version-tag">New in v21.2:</span> Use to have a `RESTORE` [job](show-jobs.html) self pause when it encounters an error. The `RESTORE` job can then be [resumed](resume-job.html) after the error has been fixed or [canceled](cancel-job.html) to rollback the job. <br><br>Example: `WITH debug_pause_on='error'`
@@ -168,6 +169,28 @@ The `RESTORE` process minimizes its impact to the cluster's performance by distr
 When a `RESTORE` fails or is canceled, partially restored data is properly cleaned up. This can have a minor, temporary impact on cluster performance.
 {{site.data.alerts.end}}
 
+## Restoring to multi-region databases
+
+<span class="version-tag">New in v21.2:</span> Restoring to a multi-region database is supported with some limitations. This section outlines details and settings that should be considered when restoring into multi-region databases.
+
+* A cluster's regions will be checked before a restore. Mismatched regions between [backup](known-limitations.html#backup-of-multi-region-tables) and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
+
+* A database that is restored with the `sql.defaults.primary_region` [cluster setting](cluster-settings.html) will have the `PRIMARY REGION` from this cluster setting assigned to the target database.
+
+{{site.data.alerts.callout_info}}
+Tables with a [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) locality cannot be restored.
+{{site.data.alerts.end}}
+
+* `RESTORE` supports restoring **non**-multi-region tables into a multi-region database and sets the table locality as [`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) to the primary region of the target database.
+
+* Restoring tables from multi-region databases with table localities set to `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported. Note that when restoring a `REGIONAL BY TABLE IN PRIMARY REGION` table, if the primary region is different in the source database to the target database this will be implicitly changed on restore.
+
+* {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
+
+The ordering of regions and how region matching is determined is a known limitation. See the [Known Limitations](#known-limitations) section for the tracking issues on limitations around `RESTORE` and multi-region support.
+
+For more on multi-region databases, see the [Multi-Region Capabilities Overview](multiregion-overview.html).
+
 ## Viewing and controlling restore jobs
 
 After CockroachDB successfully initiates a restore, it registers the restore as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
@@ -177,10 +200,6 @@ After the restore has been initiated, you can control it with [`PAUSE JOB`](paus
 {{site.data.alerts.callout_info}}
 If initiated correctly, the statement returns when the restore is finished or if it encounters an error. In some cases, the restore can continue after an error has been returned (the error message will tell you that the restore has resumed in background).
 {{site.data.alerts.end}}
-
-## Known limitations
-
-{% include {{ page.version.version }}/known-limitations/restore-aost.md %}
 
 ## Examples
 
@@ -727,6 +746,13 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 ~~~
 
 </section>
+
+## Known limitations
+
+* {% include {{ page.version.version }}/known-limitations/restore-aost.md %} [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/53044)
+* To successfully [restore a table into a multi-region database](#restoring-to-multi-region-databases), it is necessary for the order and regions to match between the source and destination database. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
+* {% include {{ page.version.version }}/known-limitations/rbr-restore-no-support.md %}
+* {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
 
 ## See also
 

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -63,7 +63,7 @@ You can include the following options as key-value pairs in the `kv_option_list`
 <a name="skip_missing_sequences"></a>`skip_missing_sequences`       | N/A                                         | Use to ignore [sequence](show-sequences.html) dependencies (i.e., the `DEFAULT` expression that uses the sequence).<br><br>Example: `WITH skip_missing_sequences`
 `skip_missing_sequence_owners`                                      | N/A                                         | Must be used when restoring either a table that was previously a [sequence owner](create-sequence.html#owned-by) or a sequence that was previously owned by a table.<br><br>Example: `WITH skip_missing_sequence_owners`
 `skip_missing_views`                                                | N/A                                         | Use to skip restoring [views](views.html) that cannot be restored because their dependencies are not being restored at the same time.<br><br>Example: `WITH skip_missing_views`
-<a name="skip-localities-check"></a>`skip_localities_check`         | N/A                                         | <span class="version-tag">New in v21.2:</span> Use to skip checking localities of a cluster before a restore when there are mismatched regions between the backup's cluster and the target cluster. <br><br>Example: `WITH skip_localities_check`
+<a name="skip-localities-check"></a>`skip_localities_check`         | N/A                                         | <span class="version-tag">New in v21.2:</span> Use to skip checking localities of a cluster before a restore when there are mismatched [cluster regions](multiregion-overview.html#cluster-regions) between the backup's cluster and the target cluster. <br><br>Example: `WITH skip_localities_check`
 `encryption_passphrase`                                             | Passphrase used to create the [encrypted backup](take-and-restore-encrypted-backups.html) |  The passphrase used to decrypt the file(s) that were encrypted by the [`BACKUP`](take-and-restore-encrypted-backups.html) statement.
 `DETACHED`                                                          | N/A                                         |  When `RESTORE` runs with `DETACHED`, the job will execute asynchronously and the job ID will be returned immediately without waiting for the job to finish. Note that with `DETACHED` specified, further job information and the job completion status will not be returned. For more on the differences between the returned job data, see the [example](restore.html#restore-a-backup-asynchronously) below. To check on the job status, use the [`SHOW JOBS`](show-jobs.html) statement. <br><br>To run a restore within a [transaction](transactions.html), use the `DETACHED` option.
 `debug_pause_on`                                                    | `"error" `                                    | <span class="version-tag">New in v21.2:</span> Use to have a `RESTORE` [job](show-jobs.html) self pause when it encounters an error. The `RESTORE` job can then be [resumed](resume-job.html) after the error has been fixed or [canceled](cancel-job.html) to rollback the job. <br><br>Example: `WITH debug_pause_on='error'`
@@ -171,11 +171,11 @@ When a `RESTORE` fails or is canceled, partially restored data is properly clean
 
 ## Restoring to multi-region databases
 
-<span class="version-tag">New in v21.2:</span> Restoring to a multi-region database is supported with some limitations. This section outlines details and settings that should be considered when restoring into multi-region databases.
+<span class="version-tag">New in v21.2:</span> Restoring to a [multi-region database](multiregion-overview.html) is supported with some limitations. This section outlines details and settings that should be considered when restoring into multi-region databases.
 
-* A cluster's regions will be checked before a restore. Mismatched regions between [backup](known-limitations.html#backup-of-multi-region-tables) and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
+* A [cluster's regions](multiregion-overview.html#cluster-regions) will be checked before a restore. Mismatched regions between [backup](known-limitations.html#backup-of-multi-region-tables) and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
 
-* A database that is restored with the `sql.defaults.primary_region` [cluster setting](cluster-settings.html) will have the `PRIMARY REGION` from this cluster setting assigned to the target database.
+* A database that is restored with the `sql.defaults.primary_region` [cluster setting](cluster-settings.html) will have the [`PRIMARY REGION`](set-primary-region.html) from this cluster setting assigned to the target database.
 
 {{site.data.alerts.callout_info}}
 Tables with a [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) locality cannot be restored.
@@ -183,7 +183,9 @@ Tables with a [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tabl
 
 * `RESTORE` supports restoring **non**-multi-region tables into a multi-region database and sets the table locality as [`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) to the primary region of the target database.
 
-* Restoring tables from multi-region databases with table localities set to `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported. Note that when restoring a `REGIONAL BY TABLE IN PRIMARY REGION` table, if the primary region is different in the source database to the target database this will be implicitly changed on restore.
+* Restoring tables from multi-region databases with table localities set to `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported.
+
+* When restoring a `REGIONAL BY TABLE IN PRIMARY REGION` table, if the primary region is different in the source database to the target database this will be implicitly changed on restore.
 
 * {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
 
@@ -750,7 +752,7 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 ## Known limitations
 
 * {% include {{ page.version.version }}/known-limitations/restore-aost.md %} [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/53044)
-* To successfully [restore a table into a multi-region database](#restoring-to-multi-region-databases), it is necessary for the order and regions to match between the source and destination database. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
+* To successfully [restore a table into a multi-region database](#restoring-to-multi-region-databases), it is necessary for the order and regions to match between the source and destination database. See the [Known Limitations](known-limitations.html#using-restore-with-multi-region-table-localities) page for detail on ordering and matching regions. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
 * {% include {{ page.version.version }}/known-limitations/rbr-restore-no-support.md %}
 * {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
 

--- a/v21.2/set-locality.md
+++ b/v21.2/set-locality.md
@@ -37,7 +37,9 @@ The user must be a member of the [`admin`](authorization.html#roles) or [owner](
 ## Examples
 
 {{site.data.alerts.callout_info}}
-[`RESTORE`](restore.html) on [`REGIONAL BY TABLE`](#regional-by-table) and [`GLOBAL`](#global) tables is supported with some limitations — see [Restoring to multi-region databases](restore.html#restoring-to-multi-region-databases) for more detail. Tables set to a [`REGIONAL BY ROW`](#regional-by-row) table locality cannot be restored.
+[`RESTORE`](restore.html) on [`REGIONAL BY TABLE`](#regional-by-table) and [`GLOBAL`](#global) tables is supported with some limitations — see [Restoring to multi-region databases](restore.html#restoring-to-multi-region-databases) for more detail.
+
+Tables set to a [`REGIONAL BY ROW`](#regional-by-row) table locality cannot be restored. See the [Known Limitations](known-limitations.html#using-restore-with-multi-region-table-localities) page for detail.
 {{site.data.alerts.end}}
 
 <a name="regional-by-table"></a>

--- a/v21.2/set-locality.md
+++ b/v21.2/set-locality.md
@@ -36,6 +36,10 @@ The user must be a member of the [`admin`](authorization.html#roles) or [owner](
 
 ## Examples
 
+{{site.data.alerts.callout_info}}
+[`RESTORE`](restore.html) on [`REGIONAL BY TABLE`](#regional-by-table) and [`GLOBAL`](#global) tables is supported with some limitations — see [Restoring to multi-region databases](restore.html#restoring-to-multi-region-databases) for more detail. Tables set to a [`REGIONAL BY ROW`](#regional-by-row) table locality cannot be restored.
+{{site.data.alerts.end}}
+
 <a name="regional-by-table"></a>
 
 ### Set the table locality to `REGIONAL BY TABLE`


### PR DESCRIPTION
Closes #10937 Draft of features for `RESTORE` & `IMPORT INTO` 21.2 multi-region features: 

`RESTORE` doc changes:

- Added section to the `RESTORE` page on restoring with the different table localities and their nuances. The RBT & RBR ordering/matching limitations are outlined here and on the known limitations page for 21.2. (Closes #11283)
- Added a bullet on the default primary region setting (Closes #11373 )
- Note on `SET LOCALITY` page
- Added the `skip-localities-check` option to the option table and this section (Closes #11278)

`IMPORT INTO` doc changes:

- Removed the section on this from the known limitation page (Closes #11919 )
- Removed the consideration bullet and added that RBR in import into is now available
- Added a bullet that import into now supports in computed columns `default` expressions with user-defined types (Closes #11720 )
