### PR TITLE
Change man in the middle to machine in the middle

### DIFF
--- a/cockroachcloud/authentication.md
+++ b/cockroachcloud/authentication.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Node identity verification
 
-The [connection string](connect-to-your-cluster.html) generated to connect to your application uses the `verify-full` [SSL mode](#ssl-mode-settings) by default to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Man in the Middle) attacks, impersonation attacks, and eavesdropping.
+The [connection string](connect-to-your-cluster.html) generated to connect to your application uses the `verify-full` [SSL mode](#ssl-mode-settings) by default to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Machine in the Middle) attacks, impersonation attacks, and eavesdropping.
 
 To connect securely to your cluster using the `verify-full` mode:
 


### PR DESCRIPTION
Following our style guidance on inclusive language: https://github.com/cockroachdb/docs/wiki/Style-Guide#avoid-unnecessarily-gendered-language.

Fixes #10546

