### PR TITLE
Wrong column name in node_statement_statistics

### DIFF
--- a/v21.2/performance-recipes-solutions.md
+++ b/v21.2/performance-recipes-solutions.md
@@ -43,7 +43,7 @@ This page provides solutions for common performance issues in your clusters. See
     ~~~ sql
     SELECT count(*) as total_full_scans
     FROM crdb_internal.node_statement_statistics
-    WHERE FullTableScan = 'True';
+    WHERE full_scan = true;
     ~~~
 * Viewing the statement plan on the [Statement details page](ui-statements-page.html#statement-details-page) of the DB Console indicates that the plan contains full table scans.
 * The statement plans returned by the [`EXPLAIN`](sql-tuning-with-explain.html) and [`EXPLAIN ANALYZE` commands](explain-analyze.html) indicate that there are full table scans.


### PR DESCRIPTION
Column "FullTableScan" in crdb_internal.node_statement_statistics should be "full_scan".
And the data type is BOOL, so remove quotation and change value to true