### PR TITLE
K8s Operator webhooks docs

### DIFF
--- a/_includes/v21.1/orchestration/operator-check-namespace.md
+++ b/_includes/v21.1/orchestration/operator-check-namespace.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+All `kubectl` steps should be performed in the [namespace where you installed the Operator](deploy-cockroachdb-with-kubernetes.html#install-the-operator). By default, this is `cockroach-operator-system`.
+{{site.data.alerts.end}}

--- a/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
@@ -33,7 +33,7 @@
         $ kubectl apply -f operator.yaml
         ~~~
 
-    If you want to the default namespace settings:
+    If you want to use the default namespace settings:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell

--- a/_includes/v21.2/orchestration/operator-check-namespace.md
+++ b/_includes/v21.2/orchestration/operator-check-namespace.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+All `kubectl` steps should be performed in the [namespace where you installed the Operator](deploy-cockroachdb-with-kubernetes.html#install-the-operator). By default, this is `cockroach-operator-system`.
+{{site.data.alerts.end}}

--- a/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
@@ -33,7 +33,7 @@
         $ kubectl apply -f operator.yaml
         ~~~
 
-    If you want to the default namespace settings:
+    If you want to use the default namespace settings:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
@@ -50,6 +50,13 @@
     serviceaccount/cockroach-operator-sa created
     rolebinding.rbac.authorization.k8s.io/cockroach-operator-default created
     deployment.apps/cockroach-operator created
+    ~~~
+
+1. Set your current namespace to the one used by the Operator. For example, to use the Operator's default namespace:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl config set-context --current --namespace=cockroach-operator-system
     ~~~
 
 1. Validate that the Operator is running:

--- a/v21.1/create-security-certificates-openssl.md
+++ b/v21.1/create-security-certificates-openssl.md
@@ -1,5 +1,5 @@
 ---
-title: Create Security Certificates using Openssl
+title: Create Security Certificates using OpenSSL
 summary: A secure CockroachDB cluster uses TLS for encrypted inter-node and client-node communication.
 toc: true
 ---

--- a/v21.1/operate-cockroachdb-kubernetes.md
+++ b/v21.1/operate-cockroachdb-kubernetes.md
@@ -46,6 +46,8 @@ You can configure, scale, and upgrade a CockroachDB deployment on Kubernetes by 
 </div>
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 {{site.data.alerts.callout_success}}
 If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html), substitute `kubectl` with `oc` in the following commands.
 {{site.data.alerts.end}}
@@ -562,21 +564,21 @@ These steps demonstrate how to use the [`openssl genrsa`](https://www.openssl.or
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ openssl genrsa -out tls.key 4096
+    openssl genrsa -out tls.key 4096
     ~~~
 
 1. Generate an X.509 certificate, valid for 10 years. You will be prompted for the certificate field values.
 
     {% include_cached copy-clipboard.html %}
-    ~~~
-    $ openssl req -x509 -new -nodes -key tls.key -sha256 -days 3650 -out tls.crt
+    ~~~ shell
+    openssl req -x509 -new -nodes -key tls.key -sha256 -days 3650 -out tls.crt
     ~~~
 
 1. Create the secret, making sure that [you are in the correct namespace](deploy-cockroachdb-with-kubernetes.html#install-the-operator):
 
     {% include_cached copy-clipboard.html %}
-    ~~~
-    $ kubectl create secret tls cockroach-operator-webhook-ca --cert=tls.crt --key=tls.key
+    ~~~ shell
+    kubectl create secret tls cockroach-operator-webhook-ca --cert=tls.crt --key=tls.key
     ~~~
 
     ~~~
@@ -586,15 +588,19 @@ These steps demonstrate how to use the [`openssl genrsa`](https://www.openssl.or
 1. Remove the certificate and key from your local environment:
 
     {% include_cached copy-clipboard.html %}
-    ~~~
-    $ rm tls.crt tls.key
+    ~~~ shell
+    rm tls.crt tls.key
     ~~~
 
 1. Roll the Operator deployment to ensure a new server certificate is generated:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f operator.yaml
+    kubectl rollout restart deploy/cockroach-operator-manager
+    ~~~
+
+    ~~~
+    deployment.apps/cockroach-operator-manager restarted
     ~~~
 </section>
 

--- a/v21.1/operate-cockroachdb-kubernetes.md
+++ b/v21.1/operate-cockroachdb-kubernetes.md
@@ -16,6 +16,7 @@ You can configure, scale, and upgrade a CockroachDB deployment on Kubernetes by 
 - [Allocate CPU and memory resources](#allocate-resources)
 - [Use a custom CA](#use-a-custom-ca)
 - [Rotate security certificates](#rotate-security-certificates)
+- [Secure webhooks](#secure-the-webhooks)
 - [Provision and expand volumes](#provision-volumes)
 - [Scale the cluster](#scale-the-cluster)
 - [Configure ports](#configure-ports)
@@ -542,6 +543,59 @@ If you previously [authenticated with `cockroach cert`](#example-authenticating-
     cockroachdb-1                         1/1     Terminating   0          4h16m
     cockroachdb-2                         1/1     Running       0          43s
     ~~~
+
+## Secure the webhooks
+
+The Operator ships with both [mutating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) and [validating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) webhooks. Communication between the Kubernetes API server and the webhook service must be secured with TLS.
+
+By default, the Operator searches for the TLS secret `cockroach-operator-webhook-ca`, which contains a CA certificate. If the secret is not found, the Operator auto-generates `cockroach-operator-webhook-ca` with a CA certificate for future runs.
+
+The Operator then generates a one-time server certificate for the webhook server that is signed with `cockroach-operator-webhook-ca`. Finally, the CA bundle for both mutating and validating webhook configurations is patched with the CA certificate.
+
+You can also use your own certificate authority rather than `cockroach-operator-webhook-ca`. Both the certificate and key files you generate must be PEM-encoded. See the following [example](#example-using-openssl-to-secure-the-webhooks).
+
+### Example: Using OpenSSL to secure the webhooks
+
+These steps demonstrate how to use the [`openssl genrsa`](https://www.openssl.org/docs/manmaster/man1/genrsa.html) and [`openssl req`](https://www.openssl.org/docs/manmaster/man1/req.html) subcommands to secure the webhooks on a running Kubernetes cluster:
+
+1. Generate a 4096-bit RSA private key:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ openssl genrsa -out tls.key 4096
+    ~~~
+
+1. Generate an X.509 certificate, valid for 10 years. You will be prompted for the certificate field values.
+
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    $ openssl req -x509 -new -nodes -key tls.key -sha256 -days 3650 -out tls.crt
+    ~~~
+
+1. Create the secret, making sure that [you are in the correct namespace](deploy-cockroachdb-with-kubernetes.html#install-the-operator):
+
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    $ kubectl create secret tls cockroach-operator-webhook-ca --cert=tls.crt --key=tls.key
+    ~~~
+
+    ~~~
+    secret/cockroach-operator-webhook-ca created
+    ~~~
+
+1. Remove the certificate and key from your local environment:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~
+    $ rm tls.crt tls.key
+    ~~~
+
+1. Roll the Operator deployment to ensure a new server certificate is generated:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ shell
+    $ kubectl apply -f operator.yaml
+    ~~~
 </section>
 
 <section class="filter-content" markdown="1" data-scope="helm">
@@ -1064,7 +1118,7 @@ This workflow is unsupported and should be enabled at your own risk.
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ kubectl apply -f operator.yaml
-    ~
+    ~~~
 
 1. Validate that the Operator is running:
 

--- a/v21.2/configure-cockroachdb-kubernetes.md
+++ b/v21.2/configure-cockroachdb-kubernetes.md
@@ -17,6 +17,8 @@ These settings override the defaults used when [deploying CockroachDB on Kuberne
 </div>
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 {{site.data.alerts.callout_success}}
 If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html), substitute `kubectl` with `oc` in the following commands.
 {{site.data.alerts.end}}

--- a/v21.2/create-security-certificates-openssl.md
+++ b/v21.2/create-security-certificates-openssl.md
@@ -1,5 +1,5 @@
 ---
-title: Create Security Certificates using Openssl
+title: Create Security Certificates using OpenSSL
 summary: A secure CockroachDB cluster uses TLS for encrypted inter-node and client-node communication.
 toc: true
 ---

--- a/v21.2/monitor-cockroachdb-kubernetes.md
+++ b/v21.2/monitor-cockroachdb-kubernetes.md
@@ -18,6 +18,8 @@ Despite CockroachDB's various [built-in safeguards against failure](architecture
 </div>
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 {{site.data.alerts.callout_success}}
 If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html), substitute `kubectl` with `oc` in the following commands.
 {{site.data.alerts.end}}

--- a/v21.2/scale-cockroachdb-kubernetes.md
+++ b/v21.2/scale-cockroachdb-kubernetes.md
@@ -19,6 +19,8 @@ This page explains how to add and remove CockroachDB nodes on Kubernetes.
 </div>
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 {{site.data.alerts.callout_success}}
 If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html), substitute `kubectl` with `oc` in the following commands.
 {{site.data.alerts.end}}

--- a/v21.2/schedule-cockroachdb-kubernetes.md
+++ b/v21.2/schedule-cockroachdb-kubernetes.md
@@ -16,6 +16,8 @@ This page describes how to configure the following, using the [Operator](https:/
 
 These settings control how CockroachDB pods can be identified or scheduled onto worker nodes.
 
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 ## Enable feature gates
 
 The [affinity](#affinities-and-anti-affinities) and [toleration](#taints-and-tolerations) rules are not yet fully supported. To enable them, [download the Operator manifest](https://raw.githubusercontent.com/cockroachdb/cockroach-operator/{{site.operator_version}}/install/operator.yaml) and add the following line to the `spec.containers.args` field:

--- a/v21.2/secure-cockroachdb-kubernetes.md
+++ b/v21.2/secure-cockroachdb-kubernetes.md
@@ -27,6 +27,8 @@ If you are running a secure Helm deployment on Kubernetes 1.22 and later, you mu
     <button class="filter-button" data-scope="helm">Helm</button>
 </div>
 
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 ## Use a custom CA
 
 <section class="filter-content" markdown="1" data-scope="operator">
@@ -605,21 +607,21 @@ These steps demonstrate how to use the [`openssl genrsa`](https://www.openssl.or
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ openssl genrsa -out tls.key 4096
+    openssl genrsa -out tls.key 4096
     ~~~
 
 1. Generate an X.509 certificate, valid for 10 years. You will be prompted for the certificate field values.
 
     {% include_cached copy-clipboard.html %}
-    ~~~
-    $ openssl req -x509 -new -nodes -key tls.key -sha256 -days 3650 -out tls.crt
+    ~~~ shell
+    openssl req -x509 -new -nodes -key tls.key -sha256 -days 3650 -out tls.crt
     ~~~
 
 1. Create the secret, making sure that [you are in the correct namespace](deploy-cockroachdb-with-kubernetes.html#install-the-operator):
 
     {% include_cached copy-clipboard.html %}
-    ~~~
-    $ kubectl create secret tls cockroach-operator-webhook-ca --cert=tls.crt --key=tls.key
+    ~~~ shell
+    kubectl create secret tls cockroach-operator-webhook-ca --cert=tls.crt --key=tls.key
     ~~~
 
     ~~~
@@ -629,14 +631,18 @@ These steps demonstrate how to use the [`openssl genrsa`](https://www.openssl.or
 1. Remove the certificate and key from your local environment:
 
     {% include_cached copy-clipboard.html %}
-    ~~~
-    $ rm tls.crt tls.key
+    ~~~ shell
+    rm tls.crt tls.key
     ~~~
 
 1. Roll the Operator deployment to ensure a new server certificate is generated:
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    $ kubectl apply -f operator.yaml
+    kubectl rollout restart deploy/cockroach-operator-manager
+    ~~~
+
+    ~~~
+    deployment.apps/cockroach-operator-manager restarted
     ~~~
 </section>

--- a/v21.2/upgrade-cockroachdb-kubernetes.md
+++ b/v21.2/upgrade-cockroachdb-kubernetes.md
@@ -21,6 +21,8 @@ The upgrade process on Kubernetes is a [staged update](https://kubernetes.io/doc
 </div>
 
 <section class="filter-content" markdown="1" data-scope="operator">
+{% include {{ page.version.version }}/orchestration/operator-check-namespace.md %}
+
 {{site.data.alerts.callout_success}}
 If you [deployed CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html), substitute `kubectl` with `oc` in the following commands.
 {{site.data.alerts.end}}


### PR DESCRIPTION
This supersedes #11939.

- Add steps for securing K8s Operator webhooks (adapted from @muto)
- Small formatting correction on our existing OpenSSL doc