### PR TITLE
Reserve none, crdb_internal*, pg_* user/role names

### DIFF
--- a/v21.2/create-role.md
+++ b/v21.2/create-role.md
@@ -19,6 +19,8 @@ The `CREATE ROLE` [statement](sql-statements.html) creates SQL [roles](authoriza
     - Must start with either a letter or underscore
     - Must contain only letters, numbers, periods, or underscores
     - Must be between 1 and 63 characters.
+    - <span class="version-tag">New in v21.2</span>: Cannot be `none`.
+    - <span class="version-tag">New in v21.2</span>: Cannot start with `pg_` or `crdb_internal`. Object names with these prefixes are reserved for [system catalogs](system-catalogs.html).
 - After creating roles, you must [grant them privileges to databases and tables](grant.html).
 - Roles and users can be members of roles.
 - Roles and users share the same namespace and must be unique.

--- a/v21.2/create-user.md
+++ b/v21.2/create-user.md
@@ -17,6 +17,8 @@ The `CREATE USER` [statement](sql-statements.html) creates SQL users, which let 
     - Must start with a letter, number, or underscore
     - Must contain only letters, numbers, periods, or underscores
     - Must be between 1 and 63 characters.
+    - <span class="version-tag">New in v21.2</span>: Cannot be `none`.
+    - <span class="version-tag">New in v21.2</span>: Cannot start with `pg_` or `crdb_internal`. Object names with these prefixes are reserved for [system catalogs](system-catalogs.html).
 - After creating users, you must [grant them privileges to databases and tables](grant.html).
 - All users belong to the `public` role, to which you can [grant](grant.html) and [revoke](revoke.html) privileges.
 - On secure clusters, you must [create client certificates for users](cockroach-cert.html#create-the-certificate-and-key-pair-for-a-client) and users must [authenticate their access to the cluster](#user-authentication).


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/11424.