### PR TITLE
fix anchor link

### DIFF
--- a/v21.1/configure-logs.md
+++ b/v21.1/configure-logs.md
@@ -96,7 +96,7 @@ sinks:
       ...
 ~~~
 
-<a name="common-sink-parameters">
+<a name="common-sink-parameters"></a>
 
 All supported sink types use the following common sink parameters:
 

--- a/v21.2/configure-logs.md
+++ b/v21.2/configure-logs.md
@@ -99,7 +99,7 @@ sinks:
       ...
 ~~~
 
-<a name="common-sink-parameters">
+<a name="common-sink-parameters"></a>
 
 All supported sink types use the following common sink parameters:
 


### PR DESCRIPTION
Fixed an open anchor link that was causing parameter names to render incorrectly.