### PR TITLE
update v21.2 self-hosted upgrade doc; fix earlier upgrade docs

### DIFF
--- a/v20.1/upgrade-cockroach-version.md
+++ b/v20.1/upgrade-cockroach-version.md
@@ -10,7 +10,7 @@ Because of CockroachDB's [multi-active availability](multi-active-availability.h
 
 To upgrade to a new version, you must first be on a [production release](../releases/#production-releases) of the previous version. The release does not need to be the **latest** production release of the previous version, but it must be a production release rather than a testing release (alpha/beta).
 
-Therefore, if you are upgrading from v19.2 to v20.1, or from a testing release (alpha/beta) of v19.2 to v20.1:
+Therefore, if you are upgrading from v19.1 to v20.1, or from a testing release (alpha/beta) of v19.2 to v20.1:
 
 1. First [upgrade to a production release of v19.2](../v19.2/upgrade-cockroach-version.html). Be sure to complete all the steps.
 

--- a/v20.2/upgrade-cockroach-version.md
+++ b/v20.2/upgrade-cockroach-version.md
@@ -10,7 +10,7 @@ Because of CockroachDB's [multi-active availability](multi-active-availability.h
 
 To upgrade to a new version, you must first be on a [production release](../releases/#production-releases) of the previous version. The release does not need to be the **latest** production release of the previous version, but it must be a production release rather than a testing release (alpha/beta).
 
-Therefore, if you are upgrading from v20.1 to v20.2, or from a testing release (alpha/beta) of v20.1 to v20.2:
+Therefore, if you are upgrading from v19.2 to v20.2, or from a testing release (alpha/beta) of v20.1 to v20.2:
 
 1. First [upgrade to a production release of v20.1](../v20.1/upgrade-cockroach-version.html). Be sure to complete all the steps.
 

--- a/v21.1/upgrade-cockroach-version.md
+++ b/v21.1/upgrade-cockroach-version.md
@@ -10,7 +10,7 @@ Because of CockroachDB's [multi-active availability](multi-active-availability.h
 
 To upgrade to a new version, you must first be on a [production release](../releases/#production-releases) of the previous version. The release does not need to be the **latest** production release of the previous version, but it must be a production release rather than a testing release (alpha/beta).
 
-Therefore, if you are upgrading from v20.1 to v20.2, or from a testing release (alpha/beta) of v20.2 to v21.1:
+Therefore, if you are upgrading from v20.1 to v21.1, or from a testing release (alpha/beta) of v20.2 to v21.1:
 
 1. First [upgrade to a production release of v20.2](../v20.2/upgrade-cockroach-version.html). Be sure to complete all the steps.
 

--- a/v21.2/upgrade-cockroach-version.md
+++ b/v21.2/upgrade-cockroach-version.md
@@ -12,7 +12,7 @@ To upgrade to a new version, you must first be on a [production release](../rele
 
 Therefore, to upgrade to v21.2:
 
-- If your current CockroachDB version is a v20.2 (or earlier) release, or a v21.1 testing release (alpha/beta):
+- If your current CockroachDB version is a v20.2 release or earlier, or a v21.1 testing release (alpha/beta):
     1. First [upgrade to a production release of v21.1](../v21.1/upgrade-cockroach-version.html). Be sure to complete all the steps.
     1. Return to this page and perform a second rolling upgrade to v21.2, starting from [step 2](#step-2-prepare-to-upgrade).
 
@@ -41,8 +41,6 @@ Verify the overall health of your cluster using the [DB Console](ui-overview.htm
 ### Review breaking changes
 
 Review the [changes in v21.2](../releases/v21.2.html). If any affect your deployment, make the necessary changes before starting the rolling upgrade to v21.2.
-
-Changes that are important to note:
 
 - Interleaving data was deprecated in v20.2, disabled by default in v21.1, and permanently removed in v21.2. If your cluster contains interleaved data, you will not be able to finalize an upgrade to v21.2. For migration steps, see the [v21.1 interleaving deprecation notice](../v21.1/interleave-in-parent.html#deprecation).
 - The `cloudstorage.gs.default.key` [cluster setting](cluster-settings.html) was deprecated in v21.1 and has been removed from v21.2. The `default` authentication mode for Google Cloud Storage is no longer supported. It is necessary to use either `specified` or `implicit` as `AUTH` parameters when connecting to Google Cloud Storage. See the [Authentication section — Bulk Operations](use-cloud-storage-for-bulk-operations.html#google-cloud-storage) for details on configuring these parameters. 

--- a/v21.2/upgrade-cockroach-version.md
+++ b/v21.2/upgrade-cockroach-version.md
@@ -8,15 +8,15 @@ Because of CockroachDB's [multi-active availability](multi-active-availability.h
 
 ## Step 1. Verify that you can upgrade
 
-To upgrade to a new version, you must first be on a [production release](../releases/#production-releases) of the previous version. The release does not need to be the **latest** production release of the previous version, but it must be a production release rather than a testing release (alpha/beta).
+To upgrade to a new version, you must first be on a [production release](../releases/#production-releases) of the previous version. The release does not need to be the latest production release of the previous version, but it **must be a production release** and not a [testing release (alpha/beta)](../releases/#testing-releases).
 
-Therefore, if you are upgrading from v20.2 to v21.1, or from a testing release (alpha/beta) of v21.1 to v21.2:
+Therefore, to upgrade to v21.2:
 
-1. First [upgrade to a production release of v21.1](../v21.1/upgrade-cockroach-version.html). Be sure to complete all the steps.
+- If your current CockroachDB version is a v20.2 (or earlier) release, or a v21.1 testing release (alpha/beta):
+    1. First [upgrade to a production release of v21.1](../v21.1/upgrade-cockroach-version.html). Be sure to complete all the steps.
+    1. Return to this page and perform a second rolling upgrade to v21.2, starting from [step 2](#step-2-prepare-to-upgrade).
 
-2. Then return to this page and perform a second rolling upgrade to v21.2.
-
-If you are upgrading from any production release of v21.1, or from any earlier v21.2 release, you do not have to go through intermediate releases; continue to step 2.
+- If your current CockroachDB version is any v21.1 production release, or any earlier v21.2 release, you do not have to go through intermediate releases; continue to [step 2](#step-2-prepare-to-upgrade).
 
 ## Step 2. Prepare to upgrade
 
@@ -72,13 +72,12 @@ By default, after all nodes are running the new version, the upgrade process wil
 
 When upgrading from v21.1 to v21.2, certain features and performance improvements will be enabled only after finalizing the upgrade, including but not limited to:
 
-- **Improved multi-region features:** After finalization, it will be possible to use new and improved [multi-region features](multiregion-overview.html), such as the ability to set database regions, survival goals, and table localities. Internal capabilities supporting these features, such as [non-voting replicas](architecture/replication-layer.html#non-voting-replicas) and [non-blocking transactions](architecture/transaction-layer.html#non-blocking-transactions), will be available after finalization as well.
-
-- **Empty arrays in inverted indexes:** After finalization, newly created [inverted indexes](inverted-indexes.html) will contain rows containing empty arrays in [`ARRAY`](array.html) columns, which allows the indexes to be used for more queries. Note, however, that rows containing `NULL` values in an indexed column will still not be included in inverted indexes.
-
-- **Virtual computed columns:** After finalization, it will be possible to use the `VIRTUAL` keyword to define [virtual computed columns](computed-columns.html).
-
-- **Changefeed support for primary key changes:** After finalization, [changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html) will detect primary key changes.
+- Expression indexes
+- Default privileges on database objects
+- Bounded staleness reads
+- Database placement using the `ALTER DATABASE ... PLACEMENT RESTRICTED` syntax
+- `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` syntax in column definitions
+- `ON UPDATE` column expressions
 
 ## Step 4. Perform the rolling upgrade
 


### PR DESCRIPTION
Fixes #12138.

- Updated the v21.2 self-hosted upgrade doc:
  - Added (tentative) list of features that require upgrade finalization
  - Tried to clarify the wording of the version requirements in Step 1.
- Also corrected some earlier upgrade docs that were naming incorrect versions.