### PR TITLE
Update to version on table to make clearer

### DIFF
--- a/_data/advisories.yml
+++ b/_data/advisories.yml
@@ -1,6 +1,6 @@
 - advisory: 72839
   summary: Backups fail during upgrade process
-  versions: 21.1.x to 21.2.0
+  versions: 21.2.0
   date: November 18, 2021
 - advisory: 71553
   summary: SQL statements that used secondary unique indexes that were created as a result of an <code>ALTER PRIMARY KEY</code> statement can return incorrect results.


### PR DESCRIPTION
Quick fix to the versions in the advisories table to make it clearer that v21.2.0 is the affected version