### PR TITLE
add v21.2 upgrade doc for cloud

### DIFF
--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -232,6 +232,12 @@
       	      ]
       	    },
             {
+              "title": "Upgrade to v21.2",
+              "urls": [
+                 "/cockroachcloud/upgrade-to-v21.2.html"
+              ]
+            },
+            {
       	      "title": "Upgrade to v21.1",
       	      "urls": [
       		       "/cockroachcloud/upgrade-to-v21.1.html"

--- a/cockroachcloud/frequently-asked-questions.md
+++ b/cockroachcloud/frequently-asked-questions.md
@@ -141,7 +141,7 @@ The following pages can be found in our [Terms & Conditions](https://www.cockroa
 
 ### Am I in control of upgrades for my {{ site.data.products.dedicated }} clusters?
 
-Yes, you can apply major release upgrades directly [through the {{ site.data.products.db }} Console](upgrade-to-v20.2.html); however, minor release upgrades are automatically applied to all clusters. {{ site.data.products.dedicated }} clusters are restarted for minor version updates, so previously established connections will need to be [reestablished after the restart](../v21.1/connection-pooling.html#validating-connections-in-a-pool). For more information, see the [Upgrade Policy](upgrade-policy.html).
+Yes, a Console Admin can apply major release upgrades directly [through the {{ site.data.products.db }} Console](upgrade-to-v21.2.html); however, minor release upgrades are automatically applied to all clusters. {{ site.data.products.dedicated }} clusters are restarted for patch version updates, so previously established connections will need to be [reestablished after the restart](../v21.2/connection-pooling.html#validating-connections-in-a-pool). For more information, see the [Upgrade Policy](upgrade-policy.html).
 
 ### What is the support policy for older versions of the software?
 

--- a/cockroachcloud/frequently-asked-questions.md
+++ b/cockroachcloud/frequently-asked-questions.md
@@ -141,7 +141,7 @@ The following pages can be found in our [Terms & Conditions](https://www.cockroa
 
 ### Am I in control of upgrades for my {{ site.data.products.dedicated }} clusters?
 
-Yes, a Console Admin can apply major release upgrades directly [through the {{ site.data.products.db }} Console](upgrade-to-v21.2.html); however, minor release upgrades are automatically applied to all clusters. {{ site.data.products.dedicated }} clusters are restarted for patch version updates, so previously established connections will need to be [reestablished after the restart](../v21.2/connection-pooling.html#validating-connections-in-a-pool). For more information, see the [Upgrade Policy](upgrade-policy.html).
+Yes, a Console Admin can apply major release upgrades directly [through the {{ site.data.products.db }} Console](upgrade-to-v21.2.html); however, patch release upgrades are automatically applied to all clusters. {{ site.data.products.dedicated }} clusters are restarted one node at a time for patch version updates, so previously established connections will need to be [reestablished after the restart](../v21.2/connection-pooling.html#validating-connections-in-a-pool). For more information, see the [Upgrade Policy](upgrade-policy.html).
 
 ### What is the support policy for older versions of the software?
 

--- a/cockroachcloud/upgrade-policy.md
+++ b/cockroachcloud/upgrade-policy.md
@@ -6,15 +6,17 @@ toc: true
 
 This page describes the upgrade policy for {{ site.data.products.db }}.
 
-{{ site.data.products.db }} supports the latest major version of CockroachDB and the version immediately preceding it. Support for these versions includes minor version updates and security patches.
+{{ site.data.products.db }} supports the latest major version of CockroachDB and the version immediately preceding it. Support for these versions includes patch version updates and security patches.
 
 {{site.data.alerts.callout_danger}}
-[{{ site.data.products.serverless }}](quickstart.html) clusters are subject to automatic upgrades for both minor and major releases.
+[{{ site.data.products.serverless }}](quickstart.html) clusters are subject to automatic upgrades for both major and patch releases.
 {{site.data.alerts.end}}
 
-## Minor version upgrades
+## Patch version upgrades
 
-[Minor versions](https://www.cockroachlabs.com/docs/releases/) (or "point" releases) are stable, backward-compatible improvements to the major versions of CockroachDB. All clusters, including both {{ site.data.products.serverless }} and {{ site.data.products.dedicated }} clusters, are subject to automatic upgrades to the latest supported minor version (for example, v21.1.0 → v21.1.1). Because these upgrades cause nodes to restart, it's important to use [connection retry logic](production-checklist.html#keeping-connections-current) in your application.
+Patch version [releases](../releases/), or "maintenance" releases, contain stable, backward-compatible improvements to the major versions of CockroachDB (for example, v21.2.0 → v21.2.1). 
+
+All {{ site.data.products.serverless }} and {{ site.data.products.dedicated }} clusters are subject to automatic upgrades to the latest supported patch version. Because these upgrades cause nodes to restart, it's important to use [connection retry logic](production-checklist.html#keeping-connections-current) in your application.
 
 {{site.data.alerts.callout_danger}}
 Single-node clusters will experience some downtime during cluster maintenance.
@@ -22,22 +24,24 @@ Single-node clusters will experience some downtime during cluster maintenance.
 
 ## Major version upgrades
 
-[Major version releases](../releases/) contain new functionality and potentially backward-incompatible changes to CockroachDB (for example, v20.2.x → v21.1.x).
+Major version [releases](../releases/) (for example, v21.1.x → v21.2.x) contain new functionality and potentially backward-incompatible changes to CockroachDB.
 
-[Console Admins](console-access-management.html#console-admin) must initiate major version upgrades. When a new major version is available, Admins will be able to [start an upgrade directly from the {{ site.data.products.db }} Console](upgrade-to-v21.1.html) for clusters using the paid version of {{ site.data.products.dedicated }}. When you initiate a major version upgrade for your cluster, it will upgrade to the latest minor version as well. {{ site.data.products.serverless }} clusters are subject to automatic upgrades to the latest supported major version.
-
-### Support downgrade for older CockroachDB versions
-
-As CockroachDB releases new major versions, older versions reach their End of Support (EOS) on {{ site.data.products.db }}. A CockroachDB version reaches EOS when it is 2 major versions behind the latest version. For example, now that CockroachDB v21.1 has been released, CockroachDB v20.1 has reached EOS.
-
-Clusters running unsupported CockroachDB versions are not eligible for our [availability SLA](https://www.cockroachlabs.com/cloud-terms-and-conditions). Further downgrades in support may occur as per the [CockroachDB Release Support Policy](../releases/release-support-policy.html).
-
-If you are running a CockroachDB version nearing EOS, you will be reminded at least one month before that version’s EOS that your clusters must be upgraded by the EOS date to avoid losing support. You can [upgrade your cluster](upgrade-to-v21.1.html) directly from the {{ site.data.products.db }} Console.
+Major version upgrades are automatic for {{ site.data.products.serverless }} clusters and opt-in for {{ site.data.products.dedicated }} clusters. [Console Admins](console-access-management.html#console-admin) must initiate major version upgrades for {{ site.data.products.dedicated }} clusters. When a new major version is available, Admins will be able to [start an upgrade](upgrade-to-v21.2.html) from the {{ site.data.products.db }} Console for clusters using the paid version of {{ site.data.products.dedicated }}. When a major version upgrade is initiated for a cluster, it will upgrade to the latest patch version as well.
 
 ### Rollback support
 
-When you upgrade to a new major version, once all nodes are running the new version, you have approximately 72 hours before the upgrade is automatically finalized. During this window, if you see unexpected behavior, you can trigger a rollback to the previous major version directly from the {{ site.data.products.db }} Console. If you see problems after the upgrade has been finalized, it will not be possible to roll back via the {{ site.data.products.db }} Console; you will have to [reach out to support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+When upgrading a {{ site.data.products.dedicated }} cluster to a new major version, once all nodes are running the new version, you have approximately 72 hours before the upgrade is automatically finalized. During this window, if you see unexpected behavior, you can [trigger a rollback to the previous major version](upgrade-to-v21.2.html#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
+
+If you see problems after the upgrade has been finalized, it will not be possible to roll back via the {{ site.data.products.db }} Console; you will have to [reach out to support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+
+### End of Support for older CockroachDB versions
+
+As CockroachDB releases new major versions, older versions reach their End of Support (EOS) on {{ site.data.products.db }}. A CockroachDB version reaches EOS when it is 2 major versions behind the latest version. For example, now that CockroachDB v21.2 has been released, CockroachDB v20.2 has reached EOS.
+
+Clusters running unsupported CockroachDB versions are not eligible for our [availability SLA](https://www.cockroachlabs.com/cloud-terms-and-conditions). Further downgrades in support may occur as per the [CockroachDB Release Support Policy](../releases/release-support-policy.html).
+
+If you are running a CockroachDB version nearing EOS, you will be reminded at least one month before that version’s EOS that your clusters must be upgraded by the EOS date to avoid losing support. A Console Admin can [upgrade your cluster](upgrade-to-v21.2.html) directly from the {{ site.data.products.db }} Console.
 
 ## See also
 
-For more details about the upgrade and finalization process, see [Upgrade to the Latest CockroachDB Version](upgrade-to-v21.1.html).
+For more details about the upgrade and finalization process, see [Upgrade to the Latest CockroachDB Version](upgrade-to-v21.2.html).

--- a/cockroachcloud/upgrade-policy.md
+++ b/cockroachcloud/upgrade-policy.md
@@ -16,7 +16,7 @@ This page describes the upgrade policy for {{ site.data.products.db }}.
 
 Patch version [releases](../releases/), or "maintenance" releases, contain stable, backward-compatible improvements to the major versions of CockroachDB (for example, v21.2.0 → v21.2.1). 
 
-All {{ site.data.products.serverless }} and {{ site.data.products.dedicated }} clusters are subject to automatic upgrades to the latest supported patch version. Because these upgrades cause nodes to restart, it's important to use [connection retry logic](production-checklist.html#keeping-connections-current) in your application.
+All {{ site.data.products.serverless }} and {{ site.data.products.dedicated }} clusters are subject to automatic upgrades to the latest supported patch version. To ensure that connections remain current during these upgrades, it's important to use [connection retry logic](production-checklist.html#keeping-connections-current) in your application.
 
 {{site.data.alerts.callout_danger}}
 Single-node clusters will experience some downtime during cluster maintenance.

--- a/cockroachcloud/upgrade-to-v21.1.md
+++ b/cockroachcloud/upgrade-to-v21.1.md
@@ -115,7 +115,7 @@ During rollback, nodes will be reverted to v20.2 one at a time without interrupt
 </section>
 
 <section class="filter-content" markdown="1" data-scope="single-node">
-Because your cluster contains a single node, the cluster will be briefly unavailable while the node is stopped and restarted with v20.2. Be sure to prepare for this brief unavailability before starting the rollback.
+Because your cluster contains a single node, the cluster will be briefly unavailable while the node is stopped and restarted with v21.1. Be sure to prepare for this brief unavailability before starting the rollback.
 </section>
 
 ## See also

--- a/cockroachcloud/upgrade-to-v21.2.md
+++ b/cockroachcloud/upgrade-to-v21.2.md
@@ -7,7 +7,7 @@ toc: true
 Now that [CockroachDB v21.2](../releases/v21.2.0.html) is available, a [Console Admin](console-access-management.html#console-admin) can upgrade your {{ site.data.products.dedicated }} cluster from the {{ site.data.products.db }} Console. This page walks through the process for an Admin.
 
 {{site.data.alerts.callout_success}}
-Upgrading a {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the {{ site.data.products.db }} [upgrade policy](upgrade-policy).
+Upgrading a {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the {{ site.data.products.db }} [upgrade policy](upgrade-policy.html).
 {{site.data.alerts.end}}
 
 ## Step 1. Verify that you can upgrade

--- a/cockroachcloud/upgrade-to-v21.2.md
+++ b/cockroachcloud/upgrade-to-v21.2.md
@@ -4,10 +4,10 @@ summary: Learn how to upgrade your CockroachDB cluster to v21.2.
 toc: true
 ---
 
-Now that [CockroachDB v21.2](../releases/v21.2.0.html) is available, a [Console Admin](console-access-management.html#console-admin) can upgrade your cluster directly from the {{ site.data.products.db }} Console. This page walks through the process for an Admin.
+Now that [CockroachDB v21.2](../releases/v21.2.0.html) is available, a [Console Admin](console-access-management.html#console-admin) can upgrade your {{ site.data.products.dedicated }} cluster from the {{ site.data.products.db }} Console. This page walks through the process for an Admin.
 
 {{site.data.alerts.callout_success}}
-Upgrading to a new major version is opt-in. Before proceeding, review the {{ site.data.products.db }} [upgrade policy](upgrade-policy).
+Upgrading a {{ site.data.products.dedicated }} cluster to a new major version is opt-in. Before proceeding, review the {{ site.data.products.db }} [upgrade policy](upgrade-policy).
 {{site.data.alerts.end}}
 
 ## Step 1. Verify that you can upgrade

--- a/cockroachcloud/upgrade-to-v21.2.md
+++ b/cockroachcloud/upgrade-to-v21.2.md
@@ -4,11 +4,15 @@ summary: Learn how to upgrade your CockroachDB cluster to v21.2.
 toc: true
 ---
 
-Now that [CockroachDB v21.2](../releases/v21.2.0.html) is available, your [Console Admin](console-access-management.html#console-admin) can upgrade your cluster directly from the {{ site.data.products.db }} Console. This page walks through the process.
+Now that [CockroachDB v21.2](../releases/v21.2.0.html) is available, a [Console Admin](console-access-management.html#console-admin) can upgrade your cluster directly from the {{ site.data.products.db }} Console. This page walks through the process for an Admin.
+
+{{site.data.alerts.callout_success}}
+Upgrading to a new major version is opt-in. Before proceeding, review the {{ site.data.products.db }} [upgrade policy](upgrade-policy).
+{{site.data.alerts.end}}
 
 ## Step 1. Verify that you can upgrade
 
-To upgrade to v21.2, you must be running v21.1. If you are not running v21.1, [upgrade to v21.1](upgrade-to-v21.1.html) and then return to this page and continue to Step 2.
+To upgrade to v21.2, you must be running v21.1. If you are not running v21.1, first [upgrade to v21.1](upgrade-to-v21.1.html). Then return to this page and continue to [Step 2](#step-2-select-your-cluster-size).
 
 ## Step 2. Select your cluster size
 
@@ -19,38 +23,37 @@ The upgrade process depends on the number of nodes in your cluster. Select wheth
   <button class="filter-button" data-scope="single-node">Single-node</button>
 </div>
 
-## Step 3. Understand the process
+## Step 3. Understand the upgrade process
 
 <section class="filter-content" markdown="1" data-scope="multi-node">
+In a multi-node cluster, the upgrade does not interrupt the cluster's overall health and availability. One node is stopped and restarted with the new version, then the next, and so on, pausing for a few minutes between each node. This "rolling upgrade" takes approximately 4-5 minutes per node and is enabled by CockroachDB's [multi-active availability](../{{site.versions["stable"]}}/multi-active-availability.html) design.
 
-In a multi-node cluster, the upgrade happens without interrupting the cluster's overall health and availability. One node is stopped and restarted with the new version, then the next, and so on, with a few minutes pause between each. In total, this "rolling upgrade" approach takes approximately 4-5 minutes per node and is possible due to CockroachDB's [multi-active availability](../{{site.versions["stable"]}}/multi-active-availability.html) design.
-
-Approximately 72 hours after all nodes are running v21.2, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v21.2](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.1, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, trigger a rollback from the {{ site.data.products.db }} Console.
-
+Approximately 72 hours after all nodes are running v21.2, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v21.2](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.1, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
 </section>
-<section class="filter-content" markdown="1" data-scope="single-node">
 
+<section class="filter-content" markdown="1" data-scope="single-node">
 When you start the upgrade, the cluster will be unavailable for a few minutes while the node is stopped and restarted with v21.2.
 
-Approximately 72 hours after the node has been restarted, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v21.2](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.1, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, trigger a rollback from the {{ site.data.products.db }} Console.
-
+Approximately 72 hours after the node has been restarted, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v21.2](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.1, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, [roll back the upgrade](#roll-back-the-upgrade) from the {{ site.data.products.db }} Console.
 </section>
 
 ## Step 4. Prepare to upgrade
 
- Before starting the upgrade, it's important to complete the following steps.
+ Before starting the upgrade, complete the following steps.
 
 <section class="filter-content" markdown="1" data-scope="single-node">
 
 ### Prepare for brief unavailability
 
-Because your cluster will be unavailable while its single node is stopped and restarted with v21.2, prepare your application for this brief downtime, typically a few minutes. Also during this time, the [**SQL Users**](user-authorization.html#create-a-sql-user) and [**Monitoring**](monitoring-page.html) tabs in the {{ site.data.products.db }} Console will be disabled.
+Your cluster will be unavailable while its single node is stopped and restarted with v21.2. Prepare your application for this brief downtime, typically a few minutes.
+
+The [**SQL Users**](user-authorization.html#create-a-sql-user) and [**Monitoring**](monitoring-page.html) tabs in the {{ site.data.products.db }} Console will also be disabled during this time.
 
 </section>
 
 ### Review breaking changes
 
-Review the [backward-incompatible changes in v21.2](../releases/v21.2.0.html#backward-incompatible-changes), and if any affect your application, make necessary changes.
+Review the [backward-incompatible changes in v21.2](../releases/v21.2.0.html#backward-incompatible-changes). If any affect your application, make necessary changes.
 
 ## Step 5. Start the upgrade
 
@@ -60,33 +63,35 @@ To start the upgrade process:
 
 2. In the **Clusters** list, select the cluster you want to upgrade.
 
-3. Select **Actions > Upgrade cluster**.
+3. Select **Actions > Upgrade major version**. 
 
-4. On the **Upgrade your cluster** dialog, confirm that you have reviewed the pre-upgrade guidance and then click **Start Upgrade**.
+4. In the **Upgrade your cluster** dialog, review the pre-upgrade message and then click **Start Upgrade**.
 
 <section class="filter-content" markdown="1" data-scope="multi-node">
-As mentioned earlier, your cluster will be upgraded one node at a time without interrupting the cluster's overall health and availability. This "rolling upgrade" approach will take approximately 4-5 minutes per node.
+Your cluster will be upgraded one node at a time without interrupting the cluster's overall health and availability. This "rolling upgrade" will take approximately 4-5 minutes per node.
 </section>
 
 <section class="filter-content" markdown="1" data-scope="single-node">
-As mentioned earlier, your single-node cluster will be unavailable for a few minutes while the node is stopped and restarted with v21.1.
+Your single-node cluster will be unavailable for a few minutes while the node is stopped and restarted with v21.2.
 </section>
 
 ## Step 6. Monitor the upgrade
 
-Once your cluster is running v21.2, you will have approximately 72 hours before the upgrade is automatically finalized. During this time, it is important to monitor your application and respect temporary limitations.
+Once your cluster is running v21.2, you will have approximately 72 hours before the upgrade is automatically finalized. During this time, it is important to [monitor your application](#monitor-your-application) and [respect temporary limitations](#respect-temporary-limitations).
+
+If you see unexpected behavior, you can [roll back](#roll-back-the-upgrade) to v21.1 during the 72-hour window. 
 
 ### Monitor your application
 
 Use the [DB Console](monitoring-page.html) or your own tooling to monitor your application for any unexpected behavior.
 
-- If everything looks good, you can wait for the upgrade to automatically finalize or you can [trigger finalization more quickly](#finalize-the-upgrade).
+- If everything looks good, you can wait for the upgrade to automatically finalize or you can [manually trigger finalization](#finalize-the-upgrade).
 
-- If you see unexpected behavior, you can [rollback to v21.1](#roll-back-the-upgrade). This option is available only during the 72-hour window. If you see unexpected behavior after the upgrade has been finalized, you will have to [reach out to support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+- If you see unexpected behavior, you can [roll back to v21.1](#roll-back-the-upgrade) during the 72-hour window.
 
 ### Respect temporary limitations
 
-Most v21.2 features can be used right away, but there are some that will be enabled only after the upgrade has been finalized. Attempting to use these features before then will result in errors:
+Most v21.2 features can be used right away, but some will be enabled only after the upgrade has been finalized. Attempting to use these features before finalization will result in errors:
 
 - Expression indexes
 - Default privileges on database objects
@@ -95,17 +100,9 @@ Most v21.2 features can be used right away, but there are some that will be enab
 - `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` syntax in column definitions
 - `ON UPDATE` column expressions
 
-## Step 7. Finish the upgrade
-
-During the 72-hour window before the upgrade is automatically finalized, if you see unexpected behavior, you can trigger a rollback to v21.1. If everything looks good, you also have the choice to finalize the upgrade more quickly so as to lift the [temporary limitations](#respect-temporary-limitations) in place during the upgrade.
-
-### Finalize the upgrade
-
-To finalize the upgrade, click **Finalize** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Finalize upgrade**.
-
-At this point, all [temporary limitations](#respect-temporary-limitations) are lifted, and all v21.2 features are available for use. However, it's no longer possible to roll back to v21.1. If you see unexpected behavior, [reach out to support](https://support.cockroachlabs.com/hc/en-us/requests/new).
-
 ### Roll back the upgrade
+
+If you see unexpected behavior, you can roll back the upgrade during the 72-hour window.
 
 To stop the upgrade and roll back to v21.1, click **Roll back** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Roll back upgrade**.
 
@@ -114,8 +111,20 @@ During rollback, nodes will be reverted to v21.1 one at a time without interrupt
 </section>
 
 <section class="filter-content" markdown="1" data-scope="single-node">
-Because your cluster contains a single node, the cluster will be briefly unavailable while the node is stopped and restarted with v21.1. Be sure to prepare for this brief unavailability before starting the rollback.
+Because your cluster contains a single node, the cluster will be briefly unavailable while the node is stopped and restarted with v21.1. Be sure to [prepare for this brief unavailability](#prepare-for-brief-unavailability) before starting the rollback.
 </section>
+
+## Step 7. Complete the upgrade
+
+If everything looks good, you can wait for the upgrade to automatically finalize, or you can manually trigger finalization to lift the [temporary limitations](#respect-temporary-limitations) on the cluster more quickly.
+
+### Finalize the upgrade
+
+The upgrade is automatically finalized after 72 hours. 
+
+To manually finalize the upgrade, click **Finalize** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Finalize upgrade**.
+
+After finalization, all [temporary limitations](#respect-temporary-limitations) will be lifted, and all v21.2 features are available for use. However, it will no longer be possible to roll back to v21.1. If you see unexpected behavior after the upgrade has been finalized, [contacts support](https://support.cockroachlabs.com/hc/en-us/requests/new).
 
 ## See also
 

--- a/cockroachcloud/upgrade-to-v21.2.md
+++ b/cockroachcloud/upgrade-to-v21.2.md
@@ -53,7 +53,7 @@ The [**SQL Users**](user-authorization.html#create-a-sql-user) and [**Monitoring
 
 ### Review breaking changes
 
-Review the [backward-incompatible changes in v21.2](../releases/v21.2.0.html#backward-incompatible-changes). If any affect your application, make necessary changes.
+Review the [backward-incompatible changes in v21.2](../releases/v21.2.0.html#backward-incompatible-changes). If any affect your applications, make the necessary changes before proceeding.
 
 ## Step 5. Start the upgrade
 
@@ -125,7 +125,7 @@ The upgrade is automatically finalized after 72 hours.
 
 To manually finalize the upgrade, click **Finalize** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Finalize upgrade**.
 
-After finalization, all [temporary limitations](#respect-temporary-limitations) will be lifted, and all v21.2 features are available for use. However, it will no longer be possible to roll back to v21.1. If you see unexpected behavior after the upgrade has been finalized, [contacts support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+After finalization, all [temporary limitations](#respect-temporary-limitations) will be lifted, and all v21.2 features are available for use. However, it will no longer be possible to roll back to v21.1. If you see unexpected behavior after the upgrade has been finalized, [contact support](https://support.cockroachlabs.com/hc/en-us/requests/new).
 
 ## See also
 

--- a/cockroachcloud/upgrade-to-v21.2.md
+++ b/cockroachcloud/upgrade-to-v21.2.md
@@ -93,12 +93,13 @@ Use the [DB Console](monitoring-page.html) or your own tooling to monitor your a
 
 Most v21.2 features can be used right away, but some will be enabled only after the upgrade has been finalized. Attempting to use these features before finalization will result in errors:
 
-- Expression indexes
-- Default privileges on database objects
-- Bounded staleness reads
-- Database placement using the `ALTER DATABASE ... PLACEMENT RESTRICTED` syntax
-- `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` syntax in column definitions
-- `ON UPDATE` column expressions
+- **Expression indexes:** [Indexes on expressions](../v21.2/expression-indexes.html) can now be created. These indexes speed up queries that filter on the result of that expression, and are especially useful for indexing only a specific field of a `JSON` object.
+- **Privilege inheritance:** CockroachDB's model for inheritance of privileges that cascade from schema objects now matches PostgreSQL. Added support for [`ALTER DEFAULT PRIVILEGES`](../v21.2/alter-default-privileges.html) and [`SHOW DEFAULT PRIVILEGES`](../v21.2/show-default-privileges.html).
+- **Bounded staleness reads:** [Bounded staleness reads](../v21.2/follower-reads.html#bounded-staleness-reads) are now available in CockroachDB. These use a dynamic, system-determined timestamp to minimize staleness while being more tolerant to replication lag than exact staleness reads. This dynamic timestamp is returned by the `with_min_timestamp()` or `with_max_staleness()` [functions](../v21.2/functions-and-operators.html). In addition, bounded staleness reads provide the ability to serve reads from local replicas even in the presence of network partitions or other failures.
+- **Restricted and default placement:** You can now use the [`ALTER DATABASE ... PLACEMENT RESTRICTED`](../v21.2/placement-restricted.html) statement to constrain the replica placement for a [multi-region database](../v21.2/multiregion-overview.html)'s [regional tables](../v21.2/regional-tables.html) to the [home regions](../v21.2/set-locality.html#crdb_region) associated with those tables.
+- **`ON UPDATE` expressions:** An [`ON UPDATE` expression](../v21.2/add-column.html#add-a-column-with-an-on-update-expression) can now be added to a column to update column values when an [`UPDATE`](../v21.2/update.html) or [`UPSERT`](../v21.2/upsert.html) statement modifies a different column value in the same row, or when an `ON UPDATE CASCADE` expression on a different column modifies an existing value in the same row.
+
+For an expanded list of features included in the v21.2 release, see the [v21.2 release notes](../releases/v21.2.0.html).
 
 ### Roll back the upgrade
 

--- a/cockroachcloud/upgrade-to-v21.2.md
+++ b/cockroachcloud/upgrade-to-v21.2.md
@@ -1,0 +1,123 @@
+---
+title: Upgrade to CockroachDB v21.2
+summary: Learn how to upgrade your CockroachDB cluster to v21.2.
+toc: true
+---
+
+Now that [CockroachDB v21.2](../releases/v21.2.0.html) is available, your [Console Admin](console-access-management.html#console-admin) can upgrade your cluster directly from the {{ site.data.products.db }} Console. This page walks through the process.
+
+## Step 1. Verify that you can upgrade
+
+To upgrade to v21.2, you must be running v21.1. If you are not running v21.1, [upgrade to v21.1](upgrade-to-v21.1.html) and then return to this page and continue to Step 2.
+
+## Step 2. Select your cluster size
+
+The upgrade process depends on the number of nodes in your cluster. Select whether your cluster has multiple nodes or a single node:
+
+<div class="filters filters-big clearfix">
+  <button class="filter-button" data-scope="multi-node">Multi-node</button>
+  <button class="filter-button" data-scope="single-node">Single-node</button>
+</div>
+
+## Step 3. Understand the process
+
+<section class="filter-content" markdown="1" data-scope="multi-node">
+
+In a multi-node cluster, the upgrade happens without interrupting the cluster's overall health and availability. One node is stopped and restarted with the new version, then the next, and so on, with a few minutes pause between each. In total, this "rolling upgrade" approach takes approximately 4-5 minutes per node and is possible due to CockroachDB's [multi-active availability](../{{site.versions["stable"]}}/multi-active-availability.html) design.
+
+Approximately 72 hours after all nodes are running v21.2, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v21.2](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.1, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, trigger a rollback from the {{ site.data.products.db }} Console.
+
+</section>
+<section class="filter-content" markdown="1" data-scope="single-node">
+
+When you start the upgrade, the cluster will be unavailable for a few minutes while the node is stopped and restarted with v21.2.
+
+Approximately 72 hours after the node has been restarted, the upgrade will be automatically finalized. This enables certain [features and performance improvements introduced in v21.2](#respect-temporary-limitations). Finalization also removes the ability to roll back to v21.1, so it's important to monitor your application during this 72-hour window and, if you see unexpected behavior, trigger a rollback from the {{ site.data.products.db }} Console.
+
+</section>
+
+## Step 4. Prepare to upgrade
+
+ Before starting the upgrade, it's important to complete the following steps.
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+
+### Prepare for brief unavailability
+
+Because your cluster will be unavailable while its single node is stopped and restarted with v21.2, prepare your application for this brief downtime, typically a few minutes. Also during this time, the [**SQL Users**](user-authorization.html#create-a-sql-user) and [**Monitoring**](monitoring-page.html) tabs in the {{ site.data.products.db }} Console will be disabled.
+
+</section>
+
+### Review breaking changes
+
+Review the [backward-incompatible changes in v21.2](../releases/v21.2.0.html#backward-incompatible-changes), and if any affect your application, make necessary changes.
+
+## Step 5. Start the upgrade
+
+To start the upgrade process:
+
+1. [Sign in](https://cockroachlabs.cloud/) to your {{ site.data.products.db }} account.
+
+2. In the **Clusters** list, select the cluster you want to upgrade.
+
+3. Select **Actions > Upgrade cluster**.
+
+4. On the **Upgrade your cluster** dialog, confirm that you have reviewed the pre-upgrade guidance and then click **Start Upgrade**.
+
+<section class="filter-content" markdown="1" data-scope="multi-node">
+As mentioned earlier, your cluster will be upgraded one node at a time without interrupting the cluster's overall health and availability. This "rolling upgrade" approach will take approximately 4-5 minutes per node.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+As mentioned earlier, your single-node cluster will be unavailable for a few minutes while the node is stopped and restarted with v21.1.
+</section>
+
+## Step 6. Monitor the upgrade
+
+Once your cluster is running v21.2, you will have approximately 72 hours before the upgrade is automatically finalized. During this time, it is important to monitor your application and respect temporary limitations.
+
+### Monitor your application
+
+Use the [DB Console](monitoring-page.html) or your own tooling to monitor your application for any unexpected behavior.
+
+- If everything looks good, you can wait for the upgrade to automatically finalize or you can [trigger finalization more quickly](#finalize-the-upgrade).
+
+- If you see unexpected behavior, you can [rollback to v21.1](#roll-back-the-upgrade). This option is available only during the 72-hour window. If you see unexpected behavior after the upgrade has been finalized, you will have to [reach out to support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+
+### Respect temporary limitations
+
+Most v21.2 features can be used right away, but there are some that will be enabled only after the upgrade has been finalized. Attempting to use these features before then will result in errors:
+
+- Expression indexes
+- Default privileges on database objects
+- Bounded staleness reads
+- Database placement using the `ALTER DATABASE ... PLACEMENT RESTRICTED` syntax
+- `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` syntax in column definitions
+- `ON UPDATE` column expressions
+
+## Step 7. Finish the upgrade
+
+During the 72-hour window before the upgrade is automatically finalized, if you see unexpected behavior, you can trigger a rollback to v21.1. If everything looks good, you also have the choice to finalize the upgrade more quickly so as to lift the [temporary limitations](#respect-temporary-limitations) in place during the upgrade.
+
+### Finalize the upgrade
+
+To finalize the upgrade, click **Finalize** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Finalize upgrade**.
+
+At this point, all [temporary limitations](#respect-temporary-limitations) are lifted, and all v21.2 features are available for use. However, it's no longer possible to roll back to v21.1. If you see unexpected behavior, [reach out to support](https://support.cockroachlabs.com/hc/en-us/requests/new).
+
+### Roll back the upgrade
+
+To stop the upgrade and roll back to v21.1, click **Roll back** in the banner at the top of the {{ site.data.products.db }} Console, and then click **Roll back upgrade**.
+
+<section class="filter-content" markdown="1" data-scope="multi-node">
+During rollback, nodes will be reverted to v21.1 one at a time without interrupting the cluster's health and availability.
+</section>
+
+<section class="filter-content" markdown="1" data-scope="single-node">
+Because your cluster contains a single node, the cluster will be briefly unavailable while the node is stopped and restarted with v21.1. Be sure to prepare for this brief unavailability before starting the rollback.
+</section>
+
+## See also
+
+- [Upgrade Policy](upgrade-policy.html)
+- [CockroachDB v21.2 Release Notes](../releases/v21.2.0.html)

--- a/v21.2/connection-pooling.md
+++ b/v21.2/connection-pooling.md
@@ -44,7 +44,7 @@ In addition to setting a maximum connection pool size, set the maximum number of
 
 ## Validating connections in a pool
 
-After a connection pool initializes connections to CockroachDB clusters, those connections can occasionally break. This could be due to changes in the cluster topography, or rolling upgrades and restarts, or network disruptions. {{ site.data.products.db }} clusters periodically are restarted for minor version updates, for example, so previously established connections would be invalid after the restart.
+After a connection pool initializes connections to CockroachDB clusters, those connections can occasionally break. This could be due to changes in the cluster topography, or rolling upgrades and restarts, or network disruptions. {{ site.data.products.db }} clusters periodically are restarted for patch version updates, for example, so previously established connections would be invalid after the restart.
 
 Validating connections is typically handled automatically by the connection pool. For example, in HikariCP the connection is validated whenever you request a connection from the pool, and the `keepaliveTime` property allows you to configure an interval to periodically check if the connections in the pool are valid. Whatever connection pool you use, make sure connection validation is enabled when running your application.
 


### PR DESCRIPTION
Fixes #12140.

- Added v21.2 upgrade doc for CockroachDB Cloud, with a tentative list of "Respect temporary limitations" features
- Verified the upgrade flow matches the steps listed [here](https://cockroachlabs.atlassian.net/browse/CC-5082)
- Added clearer "major releases are opt-in" verbiage at the top
- Did some cleanup and reorganization of the steps from previous upgrade docs (in particular, moved "roll back" up to the section about monitoring the upgrade, since this occurs prior to upgrade finalization)
- Also fixed an incorrect version number in the v21.1 upgrade doc

Also updated the Upgrade Policy and FAQ docs as part of this PR.

cc @jseldess 