### PR TITLE
Exclude old versions from link checking

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -3,7 +3,13 @@ ExternalTimeout: 30
 IgnoreDirs:
   - ^docs/stable
   - ^docs/dev
+  - ^docs/v1.0
+  - ^docs/v1.1
   - ^docs/v1.2
+  - ^docs/v2.0
+  - ^docs/v2.1
+  - ^docs/v19.1
+  - ^docs/v19.2
 IgnoreURLs:
   - "http://localhost*"
   - "https://github.com.*"

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -19,6 +19,7 @@ IgnoreURLs:
   - "https://crates.io/*"
   - "https://docs.pipenv.org/*"
   - "https://arxiv.org/*"
+  - "https://www.microsoft.com/*"
 IgnoreInternalEmptyHash: true
 TestFilesConcurrently: true
 DocumentConcurrencyLimit: 16

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{% if page.tags %}{{ page.tags | join: ', ' | escape }}{% endif %}">
-{% if page.block_search or page.url contains 'v1.0' or page.url contains 'v1.1' or page.url contains 'v2.0' or page.url contains 'v2.1' or page.url contains 'v19.1' %}
+{% if page.block_search or page.url contains 'v1.0' or page.url contains 'v1.1' or page.url contains 'v2.0' or page.url contains 'v2.1' or page.url contains 'v19.1' or page.url contains 'v19.2' %}
   <meta name="robots" content="noindex">
   <meta name="robots" content="nofollow">
   <meta name="robots" content="noarchive">

--- a/netlify/build
+++ b/netlify/build
@@ -39,7 +39,7 @@ fi;
 wget -O- https://github.com/errata-ai/vale/releases/download/v1.2.7/vale_1.2.7_Linux_64-bit.tar.gz | tar -xz vale
 
 # Run Vale, but do not fail the build if it reports errors
-./vale --no-wrap v20.2 || true
+./vale --no-wrap v21.2 || true
 
 # Run htmltest, but skip checking external links to speed things up
 $GOPATH/src/github.com/markmandel/htmltest/bin/htmltest --skip-external -l0

--- a/netlify/build
+++ b/netlify/build
@@ -19,8 +19,8 @@ cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
 
 # Set up htmltest
-go install github.com/cockroachdb/htmltest@5c863f8
-#pushd $GOPATH/src/github.com/cockroachdb/htmltest && git checkout fix-ignored-uris && ./build.sh && go install && popd
+go get github.com/cockroachdb/htmltest
+pushd $GOPATH/src/github.com/cockroachdb/htmltest && git checkout fix-ignored-uris && go install && popd
 
 # Run htmltest to check external links on scheduled nightly runs
 # (see .github/workflows/nightly.yml)

--- a/netlify/build
+++ b/netlify/build
@@ -19,13 +19,13 @@ cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
 
 # Set up htmltest
-go get -u github.com/markmandel/htmltest
-pushd $GOPATH/src/github.com/markmandel/htmltest && git checkout debug/panic && ./build.sh && popd
+go get -u github.com/cockroachdb/htmltest
+pushd $GOPATH/src/github.com/cockroachdb/htmltest && git checkout fix-ignored-uris && ./build.sh && popd
 
 # Run htmltest to check external links on scheduled nightly runs
 # (see .github/workflows/nightly.yml)
 if [[ "$INCOMING_HOOK_TITLE" = "nightly" ]]; then
-	$GOPATH/src/github.com/markmandel/htmltest/bin/htmltest
+	$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest
 	exit $?
 fi;
 
@@ -42,7 +42,7 @@ wget -O- https://github.com/errata-ai/vale/releases/download/v1.2.7/vale_1.2.7_L
 ./vale --no-wrap v21.2 || true
 
 # Run htmltest, but skip checking external links to speed things up
-$GOPATH/src/github.com/markmandel/htmltest/bin/htmltest --skip-external -l0
+$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest --skip-external
 
 if [[ $? != 0 ]]; then
   exit 1

--- a/netlify/build
+++ b/netlify/build
@@ -19,14 +19,14 @@ cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
 
 # Set up htmltest
-go get -u github.com/cockroachdb/htmltest
-pushd $GOPATH/src/github.com/cockroachdb/htmltest && ./build.sh && popd
+go get -u github.com/markmandel/htmltest@debug/panic
+pushd $GOPATH/src/github.com/markmandel/htmltest && ./build.sh && popd
 
 # Run htmltest to check external links on scheduled nightly runs
 # (see .github/workflows/nightly.yml)
 if [[ "$INCOMING_HOOK_TITLE" = "nightly" ]]; then
-	$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest
-	exit $?	
+	$GOPATH/src/github.com/markmandel/htmltest/bin/htmltest
+	exit $?
 fi;
 
 # Run Algolia if building master
@@ -42,7 +42,7 @@ wget -O- https://github.com/errata-ai/vale/releases/download/v1.2.7/vale_1.2.7_L
 ./vale --no-wrap v20.2 || true
 
 # Run htmltest, but skip checking external links to speed things up
-$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest --skip-external
+$GOPATH/src/github.com/markmandel/htmltest/bin/htmltest --skip-external
 
 if [[ $? != 0 ]]; then
   exit 1

--- a/netlify/build
+++ b/netlify/build
@@ -19,8 +19,8 @@ cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
 
 # Set up htmltest
-go get -u github.com/markmandel/htmltest@debug/panic
-pushd $GOPATH/src/github.com/markmandel/htmltest && ./build.sh && popd
+go get -u github.com/markmandel/htmltest
+pushd $GOPATH/src/github.com/markmandel/htmltest && git checkout debug/panic && ./build.sh && popd
 
 # Run htmltest to check external links on scheduled nightly runs
 # (see .github/workflows/nightly.yml)

--- a/netlify/build
+++ b/netlify/build
@@ -19,13 +19,13 @@ cp _site/docs/_redirects _site/_redirects
 cp _site/docs/404.html _site/404.html
 
 # Set up htmltest
-go get -u github.com/cockroachdb/htmltest
-pushd $GOPATH/src/github.com/cockroachdb/htmltest && git checkout fix-ignored-uris && ./build.sh && popd
+go install github.com/cockroachdb/htmltest@5c863f8
+#pushd $GOPATH/src/github.com/cockroachdb/htmltest && git checkout fix-ignored-uris && ./build.sh && go install && popd
 
 # Run htmltest to check external links on scheduled nightly runs
 # (see .github/workflows/nightly.yml)
 if [[ "$INCOMING_HOOK_TITLE" = "nightly" ]]; then
-	$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest
+	$GOROOT/bin/htmltest
 	exit $?
 fi;
 
@@ -42,7 +42,7 @@ wget -O- https://github.com/errata-ai/vale/releases/download/v1.2.7/vale_1.2.7_L
 ./vale --no-wrap v21.2 || true
 
 # Run htmltest, but skip checking external links to speed things up
-$GOPATH/src/github.com/cockroachdb/htmltest/bin/htmltest --skip-external
+$GOROOT/bin/htmltest --skip-external
 
 if [[ $? != 0 ]]; then
   exit 1

--- a/netlify/build
+++ b/netlify/build
@@ -42,7 +42,7 @@ wget -O- https://github.com/errata-ai/vale/releases/download/v1.2.7/vale_1.2.7_L
 ./vale --no-wrap v20.2 || true
 
 # Run htmltest, but skip checking external links to speed things up
-$GOPATH/src/github.com/markmandel/htmltest/bin/htmltest --skip-external
+$GOPATH/src/github.com/markmandel/htmltest/bin/htmltest --skip-external -l0
 
 if [[ $? != 0 ]]; then
   exit 1

--- a/netlify/vale/CockroachDB/Terminology.yml
+++ b/netlify/vale/CockroachDB/Terminology.yml
@@ -4,9 +4,9 @@ ignorecase: false
 level: warning
 swap:
   cockroachdb: CockroachDB
-  CockroachCloud: {{ site.data.products.db }}
-  CockroachCloud Serverless: {{ site.data.products.serverless }}
-  CockroachCloud Dedicated: {{ site.data.products.dedicated }}
+  CockroachCloud: '{{ site.data.products.db }}'
+  CockroachCloud Serverless: '{{ site.data.products.serverless }}'
+  CockroachCloud Dedicated: '{{ site.data.products.dedicated }}'
   Enterprise: Enterprise
   raft: Raft
   Raft Group: Raft group


### PR DESCRIPTION
- Tell google to ignore 19.2, which is unsupported
- Tell htmltest to ignore docs for all unsupported versions