### PR TITLE
DOC-1859: Highlight sidenav for newer TAs

### DIFF
--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -87,7 +87,12 @@
         "/advisories/a62842.html",
         "/advisories/a63162.html",
         "/advisories/a64325.html",
-        "/advisories/a68005.html"
+        "/advisories/a68005.html",
+        "/advisories/a69874.html",
+        "/advisories/a71002.html",
+        "/advisories/a71655.html",
+        "/advisories/a71553.html",
+        "/advisories/a72839.html"        
       ]
     }
   ]


### PR DESCRIPTION
"Technical Advisories" in the sidenav isn’t highlighted when viewing some more recent TAs. This PR fixes that.