### PR TITLE
Add redirect for broken link on marketing page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -91,6 +91,7 @@ layout: null
 /docs/v20.2/performance-benchmarking-with-tpc-c-1k-warehouses.html /docs/v20.2/performance-benchmarking-with-tpcc-small.html 301
 /docs/v21.1/performance-benchmarking-with-tpc-c-1k-warehouses.html /docs/v21.1/performance-benchmarking-with-tpcc-small.html 301
 /docs/stable/performance-benchmarking-with-tpc-c-1k-warehouses.html /docs/stable/performance-benchmarking-with-tpcc-small.html 301
+/docs/stable/performance-benchmarking-with-tpc-c-1k-warehouses /docs/stable/performance-benchmarking-with-tpcc-small.html 301
 /docs/v20.2/performance-benchmarking-with-tpc-c-100k-warehouses.html /docs/v20.2/performance-benchmarking-with-tpcc-large.html 301
 /docs/v21.1/performance-benchmarking-with-tpc-c-100k-warehouses.html /docs/v21.1/performance-benchmarking-with-tpcc-large.html 301
 /docs/stable/performance-benchmarking-with-tpc-c-100k-warehouses.html /docs/stable/performance-benchmarking-with-tpcc-large.html 301


### PR DESCRIPTION
"Benchmarking" link doesn't get properly redirected
for some reason, perhaps because the link is missing
the .html file ending.

https://www.cockroachlabs.com/developers/