### PR TITLE
Fix all broken or uncheckable external links across all docs.

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -5,9 +5,13 @@ IgnoreDirs:
   - ^docs/dev
   - ^docs/v1.2
 IgnoreURLs:
-  - http://localhost:4000
+  - "http://localhost*"
   - "https://github.com.*"
   - "https://movr.cloud"
+  - "https://support.cockroachlabs.com/*"
+  - "https://www.php.net/*"
+  - "https://crates.io/*"
+  - "https://docs.pipenv.org/*"
 IgnoreInternalEmptyHash: true
 TestFilesConcurrently: true
 DocumentConcurrencyLimit: 16

--- a/v1.0/build-a-php-app-with-cockroachdb.md
+++ b/v1.0/build-a-php-app-with-cockroachdb.md
@@ -5,7 +5,7 @@ toc: true
 twitter: false
 ---
 
-This tutorial shows you how build a simple PHP application with CockroachDB using a PostgreSQL-compatible driver. We've tested and can recommend the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php), so that driver is featured here.
+This tutorial shows you how build a simple PHP application with CockroachDB using a PostgreSQL-compatible driver. We've tested and can recommend the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php), so that driver is featured here.
 
 
 ## Before You Begin
@@ -14,7 +14,7 @@ Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/common-steps.md %}
 
@@ -77,7 +77,7 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's Next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 You might also be interested in using a local cluster to explore the following core CockroachDB features:
 

--- a/v1.0/install-client-drivers.md
+++ b/v1.0/install-client-drivers.md
@@ -18,5 +18,5 @@ Node.js | [pg](https://www.npmjs.com/package/pg)
 C | [libpq](http://www.postgresql.org/docs/9.5/static/libpq.html)
 C++ | [libpqxx](https://github.com/jtv/libpqxx)
 Clojure | [java.jdbc](http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html)
-PHP | [php-pgsql](http://php.net/manual/en/book.pgsql.php)
+PHP | [php-pgsql](https://www.php.net/manual/en/book.pgsql.php)
 Rust | <a href="https://crates.io/crates/postgres/" data-proofer-ignore>postgres</a> {% comment %} This link is in HTML instead of Markdown because HTML proofer dies bc of https://github.com/rust-lang/crates.io/issues/163 {% endcomment %}

--- a/v1.1/build-a-php-app-with-cockroachdb.md
+++ b/v1.1/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB using a PostgreSQL-compatible driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 
 ## Before You Begin
@@ -16,7 +16,7 @@ Make sure you have already [installed CockroachDB](install-cockroachdb.html).
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/common-steps.md %}
 
@@ -79,6 +79,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's Next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v1.1/install-client-drivers.md
+++ b/v1.1/install-client-drivers.md
@@ -21,5 +21,5 @@ C | [libpq](http://www.postgresql.org/docs/9.5/static/libpq.html)
 C++ | [libpqxx](https://github.com/jtv/libpqxx)
 C# (.NET) | [Npgsql](http://www.npgsql.org/)
 Clojure | [java.jdbc](http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html)
-PHP | [php-pgsql](http://php.net/manual/en/book.pgsql.php)
+PHP | [php-pgsql](https://www.php.net/manual/en/book.pgsql.php)
 Rust | <a href="https://crates.io/crates/postgres/" data-proofer-ignore>postgres</a> {% comment %} This link is in HTML instead of Markdown because HTML proofer dies bc of https://github.com/rust-lang/crates.io/issues/163 {% endcomment %}

--- a/v19.1/build-a-php-app-with-cockroachdb.md
+++ b/v19.1/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB using a PostgreSQL-compatible driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v19.1/encryption.md
+++ b/v19.1/encryption.md
@@ -122,7 +122,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v19.2/build-a-php-app-with-cockroachdb.md
+++ b/v19.2/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB and the php-pgsql driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v19.2/collate.md
+++ b/v19.2/collate.md
@@ -23,7 +23,7 @@ Collated strings are important because different languages have [different rules
 
 ## Supported collations
 
-CockroachDB supports collations identified by [Unicode locale identifiers](http://cldr.unicode.org/core-spec#Identifiers). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
+CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
 
 {{site.data.alerts.callout_info}}
 If a hyphen is used in a SQL query, the collation name must be enclosed in double quotes, as single quotes are used for SQL string literals.

--- a/v19.2/encryption.md
+++ b/v19.2/encryption.md
@@ -122,7 +122,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v19.2/install-client-drivers.md
+++ b/v19.2/install-client-drivers.md
@@ -390,7 +390,7 @@ For a simple but complete "Hello World" example app, see [Build a Closure App wi
 
 **Support level:** Beta
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 For a simple but complete "Hello World" example app, see [Build a PHP App with CockroachDB and the PHP pgsql Driver](build-a-php-app-with-cockroachdb.html).
 

--- a/v2.0/build-a-php-app-with-cockroachdb.md
+++ b/v2.0/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB using a PostgreSQL-compatible driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v2.0/install-client-drivers.md
+++ b/v2.0/install-client-drivers.md
@@ -21,5 +21,5 @@ C | [libpq](http://www.postgresql.org/docs/9.5/static/libpq.html)
 C++ | [libpqxx](https://github.com/jtv/libpqxx)
 C# (.NET) | [Npgsql](http://www.npgsql.org/)
 Clojure | [java.jdbc](http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html)
-PHP | [php-pgsql](http://php.net/manual/en/book.pgsql.php)
+PHP | [php-pgsql](https://www.php.net/manual/en/book.pgsql.php)
 Rust | <a href="https://crates.io/crates/postgres/" data-proofer-ignore>postgres</a> {% comment %} This link is in HTML instead of Markdown because HTML proofer dies bc of https://github.com/rust-lang/crates.io/issues/163 {% endcomment %}

--- a/v2.1/build-a-php-app-with-cockroachdb.md
+++ b/v2.1/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB using a PostgreSQL-compatible driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support, so that driver is featured here. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v2.1/encryption.md
+++ b/v2.1/encryption.md
@@ -134,7 +134,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v2.1/install-client-drivers.md
+++ b/v2.1/install-client-drivers.md
@@ -21,5 +21,5 @@ C | [libpq](http://www.postgresql.org/docs/9.5/static/libpq.html)
 C++ | [libpqxx](https://github.com/jtv/libpqxx)
 C# (.NET) | [Npgsql](http://www.npgsql.org/)
 Clojure | [java.jdbc](http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html)
-PHP | [php-pgsql](http://php.net/manual/en/book.pgsql.php)
+PHP | [php-pgsql](https://www.php.net/manual/en/book.pgsql.php)
 Rust | <a href="https://crates.io/crates/postgres/" data-proofer-ignore>postgres</a> {% comment %} This link is in HTML instead of Markdown because HTML proofer dies bc of https://github.com/rust-lang/crates.io/issues/163 {% endcomment %}

--- a/v20.1/build-a-php-app-with-cockroachdb.md
+++ b/v20.1/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB and the php-pgsql driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v20.1/collate.md
+++ b/v20.1/collate.md
@@ -23,7 +23,7 @@ Collated strings are important because different languages have [different rules
 
 ## Supported collations
 
-CockroachDB supports collations identified by [Unicode locale identifiers](http://cldr.unicode.org/core-spec#Identifiers). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
+CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
 
 {{site.data.alerts.callout_info}}
 If a hyphen is used in a SQL query, the collation name must be enclosed in double quotes, as single quotes are used for SQL string literals.

--- a/v20.1/encryption.md
+++ b/v20.1/encryption.md
@@ -122,7 +122,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v20.1/install-client-drivers.md
+++ b/v20.1/install-client-drivers.md
@@ -403,7 +403,7 @@ For a simple but complete "Hello World" example app, see [Build a Closure App wi
 
 **Support level:** Beta
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 For a simple but complete "Hello World" example app, see [Build a PHP App with CockroachDB and the PHP pgsql Driver](build-a-php-app-with-cockroachdb.html).
 

--- a/v20.2/build-a-php-app-with-cockroachdb.md
+++ b/v20.2/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB and the php-pgsql driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v20.2/collate.md
+++ b/v20.2/collate.md
@@ -20,7 +20,7 @@ Collated strings are important because different languages have [different rules
 
 ## Supported collations
 
-CockroachDB supports collations identified by [Unicode locale identifiers](http://cldr.unicode.org/core-spec#Identifiers). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
+CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
 
 {{site.data.alerts.callout_info}}
 If a hyphen is used in a SQL query, the collation name must be enclosed in double quotes, as single quotes are used for SQL string literals.

--- a/v20.2/encryption.md
+++ b/v20.2/encryption.md
@@ -122,7 +122,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v20.2/install-client-drivers.md
+++ b/v20.2/install-client-drivers.md
@@ -414,7 +414,7 @@ For a simple but complete example app, see [Build a Closure App with CockroachDB
 
 **Support level:** Beta
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 For a simple but complete example app, see [Build a PHP App with CockroachDB and the PHP pgsql Driver](build-a-php-app-with-cockroachdb.html).
 

--- a/v20.2/migrate-from-geojson.md
+++ b/v20.2/migrate-from-geojson.md
@@ -8,7 +8,7 @@ toc: true
 
 This page has instructions for migrating data from the [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) format into CockroachDB using [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) and [`IMPORT`][import].
 
-In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/dataset/underground-storage-tank-working).
+In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/sr_Latn/dataset/underground-storage-tanks-usts-facility-and-tank-details).
 
 ## Before You Begin
 

--- a/v20.2/spatial-glossary.md
+++ b/v20.2/spatial-glossary.md
@@ -152,7 +152,7 @@ This page is provided for reference purposes only. The inclusion of a term in th
 
 <a name="proj"></a>
 
-- _PROJ_: A [cartographic projection](#cartographic-projection) library. Used by CockroachDB and other projects. For more information, see <https://www.proj.org/>.
+- _PROJ_: A [cartographic projection](#cartographic-projection) library. Used by CockroachDB and other projects. For more information, see <https://proj.org/>.
 
 <a name="geobuf"></a>
 

--- a/v21.1/build-a-php-app-with-cockroachdb.md
+++ b/v21.1/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB and the php-pgsql driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v21.1/collate.md
+++ b/v21.1/collate.md
@@ -20,7 +20,7 @@ Collated strings are important because different languages have [different rules
 
 ## Supported collations
 
-CockroachDB supports collations identified by [Unicode locale identifiers](http://cldr.unicode.org/core-spec#Identifiers). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
+CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
 
 {{site.data.alerts.callout_info}}
 If a hyphen is used in a SQL query, the collation name must be enclosed in double quotes, as single quotes are used for SQL string literals.

--- a/v21.1/encryption.md
+++ b/v21.1/encryption.md
@@ -120,7 +120,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v21.1/install-client-drivers.md
+++ b/v21.1/install-client-drivers.md
@@ -414,7 +414,7 @@ For a simple but complete example app, see [Build a Clojure App with CockroachDB
 
 **Support level:** Beta
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 For a simple but complete example app, see [Build a PHP App with CockroachDB and the PHP pgsql Driver](build-a-php-app-with-cockroachdb.html).
 

--- a/v21.1/migrate-from-geojson.md
+++ b/v21.1/migrate-from-geojson.md
@@ -8,7 +8,7 @@ toc: true
 
 This page has instructions for migrating data from the [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) format into CockroachDB using [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) and [`IMPORT`][import].
 
-In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/dataset/underground-storage-tank-working).
+In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/sr_Latn/dataset/underground-storage-tanks-usts-facility-and-tank-details).
 
 ## Before You Begin
 

--- a/v21.1/spatial-glossary.md
+++ b/v21.1/spatial-glossary.md
@@ -159,7 +159,7 @@ This page is provided for reference purposes only. The inclusion of a term in th
 
 <a name="proj"></a>
 
-- _PROJ_: A [cartographic projection](#cartographic-projection) library. Used by CockroachDB and other projects. For more information, see <https://www.proj.org/>.
+- _PROJ_: A [cartographic projection](#cartographic-projection) library. Used by CockroachDB and other projects. For more information, see <https://proj.org/>.
 
 <a name="geobuf"></a>
 

--- a/v21.2/build-a-php-app-with-cockroachdb.md
+++ b/v21.2/build-a-php-app-with-cockroachdb.md
@@ -7,7 +7,7 @@ twitter: false
 
 This tutorial shows you how build a simple PHP application with CockroachDB and the php-pgsql driver.
 
-We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
+We have tested the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php) enough to claim **beta-level** support. If you encounter problems, please [open an issue](https://github.com/cockroachdb/cockroach/issues/new) with details to help us make progress toward full support.
 
 ## Before you begin
 
@@ -15,7 +15,7 @@ We have tested the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php) e
 
 ## Step 1. Install the php-pgsql driver
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 <section class="filter-content" markdown="1" data-scope="secure">
 
@@ -170,6 +170,6 @@ $ cockroach sql --insecure -e 'SELECT id, balance FROM accounts' --database=bank
 
 ## What's next?
 
-Read more about using the [php-pgsql driver](http://php.net/manual/en/book.pgsql.php).
+Read more about using the [php-pgsql driver](https://www.php.net/manual/en/book.pgsql.php).
 
 {% include {{ page.version.version }}/app/see-also-links.md %}

--- a/v21.2/collate.md
+++ b/v21.2/collate.md
@@ -20,7 +20,7 @@ Collated strings are important because different languages have [different rules
 
 ## Supported collations
 
-CockroachDB supports collations identified by [Unicode locale identifiers](http://cldr.unicode.org/core-spec#Identifiers). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
+CockroachDB supports collations identified by [Unicode locale identifiers](https://cldr.unicode.org/development/core-specification#h.vgyyng33o798). For example, `en-US` identifies US English, `es` identifies Spanish, and `fr-CA` identifies Canadian French. Collation names are case-insensitive, and hyphens and underscores are interchangeable.
 
 {{site.data.alerts.callout_info}}
 If a hyphen is used in a SQL query, the collation name must be enclosed in double quotes, as single quotes are used for SQL string literals.

--- a/v21.2/encryption.md
+++ b/v21.2/encryption.md
@@ -120,7 +120,7 @@ Generating a key file can be done using the `cockroach` CLI:
 $ cockroach gen encryption-key -s 128 /path/to/my/aes-128.key
 ~~~
 
-Or the equivalent [openssl](https://www.openssl.org/docs/man1.0.2/apps/openssl.html) CLI command:
+Or the equivalent [openssl](https://www.openssl.org/docs/man1.1.1/man1/openssl.html) CLI command:
 
 {% include copy-clipboard.html %}
 ~~~ shell

--- a/v21.2/install-client-drivers.md
+++ b/v21.2/install-client-drivers.md
@@ -414,7 +414,7 @@ For a simple but complete example app, see [Build a Clojure App with CockroachDB
 
 **Support level:** Beta
 
-Install the php-pgsql driver as described in the [official documentation](http://php.net/manual/en/book.pgsql.php).
+Install the php-pgsql driver as described in the [official documentation](https://www.php.net/manual/en/book.pgsql.php).
 
 For a simple but complete example app, see [Build a PHP App with CockroachDB and the PHP pgsql Driver](build-a-php-app-with-cockroachdb.html).
 

--- a/v21.2/migrate-from-geojson.md
+++ b/v21.2/migrate-from-geojson.md
@@ -8,7 +8,7 @@ toc: true
 
 This page has instructions for migrating data from the [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) format into CockroachDB using [`ogr2ogr`](https://gdal.org/programs/ogr2ogr.html) and [`IMPORT`][import].
 
-In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/dataset/underground-storage-tank-working).
+In the example below we will import a data set with [the locations of underground storage tanks in the state of Vermont (USA)](https://anrweb.vt.gov/DEC/ERT/UST.aspx?ustfacilityid=96) that is made available via [data.gov](https://catalog.data.gov/sr_Latn/dataset/underground-storage-tanks-usts-facility-and-tank-details).
 
 ## Before You Begin
 

--- a/v21.2/spatial-glossary.md
+++ b/v21.2/spatial-glossary.md
@@ -159,7 +159,7 @@ This page is provided for reference purposes only. The inclusion of a term in th
 
 <a name="proj"></a>
 
-- _PROJ_: A [cartographic projection](#cartographic-projection) library. Used by CockroachDB and other projects. For more information, see <https://www.proj.org/>.
+- _PROJ_: A [cartographic projection](#cartographic-projection) library. Used by CockroachDB and other projects. For more information, see <https://proj.org/>.
 
 <a name="geobuf"></a>
 


### PR DESCRIPTION
This PR fixes broken or unresolvable external links. Many domains were added to the `htmltest` ignore list as they were incorrectly returning errors for valid links, including a massive number of links to `support.cockroachlabs.com`. Other broken links were fixed as their target location changed.

When this PR is merged, there should be no broken links and the nightly Netlify builds should pass.