### PR TITLE
Reinstated correlated CTE known limitation in 21.1

### DIFF
--- a/_includes/v21.1/known-limitations/correlated-ctes.md
+++ b/_includes/v21.1/known-limitations/correlated-ctes.md
@@ -1,0 +1,20 @@
+CockroachDB does not support correlated common table expressions. This means that a CTE cannot refer to a variable defined outside the scope of that CTE.
+
+For example, the following query returns an error:
+
+{% include copy-clipboard.html %}
+~~~ sql
+> SELECT * FROM users
+  WHERE id =
+    (WITH rides_home AS
+      (SELECT revenue FROM rides
+       WHERE end_address = address)
+     SELECT rider_id FROM rides_home);
+~~~
+
+~~~
+ERROR: CTEs may not be correlated
+SQLSTATE: 0A000
+~~~
+
+This query returns an error because the `WITH rides_home` clause references a column (`address`) returned by the `SELECT` statement at the top level of the query, outside the `rides_home` CTE definition.

--- a/v21.1/common-table-expressions.md
+++ b/v21.1/common-table-expressions.md
@@ -303,6 +303,14 @@ While this practice works for testing and debugging, we do not recommend it in p
 CockroachDB does not currently support the [Postgres recursive CTE variant](https://www.postgresql.org/docs/10/queries-with.html) with the keyword `UNION`.
 {{site.data.alerts.end}}
 
+## Known limitations
+
+### Correlated common table expressions
+
+{% include {{ page.version.version }}/known-limitations/correlated-ctes.md %}
+
+For details, see the [tracking issue](https://github.com/cockroachdb/cockroach/issues/42540).
+
 ## See also
 
 - [Subqueries](subqueries.html)

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -525,6 +525,12 @@ To prevent memory exhaustion, monitor each node's memory usage and ensure there 
 
 Every [`DELETE`](delete.html) or [`UPDATE`](update.html) statement constructs a `SELECT` statement, even when no `WHERE` clause is involved. As a result, the user executing `DELETE` or `UPDATE` requires both the `DELETE` and `SELECT` or `UPDATE` and `SELECT` [privileges](authorization.html#assign-privileges) on the table.
 
+### Correlated common table expressions
+
+{% include {{ page.version.version }}/known-limitations/correlated-ctes.md %}
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/42540)
+
 ### `ROLLBACK TO SAVEPOINT` in high-priority transactions containing DDL
 
 Transactions with [priority `HIGH`](transactions.html#transaction-priorities) that contain DDL and `ROLLBACK TO SAVEPOINT` are not supported, as they could result in a deadlock. For example:


### PR DESCRIPTION
In https://github.com/cockroachdb/docs/pull/10568, I mistakenly removed correlated CTEs from the 21.1 known limitations. 

[Support for correlated CTEs](https://github.com/cockroachdb/cockroach/pull/63956) was merged into master nearly a month before the 21.1 release, but the PR was never backported into the 21.1 release branch, meaning the support is limited to 21.2+.