### PR TITLE
Remove "latest" tag from 21.1.12

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -11,7 +11,6 @@
       version: v21.2.0
     - date: Nov 15, 2021
       version: v21.1.12
-      latest: true
     - date: Oct 18, 2021
       version: v21.1.11
     - date: Oct 7, 2021


### PR DESCRIPTION
On the full release list, only the latest stable release
should have the "latest" tag.