### PR TITLE
hardcode link to Operate CockroachDB on K8s in v20.2

### DIFF
--- a/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
@@ -88,7 +88,7 @@ On a production cluster, you will need to modify the StatefulSet configuration w
 ### Initialize the cluster
 
 {{site.data.alerts.callout_info}}
-By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. To authenticate using your own CA, see [Operate CockroachDB on Kubernetes](../{{site.versions["stable"]}}/operate-cockroachdb-kubernetes.html#use-a-custom-ca).
+By default, the Operator will generate and sign 1 client and 1 node certificate to secure the cluster. To authenticate using your own CA, see [Operate CockroachDB on Kubernetes](../v21.1/operate-cockroachdb-kubernetes.html#use-a-custom-ca).
 {{site.data.alerts.end}}
 
 1. Apply `example.yaml`:


### PR DESCRIPTION
Replaced the liquid tag with a hardcoded version path to the Operate CockroachDB on Kubernetes doc.

cc @lnhsingh - This is unfortunately pointing to v21.1 from v20.2, for reasons that have to do with the Kubernetes Operator updates leading to changes in docs content + structure that became version-specific. I'm going to investigate the possibility of decoupling the K8s docs from CRDB versioning. In the meantime, this should be the only instance of the docs versions mismatching. Let me know if you think I should handle this differently.