### PR TITLE
Tech advisory notes: Backups fail during upgrade process a72839

### DIFF
--- a/_data/advisories.yml
+++ b/_data/advisories.yml
@@ -1,3 +1,7 @@
+- advisory: 72839
+  summary: Backups fail during upgrade process
+  versions: 21.1.x to 21.2.0
+  date: November 18, 2021
 - advisory: 71553
   summary: SQL statements that used secondary unique indexes that were created as a result of an <code>ALTER PRIMARY KEY</code> statement can return incorrect results.
   versions: 20.2, 21.1

--- a/advisories/a72839.md
+++ b/advisories/a72839.md
@@ -1,0 +1,60 @@
+---
+title: Technical Advisory 72839
+summary: Backups fail during upgrade process
+toc: true
+---
+
+Publication date: Nov 19, 2021
+
+## Description
+
+During an upgrade of a CockroachDB cluster from v21.1.x → v21.2.0, [backups](../v21.2/take-full-and-incremental-backups.html) will fail until the upgrade is [finalized](../v21.2/upgrade-cockroach-version.html#step-3-decide-how-the-upgrade-will-be-finalized).
+
+After the upgrade is complete and finalized, backups will continue as normal.
+
+This issue will only occur if the upgrade coincides with a backup. For small clusters, where the upgrade is quick, there may be no overlap, and you will not experience this issue.
+
+For larger clusters, or clusters with frequent backups, the likelihood of such an overlap increases. You should consider the [mitigations below](#mitigation).
+
+Newly created (non-upgrade) clusters are unaffected.
+
+## Statement
+
+Cockroach Labs has diagnosed the above-described problem, and is tracking progress in GitHub issue [#72839](https://github.com/cockroachdb/cockroach/issues/72839).
+
+We plan to improve this issue in an expedited patch version v21.2.1 in the coming days. This advisory will be updated after that release.
+
+You can track releases on our [releases page](../releases/index.html#production-releases).
+
+## Mitigation
+
+If you plan to upgrade to v21.2, please wait until the v21.2.1 release or later.
+
+If an upgrade is already in progress, we recommend either of the following:
+
+* Rolling back the upgrade and waiting for v21.2.1.
+* Finalizing the upgrade. See: [Upgrade to CockroachDB v21.2](../v21.2/upgrade-cockroach-version.html) for more details. Note: You cannot roll back after finalization is complete.
+
+If you have already completed the upgrade to v21.2, no further intervention is necessary. However, you may have skipped backups during that upgrade process, so you may wish to review your archives.
+
+If you are running v21.1.x, and anticipate running backups during an upgrade to v21.2, we recommend upgrading to the v21.1.12 patch version (or later), prior to the major-version upgrade. Once on this version, we recommend the following setting:
+
+~~~ sql
+SET CLUSTER SETTING bulkio.backup.experimental_21_2_mode.enabled = true;
+~~~
+
+This setting will reduce the likelihood of backups failing during a subsequent upgrade to v21.2.1.
+
+To minimize likelihood of backup issues, we recommend against running in a mixed-major-version state for long periods of time.
+
+[Please review our upgrade documentation](https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html).
+
+## Impact
+
+Backups may fail during the upgrade process from v21.1.x → v21.2.0.
+
+For a large cluster, or a cluster with frequent backups, this upgrade time may overlap with backup execution. These backups are likely to fail.
+
+For a small cluster, the upgrade time might not overlap with backup execution. In this case, backups will be unaffected.
+
+Please reach out to the [support team](https://support.cockroachlabs.com/) if you need more information or assistance.

--- a/releases/v21.2.0.md
+++ b/releases/v21.2.0.md
@@ -13,6 +13,14 @@ To learn more:
 - Read the [v21.2 blog post](https://www.cockroachlabs.com/blog/cockroachdb-21-2-release/).
 - Join us for a live demo and Q&A session on Tuesday, December 7. Sign up for the [North America session](https://www.cockroachlabs.com/webinars/cockroachdb-21-2-release-na) or the [EMEA session](https://www.cockroachlabs.com/webinars/cockroachdb-21-2-release-emea). We hope to see you there.
 
+{{site.data.alerts.callout_danger}}
+During an upgrade of a CockroachDB cluster from v21.1.x → v21.2.0, [backups](../v21.2/take-full-and-incremental-backups.html) will fail until the upgrade is [finalized](../v21.2/upgrade-cockroach-version.html#step-3-decide-how-the-upgrade-will-be-finalized). After the upgrade is complete and finalized, backups will continue as normal.
+
+This issue will only occur if the upgrade coincides with a backup. For small clusters, where the upgrade is quick, there may be no overlap, and you will not experience this issue.
+
+For more information, including mitigation, see [Technical Advisory 72389](../advisories/a72839.html).
+{{site.data.alerts.end}}
+
 ## Downloads
 
 <div id="os-tabs" class="filters clearfix">


### PR DESCRIPTION
Technical advisory notes relating to [#72839](https://github.com/cockroachdb/cockroach/issues/72839).

Backups fail during upgrade process v21.2 / v21.1