### PR TITLE
Clarify cluster name, tenant id, and cluster id

### DIFF
--- a/_includes/cockroachcloud/sql-connection-string-free.md
+++ b/_includes/cockroachcloud/sql-connection-string-free.md
@@ -1,28 +1,29 @@
     <section class="filter-content" markdown="1" data-scope="mac">
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach sql --url 'postgresql://<username>:<password>@<serverless-host>:26257/defaultdb?sslmode=verify-full&sslrootcert='$HOME'/.postgresql/root.crt&options=--cluster=<cluster-id>'
+    cockroach sql --url 'postgresql://<username>:<password>@<serverless-host>:26257/defaultdb?sslmode=verify-full&sslrootcert='$HOME'/.postgresql/root.crt&options=--cluster=<cluster-name>-<tenant-id>'
     ~~~
     </section>
 
     <section class="filter-content" markdown="1" data-scope="linux">
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach sql --url 'postgresql://<username>:<password>@<serverless-host>:26257/defaultdb?sslmode=verify-full&sslrootcert='$HOME'/.postgresql/root.crt&options=--cluster=<cluster-id>'
+    cockroach sql --url 'postgresql://<username>:<password>@<serverless-host>:26257/defaultdb?sslmode=verify-full&sslrootcert='$HOME'/.postgresql/root.crt&options=--cluster=<cluster-name>-<tenant-id>'
     ~~~
     </section>
 
     <section class="filter-content" markdown="1" data-scope="windows">
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach sql --url "postgresql://<username>:<password>@<serverless-host>:26257/defaultdb?sslmode=verify-full&sslrootcert=$env:appdata/.postgresql/root.crt&options=--cluster=<cluster-id>"
+    cockroach sql --url "postgresql://<username>:<password>@<serverless-host>:26257/defaultdb?sslmode=verify-full&sslrootcert=$env:appdata/.postgresql/root.crt&options=--cluster=<cluster-name>-<tenant-id>"
     ~~~
     </section>
 
     Where:
     - `<username>` is the SQL user. By default, this is your {{ site.data.products.db }} account username.
     - `<password>` is the password for the SQL user. The password will be shown only once in the **Connection info** dialog after creating the cluster.
-    - `<serverless-host>` is the hostname of the serverless cluster.
-    - `<cluster-name>` is the short name of your cluster plus the tenant ID. For example, `funny-skunk-3`. The `<cluster-name>` is used to identify your tenant cluster on a multitenant host.
+    - `<serverless-host>` is the hostname of the {{ site.data.products.serverless }} cluster.
+    - `<cluster-name>-<tenant-id>` is the short name of your cluster plus the tenant ID. For example, `funny-skunk-123`. The `<tenant-id>` is used to identify your tenant cluster on a multitenant host.
+    - `<cluster-id>` is a unique string used to identify your cluster when downloading the CA certificate. For example, `12a3bcde-4fa5-6789-1234-56bc7890d123`.
 
     You can find these settings in the **Connection parameters** tab of the **Connection info** dialog.

--- a/_includes/cockroachcloud/sql-connection-string.md
+++ b/_includes/cockroachcloud/sql-connection-string.md
@@ -1,21 +1,21 @@
     <section class="filter-content" markdown="1" data-scope="mac">
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach sql --url 'postgresql://<user>@<cluster-name>-<short-id>.<region>.<host>:26257/<database>?sslmode=verify-full&sslrootcert='$HOME'/Library/CockroachCloud/certs/<cluster-name>-ca.crt'
+    cockroach sql --url 'postgresql://<user>@<cluster-name>-<short-id>.<region>.cockroachlabs.cloud:26257/<database>?sslmode=verify-full&sslrootcert='$HOME'/Library/CockroachCloud/certs/<cluster-name>-ca.crt'
     ~~~
     </section>
 
     <section class="filter-content" markdown="1" data-scope="linux">
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach sql --url 'postgresql://<user>@<cluster-name>-<short-id>.<region>.<host>:26257/<database>?sslmode=verify-full&sslrootcert='$HOME'/Library/CockroachCloud/certs/<cluster-name>-ca.crt'
+    cockroach sql --url 'postgresql://<user>@<cluster-name>-<short-id>.<region>.cockroachlabs.cloud:26257/<database>?sslmode=verify-full&sslrootcert='$HOME'/Library/CockroachCloud/certs/<cluster-name>-ca.crt'
     ~~~
     </section>
 
     <section class="filter-content" markdown="1" data-scope="windows">
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach sql --url "postgresql://<user>@<cluster-name>-<short-id>.<region>.<host>:26257/<database>?sslmode=verify-full&sslrootcert=$env:appdata\CockroachCloud\certs\$<cluster-name>-ca.crt"
+    cockroach sql --url "postgresql://<user>@<cluster-name>-<short-id>.<region>.cockroachlabs.cloud:26257/<database>?sslmode=verify-full&sslrootcert=$env:appdata\CockroachCloud\certs\$<cluster-name>-ca.crt"
     ~~~
     </section>
     
@@ -23,5 +23,7 @@
     - `<user>` is the SQL user. By default, this is your {{ site.data.products.db }} account username.
     - `<cluster-name>-<short-id>` is the short name of your cluster plus the short ID. For example, `funny-skunk-3ab`.
     - `<cluster-id>` is a unique string used to identify your cluster when downloading the CA certificate. For example, `12a3bcde-4fa5-6789-1234-56bc7890d123`.
+    - `<region>` is the region in which your cluster is running. If you have a multi-region cluster, you can choose any of the regions in which your cluster is running. For example, `aws-us-east-1`.
+    - `<database>` is the name for your database. For example, `defaultdb`.
 
     You can find these settings in the **Connection parameters** tab of the **Connection info** dialog.

--- a/_includes/cockroachcloud/sql-connection-string.md
+++ b/_includes/cockroachcloud/sql-connection-string.md
@@ -18,3 +18,10 @@
     cockroach sql --url "postgresql://<user>@<cluster-name>-<short-id>.<region>.<host>:26257/<database>?sslmode=verify-full&sslrootcert=$env:appdata\CockroachCloud\certs\$<cluster-name>-ca.crt"
     ~~~
     </section>
+    
+    Where:
+    - `<user>` is the SQL user. By default, this is your {{ site.data.products.db }} account username.
+    - `<cluster-name>-<short-id>` is the short name of your cluster plus the short ID. For example, `funny-skunk-3ab`.
+    - `<cluster-id>` is a unique string used to identify your cluster when downloading the CA certificate. For example, `12a3bcde-4fa5-6789-1234-56bc7890d123`.
+
+    You can find these settings in the **Connection parameters** tab of the **Connection info** dialog.


### PR DESCRIPTION
Connection docs were not previously using cluster name, tenant IDs, and cluster IDs correctly. This PR updates the language temporarily,[ until tenant IDs get added to cluster names and simplify this process.](https://cockroachlabs.atlassian.net/browse/CC-5285)

Examples to illustrate correct meanings:
`cluster-name`=`funny-skunk`
`cluster-id`=`12a3bcde-4fa5-6789-1234-56bc7890d123`
(Serverless) `tenant-id`=`123`
(Dedicated) `short-id`=`6mc`

To download the CA cert, you need the cluster ID. To use the SQL connection string, you need the cluster name and tenant or short ID. Dedicated certs are saved using cluster names and Serverless certs are just saved as `root.crt`.

Closes https://cockroachlabs.atlassian.net/browse/CC-5363