### PR TITLE
fix operator.yaml links

### DIFF
--- a/v21.1/operate-cockroachdb-kubernetes.md
+++ b/v21.1/operate-cockroachdb-kubernetes.md
@@ -1049,7 +1049,7 @@ This workflow is unsupported and should be enabled at your own risk.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/manifests/operator.yaml
+    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
 1. Uncomment the following lines in the Operator manifest:

--- a/v21.2/scale-cockroachdb-kubernetes.md
+++ b/v21.2/scale-cockroachdb-kubernetes.md
@@ -215,7 +215,7 @@ This workflow is unsupported and should be enabled at your own risk.
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/manifests/operator.yaml
+    $ curl -0 https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml
     ~~~
 
 1. Uncomment the following lines in the Operator manifest:


### PR DESCRIPTION
Updated two instances of the K8s operator.yaml manifest link to the correct path.

The paths in `start-cockroachdb-operator-secure.md` (v21.1 and v21.2) are also incorrect, but should be fixed in #12198.