### PR TITLE
Clarify VPC peering instructions

### DIFF
--- a/cockroachcloud/connect-to-your-cluster.md
+++ b/cockroachcloud/connect-to-your-cluster.md
@@ -95,7 +95,7 @@ VPC peering is only available for GCP clusters, and AWS PrivateLink is only avai
 1. Click **Next** to continue to the third step.
 1. Return to the AWS console to [enable private DNS](network-authorization.html#enable-private-dns).
 1. Click **Complete**.
-1. On the **Networking** page, verify the connection status is Available.
+1. On the **Networking** page, verify the connection status is **Available**.
 
 </section>
 

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -120,6 +120,8 @@ You can use [VPC peering](network-authorization.html#vpc-peering) to connect you
         {{site.data.alerts.end}}
 
 1. Click **Next**.
+        
+        Your cluster will now have VPC Peering enabled. Once your cluster is created, see [Establish VPC Peering or AWS PrivateLink](connect-to-your-cluster.html#establish-vpc-peering-or-aws-privatelink) to finish setting up VPC Peering for your cluster.
 
 ## Step 8. Enter billing details
 

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -121,7 +121,7 @@ You can use [VPC peering](network-authorization.html#vpc-peering) to connect you
 
 1. Click **Next**.
         
-        Your cluster will now have VPC Peering enabled. Once your cluster is created, see [Establish VPC Peering or AWS PrivateLink](connect-to-your-cluster.html#establish-vpc-peering-or-aws-privatelink) to finish setting up VPC Peering for your cluster.
+        Once your cluster is created, see [Establish VPC Peering or AWS PrivateLink](connect-to-your-cluster.html#establish-vpc-peering-or-aws-privatelink) to finish setting up VPC Peering for your cluster.
 
 ## Step 8. Enter billing details
 

--- a/cockroachcloud/network-authorization.md
+++ b/cockroachcloud/network-authorization.md
@@ -26,7 +26,7 @@ If you select GCP as your cloud provider while [creating your {{ site.data.produ
 Setting up a VPC peering connection between your {{ site.data.products.dedicated }} cluster and GCP application is a two-part process:
 
 1. [Configure the IP range and size while creating the {{ site.data.products.dedicated }} cluster](#configure-the-ip-range-and-size-while-creating-your-cockroachdb-dedicated-cluster)
-1. [Configure a peering connection after creating the cluster](#establish-a-vpc-peering-connection-after-creating-your-cockroachdb-dedicated-cluster)
+1. [Establish a VPC Peering connection after creating the cluster](#establish-a-vpc-peering-connection-after-creating-your-cockroachdb-dedicated-cluster)
 
 {{site.data.alerts.callout_info}}
 Self-service VPC peering setup is not supported for {{ site.data.products.dedicated }} clusters deployed before March 5, 2020. If your cluster was deployed before March 5, 2020, you will have to [create a new cluster](create-your-cluster.html) with VPC peering enabled, then [export your data](backups-page.html) from the old cluster to the new cluster. If your cluster was deployed on or after March 5, 2020, it will be locked into {{ site.data.products.dedicated }}'s default IP range (`172.28.0.0/14`) unless you explicitly configured a different IP range during cluster creation.
@@ -34,7 +34,7 @@ Self-service VPC peering setup is not supported for {{ site.data.products.dedica
 
 ### Configure the IP range and size while creating your {{ site.data.products.dedicated }} cluster
 
-While creating your {{ site.data.products.dedicated }} cluster, [enable VPC peering](create-your-cluster.html) and configure the IP address range and size (in CIDR format) for the {{ site.data.products.dedicated }} network based on the following considerations:
+While creating your {{ site.data.products.dedicated }} cluster, [enable VPC peering](create-your-cluster.html#step-7-enable-vpc-peering-optional) and configure the IP address range and size (in CIDR format) for the {{ site.data.products.dedicated }} network based on the following considerations:
 
 -  To adhere to [GCP's overlapping subnets restriction](https://cloud.google.com/vpc/docs/vpc-peering#restrictions), configure an IP range that doesn't overlap with the IP ranges in your application network.
 - The IP range and size cannot be changed after the cluster is created. Configuring a smaller IP range size may limit your ability to expand into multiple regions in the future. We recommend configuring an IP range size of `/16` or lower.
@@ -47,7 +47,20 @@ GKE users should note that [alias IP addresses](https://cloud.google.com/kuberne
 
 ### Establish a VPC Peering connection after creating your {{ site.data.products.dedicated }} cluster
 
-After creating your {{ site.data.products.dedicated }} cluster, [request a peering connection](connect-to-your-cluster.html#establish-vpc-peering-or-aws-privatelink) from {{ site.data.products.db }}'s **Networking** page. Then accept the request by running the `gcloud` command displayed on your screen. You can check the status of the connection on the **Peering** tab on the **Networking** page. The status is shown as `PENDING` until you accept the connection request from the GCP side. After the connection is successfully established, the status changes to `ACTIVE`. You can then [select a connection method](connect-to-your-cluster.html#step-2-select-a-connection-method) and [connect to your cluster](connect-to-your-cluster.html#step-3-connect-to-your-cluster).
+After creating your {{ site.data.products.dedicated }} cluster, you can establish a VPC Peering connection from your cluster's **Networking** page:
+
+1. Navigate to your cluster's **Networking > VPC Peering** tab.
+1. Click **Set up a VPC peering connection**.
+1. On the **Request a VPC peering connection** modal, enter your [GCP Project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+1. Enter your [GCP VPC network name](https://cloud.google.com/vpc/docs/using-vpc#viewing-networks).
+1. In the **Connection name** field, enter a descriptive name for the VPC connection.
+1. Click **Request Connection**.
+1. Run the command displayed on the **Accept VPC peering connection request** window using [Google Cloud Shell](https://cloud.google.com/shell) or using the [gcloud command-line tool](https://cloud.google.com/sdk/gcloud).
+1. On the **Networking** page, verify the connection status is **Active**.
+
+    The status is shown as `PENDING` until you accept the connection request from the GCP side.
+
+You can now [select a connection method](connect-to-your-cluster.html#step-2-select-a-connection-method) and [connect to your cluster](connect-to-your-cluster.html#step-3-connect-to-your-cluster).
 
 ## AWS PrivateLink
 

--- a/cockroachcloud/network-authorization.md
+++ b/cockroachcloud/network-authorization.md
@@ -23,7 +23,7 @@ You can add up to 20 IP addresses to your allowlist. If your application servers
 
 If you select GCP as your cloud provider while [creating your {{ site.data.products.dedicated }} cluster](create-your-cluster.html), you can use [Google Cloud's VPC Network Peering](https://cloud.google.com/vpc/docs/vpc-peering) feature to connect your GCP application directly to your {{ site.data.products.dedicated }} cluster using internal IP addresses, thus limiting exposure to the public network and reducing network latency.
 
-GKE users should note that [alias IP addresses](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) are enabled by default in order to create a VPC-native cluster. If you are connecting to a [routes-based GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/routes-based-cluster) and [export custom routes](https://cloud.google.com/vpc/docs/vpc-peering#importing-exporting-routes), {{ site.data.products.db }} will import your custom routes by default.
+GKE users should note that we recommend deploying your application to a VPC-native cluster that uses [alias IP addresses](https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips). If you are connecting to a [routes-based GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/routes-based-cluster) instead, you will have to [export custom routes](https://cloud.google.com/vpc/docs/vpc-peering#importing-exporting-routes). {{ site.data.products.db }} will import your custom routes by default.
 
 Setting up a VPC peering connection between your {{ site.data.products.dedicated }} cluster and GCP application is a two-part process:
 

--- a/cockroachcloud/network-authorization.md
+++ b/cockroachcloud/network-authorization.md
@@ -23,44 +23,16 @@ You can add up to 20 IP addresses to your allowlist. If your application servers
 
 If you select GCP as your cloud provider while [creating your {{ site.data.products.dedicated }} cluster](create-your-cluster.html), you can use [Google Cloud's VPC Network Peering](https://cloud.google.com/vpc/docs/vpc-peering) feature to connect your GCP application directly to your {{ site.data.products.dedicated }} cluster using internal IP addresses, thus limiting exposure to the public network and reducing network latency.
 
+GKE users should note that [alias IP addresses](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) are enabled by default in order to create a VPC-native cluster. If you are connecting to a [routes-based GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/routes-based-cluster) and [export custom routes](https://cloud.google.com/vpc/docs/vpc-peering#importing-exporting-routes), {{ site.data.products.db }} will import your custom routes by default.
+
 Setting up a VPC peering connection between your {{ site.data.products.dedicated }} cluster and GCP application is a two-part process:
 
-1. [Configure the IP range and size while creating the {{ site.data.products.dedicated }} cluster](#configure-the-ip-range-and-size-while-creating-your-cockroachdb-dedicated-cluster)
-1. [Establish a VPC Peering connection after creating the cluster](#establish-a-vpc-peering-connection-after-creating-your-cockroachdb-dedicated-cluster)
+1. [Configure the IP range and size while creating the {{ site.data.products.dedicated }} cluster](create-your-cluster.html#step-7-enable-vpc-peering-optional)
+1. [Establish a VPC Peering connection after creating the cluster](connect-to-your-cluster.html#establish-vpc-peering-or-aws-privatelink)
 
 {{site.data.alerts.callout_info}}
 Self-service VPC peering setup is not supported for {{ site.data.products.dedicated }} clusters deployed before March 5, 2020. If your cluster was deployed before March 5, 2020, you will have to [create a new cluster](create-your-cluster.html) with VPC peering enabled, then [export your data](backups-page.html) from the old cluster to the new cluster. If your cluster was deployed on or after March 5, 2020, it will be locked into {{ site.data.products.dedicated }}'s default IP range (`172.28.0.0/14`) unless you explicitly configured a different IP range during cluster creation.
 {{site.data.alerts.end}}
-
-### Configure the IP range and size while creating your {{ site.data.products.dedicated }} cluster
-
-While creating your {{ site.data.products.dedicated }} cluster, [enable VPC peering](create-your-cluster.html#step-7-enable-vpc-peering-optional) and configure the IP address range and size (in CIDR format) for the {{ site.data.products.dedicated }} network based on the following considerations:
-
--  To adhere to [GCP's overlapping subnets restriction](https://cloud.google.com/vpc/docs/vpc-peering#restrictions), configure an IP range that doesn't overlap with the IP ranges in your application network.
-- The IP range and size cannot be changed after the cluster is created. Configuring a smaller IP range size may limit your ability to expand into multiple regions in the future. We recommend configuring an IP range size of `/16` or lower.
-
-Alternatively, you can use {{ site.data.products.dedicated }}'s default IP range and size (`172.28.0.0/14`) as long as it doesn't overlap with the IP ranges in your network.
-
-{{site.data.alerts.callout_info}}
-GKE users should note that [alias IP addresses](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) are enabled by default in order to create a VPC-native cluster.
-{{site.data.alerts.end}}
-
-### Establish a VPC Peering connection after creating your {{ site.data.products.dedicated }} cluster
-
-After creating your {{ site.data.products.dedicated }} cluster, you can establish a VPC Peering connection from your cluster's **Networking** page:
-
-1. Navigate to your cluster's **Networking > VPC Peering** tab.
-1. Click **Set up a VPC peering connection**.
-1. On the **Request a VPC peering connection** modal, enter your [GCP Project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
-1. Enter your [GCP VPC network name](https://cloud.google.com/vpc/docs/using-vpc#viewing-networks).
-1. In the **Connection name** field, enter a descriptive name for the VPC connection.
-1. Click **Request Connection**.
-1. Run the command displayed on the **Accept VPC peering connection request** window using [Google Cloud Shell](https://cloud.google.com/shell) or using the [gcloud command-line tool](https://cloud.google.com/sdk/gcloud).
-1. On the **Networking** page, verify the connection status is **Active**.
-
-    The status is shown as `PENDING` until you accept the connection request from the GCP side.
-
-You can now [select a connection method](connect-to-your-cluster.html#step-2-select-a-connection-method) and [connect to your cluster](connect-to-your-cluster.html#step-3-connect-to-your-cluster).
 
 ## AWS PrivateLink
 

--- a/cockroachcloud/network-authorization.md
+++ b/cockroachcloud/network-authorization.md
@@ -23,7 +23,7 @@ You can add up to 20 IP addresses to your allowlist. If your application servers
 
 If you select GCP as your cloud provider while [creating your {{ site.data.products.dedicated }} cluster](create-your-cluster.html), you can use [Google Cloud's VPC Network Peering](https://cloud.google.com/vpc/docs/vpc-peering) feature to connect your GCP application directly to your {{ site.data.products.dedicated }} cluster using internal IP addresses, thus limiting exposure to the public network and reducing network latency.
 
-GKE users should note that we recommend deploying your application to a VPC-native cluster that uses [alias IP addresses](https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips). If you are connecting to a [routes-based GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/routes-based-cluster) instead, you will have to [export custom routes](https://cloud.google.com/vpc/docs/vpc-peering#importing-exporting-routes). {{ site.data.products.db }} will import your custom routes by default.
+GKE users should note that we recommend deploying your application to a VPC-native cluster that uses [alias IP addresses](https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips). If you are connecting from a [routes-based GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/routes-based-cluster) instead, you will have to [export custom routes](https://cloud.google.com/vpc/docs/vpc-peering#importing-exporting-routes). {{ site.data.products.db }} will import your custom routes by default.
 
 Setting up a VPC peering connection between your {{ site.data.products.dedicated }} cluster and GCP application is a two-part process:
 

--- a/cockroachcloud/security-overview.md
+++ b/cockroachcloud/security-overview.md
@@ -80,7 +80,7 @@ The following table summarizes the {{ site.data.products.db }} security features
  <tr>
   <td>&nbsp;</td>
   <td>✓</td>
-  <td>VPC Peering for GCP cluster and AWS PrivateLink for AWS clusters </td>
+  <td><a href="network-authorization.html">VPC Peering</a> for GCP clusters and <a href="network-authorization.html">AWS PrivateLink</a> for AWS clusters </td>
  </tr>
  <tr>
    <td><a href="../{{site.versions["stable"]}}/cluster-api.html">Cluster API</a></td>


### PR DESCRIPTION
https://cockroachlabs.atlassian.net/browse/DOC-1947

On **Create a Cluster** page: mentioned that you have to actually establish the connection after enabling it during the cluster creation project, linked to instructions

On **Network Authorization** page: replaced the summarized instructions with links to detailed create & connection doc steps, added note about gke custom routes

On **Security Overview** page: linked to detailed instructions