### PR TITLE
make v20.2.18 the latest v20.2 release (new branch)

### DIFF
--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -13,7 +13,7 @@
         {
           "title": "Latest v20.2",
           "urls": [
-            "/releases/v20.2.17.html"
+            "/releases/v20.2.18.html"
           ]
         },
         {


### PR DESCRIPTION
Made a tweak that ensures v20.2.18 loads as the "latest" v20.2 version in the side nav.