### PR TITLE
Note on file_size cluster setting for backups

### DIFF
--- a/_includes/v21.2/backups/file-size-setting.md
+++ b/_includes/v21.2/backups/file-size-setting.md
@@ -1,0 +1,5 @@
+{{site.data.alerts.callout_info}}
+To set a target for the amount of backup data written to each backup file, use the `bulkio.backup.file_size` [cluster setting](cluster-settings.html).
+
+See the [`SET CLUSTER SETTING`](set-cluster-setting.html) page for more details on using cluster settings.
+{{site.data.alerts.end}}

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -129,6 +129,8 @@ This improves performance by decreasing the likelihood that the `BACKUP` will be
 
 `BACKUP` will initially ask individual ranges to backup but to skip if they encounter an intent. Any range that is skipped is placed at the end of the queue. When `BACKUP` has completed its initial pass and is revisiting ranges, it will ask any range that did not resolve within the given time limit (default 1 minute) to attempt to resolve any intents that it encounters and to _not_ skip. Additionally, the backup's transaction priority is then set to `high`, which causes other transactions to abort until the intents are resolved and the backup is finished.
 
+{% include {{ page.version.version }}/backups/file-size-setting.md %}
+
 ## Viewing and controlling backups jobs
 
 After CockroachDB successfully initiates a backup, it registers the backup as a job, and you can do the following:

--- a/v21.2/take-full-and-incremental-backups.md
+++ b/v21.2/take-full-and-incremental-backups.md
@@ -29,6 +29,8 @@ In most cases, **it's recommended to take nightly full backups of your cluster**
 - Restore database(s) from the cluster
 - Restore a full cluster
 
+{% include {{ page.version.version }}/backups/file-size-setting.md %}
+
 ### Take a full backup
 
 To do a cluster backup, use the [`BACKUP`](backup.html) statement:


### PR DESCRIPTION
Closes #10933 

Added a note to the `BACKUP` and full/incremental backup page on the `bulkio.backup.file_size` cluster setting. 

Note: This isn't yet listed on the Cluster Settings page as it was marked as non-public — this is being switched over to public and that will pull into the settings page when released.