### PR TITLE
Update to RESTORE syntax in 21.1 / 21.2

### DIFF
--- a/_includes/cockroachcloud/restore-examples.md
+++ b/_includes/cockroachcloud/restore-examples.md
@@ -1,6 +1,6 @@
 #### View the backup subdirectories
 
-<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories):
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -24,7 +24,7 @@ To restore a full cluster:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{BUCKET NAME}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}';
+RESTORE FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories).
@@ -35,7 +35,7 @@ To restore a database:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE bank FROM 's3://{BUCKET NAME}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}';
+RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories).
@@ -50,14 +50,14 @@ To restore a single table:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers FROM 's3://{BUCKET NAME}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}';
+> RESTORE TABLE bank.customers FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To restore multiple tables:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers, bank.accounts FROM 's3://{BUCKET NAME}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}';
+> RESTORE TABLE bank.customers, bank.accounts FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories).

--- a/_includes/cockroachcloud/restore-examples.md
+++ b/_includes/cockroachcloud/restore-examples.md
@@ -1,6 +1,6 @@
 #### View the backup subdirectories
 
-`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories):
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme by default, unless an [explicit subdirectory](../{{site.versions["stable"]}}/backup.html#specify-a-subdirectory-for-backups) is passed with the `BACKUP` statement. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/_includes/cockroachcloud/restore-examples.md
+++ b/_includes/cockroachcloud/restore-examples.md
@@ -8,15 +8,32 @@
 ~~~
 
 ~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+       path
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+   |—— 21-142943.73/
+       |—— 20211221/
+           |—— 144748.08/
+           |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](../{{site.versions["stable"]}}/show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](../{{site.versions["stable"]}}/take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 #### Restore a cluster
 

--- a/_includes/cockroachcloud/userfile-examples/backup-userfile.md
+++ b/_includes/cockroachcloud/userfile-examples/backup-userfile.md
@@ -21,7 +21,7 @@ This directory will hold the files that make up a backup; including the manifest
 When backing up from a cluster and restoring a database or table that is stored in your `userfile` space to a different cluster, you can run [`cockroach userfile get`](../{{site.versions["stable"]}}/cockroach-userfile-get.html) to download the backup files to a local machine and [`cockroach userfile upload --url {CONNECTION STRING}`](../{{site.versions["stable"]}}/cockroach-userfile-upload.html) to upload to the `userfile` of the alternate cluster.
 {{site.data.alerts.end}}
 
-`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/show-backup.html):
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme by default, unless an [explicit subdirectory](../{{site.versions["stable"]}}/backup.html#specify-a-subdirectory-for-backups) is passed with the `BACKUP` statement. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/restore.html#view-the-backup-subdirectories):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/_includes/cockroachcloud/userfile-examples/backup-userfile.md
+++ b/_includes/cockroachcloud/userfile-examples/backup-userfile.md
@@ -10,8 +10,9 @@ When working on the same cluster, `userfile` storage allows for database and tab
 
 First, run the following statement to backup a database to a directory in the default `userfile` space:
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
-BACKUP DATABASE bank TO 'userfile://defaultdb.public.userfiles_$user/bank-backup' AS OF SYSTEM TIME '-10s';
+BACKUP DATABASE bank INTO 'userfile://defaultdb.public.userfiles_$user/bank-backup' AS OF SYSTEM TIME '-10s';
 ~~~
 
 This directory will hold the files that make up a backup; including the manifest file and data files.
@@ -20,16 +21,34 @@ This directory will hold the files that make up a backup; including the manifest
 When backing up from a cluster and restoring a database or table that is stored in your `userfile` space to a different cluster, you can run [`cockroach userfile get`](../{{site.versions["stable"]}}/cockroach-userfile-get.html) to download the backup files to a local machine and [`cockroach userfile upload --url {CONNECTION STRING}`](../{{site.versions["stable"]}}/cockroach-userfile-upload.html) to upload to the `userfile` of the alternate cluster.
 {{site.data.alerts.end}}
 
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](../{{site.versions["stable"]}}/show-backup.html):
+
+{% include_cached copy-clipboard.html %}
+~~~ sql
+> SHOW BACKUPS IN 'userfile://defaultdb.public.userfiles_$user/bank-backup';
+~~~
+
+~~~
+       path
+------------------------
+2021/03/23-213101.37
+2021/03/24-172553.85
+2021/03/24-210532.53
+(3 rows)
+~~~
+
 In cases when your database needs to be restored, run the following:
 
+{% include_cached copy-clipboard.html %}
 ~~~sql
-RESTORE DATABASE bank FROM 'userfile://defaultdb.public.userfiles_$user/bank-backup';
+RESTORE DATABASE bank FROM '2021/03/24-210532.53' IN 'userfile://defaultdb.public.userfiles_$user/bank-backup';
 ~~~
 
 It is also possible to run `userfile:///bank-backup` as `userfile:///` refers to the default path `userfile://defaultdb.public.userfiles_$user/`.
 
 Once the backup data is no longer needed, delete from the `userfile` storage:
 
+{% include_cached copy-clipboard.html %}
 ~~~shell
 cockroach userfile delete bank-backup --url {CONNECTION STRING}
 ~~~

--- a/cockroachcloud/backups-page.md
+++ b/cockroachcloud/backups-page.md
@@ -145,7 +145,7 @@ To back up a self-hosted CockroachDB cluster into a {{ site.data.products.db }} 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    > BACKUP DATABASE example_database TO 'gs://bucket_name/path_to_backup?AUTH=specified';
+    BACKUP DATABASE example_database INTO 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
     ~~~
 
     {{site.data.alerts.callout_danger}}
@@ -163,11 +163,29 @@ To back up a self-hosted CockroachDB cluster into a {{ site.data.products.db }} 
     {% include cockroachcloud/sql-connection-string.md %}
 
 
-1. [Restore](../{{site.versions["stable"]}}/restore.html) to your {{ site.data.products.db }} cluster:
+1. [Restore](../{{site.versions["stable"]}}/restore.html) to your {{ site.data.products.db }} cluster.
+
+    Use `SHOW BACKUPS` with your external location to find the backup's subdirectory:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    > RESTORE DATABASE example_database FROM 'gs://bucket_name/path_to_backup?AUTH=specified';
+    SHOW BACKUPS IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
+    ~~~
+
+    ~~~
+            path
+    ------------------------
+    2021/03/23-213101.37
+    2021/03/24-172553.85
+    2021/03/24-210532.53
+    (3 rows)
+    ~~~
+
+    Use the subdirectory to specify the backup to restore:
+
+    {% include_cached copy-clipboard.html %}
+    ~~~ sql
+    RESTORE DATABASE example_database '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
     ~~~
 
 ## Troubleshooting

--- a/cockroachcloud/backups-page.md
+++ b/cockroachcloud/backups-page.md
@@ -185,7 +185,7 @@ To back up a self-hosted CockroachDB cluster into a {{ site.data.products.db }} 
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
-    RESTORE DATABASE example_database '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
+    RESTORE DATABASE example_database FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
     ~~~
 
 ## Troubleshooting

--- a/v21.1/backup.md
+++ b/v21.1/backup.md
@@ -160,7 +160,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -171,7 +171,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -180,7 +180,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -191,7 +191,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -200,7 +200,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -215,6 +215,7 @@ AS OF SYSTEM TIME '-10s';
 
 To store the backup in a specific subdirectory in the storage location:
 
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 BACKUP DATABASE bank INTO 'subdirectory' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
@@ -224,7 +225,7 @@ AS OF SYSTEM TIME '-10s';
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -235,7 +236,7 @@ AS OF SYSTEM TIME '-10s';
 
 Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -273,7 +274,7 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -284,7 +285,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -293,7 +294,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -304,7 +305,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -313,7 +314,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -328,6 +329,7 @@ AS OF SYSTEM TIME '-10s';
 
 To store the backup in a specific subdirectory in the storage location:
 
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 BACKUP DATABASE bank INTO 'subdirectory' IN 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
 AS OF SYSTEM TIME '-10s';
@@ -337,7 +339,7 @@ AS OF SYSTEM TIME '-10s';
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -348,7 +350,7 @@ AS OF SYSTEM TIME '-10s';
 
 Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -388,7 +390,7 @@ The examples in this section use the `AUTH=specified` parameter, which will be t
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -399,7 +401,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -408,7 +410,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -419,7 +421,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -428,7 +430,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -443,6 +445,7 @@ AS OF SYSTEM TIME '-10s';
 
 To store the backup in a specific subdirectory in the storage location:
 
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 BACKUP DATABASE bank INTO 'subdirectory' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
 AS OF SYSTEM TIME '-10s';
@@ -452,7 +455,7 @@ AS OF SYSTEM TIME '-10s';
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -463,7 +466,7 @@ AS OF SYSTEM TIME '-10s';
 
 Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \

--- a/v21.1/backup.md
+++ b/v21.1/backup.md
@@ -211,6 +211,15 @@ AS OF SYSTEM TIME '-10s';
 {% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
 {{site.data.alerts.end}}
 
+### Specify a subdirectory for backups
+
+To store the backup in a specific subdirectory in the storage location:
+
+~~~ sql
+BACKUP DATABASE bank INTO 'subdirectory' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
 ### Create incremental backups
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
@@ -314,6 +323,15 @@ AS OF SYSTEM TIME '-10s';
 {{site.data.alerts.callout_danger}}
 {% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
 {{site.data.alerts.end}}
+
+### Specify a subdirectory for backups
+
+To store the backup in a specific subdirectory in the storage location:
+
+~~~ sql
+BACKUP DATABASE bank INTO 'subdirectory' IN 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
 
 ### Create incremental backups
 
@@ -420,6 +438,15 @@ AS OF SYSTEM TIME '-10s';
 {{site.data.alerts.callout_danger}}
 {% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
 {{site.data.alerts.end}}
+
+### Specify a subdirectory for backups
+
+To store the backup in a specific subdirectory in the storage location:
+
+~~~ sql
+BACKUP DATABASE bank INTO 'subdirectory' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
 
 ### Create incremental backups
 

--- a/v21.1/restore.md
+++ b/v21.1/restore.md
@@ -4,11 +4,7 @@ summary: Restore your CockroachDB cluster to a cloud storage services such as AW
 toc: true
 ---
 
-{{site.data.alerts.callout_info}}
- `RESTORE` no longer requires an Enterprise license, regardless of the options passed to it or to the backup it is restoring.
-{{site.data.alerts.end}}
-
-The `RESTORE` [statement](sql-statements.html) restores your cluster's schemas and data from [a `BACKUP`](backup.html) stored on a services such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.
+The `RESTORE` [statement](sql-statements.html) restores your cluster's schemas and data from [a `BACKUP`](backup.html) stored on services such as AWS S3, Google Cloud Storage, NFS, or HTTP storage.
 
 Because CockroachDB is designed with high fault tolerance, restores are designed primarily for disaster recovery, i.e., restarting your cluster if it loses a majority of its nodes. Isolated issues (such as small-scale node outages) do not require any intervention.
 
@@ -18,13 +14,11 @@ You can restore:
 - [Databases](#databases)
 - [Tables](#tables)
 
-{{site.data.alerts.callout_info}}
-`RESTORE` cannot restore backups made by newer versions of CockroachDB.
-{{site.data.alerts.end}}
+## Considerations
 
-{{site.data.alerts.callout_info}}
-`RESTORE` is a blocking statement. To run a restore job asynchronously, use the `DETACHED` option. See the [options](#options) below.
-{{site.data.alerts.end}}
+- `RESTORE` cannot restore backups made by newer versions of CockroachDB.
+- `RESTORE` is a blocking statement. To run a restore job asynchronously, use the `DETACHED` option. See [Options](#options) for more usage detail.
+- `RESTORE` no longer requires an Enterprise license, regardless of the options passed to it or to the backup it is restoring.
 
 ## Required privileges
 
@@ -100,7 +94,7 @@ When you restore a full cluster with an Enterprise license, it will restore the 
 **The database cannot already exist in the target cluster.** Restoring a database will create a new database and restore all of its tables and views. The created database will have the name of the database in the backup.
 
 ~~~ sql
-RESTORE DATABASE backup_database_name FROM 'your_backup_location';
+RESTORE DATABASE backup_database_name FROM 'subdirectory' in 'your_backup_location';
 ~~~
 
 {{site.data.alerts.callout_success}}
@@ -157,8 +151,8 @@ You can either restore from a full backup or from a full backup with incremental
 
 Restore Type | Parameters
 -------------|----------
-Full backup | Include only the path to the full backup.
-Full backup + <br>incremental backups | If the full backup and incremental backups were sent to the same destination, include only the path to the full backup (e.g., `RESTORE FROM 'full_backup_location';`).<br><br>If the incremental backups were sent to a different destination from the full backup, include the path to the full backup as the first argument and the subsequent incremental backups from oldest to newest as the following arguments (e.g., `RESTORE FROM 'full_backup_location', 'incremental_location_1', 'incremental_location_2';`).
+Full backup | Include the [subdirectory](#view-the-backup-subdirectories) of the backup and the path to the full backup destination (e.g.`RESTORE ... FROM 'subdirectory' IN 'backup destination';`).
+Full backup + <br>incremental backups | Include the path that contains the backup collection and the [subdirectory](#view-the-backup-subdirectories) containing the desired backup (e.g. `RESTORE ... FROM 'subdirectory' IN 'backup collection destination';`).
 
 ## Performance
 
@@ -202,7 +196,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 <span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW BACKUPS IN 's3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
@@ -216,15 +210,15 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
 
 ### Restore a cluster
 
 To restore a full cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
+> RESTORE FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -233,9 +227,9 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 To restore a database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE bank FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
+> RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -248,16 +242,16 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 To restore a single table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
+> RESTORE TABLE bank.customers FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To restore multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers, bank.accounts FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
+> RESTORE TABLE bank.customers, bank.accounts FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -266,19 +260,9 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
-~~~
-
-To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers \
-FROM 's3://{bucket_name}/database-bank-2017-03-27-weekly?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}', \
-'s3://{bucket_name}/database-bank-2017-03-28-nightly?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}', \
-'s3://{bucket_name}/database-bank-2017-03-29-nightly?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
+RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup-collection}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -289,11 +273,9 @@ FROM 's3://{bucket_name}/database-bank-2017-03-27-weekly?AWS_ACCESS_KEY_ID={key_
 
 Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM \
-'s3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
-WITH DETACHED;
+RESTORE TABLE bank.customers FROM '2021/03/23-213101.37' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' WITH DETACHED;
 ~~~
 
 The job ID is returned immediately without waiting for the job to finish:
@@ -320,10 +302,10 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE bank.customers \
-FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+FROM '2021/09/29-153014.47' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
 WITH into_db = 'newdb';
 ~~~
 
@@ -331,10 +313,10 @@ WITH into_db = 'newdb';
 
 By default, tables with [foreign key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the foreign key constraint from the table and then restore it.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE bank.accounts \
-FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+FROM '2021/09/29-153014.47' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
 WITH skip_missing_foreign_keys;
 ~~~
 
@@ -346,26 +328,26 @@ After it's restored into a new database, you can write the restored `users` tabl
 
 First, create the new database that you'll restore the `system.users` table into:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE DATABASE newdb;
 ~~~
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE system.users \
-FROM 's3://{bucket_name}/{path/to/backup/subdirectory}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
+FROM '2021/09/29-153014.47' IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}' \
 WITH into_db = 'newdb';
 ~~~
 
 After the restore completes, add the `users` to the existing `system.users` table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > INSERT INTO system.users SELECT * FROM newdb.users;
 ~~~
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > DROP TABLE newdb.users;
 ~~~
@@ -378,7 +360,7 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 
 <span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW BACKUPS IN 'azure://{container name}/{path}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
@@ -392,15 +374,15 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
 
 ### Restore a cluster
 
 To restore a full cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+> RESTORE FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -409,9 +391,9 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 To restore a database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE bank FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+> RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -424,16 +406,16 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 To restore a single table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+> RESTORE TABLE bank.customers FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 To restore multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers, bank.accounts FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+> RESTORE TABLE bank.customers, bank.accounts FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -442,19 +424,9 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
-~~~
-
-To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers \
-FROM 'azure://{container name}/database-bank-2017-03-27-weekly?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}', \
-'azure://{container name}/database-bank-2017-03-28-nightly?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}', \
-'azure://{container name}/database-bank-2017-03-29-nightly?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup-collection}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -465,11 +437,9 @@ FROM 'azure://{container name}/database-bank-2017-03-27-weekly?AZURE_ACCOUNT_NAM
 
 Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM \
-'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
-WITH DETACHED;
+> RESTORE FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' WITH DETACHED;
 ~~~
 
 The job ID is returned immediately without waiting for the job to finish:
@@ -496,10 +466,10 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE bank.customers \
-FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
 WITH into_db = 'newdb';
 ~~~
 
@@ -507,10 +477,10 @@ WITH into_db = 'newdb';
 
 By default, tables with [foreign key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the foreign key constraint from the table and then restore it.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE bank.accounts \
-FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
 WITH skip_missing_foreign_keys;
 ~~~
 
@@ -522,26 +492,26 @@ After it's restored into a new database, you can write the restored `users` tabl
 
 First, create the new database that you'll restore the `system.users` table into:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE DATABASE newdb;
 ~~~
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE system.users \
-FROM 'azure://{container name}/{path/to/backup/subdirectory}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
+FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' \
 WITH into_db = 'newdb';
 ~~~
 
 After the restore completes, add the `users` to the existing `system.users` table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > INSERT INTO system.users SELECT * FROM newdb.users;
 ~~~
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > DROP TABLE newdb.users;
 ~~~
@@ -558,9 +528,9 @@ The examples in this section use the `AUTH=specified` parameter, which will be t
 
 <span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUPS IN 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+> SHOW BACKUPS IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
 ~~~
 
 ~~~
@@ -572,15 +542,15 @@ The examples in this section use the `AUTH=specified` parameter, which will be t
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the storage URL.
+When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
 
 ### Restore a cluster
 
 To restore a full cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+> RESTORE FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -589,9 +559,9 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 To restore a database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE bank FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+> RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -604,16 +574,16 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 To restore a single table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+> RESTORE TABLE bank.customers FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
 ~~~
 
 To restore multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers, bank.accounts FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
+> RESTORE TABLE bank.customers, bank.accounts FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}';
 ~~~
 
 To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subdirectories).
@@ -622,19 +592,9 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}';
-~~~
-
-To explicitly point to where your incremental backups are, provide the previous full and incremental backup locations in a comma-separated list. In this example, `-weekly` is the full backup and the two `-nightly` are incremental backups.
-
-{% include copy-clipboard.html %}
-~~~ sql
-> RESTORE bank.customers \
-FROM 'gs://{bucket name}/database-bank-2017-03-27-weekly?AUTH=specified&CREDENTIALS={encoded key}', \
-'gs://{bucket name}/database-bank-2017-03-28-nightly?AUTH=specified&CREDENTIALS={encoded key}', \
-'gs://{bucket name}/database-bank-2017-03-29-nightly?AUTH=specified&CREDENTIALS={encoded key}';
+RESTORE DATABASE bank FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup-collection}?AUTH=specified&CREDENTIALS={encoded key}';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -645,10 +605,9 @@ FROM 'gs://{bucket name}/database-bank-2017-03-27-weekly?AUTH=specified&CREDENTI
 
 Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM \
-'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+> RESTORE FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}'
 WITH DETACHED;
 ~~~
 
@@ -676,10 +635,9 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 By default, tables and views are restored to the database they originally belonged to. However, using the [`into_db` option](#into_db), you can control the target database.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE bank.customers \
-FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+> RESTORE bank.customers FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}' \
 WITH into_db = 'newdb';
 ~~~
 
@@ -687,10 +645,9 @@ WITH into_db = 'newdb';
 
 By default, tables with [foreign key](foreign-key.html) constraints must be restored at the same time as the tables they reference. However, using the [`skip_missing_foreign_keys`](restore.html#skip_missing_foreign_keys) option you can remove the foreign key constraint from the table and then restore it.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE bank.accounts \
-FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+> RESTORE bank.accounts FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}' \
 WITH skip_missing_foreign_keys;
 ~~~
 
@@ -702,26 +659,25 @@ After it's restored into a new database, you can write the restored `users` tabl
 
 First, create the new database that you'll restore the `system.users` table into:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE DATABASE newdb;
 ~~~
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE system.users \
-FROM 'gs://{bucket name}/{path/to/backup/subdirectory}?AUTH=specified&CREDENTIALS={encoded key}' \
+> RESTORE system.users FROM '2021/03/23-213101.37' IN 'gs://{bucket name}/{path/to/backup}?AUTH=specified&CREDENTIALS={encoded key}' \
 WITH into_db = 'newdb';
 ~~~
 
 After the restore completes, add the `users` to the existing `system.users` table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > INSERT INTO system.users SELECT * FROM newdb.users;
 ~~~
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > DROP TABLE newdb.users;
 ~~~

--- a/v21.1/restore.md
+++ b/v21.1/restore.md
@@ -194,23 +194,40 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 ### View the backup subdirectories
 
-<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme by default, unless an [explicit subdirectory](../{{site.versions["stable"]}}/backup.html#specify-a-subdirectory-for-backups) is passed with the `BACKUP` statement. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUPS IN 's3://{bucket_name}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
+> SHOW BACKUPS IN 's3://{bucket_name}/{path/to/backup}?AWS_ACCESS_KEY_ID={key_id}&AWS_SECRET_ACCESS_KEY={access_key}';
 ~~~
 
 ~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+       path
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+   |—— 21-142943.73/
+       |—— 20211221/
+           |—— 144748.08/
+           |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 ### Restore a cluster
 
@@ -258,7 +275,7 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 ### Restore from incremental backups
 
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires full and incremental backups to be in the same subdirectory:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -362,19 +379,36 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUPS IN 'azure://{container name}/{path}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+> SHOW BACKUPS IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 ~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+       path
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+   |—— 21-142943.73/
+       |—— 20211221/
+           |—— 144748.08/
+           |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 ### Restore a cluster
 
@@ -422,7 +456,7 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 ### Restore from incremental backups
 
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires full and incremental backups to be in the same subdirectory:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -534,15 +568,32 @@ The examples in this section use the `AUTH=specified` parameter, which will be t
 ~~~
 
 ~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+       path
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+   |—— 21-142943.73/
+       |—— 20211221/
+           |—— 144748.08/
+           |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 ### Restore a cluster
 
@@ -590,7 +641,7 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 ### Restore from incremental backups
 
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires full and incremental backups to be in the same subdirectory:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/v21.1/restore.md
+++ b/v21.1/restore.md
@@ -48,7 +48,7 @@ You can restore:
 
 ### Options
 
-You can control `RESTORE` behavior using any of the following in the `restore_options_list`. To set multiple `RESTORE` options, use a comma-separated list: 
+You can control `RESTORE` behavior using any of the following in the `restore_options_list`. To set multiple `RESTORE` options, use a comma-separated list:
 
  Option                                                             | <div style="width:75px">Value</div>         | Description
  -------------------------------------------------------------------+---------------+-------------------------------------------------------
@@ -94,7 +94,7 @@ When you restore a full cluster with an Enterprise license, it will restore the 
 **The database cannot already exist in the target cluster.** Restoring a database will create a new database and restore all of its tables and views. The created database will have the name of the database in the backup.
 
 ~~~ sql
-RESTORE DATABASE backup_database_name FROM 'subdirectory' in 'your_backup_location';
+RESTORE DATABASE backup_database_name FROM 'subdirectory' IN 'your_backup_location';
 ~~~
 
 {{site.data.alerts.callout_success}}
@@ -151,8 +151,8 @@ You can either restore from a full backup or from a full backup with incremental
 
 Restore Type | Parameters
 -------------|----------
-Full backup | Include the [subdirectory](#view-the-backup-subdirectories) of the backup and the path to the full backup destination (e.g.`RESTORE ... FROM 'subdirectory' IN 'backup destination';`).
-Full backup + <br>incremental backups | Include the path that contains the backup collection and the [subdirectory](#view-the-backup-subdirectories) containing the desired backup (e.g. `RESTORE ... FROM 'subdirectory' IN 'backup collection destination';`).
+Full backup | Include the path to the full backup destination and the [subdirectory](#view-the-backup-subdirectories) of the backup. See the [Examples](#examples) section for syntax of [cluster](#restore-a-cluster), [database](#restore-a-database), and [table](#restore-a-table) restores.
+Full backup + <br>incremental backups | Include the path that contains the backup collection and the [subdirectory](#view-the-backup-subdirectories) containing the incremental backup. See [Restore from incremental backups](#restore-from-incremental-backups) for an example.
 
 ## Performance
 
@@ -194,7 +194,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 ### View the backup subdirectories
 
-<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
+<span class="version-tag">New in v21.1:</span> `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme by default, unless an [explicit subdirectory](../{{site.versions["stable"]}}/backup.html#specify-a-subdirectory-for-backups) is passed with the `BACKUP` statement. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/v21.1/take-and-restore-encrypted-backups.md
+++ b/v21.1/take-and-restore-encrypted-backups.md
@@ -60,7 +60,7 @@ See below for [examples](#examples).
 
 To take an encrypted backup with AWS KMS, use the `kms` [option](backup.html#options):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION=us-east-1';
@@ -77,7 +77,7 @@ To take an encrypted backup with AWS KMS, use the `kms` [option](backup.html#opt
 
 To take a backup with [multi-region encryption](#multi-region), use the `kms` option to specify a comma-separated list of KMS URIs:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH KMS=(
@@ -99,9 +99,9 @@ To decrypt an [encrypted backup](#take-an-encrypted-backup-with-aws-kms), use th
 
 For example, the encrypted backup created in the [first example](#take-an-encrypted-backup-with-aws-kms) can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+> RESTORE FROM '{subdirectory}' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION=us-east-1';
 ~~~
 
@@ -132,9 +132,9 @@ For example, the encrypted backup created in the [first example](#take-an-encryp
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
+> BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -151,9 +151,9 @@ To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.
 
 For example, the encrypted backup created in the previous example can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
+> RESTORE FROM '{subdirectory}' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -170,9 +170,9 @@ For example, the encrypted backup created in the previous example can be restore
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -189,9 +189,9 @@ To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.
 
 For example, the encrypted backup created in the previous example can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> RESTORE FROM '{subdirectory}' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -208,9 +208,9 @@ For example, the encrypted backup created in the previous example can be restore
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> BACKUP INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -227,9 +227,9 @@ To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.
 
 For example, the encrypted backup created in the previous example can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> RESTORE FROM '{subdirectory}' IN 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes

--- a/v21.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
+++ b/v21.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
@@ -21,7 +21,7 @@ You can configure garbage collection periods using the `ttlseconds` [replication
 
 ## Create a backup with revision history
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO '{destination}' AS OF SYSTEM TIME '-10s' WITH revision_history;
 ~~~
@@ -36,9 +36,9 @@ Additionally, if you want to restore a specific incremental backup, you can do s
 
 If you do not specify a point-in-time, the data will be restored to the backup timestamp; that is, the restore will work as if the data was backed up without revision history.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM '{destination}' AS OF SYSTEM TIME '2017-02-26 10:00:00';
+> RESTORE FROM '/2021/12/13-211056.62' IN '(destination)' AS OF SYSTEM TIME '2021-12-13 10:00:00';
 ~~~
 
 To view the available backup subdirectories you can restore from, use [`SHOW BACKUPS`](restore.html#view-the-backup-subdirectories).

--- a/v21.1/take-full-and-incremental-backups.md
+++ b/v21.1/take-full-and-incremental-backups.md
@@ -35,30 +35,32 @@ Backups will export [Enterprise license keys](enterprise-licensing.html) during 
 
 To do a cluster backup, use the [`BACKUP`](backup.html) statement:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO '{destination}';
 ~~~
 
 If it's ever necessary, you can use the [`RESTORE`][restore] statement to restore a table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers FROM '{destination}';
+> RESTORE TABLE bank.customers FROM '{subdirectory}' IN '{destination}';
 ~~~
+
+To view the available backup subdirectories, use [`SHOW BACKUPS`](show-backup.html).
 
 Or to restore a  database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE bank FROM '{destination}';
+> RESTORE DATABASE bank FROM '{subdirectory}' IN '{destination}';
 ~~~
 
 Or to restore your full cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM '{destination}';
+> RESTORE FROM '{subdirectory}' IN '{destination}';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -85,14 +87,14 @@ You can configure garbage collection periods using the `ttlseconds` [replication
 
 Periodically run the [`BACKUP`][backup] command to take a full backup of your cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO '{destination}';
 ~~~
 
 Then, create nightly incremental backups based off of the full backups you've already created. To append an incremental backup to the most recent full backup created in the given destination, use `LATEST`:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN '{destination}';
 ~~~
@@ -103,7 +105,7 @@ For an example on how to specify the destination of an incremental backup, see [
 
 If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster, database(s), and/or table(s). Restoring from incremental backups requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the appended incremental backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE FROM '{subdirectory}' IN '{destination}';
 ~~~
@@ -116,7 +118,7 @@ If it's ever necessary, you can then use the [`RESTORE`][restore] command to res
 
 To explicitly control where your incremental backups go, use the [`INTO {subdirectory} IN (destination)`](backup.html#synopsis) syntax:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank INTO '{subdirectory}' IN '{destination}' \
     AS OF SYSTEM TIME '-10s' \
@@ -145,7 +147,7 @@ To take incremental backups, you need an [Enterprise license](enterprise-licensi
 
 Both core and Enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
   FOR BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
@@ -168,7 +170,7 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
 
 Both core and Enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
   FOR BACKUP INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}'
@@ -191,7 +193,7 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
 
 Both core and Enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
   FOR BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}'

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -336,12 +336,6 @@ INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_AC
 AS OF SYSTEM TIME '-10s';
 ~~~
 
-<<<<<<< HEAD
-=======
-{{site.data.alerts.callout_danger}}
-{% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
-{{site.data.alerts.end}}
-
 ### Specify a subdirectory for backups
 
 To store the backup in a specific subdirectory in the storage location:
@@ -352,7 +346,6 @@ BACKUP DATABASE bank INTO 'subdirectory' IN 'azure://{CONTAINER NAME}/{PATH}?AZU
 AS OF SYSTEM TIME '-10s';
 ~~~
 
->>>>>>> 58b0dcfb4 (Changes as per msbutler review)
 ### Backup all tables in a schema
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:
@@ -474,12 +467,6 @@ INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
-<<<<<<< HEAD
-=======
-{{site.data.alerts.callout_danger}}
-{% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
-{{site.data.alerts.end}}
-
 ### Specify a subdirectory for backups
 
 To store the backup in a specific subdirectory in the storage location:
@@ -490,7 +477,6 @@ BACKUP DATABASE bank INTO 'subdirectory' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=spec
 AS OF SYSTEM TIME '-10s';
 ~~~
 
->>>>>>> 58b0dcfb4 (Changes as per msbutler review)
 ### Backup all tables in a schema
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -207,6 +207,15 @@ INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY
 AS OF SYSTEM TIME '-10s';
 ~~~
 
+### Specify a subdirectory for backups
+
+To store the backup in a specific subdirectory in the storage location:
+
+~~~ sql
+BACKUP DATABASE bank INTO 'subdirectory' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
 ### Backup all tables in a schema
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:
@@ -326,6 +335,22 @@ INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_AC
 AS OF SYSTEM TIME '-10s';
 ~~~
 
+<<<<<<< HEAD
+=======
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
+{{site.data.alerts.end}}
+
+### Specify a subdirectory for backups
+
+To store the backup in a specific subdirectory in the storage location:
+
+~~~ sql
+BACKUP DATABASE bank INTO 'subdirectory' IN 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+>>>>>>> 58b0dcfb4 (Changes as per msbutler review)
 ### Backup all tables in a schema
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:
@@ -447,6 +472,22 @@ INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
 AS OF SYSTEM TIME '-10s';
 ~~~
 
+<<<<<<< HEAD
+=======
+{{site.data.alerts.callout_danger}}
+{% include {{page.version.version}}/backups/no-multiregion-table-backups.md %}
+{{site.data.alerts.end}}
+
+### Specify a subdirectory for backups
+
+To store the backup in a specific subdirectory in the storage location:
+
+~~~ sql
+BACKUP DATABASE bank INTO 'subdirectory' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
+AS OF SYSTEM TIME '-10s';
+~~~
+
+>>>>>>> 58b0dcfb4 (Changes as per msbutler review)
 ### Backup all tables in a schema
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -160,7 +160,7 @@ The syntax `BACKUP ... INTO` adds a backup to a collection within the backup des
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -171,7 +171,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -180,7 +180,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -191,7 +191,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -200,7 +200,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -211,6 +211,7 @@ AS OF SYSTEM TIME '-10s';
 
 To store the backup in a specific subdirectory in the storage location:
 
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 BACKUP DATABASE bank INTO 'subdirectory' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
 AS OF SYSTEM TIME '-10s';
@@ -220,7 +221,7 @@ AS OF SYSTEM TIME '-10s';
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP test_schema.*
 INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -239,7 +240,7 @@ See [Name Resolution](sql-name-resolution.html) for more details on how naming h
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -250,7 +251,7 @@ AS OF SYSTEM TIME '-10s';
 
 Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' \
@@ -288,7 +289,7 @@ The syntax `BACKUP ... INTO` adds a backup to a collection within the backup des
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -299,7 +300,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -308,7 +309,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -319,7 +320,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -328,7 +329,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -345,6 +346,7 @@ AS OF SYSTEM TIME '-10s';
 
 To store the backup in a specific subdirectory in the storage location:
 
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 BACKUP DATABASE bank INTO 'subdirectory' IN 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
 AS OF SYSTEM TIME '-10s';
@@ -355,7 +357,7 @@ AS OF SYSTEM TIME '-10s';
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP test_schema.*
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -374,7 +376,7 @@ See [Name Resolution](sql-name-resolution.html) for more details on how naming h
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -385,7 +387,7 @@ AS OF SYSTEM TIME '-10s';
 
 Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -425,7 +427,7 @@ The syntax `BACKUP ... INTO` adds a backup to a collection within the backup des
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -436,7 +438,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -445,7 +447,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple databases:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank, employees \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -456,7 +458,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of a single table or view:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -465,7 +467,7 @@ AS OF SYSTEM TIME '-10s';
 
 To take a [full backup](take-full-and-incremental-backups.html#full-backups) of multiple tables:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP bank.customers, bank.accounts \
 INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -482,6 +484,7 @@ AS OF SYSTEM TIME '-10s';
 
 To store the backup in a specific subdirectory in the storage location:
 
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 BACKUP DATABASE bank INTO 'subdirectory' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
 AS OF SYSTEM TIME '-10s';
@@ -492,7 +495,7 @@ AS OF SYSTEM TIME '-10s';
 
 <span class="version-tag">New in v21.2:</span> To back up all tables in a [specified schema](create-schema.html), use a wildcard with the schema name:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP test_schema.*
 INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' \
@@ -511,7 +514,7 @@ See [Name Resolution](sql-name-resolution.html) for more details on how naming h
 
 If you backup to a destination already containing a [full backup](take-full-and-incremental-backups.html#full-backups), an [incremental backup](take-full-and-incremental-backups.html#incremental-backups) will be appended to the full backup's path with a date-based name (e.g., `20210324`):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN \
 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \
@@ -522,7 +525,7 @@ AS OF SYSTEM TIME '-10s';
 
 Use the `DETACHED` [option](#options) to execute the backup [job](show-jobs.html) asynchronously:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO \
 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' \

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -543,8 +543,6 @@ job_id             |  status   | fraction_completed | rows | index_entries | byt
 
 {% include {{ page.version.version }}/backups/advanced-examples-list.md %}
 
-## Known limitations
-
 ## See also
 
 - [Take Full and Incremental Backups](take-full-and-incremental-backups.html)

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -246,7 +246,7 @@ In the following example `/2021/12/21-142943.73` contains the full backup. The i
            |—— 144639.97/
 ~~~
 
-To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory).
 
 See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
@@ -425,7 +425,7 @@ In the following example `/2021/12/21-142943.73` contains the full backup. The i
            |—— 144639.97/
 ~~~
 
-To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory).
 
 See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
@@ -604,7 +604,7 @@ In the following example `/2021/12/21-142943.73` contains the full backup. The i
             |—— 144639.97/
 ~~~
 
-To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory).
 
 See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -152,8 +152,8 @@ You can either restore from a full backup or from a full backup with incremental
 
 Restore Type | Parameters
 -------------|----------
-Full backup | Include the [subdirectory](#view-the-backup-subdirectories) of the backup and the path to the full backup destination (e.g.`RESTORE ... FROM 'subdirectory' IN 'backup destination';`).
-Full backup + <br>incremental backups | Include the path that contains the backup collection and the [subdirectory](#view-the-backup-subdirectories) containing the desired backup (e.g. `RESTORE ... FROM 'subdirectory' IN 'backup collection destination';`).
+Full backup | Include the path to the full backup destination and the [subdirectory](#view-the-backup-subdirectories) of the backup. See the [Examples](#examples) section for syntax of [cluster](#restore-a-cluster), [database](#restore-a-database), and [table](#restore-a-table) restores.
+Full backup + <br>incremental backups | Include the path that contains the backup collection and the [subdirectory](#view-the-backup-subdirectories) containing the incremental backup. See [Restore from incremental backups](#restore-from-incremental-backups) for an example.
 
 ## Performance
 
@@ -215,7 +215,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 ### View the backup subdirectories
 
-`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme by default, unless an [explicit subdirectory](../{{site.versions["stable"]}}/backup.html#specify-a-subdirectory-for-backups) is passed with the `BACKUP` statement. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -215,7 +215,7 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 
 ### View the backup subdirectories
 
-`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme by default, unless an [explicit subdirectory](../{{site.versions["stable"]}}/backup.html#specify-a-subdirectory-for-backups) is passed with the `BACKUP` statement. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -223,15 +223,32 @@ The examples in this section use the **default** `AUTH=specified` parameter. For
 ~~~
 
 ~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+       path
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+   |—— 21-142943.73/
+       |—— 20211221/
+           |—— 144748.08/
+           |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 ### Restore a cluster
 
@@ -279,7 +296,7 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 ### Restore from incremental backups
 
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires full and incremental backups to be in the same subdirectory:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -377,23 +394,40 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 
 ### View the backup subdirectories
 
- `BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
+`BACKUP ... INTO` adds a backup to a collection within the backup destination. The path to the backup is created using a date-based naming scheme. To view the backup paths in a given destination, use [`SHOW BACKUPS`](show-backup.html):
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> SHOW BACKUPS IN 'azure://{container name}/{path}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
+> SHOW BACKUPS IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}';
 ~~~
 
 ~~~
-        path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+       path
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+   |—— 21-142943.73/
+       |—— 20211221/
+           |—— 144748.08/
+           |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 ### Restore a cluster
 
@@ -441,7 +475,7 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 ### Restore from incremental backups
 
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires full and incremental backups to be in the same subdirectory:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
@@ -548,14 +582,31 @@ The examples in this section use the `AUTH=specified` parameter, which will be t
 
 ~~~
         path
-------------------------
-2021/03/23-213101.37
-2021/03/24-172553.85
-2021/03/24-210532.53
+-------------------------
+/2021/12/14-190909.83
+/2021/12/20-155249.37
+/2021/12/21-142943.73
 (3 rows)
 ~~~
 
-When you restore a backup, add the backup's subdirectory path (e.g., `2021/03/23-213101.37`) to the `RESTORE` statement.
+When you restore a backup, add the backup's subdirectory path (e.g. `/2021/12/21-142943.73`) to the `RESTORE` statement.
+
+Incremental backups will be appended to the full backup with `BACKUP ... INTO LATEST IN {destination}`. Your storage location will contain the incremental as a date-based subdirectory within the full backup.
+
+In the following example `/2021/12/21-142943.73` contains the full backup. The incremental backups (`144748.08/` and `144639.97/`) are appended as subdirectories to the full backup:
+
+~~~
+2021
+|—— 12
+    |—— 21-142943.73/
+        |—— 20211221/
+            |—— 144748.08/
+            |—— 144639.97/
+~~~
+
+To output more detail about the backups contained within a directory, see [View a list of the full and incremental backups in a specific full backup subdirectory](show-backup.html#view-a-list-of-the-full-and-incremental-backups-in-a-specific-full-backup-subdirectory)
+
+See [Incremental backups with explicitly specified destinations](take-full-and-incremental-backups.html#incremental-backups-with-explicitly-specified-destinations) to control where your backups go.
 
 ### Restore a cluster
 
@@ -603,7 +654,7 @@ To view the available subdirectories, use [`SHOW BACKUPS`](#view-the-backup-subd
 
 ### Restore from incremental backups
 
-Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the incremental backups (stored as subdirectories):
+Restoring from [incremental backups](take-full-and-incremental-backups.html#incremental-backups) requires full and incremental backups to be in the same subdirectory:
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -48,7 +48,7 @@ You can restore:
 
 ### Options
 
-You can control `RESTORE` behavior using any of the following in the `restore_options_list`. To set multiple `RESTORE` options, use a comma-separated list: 
+You can control `RESTORE` behavior using any of the following in the `restore_options_list`. To set multiple `RESTORE` options, use a comma-separated list:
 
  Option                                                             | <div style="width:75px">Value</div>         | Description
  -------------------------------------------------------------------+---------------+-------------------------------------------------------
@@ -458,7 +458,7 @@ Use the `DETACHED` [option](#options) to execute the restore [job](show-jobs.htm
 
 {% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' WITH DETACHED;
+> RESTORE FROM '2021/03/23-213101.37' IN 'azure://{container name}/{path/to/backup}?AZURE_ACCOUNT_NAME={account name}&AZURE_ACCOUNT_KEY={url-encoded key}' WITH DETACHED;
 ~~~
 
 The job ID is returned immediately without waiting for the job to finish:

--- a/v21.2/take-and-restore-encrypted-backups.md
+++ b/v21.2/take-and-restore-encrypted-backups.md
@@ -60,7 +60,7 @@ See below for [examples](#examples).
 
 To take an encrypted backup with AWS KMS, use the `kms` [option](backup.html#options):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION=us-east-1';
@@ -77,7 +77,7 @@ To take an encrypted backup with AWS KMS, use the `kms` [option](backup.html#opt
 
 To take a backup with [multi-region encryption](#multi-region), use the `kms` option to specify a comma-separated list of KMS URIs:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH KMS=(
@@ -99,9 +99,9 @@ To decrypt an [encrypted backup](#take-an-encrypted-backup-with-aws-kms), use th
 
 For example, the encrypted backup created in the [first example](#take-an-encrypted-backup-with-aws-kms) can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+> RESTORE FROM '{subdirectory}' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
     WITH kms = 'aws:///<cmk>?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}&REGION=us-east-1';
 ~~~
 
@@ -132,9 +132,9 @@ For example, the encrypted backup created in the [first example](#take-an-encryp
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
+> BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -151,9 +151,9 @@ To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.
 
 For example, the encrypted backup created in the previous example can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
+> RESTORE FROM '{subdirectory}' IN 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -170,9 +170,9 @@ For example, the encrypted backup created in the previous example can be restore
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -189,9 +189,9 @@ To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.
 
 For example, the encrypted backup created in the previous example can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> RESTORE FROM '{subdirectory}' IN 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -208,9 +208,9 @@ For example, the encrypted backup created in the previous example can be restore
 
 To take an encrypted backup, use the [`encryption_passphrase` option](backup.html#with-encryption-passphrase):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> BACKUP TO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> BACKUP INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes
@@ -227,9 +227,9 @@ To decrypt an encrypted backup, use the [`encryption_passphrase` option](backup.
 
 For example, the encrypted backup created in the previous example can be restored with:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
+> RESTORE FROM '{subdirectory}' IN 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}' WITH encryption_passphrase = 'password123';
 ~~~
 ~~~
         job_id       |  status   | fraction_completed | rows | index_entries | bytes

--- a/v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
+++ b/v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
@@ -21,7 +21,7 @@ You can configure garbage collection periods using the `ttlseconds` [replication
 
 ## Create a backup with revision history
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO '{destination}' AS OF SYSTEM TIME '-10s' WITH revision_history;
 ~~~
@@ -36,9 +36,9 @@ Additionally, if you want to restore a specific incremental backup, you can do s
 
 If you do not specify a point-in-time, the data will be restored to the backup timestamp; that is, the restore will work as if the data was backed up without revision history.
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM '{destination}' AS OF SYSTEM TIME '2017-02-26 10:00:00';
+> RESTORE FROM '/2021/12/13-211056.62' IN '(destination)' AS OF SYSTEM TIME '2021-12-13 10:00:00';
 ~~~
 
 To view the available backup subdirectories you can restore from, use [`SHOW BACKUPS`](restore.html#view-the-backup-subdirectories).

--- a/v21.2/take-full-and-incremental-backups.md
+++ b/v21.2/take-full-and-incremental-backups.md
@@ -37,30 +37,32 @@ Backups will export [Enterprise license keys](enterprise-licensing.html) during 
 
 To do a cluster backup, use the [`BACKUP`](backup.html) statement:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO '{destination}';
 ~~~
 
 If it's ever necessary, you can use the [`RESTORE`][restore] statement to restore a table:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE TABLE bank.customers FROM '{destination}';
+> RESTORE TABLE bank.customers FROM '{subdirectory}' IN '{destination}';
 ~~~
+
+To view the available backup subdirectories, use [`SHOW BACKUPS`](show-backup.html).
 
 Or to restore a  database:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE DATABASE bank FROM '{destination}';
+> RESTORE DATABASE bank FROM '{subdirectory}' IN '{destination}';
 ~~~
 
 Or to restore your full cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> RESTORE FROM '{destination}';
+> RESTORE FROM '{subdirectory}' IN '{destination}';
 ~~~
 
 {{site.data.alerts.callout_info}}
@@ -87,14 +89,14 @@ You can configure garbage collection periods using the `ttlseconds` [replication
 
 Periodically run the [`BACKUP`][backup] command to take a full backup of your cluster:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO '{destination}';
 ~~~
 
 Then, create nightly incremental backups based off of the full backups you've already created. To append an incremental backup to the most recent full backup created in the given destination, use `LATEST`:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP INTO LATEST IN '{destination}';
 ~~~
@@ -103,7 +105,7 @@ For an example on how to specify the destination of an incremental backup, see [
 
 If it's ever necessary, you can then use the [`RESTORE`][restore] command to restore your cluster, database(s), and/or table(s). Restoring from incremental backups requires previous full and incremental backups. To restore from a destination containing the full backup, as well as the appended incremental backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > RESTORE FROM '{subdirectory}' IN '{destination}';
 ~~~
@@ -116,7 +118,7 @@ If it's ever necessary, you can then use the [`RESTORE`][restore] command to res
 
 To explicitly control where your incremental backups go, use the [`INTO {subdirectory} IN (destination)`](backup.html#synopsis) syntax:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > BACKUP DATABASE bank INTO '{subdirectory}' IN '{destination}' \
     AS OF SYSTEM TIME '-10s' \
@@ -145,7 +147,7 @@ To take incremental backups, you need an [Enterprise license](enterprise-licensi
 
 Both core and Enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
   FOR BACKUP INTO 's3://{BUCKET NAME}/{PATH}?AWS_ACCESS_KEY_ID={KEY ID}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
@@ -168,7 +170,7 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
 
 Both core and Enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
   FOR BACKUP INTO 'azure://{CONTAINER NAME}/{PATH}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={URL-ENCODED KEY}'
@@ -191,7 +193,7 @@ Both core and Enterprise users can use backup scheduling for full backups of clu
 
 Both core and Enterprise users can use backup scheduling for full backups of clusters, databases, or tables. To create schedules that only take full backups, include the `FULL BACKUP ALWAYS` clause. For example, to create a schedule for taking full cluster backups:
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE SCHEDULE core_schedule_label
   FOR BACKUP INTO 'gs://{BUCKET NAME}/{PATH}?AUTH=specified&CREDENTIALS={ENCODED KEY}'


### PR DESCRIPTION
Fixes [DOC-2116](https://cockroachlabs.atlassian.net/browse/DOC-2116)

Syntax for RESTORE across the bulk docs needed updating to the `RESTORE FROM 'x' in 'y'` rather than the older `RESTORE FROM 'y/x'` syntax.

Plus a couple of other opportunistic edits (BACKUP syntax in places was not up-to-date, removed stacked notes at top of RESTORE doc into considerations, typo fix)