### PR TITLE
lock_timeout, backslash_quote session variables

### DIFF
--- a/_includes/v21.2/misc/session-vars.html
+++ b/_includes/v21.2/misc/session-vars.html
@@ -316,8 +316,8 @@
    <td>
     <code>lock_timeout</code>
    </td>
-   <td><span class="version-tag">New in v21.2</span>: The amount of time a query can spend acquiring a single <a href="architecture/transaction-layer.html#concurrency-control">row-level lock</a>.<br>
-    In CockroachDB, unlike in PostgreSQL, non-locking reads wait for conflicting locks to be released. As a result, the <code>lock_timeout</code> configuration applies to non-locking reads in read-write and read-only transactions.<br>
+   <td><span class="version-tag">New in v21.2</span>: The amount of time a query can spend acquiring or waiting for a single <a href="architecture/transaction-layer.html#concurrency-control">row-level lock</a>.<br>
+    In CockroachDB, unlike in PostgreSQL, non-locking reads wait for conflicting locks to be released. As a result, the <code>lock_timeout</code> configuration applies to writes, and to locking and non-locking reads in read-write and read-only transactions.<br>
     If <code>lock_timeout = 0</code>, queries do not timeout due to lock acquisitions.
    </td>
    <td>

--- a/_includes/v21.2/misc/session-vars.html
+++ b/_includes/v21.2/misc/session-vars.html
@@ -314,6 +314,21 @@
 
   <tr>
    <td>
+    <code>lock_timeout</code>
+   </td>
+   <td><span class="version-tag">New in v21.2</span>: The amount of time a query can spend acquiring a single <a href="architecture/transaction-layer.html#concurrency-control">row-level lock</a>.<br>
+    In CockroachDB, unlike in PostgreSQL, non-locking reads wait for conflicting locks to be released. As a result, the <code>lock_timeout</code> configuration applies to non-locking reads in read-write and read-only transactions.<br>
+    If <code>lock_timeout = 0</code>, queries do not timeout due to lock acquisitions.
+   </td>
+   <td>
+    The value set by the <code>sql.defaults.lock_timeout</code> <a href="cluster-settings.html">cluster setting</a> (<code>0</code>, by default)
+   </td>
+   <td>Yes</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>node_id</code>
    </td>
    <td>The ID of the node currently connected to.<br />
@@ -663,6 +678,18 @@
 
   <tr>
    <td>
+    <code>backslash_quote</code>
+   </td>
+   <td>(Reserved; exposed only for ORM compatibility.)</td>
+   <td>
+    <code>safe_encoding</code>
+   </td>
+   <td>No</td>
+   <td>Yes</td>
+  </tr>
+
+  <tr>
+   <td>
     <code>client_encoding</code>
    </td>
    <td>(Reserved; exposed only for ORM compatibility.)</td>
@@ -716,18 +743,6 @@
    <td>(Reserved; exposed only for ORM compatibility.)</td>
    <td>
     <code>on</code>
-   </td>
-   <td>No</td>
-   <td>Yes</td>
-  </tr>
-
-  <tr>
-   <td>
-    <code>lock_timeout</code>
-   </td>
-   <td>(Reserved; exposed only for ORM compatibility.)</td>
-   <td>
-    <code>0</code>
    </td>
    <td>No</td>
    <td>Yes</td>


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/11363.
Fixes https://github.com/cockroachdb/docs/issues/11416.