### PR TITLE
Clarify UPSERT vs INSERT ON CONFLICT performance

### DIFF
--- a/v20.2/insert.md
+++ b/v20.2/insert.md
@@ -68,11 +68,24 @@ examples below.
 If the values in the `SET` expression cause uniqueness conflicts,
 CockroachDB will return an error.
 
+### `INSERT ON CONFLICT` vs. `UPSERT`
+
 As a short-hand alternative to the `ON
 CONFLICT` clause, you can use the [`UPSERT`](upsert.html)
 statement. However, `UPSERT` does not let you specify the column(s) with
 the unique constraint; it always uses the column(s) from the primary
 key. Using `ON CONFLICT` is therefore more flexible.
+
+When inserting/updating all columns of a table, and the table has no secondary
+indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the
+equivalent `INSERT ON CONFLICT` statement. Whereas `INSERT ON CONFLICT` always
+performs a read to determine the necessary writes, the `UPSERT` statement writes
+without reading, making it faster. For tables with secondary indexes, there is
+no performance difference between `UPSERT` and `INSERT ON CONFLICT`.
+
+This issue is particularly relevant when using a simple SQL table of two columns
+to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store).
+In this case, be sure to use the `UPSERT` statement.
 
 ## Examples
 

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -355,12 +355,6 @@ SQLSTATE: 0A000
 
 {% include {{ page.version.version }}/known-limitations/schema-changes-between-prepared-statements.md %}
 
-### `INSERT ON CONFLICT` vs. `UPSERT`
-
-When inserting/updating all columns of a table, and the table has no secondary indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the equivalent [`INSERT ON CONFLICT`](insert.html) statement. Whereas `INSERT ON CONFLICT` always performs a read to determine the necessary writes, the `UPSERT` statement writes without reading, making it faster.
-
-This issue is particularly relevant when using a simple SQL table of two columns to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store). In this case, be sure to use the `UPSERT` statement.
-
 ### Size limits on statement input from SQL clients
 
 CockroachDB imposes a hard limit of 16MiB on the data input for a single statement passed to CockroachDB from a client (including the SQL shell). We do not recommend attempting to execute statements from clients with large input.

--- a/v20.2/performance-best-practices-overview.md
+++ b/v20.2/performance-best-practices-overview.md
@@ -27,6 +27,20 @@ For more information, see:
 - [Delete Data](delete-data.html)
 - [How to improve IoT application performance with multi-row DML](https://www.cockroachlabs.com/blog/multi-row-dml/)
 
+### Use `UPSERT` instead of `INSERT ON CONFLICT` on tables with no secondary indexes
+
+When inserting/updating all columns of a table, and the table has no secondary
+indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the
+equivalent [`INSERT ON CONFLICT`](insert.html) statement. Whereas `INSERT ON
+CONFLICT` always performs a read to determine the necessary writes, the `UPSERT`
+statement writes without reading, making it faster. For tables with secondary
+indexes, there is no performance difference between `UPSERT` and `INSERT ON
+CONFLICT`.
+
+This issue is particularly relevant when using a simple SQL table of two columns
+to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store).
+In this case, be sure to use the `UPSERT` statement.
+
 ## Bulk-insert best practices
 
 ### Use multi-row `INSERT` statements for bulk-inserts into existing tables

--- a/v21.1/insert.md
+++ b/v21.1/insert.md
@@ -68,11 +68,24 @@ examples below.
 If the values in the `SET` expression cause uniqueness conflicts,
 CockroachDB will return an error.
 
+### `INSERT ON CONFLICT` vs. `UPSERT`
+
 As a short-hand alternative to the `ON
 CONFLICT` clause, you can use the [`UPSERT`](upsert.html)
 statement. However, `UPSERT` does not let you specify the column(s) with
 the unique constraint; it always uses the column(s) from the primary
 key. Using `ON CONFLICT` is therefore more flexible.
+
+When inserting/updating all columns of a table, and the table has no secondary
+indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the
+equivalent `INSERT ON CONFLICT` statement. Whereas `INSERT ON CONFLICT` always
+performs a read to determine the necessary writes, the `UPSERT` statement writes
+without reading, making it faster. For tables with secondary indexes, there is
+no performance difference between `UPSERT` and `INSERT ON CONFLICT`.
+
+This issue is particularly relevant when using a simple SQL table of two columns
+to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store).
+In this case, be sure to use the `UPSERT` statement.
 
 ## Examples
 

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -443,12 +443,6 @@ SQLSTATE: 0A000
 
 {% include {{ page.version.version }}/known-limitations/schema-changes-between-prepared-statements.md %}
 
-### `INSERT ON CONFLICT` vs. `UPSERT`
-
-When inserting/updating all columns of a table, and the table has no secondary indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the equivalent [`INSERT ON CONFLICT`](insert.html) statement. Whereas `INSERT ON CONFLICT` always performs a read to determine the necessary writes, the `UPSERT` statement writes without reading, making it faster.
-
-This issue is particularly relevant when using a simple SQL table of two columns to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store). In this case, be sure to use the `UPSERT` statement.
-
 ### Size limits on statement input from SQL clients
 
 CockroachDB imposes a hard limit of 16MiB on the data input for a single statement passed to CockroachDB from a client (including the SQL shell). We do not recommend attempting to execute statements from clients with large input.

--- a/v21.1/performance-best-practices-overview.md
+++ b/v21.1/performance-best-practices-overview.md
@@ -27,6 +27,20 @@ For more information, see:
 - [Delete Data](delete-data.html)
 - [How to improve IoT application performance with multi-row DML](https://www.cockroachlabs.com/blog/multi-row-dml/)
 
+### Use `UPSERT` instead of `INSERT ON CONFLICT` on tables with no secondary indexes
+
+When inserting/updating all columns of a table, and the table has no secondary
+indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the
+equivalent [`INSERT ON CONFLICT`](insert.html) statement. Whereas `INSERT ON
+CONFLICT` always performs a read to determine the necessary writes, the `UPSERT`
+statement writes without reading, making it faster. For tables with secondary
+indexes, there is no performance difference between `UPSERT` and `INSERT ON
+CONFLICT`.
+
+This issue is particularly relevant when using a simple SQL table of two columns
+to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store).
+In this case, be sure to use the `UPSERT` statement.
+
 ## Bulk-insert best practices
 
 ### Use multi-row `INSERT` statements for bulk-inserts into existing tables

--- a/v21.2/insert.md
+++ b/v21.2/insert.md
@@ -68,11 +68,24 @@ examples below.
 If the values in the `SET` expression cause uniqueness conflicts,
 CockroachDB will return an error.
 
+### `INSERT ON CONFLICT` vs. `UPSERT`
+
 As a short-hand alternative to the `ON
 CONFLICT` clause, you can use the [`UPSERT`](upsert.html)
 statement. However, `UPSERT` does not let you specify the column(s) with
 the unique constraint; it always uses the column(s) from the primary
 key. Using `ON CONFLICT` is therefore more flexible.
+
+When inserting/updating all columns of a table, and the table has no secondary
+indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the
+equivalent `INSERT ON CONFLICT` statement. Whereas `INSERT ON CONFLICT` always
+performs a read to determine the necessary writes, the `UPSERT` statement writes
+without reading, making it faster. For tables with secondary indexes, there is
+no performance difference between `UPSERT` and `INSERT ON CONFLICT`.
+
+This issue is particularly relevant when using a simple SQL table of two columns
+to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store).
+In this case, be sure to use the `UPSERT` statement.
 
 ## Examples
 

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -410,12 +410,6 @@ SQLSTATE: 0A000
 
 {% include {{ page.version.version }}/known-limitations/schema-changes-between-prepared-statements.md %}
 
-### `INSERT ON CONFLICT` vs. `UPSERT`
-
-When inserting/updating all columns of a table, and the table has no secondary indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the equivalent [`INSERT ON CONFLICT`](insert.html) statement. Whereas `INSERT ON CONFLICT` always performs a read to determine the necessary writes, the `UPSERT` statement writes without reading, making it faster.
-
-This issue is particularly relevant when using a simple SQL table of two columns to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store). In this case, be sure to use the `UPSERT` statement.
-
 ### Size limits on statement input from SQL clients
 
 CockroachDB imposes a hard limit of 16MiB on the data input for a single statement passed to CockroachDB from a client (including the SQL shell). We do not recommend attempting to execute statements from clients with large input.

--- a/v21.2/performance-best-practices-overview.md
+++ b/v21.2/performance-best-practices-overview.md
@@ -27,6 +27,20 @@ For more information, see:
 - [Delete Data](delete-data.html)
 - [How to improve IoT application performance with multi-row DML](https://www.cockroachlabs.com/blog/multi-row-dml/)
 
+### Use `UPSERT` instead of `INSERT ON CONFLICT` on tables with no secondary indexes
+
+When inserting/updating all columns of a table, and the table has no secondary
+indexes, we recommend using an [`UPSERT`](upsert.html) statement instead of the
+equivalent [`INSERT ON CONFLICT`](insert.html) statement. Whereas `INSERT ON
+CONFLICT` always performs a read to determine the necessary writes, the `UPSERT`
+statement writes without reading, making it faster. For tables with secondary
+indexes, there is no performance difference between `UPSERT` and `INSERT ON
+CONFLICT`.
+
+This issue is particularly relevant when using a simple SQL table of two columns
+to [simulate direct KV access](sql-faqs.html#can-i-use-cockroachdb-as-a-key-value-store).
+In this case, be sure to use the `UPSERT` statement.
+
 ## Bulk-insert best practices
 
 ### Use multi-row `INSERT` statements for bulk-inserts into existing tables


### PR DESCRIPTION
* Move performance note about UPSERT vs INSERT ON CONFLICT from
  "known limitations" to "insert" and "performance best practices".

* Add a sentence to clarify that performance of UPSERT and INSERT ON
  CONFLICT is the same when a table has secondary indexes.