### PR TITLE
Removed Caddy section from local file server docs

### DIFF
--- a/v20.2/use-a-local-file-server-for-bulk-operations.md
+++ b/v20.2/use-a-local-file-server-for-bulk-operations.md
@@ -24,7 +24,6 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
 - [Using PHP with `IMPORT`](#using-php-with-import)
 - [Using Python with `IMPORT`](#using-python-with-import)
 - [Using Ruby with `IMPORT`](#using-ruby-with-import)
-- [Using Caddy as a file server](#using-caddy-as-a-file-server)
 - [Using nginx as a file server](#using-nginx-as-a-file-server)
 
 {{site.data.alerts.callout_info}}We do not recommend using any machines running <code>cockroach</code> as file servers. Using machines that are running cockroach as file servers could negatively impact performance if I/O operations exceed capacity.{{site.data.alerts.end}}
@@ -66,29 +65,6 @@ The Ruby language has an HTTP server included in the standard library.  You can 
 $ cd /path/to/data
 $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/data.sql'
 ~~~
-
-### Using Caddy as a file server
-
-1. [Download the Caddy web server](https://caddyserver.com/download).  Before downloading, in the **Customize your build** step, open the list of **Plugins** and make sure to check the `http.upload` option.
-
-2. Copy the `caddy` binary to the directory containing the files you want to serve, and run it [with an upload directive](https://caddyserver.com/docs/http.upload), either in the command line or via [Caddyfile](https://caddyserver.com/docs/caddyfile).
-
-- Command line example (with no TLS):
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ caddy -root /mnt/cockroach-exports "upload / {" 'to "/mnt/cockroach-exports"' 'yes_without_tls' "}"
-    ~~~
-- `Caddyfile` example (using a key and cert):
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    tls key cert
-    root "/mnt/cockroach-exports"
-    upload / {
-      to "/mnt/cockroach-exports"
-    }
-    ~~~
-
-For more information about Caddy, see [its documentation](https://caddyserver.com/docs).
 
 ### Using nginx as a file server
 

--- a/v21.1/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.1/use-a-local-file-server-for-bulk-operations.md
@@ -24,7 +24,6 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
 - [Using PHP with `IMPORT`](#using-php-with-import)
 - [Using Python with `IMPORT`](#using-python-with-import)
 - [Using Ruby with `IMPORT`](#using-ruby-with-import)
-- [Using Caddy as a file server](#using-caddy-as-a-file-server)
 - [Using nginx as a file server](#using-nginx-as-a-file-server)
 
 {{site.data.alerts.callout_info}}We do not recommend using any machines running <code>cockroach</code> as file servers. Using machines that are running cockroach as file servers could negatively impact performance if I/O operations exceed capacity.{{site.data.alerts.end}}
@@ -66,29 +65,6 @@ The Ruby language has an HTTP server included in the standard library.  You can 
 $ cd /path/to/data
 $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/data.sql'
 ~~~
-
-### Using Caddy as a file server
-
-1. [Download the Caddy web server](https://caddyserver.com/download).  Before downloading, in the **Customize your build** step, open the list of **Plugins** and make sure to check the `http.upload` option.
-
-2. Copy the `caddy` binary to the directory containing the files you want to serve, and run it [with an upload directive](https://caddyserver.com/docs/http.upload), either in the command line or via [Caddyfile](https://caddyserver.com/docs/caddyfile).
-
-- Command line example (with no TLS):
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ caddy -root /mnt/cockroach-exports "upload / {" 'to "/mnt/cockroach-exports"' 'yes_without_tls' "}"
-    ~~~
-- `Caddyfile` example (using a key and cert):
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    tls key cert
-    root "/mnt/cockroach-exports"
-    upload / {
-      to "/mnt/cockroach-exports"
-    }
-    ~~~
-
-For more information about Caddy, see [its documentation](https://caddyserver.com/docs).
 
 ### Using nginx as a file server
 

--- a/v21.2/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.2/use-a-local-file-server-for-bulk-operations.md
@@ -24,7 +24,6 @@ You can use any file server software that supports `GET`, `PUT` and `DELETE` met
 - [Using PHP with `IMPORT`](#using-php-with-import)
 - [Using Python with `IMPORT`](#using-python-with-import)
 - [Using Ruby with `IMPORT`](#using-ruby-with-import)
-- [Using Caddy as a file server](#using-caddy-as-a-file-server)
 - [Using nginx as a file server](#using-nginx-as-a-file-server)
 
 {{site.data.alerts.callout_info}}We do not recommend using any machines running <code>cockroach</code> as file servers. Using machines that are running cockroach as file servers could negatively impact performance if I/O operations exceed capacity.{{site.data.alerts.end}}
@@ -66,29 +65,6 @@ The Ruby language has an HTTP server included in the standard library.  You can 
 $ cd /path/to/data
 $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/data.sql'
 ~~~
-
-### Using Caddy as a file server
-
-1. [Download the Caddy web server](https://caddyserver.com/download).  Before downloading, in the **Customize your build** step, open the list of **Plugins** and make sure to check the `http.upload` option.
-
-2. Copy the `caddy` binary to the directory containing the files you want to serve, and run it [with an upload directive](https://caddyserver.com/docs/http.upload), either in the command line or via [Caddyfile](https://caddyserver.com/docs/caddyfile).
-
-- Command line example (with no TLS):
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    $ caddy -root /mnt/cockroach-exports "upload / {" 'to "/mnt/cockroach-exports"' 'yes_without_tls' "}"
-    ~~~
-- `Caddyfile` example (using a key and cert):
-    {% include copy-clipboard.html %}
-    ~~~ shell
-    tls key cert
-    root "/mnt/cockroach-exports"
-    upload / {
-      to "/mnt/cockroach-exports"
-    }
-    ~~~
-
-For more information about Caddy, see [its documentation](https://caddyserver.com/docs).
 
 ### Using nginx as a file server
 


### PR DESCRIPTION
Closes #10621

As per the issue and discussion with Michael some time ago, removing the Caddy section from the local file server section.