### PR TITLE
Make link text consistent with page title.

### DIFF
--- a/_includes/common/ui/statements-page.md
+++ b/_includes/common/ui/statements-page.md
@@ -250,13 +250,13 @@ The Execution Stats section has three subsections:
     Rows Read | The number of rows read by the statement. The gray bar indicates the mean number of rows read. The blue bar indicates one standard deviation from the mean.
     Disk Bytes Read | The size of the data read by the statement. The gray bar indicates the mean number of bytes read. The blue bar indicates one standard deviation from the mean.
 
-- **Stats by Node** provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Make Queries Fast]({{ link_prefix }}make-queries-fast.html#cluster-topology)). <br><br>**Stats by Node** are not visible for {{ site.data.products.serverless }} clusters.
+- **Stats by Node** provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Optimize Statement Performance]({{ link_prefix }}make-queries-fast.html#cluster-topology)). <br><br>**Stats by Node** are not visible for {{ site.data.products.serverless }} clusters.
 
 ## See also
 
 - [Troubleshoot Query Behavior]({{ link_prefix }}query-behavior-troubleshooting.html)
 - [Transaction retries]({{ link_prefix }}transactions.html#transaction-retries)
-- [Make Queries Fast]({{ link_prefix }}make-queries-fast.html)
+- [Optimize Statement Performance]({{ link_prefix }}make-queries-fast.html)
 - [Support Resources]({{ link_prefix }}support-resources.html)
 - [Raw Status Endpoints]({{ link_prefix }}monitoring-and-alerting.html#raw-status-endpoints)
 - [Transactions Page]({{ page_prefix }}transactions-page.html)

--- a/cockroachcloud/hello-world-example-apps.md
+++ b/cockroachcloud/hello-world-example-apps.md
@@ -41,6 +41,6 @@ Specific tasks:
 - [Connect to Your Cluster](connect-to-a-serverless-cluster.html)
 - [Insert Data](../{{site.versions["stable"]}}/insert-data.html)
 - [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
-- [Make Queries Fast](../{{site.versions["stable"]}}/make-queries-fast.html)
+- [Optimize Statement Performance](../{{site.versions["stable"]}}/make-queries-fast.html)
 - [Run Multi-Statement Transactions](../{{site.versions["stable"]}}/run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](../{{site.versions["stable"]}}/error-handling-and-troubleshooting.html)

--- a/v20.1/admin-ui-statements-page.md
+++ b/v20.1/admin-ui-statements-page.md
@@ -160,7 +160,7 @@ By default, the logical plan for each fingerprint is sampled every 5 minutes. Yo
 Service latency can be affected by network latency, which is displayed for your cluster on the [Network Latency](admin-ui-network-latency-page.html) page.
 {{site.data.alerts.end}}
 
-The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Make Queries Fast](make-queries-fast.html#cluster-topology)).
+The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Optimize Query Performance](make-queries-fast.html#cluster-topology)).
 
 Parameter | Description
 -----|------------
@@ -174,6 +174,6 @@ Latency | Average service latency of statements with this fingerprint within the
 
 - [Troubleshoot Query Behavior](query-behavior-troubleshooting.html)
 - [Transaction retries](transactions.html#transaction-retries)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Support Resources](support-resources.html)
 - [Raw Status Endpoints](monitoring-and-alerting.html#raw-status-endpoints)

--- a/v20.1/connect-to-the-database.md
+++ b/v20.1/connect-to-the-database.md
@@ -124,7 +124,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.1/delete-data.md
+++ b/v20.1/delete-data.md
@@ -140,7 +140,7 @@ Other common tasks:
 - [Update Data](update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.1/developer-guide-overview.md
+++ b/v20.1/developer-guide-overview.md
@@ -16,7 +16,7 @@ This guide shows you how to do common tasks that come up when you build an appli
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 
 ## Sample Apps and Tutorials
 

--- a/v20.1/error-handling-and-troubleshooting.md
+++ b/v20.1/error-handling-and-troubleshooting.md
@@ -8,9 +8,9 @@ This page has instructions for handling errors and troubleshooting problems that
 
 ## Troubleshooting query problems
 
-If you are not satisfied with your SQL query performance, follow the instructions in [Make Queries Fast][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
+If you are not satisfied with your SQL query performance, follow the instructions in [Optimize Query Performance][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
 
-If you have already optimized your SQL queries as described in [Make Queries Fast][fast] and are still having issues such as:
+If you have already optimized your SQL queries as described in [Optimize Query Performance][fast] and are still having issues such as:
 
 - Hanging or "stuck" queries
 - Queries that are slow some of the time (but not always)
@@ -87,7 +87,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-queries)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.1/hello-world-example-apps.md
+++ b/v20.1/hello-world-example-apps.md
@@ -34,6 +34,6 @@ Specific tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)

--- a/v20.1/insert-data.md
+++ b/v20.1/insert-data.md
@@ -123,7 +123,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.1/make-queries-fast.md
+++ b/v20.1/make-queries-fast.md
@@ -1,5 +1,5 @@
 ---
-title: Make Queries Fast
+title: Optimize Query Performance
 summary: How to make your queries run faster during application development
 toc: true
 ---

--- a/v20.1/performance-tuning.md
+++ b/v20.1/performance-tuning.md
@@ -1281,7 +1281,7 @@ In each of the new zones, SSH to the instance not running a CockroachDB node, an
 
 - [SQL Performance Best Practices](performance-best-practices-overview.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-queries)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Performance Benchmarking](performance-benchmarking-with-tpc-c-1k-warehouses.html)
 - [Network Latency Page](admin-ui-network-latency-page.html)
 - [Production Checklist](recommended-production-settings.html)

--- a/v20.1/query-behavior-troubleshooting.md
+++ b/v20.1/query-behavior-troubleshooting.md
@@ -7,7 +7,7 @@ toc: true
 If a [SQL statement](sql-statements.html) returns an unexpected result or takes longer than expected to process, this page will help you troubleshoot the issue.
 
 {{site.data.alerts.callout_success}}
-For a developer-centric walkthrough of optimizing SQL query performance, see [Make Queries Fast](make-queries-fast.html).
+For a developer-centric walkthrough of optimizing SQL query performance, see [Optimize Query Performance](make-queries-fast.html).
 {{site.data.alerts.end}}
 
 ## Identify slow queries

--- a/v20.1/query-data.md
+++ b/v20.1/query-data.md
@@ -166,7 +166,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.1/run-multi-statement-transactions.md
+++ b/v20.1/run-multi-statement-transactions.md
@@ -87,7 +87,7 @@ Other common tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 

--- a/v20.1/sql-tuning-with-explain.md
+++ b/v20.1/sql-tuning-with-explain.md
@@ -364,4 +364,4 @@ To speed up the query, you can provide the primary key to allow the cost-based o
 
 - [SQL Best Practices](performance-best-practices-overview.html)
 - [Troubleshoot SQL Behavior](query-behavior-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)

--- a/v20.1/update-data.md
+++ b/v20.1/update-data.md
@@ -113,7 +113,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting][error_handling]
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/connect-to-the-database-cockroachcloud.md
+++ b/v20.2/connect-to-the-database-cockroachcloud.md
@@ -144,7 +144,7 @@ You might also be interested in the following pages:
 - [Orchestrated Deployments][orchestrated]
 - [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/connect-to-the-database.md
+++ b/v20.2/connect-to-the-database.md
@@ -136,7 +136,7 @@ You might also be interested in the following pages:
 - [Orchestrated Deployments][orchestrated]
 - [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/delete-data.md
+++ b/v20.2/delete-data.md
@@ -248,7 +248,7 @@ Other common tasks:
 - [Update Data](update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/error-handling-and-troubleshooting.md
+++ b/v20.2/error-handling-and-troubleshooting.md
@@ -8,9 +8,9 @@ This page has instructions for handling errors and troubleshooting problems that
 
 ## Troubleshooting query problems
 
-If you are not satisfied with your SQL query performance, follow the instructions in [Make Queries Fast][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
+If you are not satisfied with your SQL query performance, follow the instructions in [Optimize Query Performance][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
 
-If you have already optimized your SQL queries as described in [Make Queries Fast][fast] and are still having issues such as:
+If you have already optimized your SQL queries as described in [Optimize Query Performance][fast] and are still having issues such as:
 
 - Hanging or "stuck" queries
 - Queries that are slow some of the time (but not always)
@@ -89,7 +89,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-queries)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/example-apps.md
+++ b/v20.2/example-apps.md
@@ -109,6 +109,6 @@ Specific tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)

--- a/v20.2/insert-data.md
+++ b/v20.2/insert-data.md
@@ -124,7 +124,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/performance-tuning.md
+++ b/v20.2/performance-tuning.md
@@ -1280,7 +1280,7 @@ In each of the new zones, SSH to the instance not running a CockroachDB node, an
 
 - [SQL Performance Best Practices](performance-best-practices-overview.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-queries)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Performance Benchmarking](performance-benchmarking-with-tpcc-small.html)
 - [Network Latency Page](ui-network-latency-page.html)
 - [Production Checklist](recommended-production-settings.html)

--- a/v20.2/query-behavior-troubleshooting.md
+++ b/v20.2/query-behavior-troubleshooting.md
@@ -7,7 +7,7 @@ toc: true
 If a [SQL statement](sql-statements.html) returns an unexpected result or takes longer than expected to process, this page will help you troubleshoot the issue.
 
 {{site.data.alerts.callout_success}}
-For a developer-centric walkthrough of optimizing SQL query performance, see [Make Queries Fast](make-queries-fast.html).
+For a developer-centric walkthrough of optimizing SQL query performance, see [Optimize Query Performance](make-queries-fast.html).
 {{site.data.alerts.end}}
 
 ## Identify slow queries

--- a/v20.2/query-data.md
+++ b/v20.2/query-data.md
@@ -197,7 +197,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v20.2/run-multi-statement-transactions.md
+++ b/v20.2/run-multi-statement-transactions.md
@@ -87,7 +87,7 @@ Other common tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast][fast]
+- [Optimize Query Performance][fast]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 

--- a/v20.2/sql-tuning-with-explain.md
+++ b/v20.2/sql-tuning-with-explain.md
@@ -377,4 +377,4 @@ To speed up the query, you can provide the primary key to allow the cost-based o
 
 - [SQL Best Practices](performance-best-practices-overview.html)
 - [Troubleshoot SQL Behavior](query-behavior-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)

--- a/v20.2/ui-statements-page.md
+++ b/v20.2/ui-statements-page.md
@@ -171,7 +171,7 @@ Parameter | Description
 Rows Read | The number of rows read by the statement. The gray bar indicates the mean number of rows read. The blue bar indicates one standard deviation from the mean.
 Disk Bytes Read | The size of the data read by the statement. The gray bar indicates the mean number of bytes read. The blue bar indicates one standard deviation from the mean.
 
-The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Make Queries Fast](make-queries-fast.html#cluster-topology)).
+The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Optimize Query Performance](make-queries-fast.html#cluster-topology)).
 
 Parameter | Description
 -----|------------
@@ -185,6 +185,6 @@ Latency | Average service latency of statements with this fingerprint within the
 
 - [Troubleshoot Query Behavior](query-behavior-troubleshooting.html)
 - [Transaction retries](transactions.html#transaction-retries)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Support Resources](support-resources.html)
 - [Raw Status Endpoints](monitoring-and-alerting.html#raw-status-endpoints)

--- a/v20.2/update-data.md
+++ b/v20.2/update-data.md
@@ -424,7 +424,7 @@ Other common tasks:
 - [Bulk-update Data](bulk-update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting][error_handling]
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Query Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/connect-to-the-database-cockroachcloud.md
+++ b/v21.1/connect-to-the-database-cockroachcloud.md
@@ -144,7 +144,7 @@ You might also be interested in the following pages:
 - [Orchestrated Deployments][orchestrated]
 - [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/connect-to-the-database.md
+++ b/v21.1/connect-to-the-database.md
@@ -136,7 +136,7 @@ You might also be interested in the following pages:
 - [Orchestrated Deployments][orchestrated]
 - [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/delete-data.md
+++ b/v21.1/delete-data.md
@@ -248,7 +248,7 @@ Other common tasks:
 - [Update Data](update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/error-handling-and-troubleshooting.md
+++ b/v21.1/error-handling-and-troubleshooting.md
@@ -8,9 +8,9 @@ This page has instructions for handling errors and troubleshooting problems that
 
 ## Troubleshooting query problems
 
-If you are not satisfied with your SQL query performance, follow the instructions in [Make Queries Fast][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
+If you are not satisfied with your SQL query performance, follow the instructions in [Optimize Statement Performance][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
 
-If you have already optimized your SQL queries as described in [Make Queries Fast][fast] and are still having issues such as:
+If you have already optimized your SQL queries as described in [Optimize Statement Performance][fast] and are still having issues such as:
 
 - Hanging or "stuck" queries
 - Queries that are slow some of the time (but not always)
@@ -89,7 +89,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-statements)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/example-apps.md
+++ b/v21.1/example-apps.md
@@ -110,6 +110,6 @@ Specific tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)

--- a/v21.1/insert-data.md
+++ b/v21.1/insert-data.md
@@ -126,7 +126,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/query-behavior-troubleshooting.md
+++ b/v21.1/query-behavior-troubleshooting.md
@@ -7,7 +7,7 @@ toc: true
 If a [SQL statement](sql-statements.html) returns an unexpected result or takes longer than expected to process, this page will help you troubleshoot the issue.
 
 {{site.data.alerts.callout_success}}
-For a developer-centric walkthrough of optimizing SQL query performance, see [Make Queries Fast](make-queries-fast.html).
+For a developer-centric walkthrough of optimizing SQL query performance, see [Optimize Statement Performance](make-queries-fast.html).
 {{site.data.alerts.end}}
 
 ## Identify slow statements

--- a/v21.1/query-data.md
+++ b/v21.1/query-data.md
@@ -197,7 +197,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.1/run-multi-statement-transactions.md
+++ b/v21.1/run-multi-statement-transactions.md
@@ -87,7 +87,7 @@ Other common tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 

--- a/v21.1/sql-tuning-with-explain.md
+++ b/v21.1/sql-tuning-with-explain.md
@@ -422,4 +422,4 @@ Time: 1ms total (execution 1ms / network 0ms)
 
 - [SQL Best Practices](performance-best-practices-overview.html)
 - [Troubleshoot SQL Behavior](query-behavior-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)

--- a/v21.1/ui-statements-page.md
+++ b/v21.1/ui-statements-page.md
@@ -168,12 +168,12 @@ Statistic | Description
 Rows Read | The number of rows read by the statement. The gray bar indicates the mean number of rows read. The blue bar indicates one standard deviation from the mean.
 Disk Bytes Read | The size of the data read by the statement. The gray bar indicates the mean number of bytes read. The blue bar indicates one standard deviation from the mean.
 
-The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Make Queries Fast](make-queries-fast.html#cluster-topology)).
+The **Statistics by Node** table provides a breakdown of the number of statements of the selected fingerprint per gateway node. You can use this table to determine whether, for example, you are executing queries on a node that is far from the data you are requesting (see [Optimize Statement Performance](make-queries-fast.html#cluster-topology)).
 
 ## See also
 
 - [Troubleshoot Query Behavior](query-behavior-troubleshooting.html)
 - [Transaction retries](transactions.html#transaction-retries)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Support Resources](support-resources.html)
 - [Raw Status Endpoints](monitoring-and-alerting.html#raw-status-endpoints)

--- a/v21.1/update-data.md
+++ b/v21.1/update-data.md
@@ -424,7 +424,7 @@ Other common tasks:
 - [Bulk-update Data](bulk-update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting][error_handling]
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/connect-to-the-database-cockroachcloud.md
+++ b/v21.2/connect-to-the-database-cockroachcloud.md
@@ -144,7 +144,7 @@ You might also be interested in the following pages:
 - [Orchestrated Deployments][orchestrated]
 - [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/connect-to-the-database.md
+++ b/v21.2/connect-to-the-database.md
@@ -136,7 +136,7 @@ You might also be interested in the following pages:
 - [Orchestrated Deployments][orchestrated]
 - [Start a Local Cluster][local_secure]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/delete-data.md
+++ b/v21.2/delete-data.md
@@ -248,7 +248,7 @@ Other common tasks:
 - [Update Data](update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/error-handling-and-troubleshooting.md
+++ b/v21.2/error-handling-and-troubleshooting.md
@@ -8,9 +8,9 @@ This page has instructions for handling errors and troubleshooting problems that
 
 ## Troubleshooting query problems
 
-If you are not satisfied with your SQL query performance, follow the instructions in [Make Queries Fast][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
+If you are not satisfied with your SQL query performance, follow the instructions in [Optimize Statement Performance][fast] to be sure you are avoiding common performance problems like full table scans, missing indexes, etc.
 
-If you have already optimized your SQL queries as described in [Make Queries Fast][fast] and are still having issues such as:
+If you have already optimized your SQL queries as described in [Optimize Statement Performance][fast] and are still having issues such as:
 
 - Hanging or "stuck" queries
 - Queries that are slow some of the time (but not always)
@@ -89,7 +89,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-statements)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/example-apps.md
+++ b/v21.2/example-apps.md
@@ -110,6 +110,6 @@ Specific tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)

--- a/v21.2/insert-data.md
+++ b/v21.2/insert-data.md
@@ -126,7 +126,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/query-behavior-troubleshooting.md
+++ b/v21.2/query-behavior-troubleshooting.md
@@ -7,7 +7,7 @@ toc: true
 If a [SQL statement](sql-statements.html) returns an unexpected result or takes longer than expected to process, this page will help you troubleshoot the issue.
 
 {{site.data.alerts.callout_success}}
-For a developer-centric walkthrough of optimizing SQL query performance, see [Make Queries Fast](make-queries-fast.html).
+For a developer-centric walkthrough of optimizing SQL query performance, see [Optimize Statement Performance](make-queries-fast.html).
 {{site.data.alerts.end}}
 
 ## Identify slow statements

--- a/v21.2/query-data.md
+++ b/v21.2/query-data.md
@@ -197,7 +197,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->

--- a/v21.2/run-multi-statement-transactions.md
+++ b/v21.2/run-multi-statement-transactions.md
@@ -87,7 +87,7 @@ Other common tasks:
 - [Query Data](query-data.html)
 - [Update Data](update-data.html)
 - [Delete Data](delete-data.html)
-- [Make Queries Fast][fast]
+- [Optimize Statement Performance][fast]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 

--- a/v21.2/sql-tuning-with-explain.md
+++ b/v21.2/sql-tuning-with-explain.md
@@ -434,4 +434,4 @@ Time: 1ms total (execution 1ms / network 0ms)
 
 - [SQL Best Practices](performance-best-practices-overview.html)
 - [Troubleshoot SQL Behavior](query-behavior-troubleshooting.html)
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)

--- a/v21.2/update-data.md
+++ b/v21.2/update-data.md
@@ -424,7 +424,7 @@ Other common tasks:
 - [Bulk-update Data](bulk-update-data.html)
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting][error_handling]
-- [Make Queries Fast](make-queries-fast.html)
+- [Optimize Statement Performance](make-queries-fast.html)
 - [Hello World Example apps](hello-world-example-apps.html)
 
 <!-- Reference Links -->


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-1063

I can't solve the general problem as it requires consensus in the doc team. I think you need to open a doc ticket for the general problem of title renaming.

I believe it's related to your previous issue too: https://cockroachlabs.atlassian.net/browse/DOC-367 and it's follow on https://cockroachlabs.atlassian.net/browse/DOC-2086.