### PR TITLE
Fix database value in Sequelize Serverless

### DIFF
--- a/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -55,8 +55,13 @@ Open `app.js`, and edit the connection configuration parameters:
 
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
+- At the top of the file, uncomment the `const fs = require('fs');` line.
+
+    This line imports the `fs` Node module, which enables you to read in the CA cert that you downloaded from the {{ site.data.products.db }} Console.
 - Replace the values for `username`, `host`, `port`, and `database` with values from the **Connection parameters** tab of **Connection info**.
 - Replace the value for `password` with the password you created for your user.
+- Remove the `rejectUnauthorized` key-value pair.
+- Uncomment the `ca` key-value pair, and edit the `fs.readFileSync('certs/ca.crt').toString()` call to use the path to the `cc-ca.crt` file that you downloaded from the {{ site.data.products.db }} Console.
 
 </section>
 

--- a/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -58,11 +58,8 @@ Open `app.js`, and edit the connection configuration parameters:
 - At the top of the file, uncomment the `const fs = require('fs');` line.
 
     This line imports the `fs` Node module, which enables you to read in the CA cert that you downloaded from the {{ site.data.products.db }} Console.
-- Replace the value for `username` with the user you created earlier.
+- Replace the values for `username`, `host`, `port`, and `database` with values from the "Connection parameters" tab of "Connection info."
 - Replace the value for `password` with the password you created for your user.
-- Replace the value for `host` with the name of the {{ site.data.products.serverless-plan }} host (e.g., `host: 'free-tier.gcp-us-central1.cockroachlabs.cloud'`).
-- Replace the value for `port` with the port to your cluster.
-- Replace the value for `database` with the database that you created earlier, suffixed with the name of the cluster (e.g., `database: '{cluster_name}.bank'`).
 - Remove the `rejectUnauthorized` key-value pair.
 - Uncomment the `ca` key-value pair, and edit the `fs.readFileSync('certs/ca.crt').toString()` call to use the path to the `cc-ca.crt` file that you downloaded from the {{ site.data.products.db }} Console.
 

--- a/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -55,13 +55,8 @@ Open `app.js`, and edit the connection configuration parameters:
 
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
-- At the top of the file, uncomment the `const fs = require('fs');` line.
-
-    This line imports the `fs` Node module, which enables you to read in the CA cert that you downloaded from the {{ site.data.products.db }} Console.
 - Replace the values for `username`, `host`, `port`, and `database` with values from the "Connection parameters" tab of "Connection info."
 - Replace the value for `password` with the password you created for your user.
-- Remove the `rejectUnauthorized` key-value pair.
-- Uncomment the `ca` key-value pair, and edit the `fs.readFileSync('certs/ca.crt').toString()` call to use the path to the `cc-ca.crt` file that you downloaded from the {{ site.data.products.db }} Console.
 
 </section>
 

--- a/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
+++ b/v21.1/build-a-nodejs-app-with-cockroachdb-sequelize.md
@@ -55,7 +55,7 @@ Open `app.js`, and edit the connection configuration parameters:
 
 <section class="filter-content" markdown="1" data-scope="cockroachcloud">
 
-- Replace the values for `username`, `host`, `port`, and `database` with values from the "Connection parameters" tab of "Connection info."
+- Replace the values for `username`, `host`, `port`, and `database` with values from the **Connection parameters** tab of **Connection info**.
 - Replace the value for `password` with the password you created for your user.
 
 </section>


### PR DESCRIPTION
The first part of the value for "database" actually needs to be the cluster's tenant name (which is the cluster name plus a short ID) instead of just the cluster name. The user can easily get all of the relevant values from the "Connection parameters" tab.