### PR TITLE
NOT NULL virtual computed column limitation docs

### DIFF
--- a/_includes/v21.1/cdc/not-null-virtual.md
+++ b/_includes/v21.1/cdc/not-null-virtual.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+Changefeeds will fail when there is a [`VIRTUAL` computed column](computed-columns.html) with [`NOT NULL`](not-null.html) present in the target table. See [Known Limitations](#known-limitations) for more information.
+{{site.data.alerts.end}}

--- a/_includes/v21.1/known-limitations/cdc.md
+++ b/_includes/v21.1/known-limitations/cdc.md
@@ -1,6 +1,7 @@
 - Changefeeds only work on tables with a single [column family](column-families.html) (which is the default for new tables).
 - Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
 - Many DDL queries (including [`TRUNCATE`](truncate.html) and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. You will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).
+- Changefeeds will fail when there is a [`VIRTUAL` computed column](computed-columns.html) with [`NOT NULL`](not-null.html) present in the target table. [GitHub Tracking Issue](https://github.com/cockroachdb/cockroach/issues/73138)
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html).
 - Partial or intermittent sink unavailability may impact changefeed stability; however, [ordering guarantees](stream-data-out-of-cockroachdb-using-changefeeds.html#ordering-guarantees) will still hold for as long as a changefeed [remains active](stream-data-out-of-cockroachdb-using-changefeeds.html#monitor-a-changefeed).
 - Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).

--- a/_includes/v21.2/cdc/not-null-virtual.md
+++ b/_includes/v21.2/cdc/not-null-virtual.md
@@ -1,0 +1,3 @@
+{{site.data.alerts.callout_info}}
+Changefeeds will fail when there is a [`VIRTUAL` computed column](computed-columns.html) with [`NOT NULL`](not-null.html) present in the target table. See [Known Limitations](#known-limitations) for more information.
+{{site.data.alerts.end}}

--- a/_includes/v21.2/known-limitations/cdc.md
+++ b/_includes/v21.2/known-limitations/cdc.md
@@ -1,6 +1,7 @@
 - Changefeeds only work on tables with a single [column family](column-families.html) (which is the default for new tables).
 - Changefeeds do not share internal buffers, so each running changefeed will increase total memory usage. To watch multiple tables, we recommend creating a changefeed with a comma-separated list of tables.
 - Many DDL queries (including [`TRUNCATE`](truncate.html) and [`DROP TABLE`](drop-table.html)) will cause errors on a changefeed watching the affected tables. You will need to [start a new changefeed](create-changefeed.html#start-a-new-changefeed-where-another-ended).
+- Changefeeds will fail when there is a [`VIRTUAL` computed column](computed-columns.html) with [`NOT NULL`](not-null.html) present in the target table. [GitHub Tracking Issue](https://github.com/cockroachdb/cockroach/issues/73138)
 - Changefeeds cannot be [backed up](backup.html) or [restored](restore.html).
 - Partial or intermittent sink unavailability may impact changefeed stability; however, [ordering guarantees](stream-data-out-of-cockroachdb-using-changefeeds.html#ordering-guarantees) will still hold for as long as a changefeed [remains active](stream-data-out-of-cockroachdb-using-changefeeds.html#monitor-a-changefeed).
 - Changefeeds cannot be altered. To alter, cancel the changefeed and [create a new one with updated settings from where it left off](create-changefeed.html#start-a-new-changefeed-where-another-ended).
@@ -10,4 +11,4 @@
 - Webhook sinks only support HTTPS. Use the [`insecure_tls_skip_verify`](create-changefeed.html#tls-skip-verify) parameter when testing to disable certificate verification; however, this still requires HTTPS and certificates.
 - Currently, webhook sinks only have support for emitting `JSON`.
 - There is no concurrency configurability for [webhook sinks](create-changefeed.html#webhook-sink).
-- {{ site.data.products.enterprise }} changefeeds are currently disabled for [{{ site.data.products.serverless }} clusters](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart). Core changefeeds are enabled.    
+- {{ site.data.products.enterprise }} changefeeds are currently disabled for [{{ site.data.products.serverless }} clusters](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart). Core changefeeds are enabled.

--- a/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.1/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -150,6 +150,8 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 [3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
 ~~~
 
+{% include {{ page.version.version }}/cdc/not-null-virtual.md %}
+
 ## Changefeeds on regional by row tables
 
 Changefeeds are supported on [regional by row tables](multiregion-overview.html#regional-by-row-tables). When working with changefeeds on regional by row tables, it is necessary to consider the following:

--- a/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
+++ b/v21.2/stream-data-out-of-cockroachdb-using-changefeeds.md
@@ -150,6 +150,8 @@ The changefeed emits duplicate records 1, 2, and 3 before outputting the records
 [3]	{"id": 3, "likes_treats": true, "name": "Ernie"}
 ~~~
 
+{% include {{ page.version.version }}/cdc/not-null-virtual.md %}
+
 ## Changefeeds on regional by row tables
 
 <span class="version-tag">New in v21.2:</span> Changefeeds are supported on [regional by row tables](multiregion-overview.html#regional-by-row-tables). When working with changefeeds on regional by row tables, it is necessary to consider the following:


### PR DESCRIPTION
Closes [DOC-2084](https://cockroachlabs.atlassian.net/browse/DOC-2084)

Added limitation to CDC docs & KL page that a `VIRTUAL` computed column with a `NOT NULL` constraint will cause a changefeed to fail. 

Also included a note on this within the schema change column backfill section