### PR TITLE
21.2 SQL Feature Support (SQL XP)

### DIFF
--- a/v21.2/sql-feature-support.md
+++ b/v21.2/sql-feature-support.md
@@ -168,6 +168,7 @@ table tr td:nth-child(2) {
  Roles | ✓ | Standard | [Roles documentation](authorization.html#roles)
  Object ownership | ✓ | Common Extension | [Ownership documentation](authorization.html#object-ownership)
  Privileges | ✓ | Standard | [Privileges documentation](authorization.html#assign-privileges)
+ Default privileges | ✓ | PostgreSQL Extension | [Default privileges documentation](authorization.html#default-privileges)
 
 ### Miscellaneous
 
@@ -175,9 +176,11 @@ table tr td:nth-child(2) {
 -----------|-----------|------|---------
  Column families | ✓ | CockroachDB Extension | [Column Families documentation](column-families.html)
  Computed columns (stored and virtual) | ✓ | Common Extension | [Computed Columns documentation](computed-columns.html)
+ `ON UPDATE` expressions | ✓ | PostgreSQL, MySQL Extension | [`ON UPDATE` expressions documentation](create-table.html#on-update-expressions)
  Multi-region capabilities | ✓ | CockroachDB Extension | [Multi-region documentation](multiregion-overview.html)
  System catalog schemas | ✓ | Standard, PostgreSQL/CockroachDB Extension | [`crdb_internal`](crdb-internal.html) (CockroachDB Extension)<br>[`information_schema`](information-schema.html) (Standard)<br>[`pg_catalog`](pg-catalog.html) (PostgreSQL Extension)<br>[`pg_extension`](pg-extension.html) (PostgreSQL Extension)
  Sequences |  ✓ | Common Extension | [`CREATE SEQUENCE` documentation](create-sequence.html)
+ Identity columns | ✓ | Common Extension | [Identity columns documentation](create-table.html#identity-columns)
  Views | ✓ | Standard | [Views documentation](views.html)
  Materialized views | ✓ | Common Extension |  [Materialized views documentation](views.html#materialized-views)
  Window functions | ✓ | Standard | [Window Functions documentation](window-functions.html)

--- a/v21.2/sql-feature-support.md
+++ b/v21.2/sql-feature-support.md
@@ -168,7 +168,7 @@ table tr td:nth-child(2) {
  Roles | ✓ | Standard | [Roles documentation](authorization.html#roles)
  Object ownership | ✓ | Common Extension | [Ownership documentation](authorization.html#object-ownership)
  Privileges | ✓ | Standard | [Privileges documentation](authorization.html#assign-privileges)
- Default privileges | ✓ | PostgreSQL Extension | [Default privileges documentation](authorization.html#default-privileges)
+ Default privileges | Partial | PostgreSQL Extension | [Default privileges documentation](authorization.html#default-privileges)
 
 ### Miscellaneous
 
@@ -176,7 +176,7 @@ table tr td:nth-child(2) {
 -----------|-----------|------|---------
  Column families | ✓ | CockroachDB Extension | [Column Families documentation](column-families.html)
  Computed columns (stored and virtual) | ✓ | Common Extension | [Computed Columns documentation](computed-columns.html)
- `ON UPDATE` expressions | ✓ | PostgreSQL, MySQL Extension | [`ON UPDATE` expressions documentation](create-table.html#on-update-expressions)
+ `ON UPDATE` expressions | ✓ | MySQL Extension | [`ON UPDATE` expressions documentation](create-table.html#on-update-expressions)
  Multi-region capabilities | ✓ | CockroachDB Extension | [Multi-region documentation](multiregion-overview.html)
  System catalog schemas | ✓ | Standard, PostgreSQL/CockroachDB Extension | [`crdb_internal`](crdb-internal.html) (CockroachDB Extension)<br>[`information_schema`](information-schema.html) (Standard)<br>[`pg_catalog`](pg-catalog.html) (PostgreSQL Extension)<br>[`pg_extension`](pg-extension.html) (PostgreSQL Extension)
  Sequences |  ✓ | Common Extension | [`CREATE SEQUENCE` documentation](create-sequence.html)


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/docs/issues/12148.

I've gone through [PostgreSQL Compatibility](https://www.cockroachlabs.com/docs/v21.2/postgresql-compatibility.html) and [SQL Feature Support](https://www.cockroachlabs.com/docs/v21.2/sql-feature-support.html), and I believe this PR finishes updating our SQL Feature Support for 21.2, following https://github.com/cockroachdb/docs/pull/12211. 

LMK if you disagree though. Happy to make edits/additions!