### PR TITLE
Added guidance on trade-off between index & import

### DIFF
--- a/v21.1/import-into.md
+++ b/v21.1/import-into.md
@@ -149,6 +149,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
 
+For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
+
 ## Viewing and controlling import jobs
 
 After CockroachDB successfully initiates an import into an existing table, it registers the import as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
@@ -472,3 +474,4 @@ For more information about importing data from Avro, including examples, see [Mi
 - [`IMPORT`](import.html)
 - [Migration Overview](migration-overview.html)
 - [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
+- [Import Performance Best Practices](import-performance-best-practices.html)

--- a/v21.1/import-performance-best-practices.md
+++ b/v21.1/import-performance-best-practices.md
@@ -125,11 +125,9 @@ This method has the added benefit of alerting on potential issues with the impor
 
 ### Import into a schema with secondary indexes
 
-Importing data into a schema that has [secondary indexes](schema-design-indexes.html) will increase the import's total time to completion. The import job will perform the import and populate the indexes concurrently, which causes the longer import time.
+When importing data into a table with secondary indexes, the import job will ingest the table data and required secondary index data concurrently. This may result in a longer import time compared to a table without secondary indexes. Typically, this adds less time to the initial import than following it with a separate pass to add the indexes. As a result, importing tables with their secondary indexes is the default workflow, suitable for most import jobs.
 
-The default workflow is suitable for most import jobs; that is, the import and index population taking place concurrently as part of the import job.
-
-For **large** imports, consider removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately as this will result in the import being faster. This alternative approach does involve more steps overall, however, it offers a clearer view of the work progressing.
+However, in **large** imports, removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately may be preferable for the increased visibility into its progress and ability to retry each step independently.
 
 - [Remove the secondary indexes](drop-index.html)
 - [Perform the import](import-into.html)

--- a/v21.1/import-performance-best-practices.md
+++ b/v21.1/import-performance-best-practices.md
@@ -123,6 +123,18 @@ CSV DATA (
 
 This method has the added benefit of alerting on potential issues with the import sooner; that is, you will not have to wait for the file to load both the schema and data just to find an error in the schema.
 
+### Import into a schema with secondary indexes
+
+Importing data into a schema that has [secondary indexes](schema-design-indexes.html) will increase the import's total time to completion. The import job will perform the import and populate the indexes concurrently, which causes the longer import time.
+
+The default workflow is suitable for most import jobs; that is, the import and index population taking place concurrently as part of the import job.
+
+For **large** imports, consider removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately as this will result in the import being faster. This alternative approach does involve more steps overall, however, it offers a clearer view of the work progressing.
+
+- [Remove the secondary indexes](drop-index.html)
+- [Perform the import](import-into.html)
+- [Create a secondary index](schema-design-indexes.html#create-a-secondary-index)
+
 ## See also
 
 - [`IMPORT`](import.html)

--- a/v21.1/import-performance-best-practices.md
+++ b/v21.1/import-performance-best-practices.md
@@ -125,9 +125,9 @@ This method has the added benefit of alerting on potential issues with the impor
 
 ### Import into a schema with secondary indexes
 
-When importing data into a table with secondary indexes, the import job will ingest the table data and required secondary index data concurrently. This may result in a longer import time compared to a table without secondary indexes. Typically, this adds less time to the initial import than following it with a separate pass to add the indexes. As a result, importing tables with their secondary indexes is the default workflow, suitable for most import jobs.
+When importing data into a table with secondary indexes, the import job will ingest the table data and required secondary index data concurrently. This may result in a longer import time compared to a table without secondary indexes. However, this typically adds less time to the initial import than following it with a separate pass to add the indexes. As a result, importing tables with their secondary indexes is the default workflow, suitable for most import jobs.
 
-However, in **large** imports, removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately may be preferable for the increased visibility into its progress and ability to retry each step independently.
+However, in **large** imports, it may be preferable to remove the secondary indexes from the schema, perform the import, and then re-create the indexes separately. This provides increased visibility into its progress and ability to retry each step independently.
 
 - [Remove the secondary indexes](drop-index.html)
 - [Perform the import](import-into.html)

--- a/v21.1/import.md
+++ b/v21.1/import.md
@@ -178,6 +178,8 @@ Imported tables are treated as new tables, so you must [`GRANT`](grant.html) pri
 - To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
 - To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
 
+For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
+
 ## Viewing and controlling import jobs
 
 After CockroachDB initiates an import, you can view its progress with [`SHOW JOBS`](show-jobs.html) and on the [**Jobs** page](ui-jobs-page.html) of the DB Console, and you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).
@@ -1287,6 +1289,7 @@ CSV DATA ('nodelocal://2/customers.csv')
 - [Migrate from CSV][csv]
 - [Migrate from Avro][avro]
 - [`IMPORT INTO`](import-into.html)
+- [Import Performance Best Practices](import-performance-best-practices.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/import-into.md
+++ b/v21.2/import-into.md
@@ -152,6 +152,8 @@ CockroachDB uses the URL provided to construct a secure API call to the service 
 
 All nodes are used during the import job, which means all nodes' CPU and RAM will be partially consumed by the `IMPORT` task in addition to serving normal traffic.
 
+For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
+
 ## Viewing and controlling import jobs
 
 After CockroachDB successfully initiates an import into an existing table, it registers the import as a job, which you can view with [`SHOW JOBS`](show-jobs.html).
@@ -475,3 +477,4 @@ For more information about importing data from Avro, including examples, see [Mi
 - [`IMPORT`](import.html)
 - [Migration Overview](migration-overview.html)
 - [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)
+- [Import Performance Best Practices](import-performance-best-practices.html)

--- a/v21.2/import-performance-best-practices.md
+++ b/v21.2/import-performance-best-practices.md
@@ -125,11 +125,9 @@ This method has the added benefit of alerting on potential issues with the impor
 
 ### Import into a schema with secondary indexes
 
-Importing data into a schema that has [secondary indexes](schema-design-indexes.html) will increase the import's total time to completion. The import job will perform the import and populate the indexes concurrently, which causes the longer import time.
+When importing data into a table with secondary indexes, the import job will ingest the table data and required secondary index data concurrently. This may result in a longer import time compared to a table without secondary indexes. Typically, this adds less time to the initial import than following it with a separate pass to add the indexes. As a result, importing tables with their secondary indexes is the default workflow, suitable for most import jobs.
 
-The default workflow is suitable for most import jobs; that is, the import and index population taking place concurrently as part of the import job.
-
-For **large** imports, consider removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately as this will result in the import being faster. This alternative approach does involve more steps overall, however, it offers a clearer view of the work progressing.
+However, in **large** imports, removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately may be preferable for the increased visibility into its progress and ability to retry each step independently.
 
 - [Remove the secondary indexes](drop-index.html)
 - [Perform the import](import-into.html)

--- a/v21.2/import-performance-best-practices.md
+++ b/v21.2/import-performance-best-practices.md
@@ -123,6 +123,18 @@ CSV DATA (
 
 This method has the added benefit of alerting on potential issues with the import sooner; that is, you will not have to wait for the file to load both the schema and data just to find an error in the schema.
 
+### Import into a schema with secondary indexes
+
+Importing data into a schema that has [secondary indexes](schema-design-indexes.html) will increase the import's total time to completion. The import job will perform the import and populate the indexes concurrently, which causes the longer import time.
+
+The default workflow is suitable for most import jobs; that is, the import and index population taking place concurrently as part of the import job.
+
+For **large** imports, consider removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately as this will result in the import being faster. This alternative approach does involve more steps overall, however, it offers a clearer view of the work progressing.
+
+- [Remove the secondary indexes](drop-index.html)
+- [Perform the import](import-into.html)
+- [Create a secondary index](schema-design-indexes.html#create-a-secondary-index)
+
 ## See also
 
 - [`IMPORT`](import.html)

--- a/v21.2/import-performance-best-practices.md
+++ b/v21.2/import-performance-best-practices.md
@@ -125,9 +125,9 @@ This method has the added benefit of alerting on potential issues with the impor
 
 ### Import into a schema with secondary indexes
 
-When importing data into a table with secondary indexes, the import job will ingest the table data and required secondary index data concurrently. This may result in a longer import time compared to a table without secondary indexes. Typically, this adds less time to the initial import than following it with a separate pass to add the indexes. As a result, importing tables with their secondary indexes is the default workflow, suitable for most import jobs.
+When importing data into a table with secondary indexes, the import job will ingest the table data and required secondary index data concurrently. This may result in a longer import time compared to a table without secondary indexes. However, this typically adds less time to the initial import than following it with a separate pass to add the indexes. As a result, importing tables with their secondary indexes is the default workflow, suitable for most import jobs.
 
-However, in **large** imports, removing the secondary indexes from the schema, performing the import, and then re-creating the indexes separately may be preferable for the increased visibility into its progress and ability to retry each step independently.
+However, in **large** imports, it may be preferable to remove the secondary indexes from the schema, perform the import, and then re-create the indexes separately. This provides increased visibility into its progress and ability to retry each step independently.
 
 - [Remove the secondary indexes](drop-index.html)
 - [Perform the import](import-into.html)

--- a/v21.2/import.md
+++ b/v21.2/import.md
@@ -178,6 +178,8 @@ Imported tables are treated as new tables, so you must [`GRANT`](grant.html) pri
 - To improve performance, import at least as many files as you have nodes (i.e., there is at least one file for each node to import) to increase parallelism.
 - To further improve performance, order the data in the imported files by [primary key](primary-key.html) and ensure the primary keys do not overlap between files.
 
+For more detail on optimizing import performance, see [Import Performance Best Practices](import-performance-best-practices.html).
+
 ## Viewing and controlling import jobs
 
 After CockroachDB initiates an import, you can view its progress with [`SHOW JOBS`](show-jobs.html) and on the [**Jobs** page](ui-jobs-page.html) of the DB Console, and you can control it with [`PAUSE JOB`](pause-job.html), [`RESUME JOB`](resume-job.html), and [`CANCEL JOB`](cancel-job.html).


### PR DESCRIPTION
Fixes [DOC-1301](https://cockroachlabs.atlassian.net/browse/DOC-1301)

Added a section describing the trade-off between imports into schema with secondary indexes. 

Also added links from the main import pages to the best practices page. Fixes [DOC-1013](https://cockroachlabs.atlassian.net/browse/DOC-1013)