### PR TITLE
Expression indexes can't reference computed cols

### DIFF
--- a/_includes/v21.2/sql/expression-indexes-cannot-reference-computed-columns.md
+++ b/_includes/v21.2/sql/expression-indexes-cannot-reference-computed-columns.md
@@ -1,0 +1,3 @@
+CockroachDB does not allow {% if page.name == "expression-indexes.md" %} expression indexes {% else %} [expression indexes](expression-indexes.html) {% endif %} to reference [computed columns](computed-columns.html).
+
+[Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67900)

--- a/v21.2/expression-indexes.md
+++ b/v21.2/expression-indexes.md
@@ -125,9 +125,9 @@ To query for a specific birthdate, run the following:
 Expression indexes have the following limitations:
 
 - The expression cannot reference columns outside the index's table.
-- The expression cannot reference [computed columns](computed-columns.html). [Tracking issue](https://github.com/cockroachdb/cockroach/issues/67900)
 - Functional expression output must be determined by the input arguments. For example, you can't use the function `now()` to create an index because its output depends on more than just the function arguments.
 
+{% include {{page.version.version}}/sql/expression-indexes-cannot-reference-computed-columns.md %}
 
 ## See also
 

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -177,6 +177,10 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 {% include {{ page.version.version }}/sql/locality-optimized-search-limited-records.md %}
 
+### Expression indexes cannot reference computed columns
+
+{% include {{page.version.version}}/sql/expression-indexes-cannot-reference-computed-columns.md %}
+
 ## Unresolved limitations
 
 ### Optimizer stale statistics deletion when columns are dropped


### PR DESCRIPTION
Fixes cockroachdb/docs#12171