### PR TITLE
DOC-1511: Added off-peak recommendation for secondary indexes

### DIFF
--- a/v21.1/schema-design-indexes.md
+++ b/v21.1/schema-design-indexes.md
@@ -86,6 +86,8 @@ Here are some best practices for creating indexes:
 
     Also note that [`ALTER PRIMARY KEY`](alter-primary-key.html) creates a secondary index from the old primary key. If you need to [change a primary key](constraints.html#change-constraints), and you do not plan to filter queries on the old primary key column(s), do not use `ALTER PRIMARY KEY`. Instead, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key), which does not create a secondary index.
 
+- Limit creation and deletion of secondary indexes to off-peak hours. Performance impacts are likely if done during peak business hours.
+
 - Use a [`STORING` clause](create-index.html#parameters) to store columns of data that you want returned by common queries, but that you do not plan to use in query filters.
 
     The `STORING` clause specifies columns that are not part of the index key but should be stored in the index, without being sorted. If a column is specified in a query, and the column is neither indexed nor stored in an index, CockroachDB will perform a full scan of the table, which can result in poor performance. For an example, see [below](#example).

--- a/v21.2/schema-design-indexes.md
+++ b/v21.2/schema-design-indexes.md
@@ -80,6 +80,8 @@ Here are some best practices for creating and using indexes:
 
     [`ALTER PRIMARY KEY`](alter-primary-key.html) creates a secondary index from the old primary key. If you need to [change a primary key](constraints.html#change-constraints), and you do not plan to filter queries on the old primary key column(s), do not use `ALTER PRIMARY KEY`. Instead, use [`DROP CONSTRAINT ... PRIMARY KEY`/`ADD CONSTRAINT ... PRIMARY KEY`](add-constraint.html#changing-primary-keys-with-add-constraint-primary-key), which does not create a secondary index.
 
+- Limit creation and deletion of secondary indexes to off-peak hours. Performance impacts are likely if done during peak business hours.
+
 - [Drop unused indexes](drop-index.html) whenever possible.
 
     To understand usage statistics for an index, query the <a href="performance-recipes.html#slow-writes"><code>crdb_internal.index_usage_statistics</code> table</a>.


### PR DESCRIPTION
Added recommendation to limit secondary index operations during off-peak hours