### PR TITLE
v20.2.18 is the latest v20.2 version

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -72,11 +72,11 @@ release_info:
     start_time: 2021-05-17 11:01:26.34274101 +0000 UTC
     version: v20.1.17
   v20.2:
-    build_time: 2021/10/11 11:00:26 (go1.13.4)
+    build_time: 2021/11/08 11:00:26 (go1.13.4)
     docker_image: cockroachdb/cockroach
-    name: v20.2.17
-    start_time: 2021-10-11 11:01:26.34274101 +0000 UTC
-    version: v20.2.17
+    name: v20.2.18
+    start_time: 2021-11-08 11:01:26.34274101 +0000 UTC
+    version: v20.2.18
   v21.1:
     build_time: 2021/10/18 11:00:26 (go1.15.5)
     docker_image: cockroachdb/cockroach

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -26,6 +26,8 @@
       version: v21.1.1
     - date: May 18, 2021
       version: v21.1.0
+    - date: Nov 08, 2021
+      version: v20.2.18
     - date: Oct 11, 2021
       version: v20.2.17
     - date: Sep 13, 2021

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -38,6 +38,7 @@
             "/releases/v21.1.2.html",
             "/releases/v21.1.1.html",
             "/releases/v21.1.0.html",
+            "/releases/v20.2.18.html",
             "/releases/v20.2.17.html",
             "/releases/v20.2.16.html",
             "/releases/v20.2.15.html",

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -13,7 +13,7 @@
         {
           "title": "Latest v20.2",
           "urls": [
-            "/releases/v20.2.17.html"
+            "/releases/v20.2.18.html"
           ]
         },
         {

--- a/releases/v20.2.18.md
+++ b/releases/v20.2.18.md
@@ -42,14 +42,14 @@ $ docker pull cockroachdb/cockroach:v20.2.18
 
 ### Bug fixes
 
-- Fixed an internal error with joins that are both `LATERAL` and `NATURAL`/`USING`. [#70806][#70806]
-- Previously, in v21.1.x and earlier, CockroachDB could incorrectly read the data of a unique secondary index that used to be a primary index that was created via [`ALTER PRIMARY KEY`](../v20.2/alter-primary-key.html). This has been fixed. [#71589][#71589]
-- CockroachDB now avoids dialing nodes in performance-critical code paths, which could cause substantial latency when encountering unresponsive nodes (e.g., when a VM or server was shut down). [#70487][#70487]
+- Fixed an internal error with [joins](../v20.2/joins.html) that are both `LATERAL` and `NATURAL`/`USING`. [#70806][#70806]
+- Previously, in v21.1.x and earlier, CockroachDB could incorrectly read the data of a unique secondary index that used to be a primary index created via [`ALTER PRIMARY KEY`](../v20.2/alter-primary-key.html). This has been fixed. [#71589][#71589]
+- CockroachDB now avoids dialing nodes in performance-critical code paths, because doing so could cause substantial latency when encountering unresponsive nodes (e.g., when a VM or server was shut down). [#70487][#70487]
 - CockroachDB could crash if network connectivity was impaired. The stack trace (in `cockroach-stderr.log`) would contain `server.(*statusServer).NodesUI` in that case. This has been fixed. [#71793][#71793]
 - Fixed a panic that could occur with invalid GeoJSON input using `ST_GeomFromGeoJSON`/`ST_GeogFromGeoJSON`. [#71307][#71307]
 - Fixed a bug which caused [`ALTER COLUMN TYPE`](../v20.2/alter-column.html) statements to fail when they should not have. [#71167][#71167]
 - Connect timeout for grpc connections is now set to 20s to match the pre-v20.2 default value. [#71514][#71514]
-- Fixed a bug which caused incorrect results for some queries that utilized a zigzag join. The bug could only reproduce on tables with at least two multi-column indexes with nullable columns. The bug was present since v19.2.0. [#71850][#71850]
+- Fixed a bug which caused incorrect results for some queries that utilized a zig-zag join. The bug could only reproduce on tables with at least two multi-column indexes with nullable columns. The bug was present since v19.2.0. [#71850][#71850]
 
 ### Performance improvements
 

--- a/releases/v20.2.18.md
+++ b/releases/v20.2.18.md
@@ -1,0 +1,71 @@
+---
+title: What&#39;s New in v20.2.18
+toc: true
+summary: Additions and changes in CockroachDB version v20.2.18 since version v20.2.17
+---
+
+## November 08, 2021
+
+This page lists additions and changes in v20.2.18 since v20.2.17.
+
+- For a comprehensive summary of features in v20.2, see the [v20.2 GA release notes](v20.2.0.html).
+- To upgrade to v20.2, see [Upgrade to CockroachDB v20.2](../v20.2/upgrade-cockroach-version.html).
+
+Get future release notes emailed to you:
+
+{% include_cached marketo.html %}
+
+
+### Downloads
+
+<div id="os-tabs" class="filters clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.18.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.18.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.18.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v20.2.18.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+<section class="filter-content" data-scope="windows">
+{% include_cached windows_warning.md %}
+</section>
+
+### Docker image
+
+{% include_cached copy-clipboard.html %}
+~~~shell
+$ docker pull cockroachdb/cockroach:v20.2.18
+~~~
+
+### DB Console changes
+
+- Non-`admin` users of the DB Console have regained the ability to view the [Cluster Overview page](../v20.2/ui-cluster-overview-page.html). Users without the [`admin` role](../v20.2/authorization.html#admin-role) will still see most data about their nodes, but information such as command-line arguments, environment variables, and IP addresses and DNS names of nodes will be hidden. [#71793][#71793]
+
+### Bug fixes
+
+- Fixed an internal error with joins that are both `LATERAL` and `NATURAL`/`USING`. [#70806][#70806]
+- Previously, in v21.1.x and earlier, CockroachDB could incorrectly read the data of a unique secondary index that used to be a primary index that was created via [`ALTER PRIMARY KEY`](../v20.2/alter-primary-key.html). This has been fixed. [#71589][#71589]
+- CockroachDB now avoids dialing nodes in performance-critical code paths, which could cause substantial latency when encountering unresponsive nodes (e.g., when a VM or server was shut down). [#70487][#70487]
+- CockroachDB could crash if network connectivity was impaired. The stack trace (in `cockroach-stderr.log`) would contain `server.(*statusServer).NodesUI` in that case. This has been fixed. [#71793][#71793]
+- Fixed a panic that could occur with invalid GeoJSON input using `ST_GeomFromGeoJSON`/`ST_GeogFromGeoJSON`. [#71307][#71307]
+- Fixed a bug which caused [`ALTER COLUMN TYPE`](../v20.2/alter-column.html) statements to fail when they should not have. [#71167][#71167]
+- Connect timeout for grpc connections is now set to 20s to match the pre-v20.2 default value. [#71514][#71514]
+- Fixed a bug which caused incorrect results for some queries that utilized a zigzag join. The bug could only reproduce on tables with at least two multi-column indexes with nullable columns. The bug was present since v19.2.0. [#71850][#71850]
+
+### Performance improvements
+
+- Reduced memory usage slightly during [`ANALYZE`](../v20.2/create-statistics.html) or [`CREATE STATISTICS`](../v20.2/create-statistics.html) statements. [#71773][#71773]
+
+### Contributors
+
+This release includes 16 merged PRs by 16 authors.
+
+[#70487]: https://github.com/cockroachdb/cockroach/pull/70487
+[#70806]: https://github.com/cockroachdb/cockroach/pull/70806
+[#71167]: https://github.com/cockroachdb/cockroach/pull/71167
+[#71307]: https://github.com/cockroachdb/cockroach/pull/71307
+[#71514]: https://github.com/cockroachdb/cockroach/pull/71514
+[#71589]: https://github.com/cockroachdb/cockroach/pull/71589
+[#71773]: https://github.com/cockroachdb/cockroach/pull/71773
+[#71793]: https://github.com/cockroachdb/cockroach/pull/71793
+[#71850]: https://github.com/cockroachdb/cockroach/pull/71850
+


### PR DESCRIPTION
Made a tweak that ensures v20.2.18 loads as the "latest" v20.2 version in the side nav.