### PR TITLE
Known limitation for optimizer deletion of multi-col/single col stale stats

### DIFF
--- a/_includes/v20.2/known-limitations/old-multi-col-stats.md
+++ b/_includes/v20.2/known-limitations/old-multi-col-stats.md
@@ -1,0 +1,3 @@
+When a column is dropped from a multi-column index, the {% if page.name == "cost-based-optimizer.md" %} optimizer {% else %} [optimizer](cost-based-optimizer.html) {% endif %} will not collect new statistics for the deleted column. However, the optimizer never deletes the old [multi-column statistics](create-statistics.html#create-statistics-on-multiple-columns). This can cause a buildup of statistics in `system.table_statistics` leading the optimizer to use stale statistics, which could result in sub-optimal plans. To workaround this issue and avoid these scenarios, explicitly [delete those statistics](create-statistics.html#delete-statistics) from the `system.table_statistics` table.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/_includes/v20.2/known-limitations/single-col-stats-deletion.md
+++ b/_includes/v20.2/known-limitations/single-col-stats-deletion.md
@@ -1,0 +1,3 @@
+[Single-column statistics](create-statistics.html#create-statistics-on-a-single-column) are not deleted when columns are dropped, which could cause minor performance issues.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/_includes/v21.1/known-limitations/old-multi-col-stats.md
+++ b/_includes/v21.1/known-limitations/old-multi-col-stats.md
@@ -1,0 +1,3 @@
+When a column is dropped from a multi-column index, the {% if page.name == "cost-based-optimizer.md" %} optimizer {% else %} [optimizer](cost-based-optimizer.html) {% endif %} will not collect new statistics for the deleted column. However, the optimizer never deletes the old [multi-column statistics](create-statistics.html#create-statistics-on-multiple-columns). This can cause a buildup of statistics in `system.table_statistics` leading the optimizer to use stale statistics, which could result in sub-optimal plans. To workaround this issue and avoid these scenarios, explicitly [delete those statistics](create-statistics.html#delete-statistics) from the `system.table_statistics` table.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/_includes/v21.1/known-limitations/single-col-stats-deletion.md
+++ b/_includes/v21.1/known-limitations/single-col-stats-deletion.md
@@ -1,0 +1,3 @@
+[Single-column statistics](create-statistics.html#create-statistics-on-a-single-column) are not deleted when columns are dropped, which could cause minor performance issues.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/_includes/v21.2/known-limitations/old-multi-col-stats.md
+++ b/_includes/v21.2/known-limitations/old-multi-col-stats.md
@@ -1,0 +1,3 @@
+When a column is dropped from a multi-column index, the {% if page.name == "cost-based-optimizer.md" %} optimizer {% else %} [optimizer](cost-based-optimizer.html) {% endif %} will not collect new statistics for the deleted column. However, the optimizer never deletes the old [multi-column statistics](create-statistics.html#create-statistics-on-multiple-columns). This can cause a buildup of statistics in `system.table_statistics` leading the optimizer to use stale statistics, which could result in sub-optimal plans. To workaround this issue and avoid these scenarios, explicitly [delete those statistics](create-statistics.html#delete-statistics) from the `system.table_statistics` table.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/_includes/v21.2/known-limitations/single-col-stats-deletion.md
+++ b/_includes/v21.2/known-limitations/single-col-stats-deletion.md
@@ -1,0 +1,3 @@
+[Single-column statistics](create-statistics.html#create-statistics-on-a-single-column) are not deleted when columns are dropped, which could cause minor performance issues.
+
+    [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67407)

--- a/v20.2/cost-based-optimizer.md
+++ b/v20.2/cost-based-optimizer.md
@@ -675,6 +675,10 @@ $ cockroach sql --insecure --host=localhost --port=26257 --database=auth # "East
 
 You'll need to make changes to the above configuration to reflect your [production environment](recommended-production-settings.html), but the concepts will be the same.
 
+## Known Limitations
+
+* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
 
 ## See also
 

--- a/v20.2/known-limitations.md
+++ b/v20.2/known-limitations.md
@@ -97,6 +97,12 @@ CockroachDB supports efficiently storing and querying [spatial data](spatial-dat
 
 ## Unresolved limitations
 
+### Optimizer stale statistics deletion when columns are dropped
+
+* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+
+* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
+
 ### Differences in syntax and behavior between CockroachDB and PostgreSQL
 
 CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of its syntax. However, CockroachDB does not support some of the PostgreSQL features or behaves differently from PostgreSQL because not all features can be easily implemented in a distributed system.

--- a/v21.1/cost-based-optimizer.md
+++ b/v21.1/cost-based-optimizer.md
@@ -195,6 +195,11 @@ To make the optimizer prefer lookup joins to merge joins when performing foreign
 
 {% include {{ page.version.version }}/sql/inverted-joins.md %}
 
+## Known Limitations
+
+* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
+
 ## See also
 
 - [`JOIN` expressions](joins.html)

--- a/v21.1/known-limitations.md
+++ b/v21.1/known-limitations.md
@@ -161,6 +161,12 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ## Unresolved limitations
 
+### Optimizer stale statistics deletion when columns are dropped
+
+* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+
+* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
+
 ### `IMPORT` into a `REGIONAL BY ROW` table
 
 CockroachDB does not currently support [`IMPORT`s](import.html) into [`REGIONAL BY ROW`](set-locality.html#regional-by-row) tables that are part of [multi-region databases](multiregion-overview.html).

--- a/v21.2/cost-based-optimizer.md
+++ b/v21.2/cost-based-optimizer.md
@@ -248,6 +248,11 @@ SELECT * FROM abc@{NO_ZIGZAG_JOIN};
 
 {% include {{ page.version.version }}/sql/inverted-joins.md %}
 
+## Known Limitations
+
+* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
+
 ## See also
 
 - [`JOIN` expressions](joins.html)

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -171,6 +171,12 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ## Unresolved limitations
 
+### Optimizer stale statistics deletion when columns are dropped
+
+* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+
+* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
+
 ### `BACKUP` of multi-region tables
 
 {% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}


### PR DESCRIPTION
Closes #12173 

Added known limitation to main limitation page and optimizer page: 

* old multi-column statistics not being deleted on column deletion from multi-col index
* single-column statistics not being deleted causing performance issues 

