### PR TITLE
CC FAQ Dedicated definition

### DIFF
--- a/cockroachcloud/frequently-asked-questions.md
+++ b/cockroachcloud/frequently-asked-questions.md
@@ -11,7 +11,11 @@ This page answers the frequently asked questions about {{ site.data.products.ser
     <a href="frequently-asked-questions.html"><button class="filter-button page-level current">{{ site.data.products.dedicated }}</button></a>
 </div>
 
-## Cluster basics
+## General
+
+### What is {{ site.data.products.dedicated }}?
+
+{{ site.data.products.dedicated }} provides fully-managed, single-tenant CockroachDB clusters with no shared resources. {{ site.data.products.dedicated }} supports single and multi-region clusters in AWS and GCP.
 
 ### Why are certain regions in AWS and GCP not available?
 


### PR DESCRIPTION
Added an entry defining CockroachDB Dedicated to the FAQ, and changed ## Cluster basics --> ## General to align with the Serverless FAQs.

Closes https://cockroachlabs.atlassian.net/browse/CC-5130