### PR TITLE
Local testing best practices

### DIFF
--- a/_includes/sidebar-data-v21.1.json
+++ b/_includes/sidebar-data-v21.1.json
@@ -371,6 +371,12 @@
             ]
           },
           {
+            "title": "Test Your Application",
+            "urls": [
+              "/${VERSION}/local-testing.html"
+            ]
+          },
+          {
             "title": "Debug Your Application",
             "items":
             [

--- a/_includes/sidebar-data-v21.2.json
+++ b/_includes/sidebar-data-v21.2.json
@@ -377,6 +377,12 @@
             ]
           },
           {
+            "title": "Test Your Application",
+            "urls": [
+              "/${VERSION}/local-testing.html"
+            ]
+          },
+          {
             "title": "Debug Your Application",
             "items":
             [

--- a/v21.1/local-testing.md
+++ b/v21.1/local-testing.md
@@ -1,0 +1,49 @@
+---
+title: Test Your Application
+summary: Best practices for locally testing an application built on CockroachDB
+toc: true
+---
+
+This page documents best practices for unit testing applications built on CockroachDB.
+
+If you are deploying a self-hosted cluster, see the [Production Checklist](recommended-production-settings.html) for information about preparing your cluster for production.
+
+## Use a local, single-node cluster with in-memory storage
+
+The [`cockroach start-single-node`](cockroach-start-single-node.html) command starts a single-node, insecure cluster with [in-memory storage](cockroach-start-single-node.html#store):
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+cockroach start-single-node --insecure --store=type=mem,size=0.25 --advertise-addr=localhost
+~~~
+
+Using in-memory storage improves the speed of the cluster for local testing purposes.
+
+## Log test output to a file
+
+By default, `cockroach start-single-node` logs cluster activity to a file with the [default logging configuration](configure-logs.html#default-logging-configuration). When you specify the `--store=type=mem` flag, the command prints cluster activity directly to the console instead.
+
+To customize logging behavior for local clusters, use the [`--log` flag](cockroach-start-single-node.html#logging):
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+cockroach start-single-node --insecure --store=type=mem,size=0.25 --advertise-addr=localhost --log="{file-defaults: {dir: /path/to/logs}, sinks: {stderr: {filter: NONE}}}"
+~~~
+
+The `log` flag has two suboptions:
+
+- `file-defaults`, which specifies the path of the file in which to log events (`/path/to/logs`).
+- `sinks`, which provides a secondary destination to which to log events (`stderr`).
+
+For more information about logging, see [Configure logs](configure-logs.html).
+
+## Use a local file server for bulk operations
+
+To test bulk operations like [`IMPORT`](import.html), [`BACKUP`](backup.html), or [`RESTORE`](restore.html), we recommend using a local file server.
+
+For more details, see [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html).
+
+## See also
+
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Optimize Statement Performance](make-queries-fast.html)

--- a/v21.2/local-testing.md
+++ b/v21.2/local-testing.md
@@ -19,11 +19,9 @@ cockroach start-single-node --insecure --store=type=mem,size=0.25 --advertise-ad
 
 Using in-memory storage improves the speed of the cluster for local testing purposes.
 
-You can also run `cockroach start-single-node` in [secure mode](cockroach-start-single-node.html#security).
-
 ## Log test output to a file
 
-By default, `cockroach start-single-node` logs cluster activity to a file with the [default logging configuration](configure-logs.html#default-logging-configuration). When the `--store=type=mem` flag is specified, the command prints cluster activity directly to the console instead.
+By default, `cockroach start-single-node` logs cluster activity to a file with the [default logging configuration](configure-logs.html#default-logging-configuration). When you specify the `--store=type=mem` flag, the command prints cluster activity directly to the console instead.
 
 To customize logging behavior for local clusters, use the [`--log` flag](cockroach-start-single-node.html#logging):
 
@@ -32,9 +30,10 @@ To customize logging behavior for local clusters, use the [`--log` flag](cockroa
 cockroach start-single-node --insecure --store=type=mem,size=0.25 --advertise-addr=localhost --log="{file-defaults: {dir: /path/to/logs}, sinks: {stderr: {filter: NONE}}}"
 ~~~
 
-This particular command includes two options:
- - `file-defaults`, which specifies the path of the file in which to log events (`/path/to/logs`).
- - `sinks`, which provides a secondary destination to which to log events (`stderr`).
+The `log` flag has two suboptions:
+
+- `file-defaults`, which specifies the path of the file in which to log events (`/path/to/logs`).
+- `sinks`, which provides a secondary destination to which to log events (`stderr`).
 
 For more information about logging, see [Configure logs](configure-logs.html).
 

--- a/v21.2/local-testing.md
+++ b/v21.2/local-testing.md
@@ -1,0 +1,50 @@
+---
+title: Test Your Application
+summary: Best practices for locally testing an application built on CockroachDB
+toc: true
+---
+
+This page documents best practices for unit testing applications built on CockroachDB.
+
+If you are deploying a self-hosted cluster, see the [Production Checklist](recommended-production-settings.html) for information about preparing your cluster for production.
+
+## Use a local, single-node cluster with in-memory storage
+
+The [`cockroach start-single-node`](cockroach-start-single-node.html) command starts a single-node, insecure cluster with [in-memory storage](cockroach-start-single-node.html#store):
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+cockroach start-single-node --insecure --store=type=mem,size=0.25 --advertise-addr=localhost
+~~~
+
+Using in-memory storage improves the speed of the cluster for local testing purposes.
+
+You can also run `cockroach start-single-node` in [secure mode](cockroach-start-single-node.html#security).
+
+## Log test output to a file
+
+By default, `cockroach start-single-node` logs cluster activity to a file with the [default logging configuration](configure-logs.html#default-logging-configuration).
+
+The [`--log` flag](cockroach-start-single-node.html#logging) customizes logging behavior for local clusters:
+
+{% include_cached copy-clipboard.html %}
+~~~ shell
+cockroach start-single-node --insecure --store=type=mem,size=0.25 --advertise-addr=localhost --log="{file-defaults: {dir: /path/to/logs}, sinks: {stderr: {filter: NONE}}}"
+~~~
+
+This particular command includes two options:
+ - `file-defaults`, which specifies the path of the file in which to log events (`/path/to/logs`).
+ - `sinks`, which provides a secondary destination to which to log events (`stderr`).
+
+For more information about logging, see [Configure logs](configure-logs.html).
+
+## Use a local file server for bulk operations
+
+To test bulk operations like [`IMPORT`](import.html), [`BACKUP`](backup.html), or [`RESTORE`](restore.html), we recommend using a local file server.
+
+For more details, see [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html).
+
+## See also
+
+- [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
+- [Optimize Statement Performance](make-queries-fast.html)

--- a/v21.2/local-testing.md
+++ b/v21.2/local-testing.md
@@ -23,9 +23,9 @@ You can also run `cockroach start-single-node` in [secure mode](cockroach-start-
 
 ## Log test output to a file
 
-By default, `cockroach start-single-node` logs cluster activity to a file with the [default logging configuration](configure-logs.html#default-logging-configuration).
+By default, `cockroach start-single-node` logs cluster activity to a file with the [default logging configuration](configure-logs.html#default-logging-configuration). When the `--store=type=mem` flag is specified, the command prints cluster activity directly to the console instead.
 
-The [`--log` flag](cockroach-start-single-node.html#logging) customizes logging behavior for local clusters:
+To customize logging behavior for local clusters, use the [`--log` flag](cockroach-start-single-node.html#logging):
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/10991.

This doc is just the first iteration of an app-testing docs page for developer users. This first iteration can just focus on local unit testing. We can further break this page up into sections for unit testing, integration testing, and automation (see https://github.com/cockroachdb/docs/issues/12077 and https://github.com/cockroachdb/docs/issues/10800).

I initially started working on this to resolve https://github.com/cockroachdb/docs/issues/10991, as it relates to https://cockroachlabs.atlassian.net/browse/CRDB-2459. We don't have full TestContainer support yet (AFAIK), so I just added some extra tips that may/may not be relevant to people reading this page (happy to remove those).

Some open questions:

- Do we really want to recommend unit-testing applications against a local, single-node, insecure cluster? What about free tier/serverless? (see https://github.com/cockroachdb/docs/issues/10991#issuecomment-954015843)
- Are there any more best practices that we can add here? (e.g., cluster settings to temporarily set? third-party unit testing tools to recommend?)