### PR TITLE
Refactor Cloud API docs with warnings.

### DIFF
--- a/_includes/cockroachcloud/experimental-warning.md
+++ b/_includes/cockroachcloud/experimental-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-**This is a private and experimental feature**. The interface and output are subject to change.
+**This is a private and experimental feature**. The interface and output are subject to change. To request access to this feature, contact us at <a href="mailto:earlyaccess@cockroachlabs.com">earlyaccess@cockroachlabs.com</a>.
 {{site.data.alerts.end}}

--- a/_includes/cockroachcloud/experimental-warning.md
+++ b/_includes/cockroachcloud/experimental-warning.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_danger}}
+**This is a private and experimental feature**. The interface and output are subject to change.
+{{site.data.alerts.end}}

--- a/_includes/common/experimental-warning.md
+++ b/_includes/common/experimental-warning.md
@@ -1,3 +1,3 @@
 {{site.data.alerts.callout_danger}}
-This feature is considered experimental, and it may not be available to all users. The functionality is subject to change, and there may be bugs.
+**This is an experimental feature**. The interface and output are subject to change.
 {{site.data.alerts.end}}

--- a/_includes/common/experimental-warning.md
+++ b/_includes/common/experimental-warning.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_danger}}
+This feature is considered experimental, and it may not be available to all users. The functionality is subject to change, and there may be bugs.
+{{site.data.alerts.end}}

--- a/_includes/sidebar-data-cockroachcloud.json
+++ b/_includes/sidebar-data-cockroachcloud.json
@@ -39,6 +39,12 @@
       	  "urls": [
             "/cockroachcloud/hello-world-example-apps.html"
         	  ]
+        },
+        {
+          "title": "Use the Cloud API",
+          "urls": [
+            "/cockroachcloud/cloud-api.html"
+          ]
         }
       ]
     },

--- a/_includes/v21.2/misc/experimental-warning.md
+++ b/_includes/v21.2/misc/experimental-warning.md
@@ -1,3 +1,0 @@
-{{site.data.alerts.callout_danger}}
-**This is an experimental feature**. The interface and output are subject to change.
-{{site.data.alerts.end}}

--- a/_includes/v21.2/sidebar-data/manage.json
+++ b/_includes/v21.2/sidebar-data/manage.json
@@ -16,6 +16,12 @@
           "urls": [
             "/cockroachcloud/cluster-management.html"
           ]
+        },
+        {
+          "title": "Use the Cloud API",
+          "urls": [
+            "/cockroachcloud/cloud-api.html"
+          ]
         }
       ]
     },

--- a/_includes/v21.2/sidebar-data/reference.json
+++ b/_includes/v21.2/sidebar-data/reference.json
@@ -1700,6 +1700,12 @@
         ]
       },
       {
+        "title": "Cloud API",
+        "urls": [
+          "/api/cloud/v1.html"
+        ]
+      },
+      {
         "title": "Logging",
         "items": [
           {

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -6,94 +6,15 @@ toc: true
 
 The Cloud API is a [REST interface](https://en.wikipedia.org/wiki/Representational_state_transfer) that allows users programmatic access to manage the lifecycle of clusters within their organization.
 
-{{site.data.alerts.callout_danger}}
-This page describes an early access, experimental version of the Cloud API. The interface and output are subject to change, and there may be bugs.
-{{site.data.alerts.end}}
+{% include_cached common/experimental-warning.md %}
 
 ## API reference
 
 Refer to the [full API reference documentation](../api/cloud/v1.html) for detailed descriptions of the API endpoints and options.
 
-{%comment %} START of temporary content while API is still behind a feature-flag{% endcomment %}
-## Service accounts
-
-Service accounts are used by applications accessing the API to manage {{ site.data.products.db }} clusters within the organization. Service accounts are not for human users.
-
-To create a service account:
-
-1. Click **Create Service Account**.
-1. In the **Create service account** dialog:
-    1. Enter the **Account name**.
-    1. (Optional) Enter a **Description** of the service account.
-    1. Set the **Permissions** of the service account.
-
-        Granting `ADMIN` permissions allows the service account full authorization for the organization, where the service account can create, modify, and delete clusters.
-
-        The `CREATE` permission allows the service account to create new clusters within the organization.
-
-        The `DELETE` permission allows the service account to delete clusters within the organization.
-
-        The `EDIT` permission allows the service account to modify clusters within the organization.
-
-        The `READ` permission allows the service account to get details about clusters within the organization.
-
-    1. Click **Create**.
-
-1. [Create an API key](#create-api-keys) for the newly created service account, or click **Skip** to go back to the Service Accounts table.
-
-### Modify a service account
-
-To modify the name, description, or permissions of a service account:
-
-1. Click the **Action** button for the service account name in the **Service Accounts** table.
-1. Select **Edit**.
-1. In the **Edit service account** dialog, modify the name, description, or permissions for the service account.
-1. Click **Save changes**.
-
-### API access
-
-Each service account can have one or more API keys. API keys are used to authenticate and authorize service accounts when using the API. All API keys created by the account are listed under **API Access**.
-
-We recommend creating service accounts with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), and giving each application that accesses the API its own API key. This allows fine-grained permission and API key access to the cluster.
-
-#### Create API keys
-
-To create an API key:
-
-1. Click **Create API Key**.
-1. Enter the **API key name** and click **Create**. The name should identify how the API key will be used. For example, you could name your API key for the application that will use the key.
-1. Copy the **Secret key** and store it in a secure location. There is a **Copy** button to the right of the displayed secret key that will copy the secret key to your OS clipboard.
-
-    The secret key contains the API key and secret. It should never be shared or publicly accessable. Anyone with the secret key can use the API with the permissions of the service account.
-
-    {{site.data.alerts.callout_danger}}
-    The secret key will not be available after closing the **Create API key** dialog. If you have lost your secret key, you should [delete the API key](#delete-api-keys) and create a new one.
-    {{site.data.alerts.end}}
-
-1. Click **Done**.
-
-#### Delete API keys
-
-To delete an API key associated with a service account:
-
-1. Click the **Action** button for the API key ID in the **API Access** table.
-1. Select **Delete**.
-1. In the **Delete API key** dialog enter the name of the service account to confirm the delete operation, then click **Delete**.
-
-#### Edit API key names
-
-To change the API key name for an existing API key:
-
-1. Find the API key ID in the **API Access** table.
-1. Click the **Action** button.
-1. Select **Edit**.
-1. In the **Edit API key name** dialog modify the API key name and click **Save changes**.
-
-{%comment %} END of temporary content while API is still behind a feature-flag{% endcomment %}
-
 ## Call the API
 
-The API uses [bearer token authentication](https://swagger.io/docs/specification/authentication/bearer-authentication/), and each request requires a [secret key](#api-access). The secret key is associated with a service account, and inherits the [permissions of the account](#service-accounts).
+The API uses [bearer token authentication](https://swagger.io/docs/specification/authentication/bearer-authentication/), and each request requires a [secret key](console-access-management.html#api-access). The secret key is associated with a service account, and inherits the [permissions of the account](console-access-management.html#service-accounts).
 
 To send the secret key when making an API call, add the secret key to the `Authorization` HTTP header sent with the request.
 
@@ -118,7 +39,7 @@ Authorization: Bearer {secret key}
 ~~~
 </section>
 
-Where `{secret key}` is the [secret key string you stored when you created the API key in the Console](#create-api-keys).
+Where `{secret key}` is the [secret key string you stored when you created the API key in the Console](console-access-management.html#create-api-keys).
 
 ## Create a new cluster
 

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -6,7 +6,7 @@ toc: true
 
 The Cloud API is a [REST interface](https://en.wikipedia.org/wiki/Representational_state_transfer) that allows users programmatic access to manage the lifecycle of clusters within their organization.
 
-{% include_cached common/experimental-warning.md %}
+{% include_cached cockroachcloud/experimental-warning.md %}
 
 ## API reference
 

--- a/cockroachcloud/cloud-api.md
+++ b/cockroachcloud/cloud-api.md
@@ -141,7 +141,10 @@ If the request was successful, the API will return information about the newly c
 
 Where:
 
-  - `{clusterId}` is the unique ID of this cluster. Use this ID when making API requests for this particular cluster.
+  - `{clusterId}` is the unique ID of this cluster. Use this ID when making API requests for this particular cluster. Note:
+    {{site.data.alerts.callout_info}}
+    The cluster ID used in the Cloud API is different than the cluster name and tenant ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
+    {{site.data.alerts.end}}
   - `{cluster name}` is the name of the cluster you specified when creating the cluster.
   - `{CockroachDB version}` is the version of CockroachDB running on this cluster.
   - `{account ID}` is the ID of the account that created the cluster. If the cluster was created using the API, this will be the service account ID associated with the secret key used when creating the cluster.
@@ -161,6 +164,9 @@ curl --request GET \
 Where:
 
   - `{clusterId}` is the cluster ID returned after creating the cluster.
+  {{site.data.alerts.callout_info}}
+  The cluster ID used in the Cloud API is different than the cluster name and tenant ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
+  {{site.data.alerts.end}}
   - `{secret key}` is the secret key for the service account.
 
 If the request was successful, the API will return detailed information about the cluster.
@@ -205,6 +211,9 @@ If the request was successful, the API will return detailed information about th
 Where:
 
   - `{clusterId}` is the unique ID of this cluster. Use this ID when making API requests for this particular cluster.
+  {{site.data.alerts.callout_info}}
+  The cluster ID used in the Cloud API is different than the cluster name and tenant ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
+  {{site.data.alerts.end}}
   - `{cluster name}` is the name of the cluster you specified when creating the cluster.
   - `{CockroachDB version}` is the version of CockroachDB running on this cluster.
   - `{cloud provider}` is the name of the cloud infrastructure provider on which you want your cluster to run. Possible values are: `GCP` and `AWS`. The default value is `GCP`.
@@ -245,6 +254,9 @@ curl --request PUT \
 Where:
 
   - `{clusterId}` is the unique ID of this cluster.
+  {{site.data.alerts.callout_info}}
+  The cluster ID used in the Cloud API is different than the cluster name and tenant ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
+  {{site.data.alerts.end}}
   - `{secret key}` is the secret key for the service account.
   - `{spend limit}` is the [maximum amount of money, in US cents, you want to spend per month](serverless-cluster-management.html#planning-your-cluster) on this cluster.
 
@@ -265,7 +277,11 @@ curl --request DELETE \
 
 Where:
 
-  - `{clusterId}` is the cluster ID.
+  - `{organizationId}` is the organization ID found in the **Settings** page of the Console.
+  - `{clusterId}` is the unique ID of this cluster.
+  {{site.data.alerts.callout_info}}
+  The cluster ID used in the Cloud API is different than the cluster name and tenant ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
+  {{site.data.alerts.end}}
   - `{secret key}` is the secret key for the service account.
 
 If the `DELETE` request was successful the client will not receive a response payload.
@@ -318,6 +334,9 @@ If the request was successful, the client will receive a list of all clusters wi
 Where:
 
   - `{clusterId}` is the unique ID of this cluster.
+  {{site.data.alerts.callout_info}}
+  The cluster ID used in the Cloud API is different than the cluster name and tenant ID used when [connecting to clusters](connect-to-a-serverless-cluster.html).
+  {{site.data.alerts.end}}
   - `{cluster name}` is the name of the cluster.
   - `{CockroachDB version}` is the version of CockroachDB running on this cluster.
   - `{cloud provider}` is the name of the cloud infrastructure provider. Possible values are: `GCP` and `AWS`.

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -4,7 +4,7 @@ summary: Manage your account roles and permissions.
 toc: true
 ---
 
-The **Access** page displays the name, email address, role, and invite acceptance status of the Team Members with access to your {{ site.data.products.db }} organization. To view the Access page, [log in](https://cockroachlabs.cloud/) and click **Access**.
+The **Access** page displays the name, email address, role, and invite acceptance status of the Team Members with access to your {{ site.data.products.db }} organization. To view the **Access** page, [log in](https://cockroachlabs.cloud/) and click **Access**.
 
 ## Organization
 
@@ -53,6 +53,7 @@ Service accounts are used by applications accessing the [Cloud API](cloud-api.ht
 
 To create a service account:
 
+1.  On the **Access** page, select the **Service Accounts** tab.
 1. Click **Create Service Account**.
 1. In the **Create service account** dialog:
     1. Enter the **Account name**.
@@ -94,6 +95,8 @@ We recommend creating service accounts with the [principle of least privilege](h
 
 To create an API key:
 
+1. On the **Access** page, select the **Service Accounts** tab.
+1. Click the service account for which you want to create an API key to bring up the **Service Account Details** page.
 1. Click **Create API Key**.
 1. Enter the **API key name** and click **Create**. The name should identify how the API key will be used. For example, you could name your API key for the application that will use the key.
 1. Copy the **Secret key** and store it in a secure location. There is a **Copy** button to the right of the displayed secret key that will copy the secret key to your OS clipboard.
@@ -110,6 +113,8 @@ To create an API key:
 
 To delete an API key associated with a service account:
 
+1. On the **Access** page, select the **Service Accounts** tab.
+1. Click the service account for which you want to create an API key to bring up the **Service Account Details** page.
 1. Click the **Action** button for the API key ID in the **API Access** table.
 1. Select **Delete**.
 1. In the **Delete API key** dialog enter the name of the service account to confirm the delete operation, then click **Delete**.
@@ -118,6 +123,8 @@ To delete an API key associated with a service account:
 
 To change the API key name for an existing API key:
 
+1. On the **Access** page, select the **Service Accounts** tab.
+1. Click the service account for which you want to create an API key to bring up the **Service Account Details** page.
 1. Find the API key ID in the **API Access** table.
 1. Click the **Action** button.
 1. Select **Edit**.

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -47,7 +47,7 @@ A Console Admin is an all-access role. A Console Admin can perform the following
 
 ## Service accounts
 
-{% include_cached common/experimental-warning.md %}
+{% include_cached cockroachcloud/experimental-warning.md %}
 
 Service accounts are used by applications accessing the [Cloud API](cloud-api.html) to manage {{ site.data.products.db }} clusters within the organization. Service accounts are not for human users.
 
@@ -84,7 +84,7 @@ To modify the name, description, or permissions of a service account:
 
 ### API access
 
-{% include_cached common/experimental-warning.md %}
+{% include_cached cockroachcloud/experimental-warning.md %}
 
 Each service account can have one or more API keys. API keys are used to authenticate and authorize service accounts when using the API. All API keys created by the account are listed under **API Access**.
 

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -45,6 +45,84 @@ A Console Admin is an all-access role. A Console Admin can perform the following
 - [Restore databases and tables from a {{ site.data.products.db }} backup](backups-page.html#ways-to-restore-data)
 - [Delete an organization](#delete-an-organization)
 
+## Service accounts
+
+{% include_cached common/experimental-warning.md %}
+
+Service accounts are used by applications accessing the [Cloud API](cloud-api.html) to manage {{ site.data.products.db }} clusters within the organization. Service accounts are not for human users.
+
+To create a service account:
+
+1. Click **Create Service Account**.
+1. In the **Create service account** dialog:
+    1. Enter the **Account name**.
+    1. (Optional) Enter a **Description** of the service account.
+    1. Set the **Permissions** of the service account.
+
+        Granting `ADMIN` permissions allows the service account full authorization for the organization, where the service account can create, modify, and delete clusters.
+
+        The `CREATE` permission allows the service account to create new clusters within the organization.
+
+        The `DELETE` permission allows the service account to delete clusters within the organization.
+
+        The `EDIT` permission allows the service account to modify clusters within the organization.
+
+        The `READ` permission allows the service account to get details about clusters within the organization.
+
+    1. Click **Create**.
+
+1. [Create an API key](#create-api-keys) for the newly created service account, or click **Skip** to go back to the Service Accounts table.
+
+### Modify a service account
+
+To modify the name, description, or permissions of a service account:
+
+1. Click the **Action** button for the service account name in the **Service Accounts** table.
+1. Select **Edit**.
+1. In the **Edit service account** dialog, modify the name, description, or permissions for the service account.
+1. Click **Save changes**.
+
+### API access
+
+{% include_cached common/experimental-warning.md %}
+
+Each service account can have one or more API keys. API keys are used to authenticate and authorize service accounts when using the API. All API keys created by the account are listed under **API Access**.
+
+We recommend creating service accounts with the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), and giving each application that accesses the API its own API key. This allows fine-grained permission and API key access to the cluster.
+
+#### Create API keys
+
+To create an API key:
+
+1. Click **Create API Key**.
+1. Enter the **API key name** and click **Create**. The name should identify how the API key will be used. For example, you could name your API key for the application that will use the key.
+1. Copy the **Secret key** and store it in a secure location. There is a **Copy** button to the right of the displayed secret key that will copy the secret key to your OS clipboard.
+
+    The secret key contains the API key and secret. It should never be shared or publicly accessible. Anyone with the secret key can use the API with the permissions of the service account.
+
+    {{site.data.alerts.callout_danger}}
+    The secret key will not be available after closing the **Create API key** dialog. If you have lost your secret key, you should [delete the API key](#delete-api-keys) and create a new one.
+    {{site.data.alerts.end}}
+
+1. Click **Done**.
+
+#### Delete API keys
+
+To delete an API key associated with a service account:
+
+1. Click the **Action** button for the API key ID in the **API Access** table.
+1. Select **Delete**.
+1. In the **Delete API key** dialog enter the name of the service account to confirm the delete operation, then click **Delete**.
+
+#### Edit API key names
+
+To change the API key name for an existing API key:
+
+1. Find the API key ID in the **API Access** table.
+1. Click the **Action** button.
+1. Select **Edit**.
+1. In the **Edit API key name** dialog modify the API key name and click **Save changes**.
+
 ## Administrative tasks
 
 ### Invite Team Members to {{ site.data.products.db }}

--- a/v21.2/changefeed-for.md
+++ b/v21.2/changefeed-for.md
@@ -14,7 +14,7 @@ The `EXPERIMENTAL CHANGEFEED FOR` [statement](sql-statements.html) creates a new
 
 For more information, see [Stream Data Out of CockroachDB Using Changefeeds](stream-data-out-of-cockroachdb-using-changefeeds.html).
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 ## Required privileges
 

--- a/v21.2/cockroach-demo.md
+++ b/v21.2/cockroach-demo.md
@@ -494,7 +494,7 @@ For a tutorial that uses a demo cluster to demonstrate CockroachDB's multi-regio
 
 In a multi-node demo cluster, you can use `\demo` [shell commands](#commands) to add, shut down, restart, decommission, and recommission individual nodes.
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v21.2/cockroach-sqlfmt.md
+++ b/v21.2/cockroach-sqlfmt.md
@@ -12,7 +12,7 @@ CockroachDB.
 
 A [web interface to this feature](https://sqlfum.pt/) is also available.
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 ## Synopsis
 

--- a/v21.2/experimental-audit.md
+++ b/v21.2/experimental-audit.md
@@ -23,7 +23,7 @@ For descriptions of all SQL audit event types and their fields, see [Notable Eve
 
 CockroachDB stores audit log information in a way that ensures durability, but negatively impacts performance. As a result, we recommend using SQL audit logs for security purposes only. For more information, see [Performance considerations](#performance-considerations).
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 {% include {{ page.version.version }}/sql/combine-alter-table-commands.md %}
 

--- a/v21.2/hash-sharded-indexes.md
+++ b/v21.2/hash-sharded-indexes.md
@@ -6,7 +6,7 @@ toc: true
 
 If you are working with a table that must be indexed on sequential keys, you should use **hash-sharded indexes**. Hash-sharded indexes distribute sequential traffic uniformly across ranges, eliminating single-range hotspots and improving write performance on sequentially-keyed indexes at a small cost to read performance.
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 ## How hash-sharded indexes work
 

--- a/v21.2/logging-use-cases.md
+++ b/v21.2/logging-use-cases.md
@@ -152,7 +152,7 @@ The [`SESSIONS`](logging.html#sessions) channel logs SQL session events. This in
 These logs perform one disk I/O per event. Enabling each setting will impact performance.
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 #### Example: Client connection events
 
@@ -227,7 +227,7 @@ The [`SENSITIVE_ACCESS`](logging.html#sensitive_access) channel logs SQL audit e
 Enabling these logs can negatively impact performance. We recommend using `SENSITIVE_ACCESS` for security purposes only.
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 To log all queries against a specific table, enable auditing on the table with [`ALTER TABLE ... EXPERIMENTAL_AUDIT`](experimental-audit.html). 
 

--- a/v21.2/set-locality.md
+++ b/v21.2/set-locality.md
@@ -142,7 +142,7 @@ ALTER TABLE rides ADD COLUMN region crdb_internal_region AS (
 
 ### Turn on auto-rehoming for `REGIONAL BY ROW` tables
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 This feature is disabled by default.
 

--- a/v21.2/show-range-for-row.md
+++ b/v21.2/show-range-for-row.md
@@ -6,7 +6,7 @@ toc: true
 
 The `SHOW RANGE ... FOR ROW` [statement](sql-statements.html) shows information about a [range](architecture/overview.html#glossary) for a single row in a table or index. This information is useful for verifying how SQL data maps to underlying ranges, and where the replicas for a range are located.
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 {{site.data.alerts.callout_info}}
 To show information about the ranges for all data in a table, index, or database, use the [`SHOW RANGES`](show-ranges.html) statement.

--- a/v21.2/sql-audit-logging.md
+++ b/v21.2/sql-audit-logging.md
@@ -20,7 +20,7 @@ Note that enabling SQL audit logs can negatively impact performance. As a result
 For the best visibility into security-related events on your cluster, we recommend configuring `SENSITIVE_ACCESS` together with the `USER_ADMIN`, `PRIVILEGES`, and `SESSIONS` logging channels. To learn more, see [Logging Use Cases](logging-use-cases.html#security-and-audit-monitoring).
 {{site.data.alerts.end}}
 
-{% include {{ page.version.version }}/misc/experimental-warning.md %}
+{% include common/experimental-warning.md %}
 
 ## Step 1. Create sample tables
 


### PR DESCRIPTION
Fixes CC-5426.

This PR:

- Breaks out the service account and API key creation docs into the main managing accounts doc.
- Adds the Cloud API reference and quickstart to the sidebar navigation.
- Adds a general purpose warning that can be used across the docs for experimental features.