### PR TITLE
DOC-1875: Corrected typo on restore cc page

### DIFF
--- a/cockroachcloud/backups-page.md
+++ b/cockroachcloud/backups-page.md
@@ -124,7 +124,7 @@ To restore a table:
 1. In the **Restore to** field, enter the name of the destination database.
 
     {{site.data.alerts.callout_info}}
-    [Resolve any naming conflicts](#resolve-a-table-naming-conflict) by using [`DROP`](../{{site.versions["stable"]}}/drop-table.html) or [`RENAME`](../{{site.versions["stable"]}}/rename-table.html) on the existing table. If you enter a unique name in the **Restore to** field, a new table will be created.
+    If you enter the name of an existing database, the table will be restored into that existing database. To use the name of an existing database, first [resolve any naming conflicts](#resolve-a-database-naming-conflict) by using [`DROP`](../{{site.versions["stable"]}}/drop-database.html) or [`RENAME`](../{{site.versions["stable"]}}/rename-database.html) on the existing database. If you enter a unique name in the **Restore to** field, a new database will be created.
     {{site.data.alerts.end}}  
 
 1. Select any of the **Dependency options** to skip. You can:


### PR DESCRIPTION
Fixes DOC-1875

The CockroachCloud Restore data page currently notes that the **Restore to** field will create a new table, but it's actually a database, which makes sense from the text above the note.