### PR TITLE
Product area category per page via front-matter

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -36,6 +36,15 @@ layout: default
       <div id="toc"></div>
    {% endif %}
 
+   {% if page.category %}
+      <a href="#{{ page.category }}" id=#doc-category" data-proofer-ignore></a>
+      <script>
+        $(document).ready(function(){
+          $('#doc-category').trigger('click');
+        });
+      </script>
+   {% endif %}
+
    {% if page.url contains "v1.0" or page.url contains 'v1.1' or page.url contains 'v2.0' or page.url contains 'v2.1' or page.url contains 'v19.1'  or page.url contains 'v19.2' or page.url contains 'v20.1'%}
       {% include_cached unsupported-version.md %}
    {% endif %}

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -2,6 +2,7 @@
 title: Quickstart with CockroachDB Serverless (beta)
 summary: Learn how to create and use your free CockroachDB Cloud cluster.
 toc: true
+category: cloud
 ---
 
 <div class="filters clearfix">

--- a/v21.2/add-column.md
+++ b/v21.2/add-column.md
@@ -2,6 +2,7 @@
 title: ADD COLUMN
 summary: Use the ADD COLUMN statement to add columns to tables.
 toc: true
+category: sql
 ---
 
 `ADD COLUMN` is a subcommand of [`ALTER TABLE`](alter-table.html). Use `ADD COLUMN` to add columns to existing tables.

--- a/v21.2/import.md
+++ b/v21.2/import.md
@@ -2,6 +2,7 @@
 title: IMPORT
 summary: The IMPORT statement imports various types of data into CockroachDB.
 toc: true
+category: io
 ---
 
 The `IMPORT` [statement](sql-statements.html) imports the following types of data into CockroachDB:


### PR DESCRIPTION
This PR is an experiment to see how we might use a
front-matter field to more easily bucket pages
for analytics.

Specifically, we set an href on the page based
on the category front-matter field and then use
JS to auto-click the link so it will get
tracked in Google Analytics as a default event.