### PR TITLE
Note added to Serverless FAQs re the error on cloud storage/free tier

### DIFF
--- a/cockroachcloud/serverless-faqs.md
+++ b/cockroachcloud/serverless-faqs.md
@@ -123,7 +123,7 @@ Yes, you can view and your clusters in the [{{ site.data.products.db }} Console]
 
 ### Can I run bulk operations such as `IMPORT` and `EXPORT` from my cluster?
 
-Yes, you can [run bulk operations on Serverless clusters](run-bulk-operations.html). If you [add billing information to your organization](billing-management.html) you can run bulk operations using cloud storage providers. If you don't have billing set up for your organization, you can set up a [`userfile`](../{{site.versions["stable"]}}/use-userfile-for-bulk-operations.html) location for bulk operations.
+Yes, you can [run bulk operations on Serverless clusters](run-bulk-operations.html). If you [add billing information to your organization](billing-management.html), even if you don't set a spend limit, you can run bulk operations using cloud storage providers. If you don't have billing set up for your organization, you can set up a [`userfile`](../{{site.versions["stable"]}}/use-userfile-for-bulk-operations.html) location for bulk operations.
 
 {{site.data.alerts.callout_danger}}
 We don't recommend `userfile` for `EXPORT` operations. You can either add billing information to your organization to enable access to cloud storage, or [export data to a local CSV file](migrate-from-serverless-to-dedicated.html#step-1-export-data-to-a-local-csv-file).
@@ -136,3 +136,7 @@ Yes, {{ site.data.products.serverless-plan }} clusters have access to [Core Chan
 ### Can I backup my {{ site.data.products.serverless }} cluster? Does Cockroach Labs take backups of my cluster?
 
 {{ site.data.products.db }} does not take incremental backups of Serverless clusters, and you cannot restore backups from the Console. However, you can backup and restore your {{ site.data.products.serverless }} cluster manually. If you don't have [billing information on file](billing-management.html) for your organization, you can [take backups locally](run-bulk-operations.html#backup-and-restore-data) to `userfile`. Once you enter billing information, even if you don't set a spend limit, you can also [backup to cloud storage](run-bulk-operations.html#backup-and-restore-data).
+
+{{site.data.alerts.callout_info}}
+Running a [bulk operation](run-bulk-operations.html) to cloud storage from a {{ site.data.products.serverless }} cluster without first entering billing information will cause the following error: `external network access is disabled`.
+{{site.data.alerts.end}}


### PR DESCRIPTION
Fixes DOC-2092 

Added a note to the Serverless FAQ page that mentions the error that users will receive if they attempt to run a bulk operation to cloud storage without having entered billing info first. This had come up as a question multiple times — hope is that this will add a little more discoverability while changing the actual error message currently has a few more complexities around it. 