### PR TITLE
Use better links to Pebble docs

### DIFF
--- a/v21.1/cockroach-start.md
+++ b/v21.1/cockroach-start.md
@@ -130,7 +130,7 @@ The `--locality` flag accepts arbitrary key-value pairs that describe the locati
 
 The `--storage-engine` flag is used to choose the storage engine used by the node. Note that this setting applies to all [stores](#store) on the node, including the [temp store](#temp-dir).
 
-<span class="version-tag">Changed in v21.1:</span> As of v21.1, CockroachDB always uses the [Pebble storage engine](https://github.com/cockroachdb/pebble). As such, `pebble` is the default and only option for the `--storage-engine` flag.
+<span class="version-tag">Changed in v21.1:</span> As of v21.1, CockroachDB always uses the [Pebble storage engine](architecture/storage-layer.html#pebble). As such, `pebble` is the default and only option for the `--storage-engine` flag.
 
 {{site.data.alerts.callout_danger}}
 If you specified `--storage-engine=rocksdb` when starting nodes with v20.2, be sure to change that to `--storage-engine=pebble` or remove the flag entirely before [upgrading to v21.1](upgrade-cockroach-version.html). Pebble is intended to be bi-directionally compatible with the RocksDB on-disk format, so the switch will be seamless during the upgrade process.

--- a/v21.2/cockroach-start.md
+++ b/v21.2/cockroach-start.md
@@ -130,7 +130,7 @@ The `--locality` flag accepts arbitrary key-value pairs that describe the locati
 
 The `--storage-engine` flag is used to choose the storage engine used by the node. Note that this setting applies to all [stores](#store) on the node, including the [temp store](#temp-dir).
 
- As of v21.1 and later, CockroachDB always uses the [Pebble storage engine](https://github.com/cockroachdb/pebble). As such, `pebble` is the default and only option for the `--storage-engine` flag.
+ As of v21.1 and later, CockroachDB always uses the [Pebble storage engine](architecture/storage-layer.html#pebble). As such, `pebble` is the default and only option for the `--storage-engine` flag.
 
 #### Store
 


### PR DESCRIPTION
We have a section on Pebble in the Architecture > Storage Layer docs which includes this info and more, so let's use that.