### PR TITLE
Updates to Multi-region RESTORE/BACKUP with updates in 21.2.3

### DIFF
--- a/_includes/v21.2/known-limitations/rbr-restore-no-support.md
+++ b/_includes/v21.2/known-limitations/rbr-restore-no-support.md
@@ -1,1 +1,0 @@
-Restoring [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) tables is currently not supported. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/67269)

--- a/_includes/v21.2/known-limitations/restore-multiregion-match.md
+++ b/_includes/v21.2/known-limitations/restore-multiregion-match.md
@@ -1,6 +1,4 @@
-[`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) tables can be restored **only** if the [table locality](multiregion-overview.html#table-locality) matches that of the target database.
-
-    The following must also be true for `RESTORE` to be successful:
+[`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) and [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) tables can be restored **only** if the regions of the backed-up table match those of the target database. All of the following must be true for `RESTORE` to be successful:
 
     * The [regions](multiregion-overview.html#database-regions) of the source database and the regions of the destination database have the same set of regions.
     * The regions were added to each of the databases in the same order.
@@ -11,19 +9,19 @@
     Running on the source database:
 
     ~~~ sql
-    > ALTER DATABASE source_database SET PRIMARY REGION "us-east1";
+    ALTER DATABASE source_database SET PRIMARY REGION "us-east1";
     ~~~
     ~~~ sql
-    > ALTER DATABASE source_database ADD region "us-west1";  
+    ALTER DATABASE source_database ADD region "us-west1";  
     ~~~
 
     Running on the destination database:
 
     ~~~ sql
-    > ALTER DATABASE destination_database SET PRIMARY REGION "us-west1";
+    ALTER DATABASE destination_database SET PRIMARY REGION "us-west1";
     ~~~
     ~~~ sql
-    > ALTER DATABASE destination_database ADD region "us-east1";  
+    ALTER DATABASE destination_database ADD region "us-east1";  
     ~~~
 
     In addition, the following scenario has mismatched regions between the databases since the regions were not added to the database in the same order.
@@ -31,20 +29,20 @@
     Running on the source database:
 
     ~~~ sql
-    > ALTER DATABASE source_database SET PRIMARY REGION "us-east1";
+    ALTER DATABASE source_database SET PRIMARY REGION "us-east1";
     ~~~
     ~~~ sql
-    > ALTER DATABASE source_database ADD region "us-west1";  
+    ALTER DATABASE source_database ADD region "us-west1";  
     ~~~
 
     Running on the destination database:
 
     ~~~ sql
-    > ALTER DATABASE destination_database SET PRIMARY REGION "us-west1";
+    ALTER DATABASE destination_database SET PRIMARY REGION "us-west1";
     ~~~
     ~~~ sql
-    > ALTER DATABASE destination_database ADD region "us-east1";
+    ALTER DATABASE destination_database ADD region "us-east1";
     ~~~
     ~~~ sql  
-    > ALTER DATABASE destination_database SET PRIMARY REGION "us-east1";    
+    ALTER DATABASE destination_database SET PRIMARY REGION "us-east1";    
     ~~~

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -19,7 +19,7 @@ You can also backup:
 - [An individual database](#backup-a-database), which includes all of its tables and views.
 - [An individual table](#backup-a-table-or-view), which includes its indexes and views.
 
-    `BACKUP` only backs up entire tables; it _does not_ support backing up subsets of a table.
+    `BACKUP` only backs up entire tables; it **does not** support backing up subsets of a table.
 
 Because CockroachDB is designed with high fault tolerance, these backups are designed primarily for disaster recovery (i.e., if your cluster loses a majority of its nodes) through [`RESTORE`](restore.html). Isolated issues (such as small-scale node outages) do not require any intervention.
 

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -161,8 +161,6 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ### Using `RESTORE` with multi-region table localities
 
-* {% include {{ page.version.version }}/known-limitations/rbr-restore-no-support.md %}
-
 * {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
 
 * {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}

--- a/v21.2/known-limitations.md
+++ b/v21.2/known-limitations.md
@@ -161,9 +161,9 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ### Using `RESTORE` with multi-region table localities
 
-* {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
+- {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
 
-* {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
+- {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
 
 [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
 
@@ -199,9 +199,9 @@ UNION ALL SELECT * FROM t1 LEFT JOIN t2 ON st_contains(t1.geom, t2.geom) AND t2.
 
 ### Optimizer stale statistics deletion when columns are dropped
 
-* {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
+- {% include {{page.version.version}}/known-limitations/old-multi-col-stats.md %}
 
-* {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
+- {% include {{page.version.version}}/known-limitations/single-col-stats-deletion.md %}
 
 ### Automatic statistics refresher may not refresh after upgrade
 

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -167,19 +167,19 @@ When a `RESTORE` fails or is canceled, partially restored data is properly clean
 
 <span class="version-tag">New in v21.2:</span> Restoring to a [multi-region database](multiregion-overview.html) is supported with some limitations. This section outlines details and settings that should be considered when restoring into multi-region databases:
 
-* A [cluster's regions](multiregion-overview.html#cluster-regions) will be checked before a restore. Mismatched regions between backup and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
+- A [cluster's regions](multiregion-overview.html#cluster-regions) will be checked before a restore. Mismatched regions between backup and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
 
-* A database that is restored with the `sql.defaults.primary_region` [cluster setting](cluster-settings.html) will have the [`PRIMARY REGION`](set-primary-region.html) from this cluster setting assigned to the target database.
+- A database that is restored with the `sql.defaults.primary_region` [cluster setting](cluster-settings.html) will have the [`PRIMARY REGION`](set-primary-region.html) from this cluster setting assigned to the target database.
 
-* `RESTORE` supports restoring **non**-multi-region tables into a multi-region database and sets the table locality as [`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) to the primary region of the target database.
+- `RESTORE` supports restoring **non**-multi-region tables into a multi-region database and sets the table locality as [`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) to the primary region of the target database.
 
-* Restoring tables from multi-region databases with table localities set to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables), `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported.
+- Restoring tables from multi-region databases with table localities set to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables), `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported.
 
-* When restoring a `REGIONAL BY TABLE IN PRIMARY REGION` table, if the primary region is different in the source database to the target database this will be implicitly changed on restore.
+- When restoring a `REGIONAL BY TABLE IN PRIMARY REGION` table, if the primary region is different in the source database to the target database this will be implicitly changed on restore.
 
-* Restoring a [partition](partitioning.html) of a `REGIONAL BY ROW` table is not supported.
+- Restoring a [partition](partitioning.html) of a `REGIONAL BY ROW` table is not supported.
 
-* {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
+- {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
 
 The ordering of regions and how region matching is determined is a known limitation. See the [Known Limitations](#known-limitations) section for the tracking issues on limitations around `RESTORE` and multi-region support.
 
@@ -744,9 +744,9 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 
 ## Known limitations
 
-* {% include {{ page.version.version }}/known-limitations/restore-aost.md %} [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/53044)
-* To successfully [restore a table into a multi-region database](#restoring-to-multi-region-databases), it is necessary for the order and regions to match between the source and destination database. See the [Known Limitations](known-limitations.html#using-restore-with-multi-region-table-localities) page for detail on ordering and matching regions. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
-* {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
+- {% include {{ page.version.version }}/known-limitations/restore-aost.md %} [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/53044)
+- To successfully [restore a table into a multi-region database](#restoring-to-multi-region-databases), it is necessary for the order and regions to match between the source and destination database. See the [Known Limitations](known-limitations.html#using-restore-with-multi-region-table-localities) page for detail on ordering and matching regions. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
+- {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
 
 ## See also
 

--- a/v21.2/restore.md
+++ b/v21.2/restore.md
@@ -115,7 +115,7 @@ The target database must not have tables or views with the same name as the tabl
 - [Restore the table or view into a different database](#into_db).
 
 {{site.data.alerts.callout_info}}
-`RESTORE` only offers table-level granularity; it _does not_ support restoring subsets of a table.
+`RESTORE` only offers table-level granularity; it **does not** support restoring subsets of a table.
 {{site.data.alerts.end}}
 
 When restoring an individual table that references a user-defined type (e.g., [`ENUM`](enum.html)), CockroachDB will first check to see if the type already exists. The restore will attempt the following for each user-defined type within a table backup:
@@ -165,21 +165,19 @@ When a `RESTORE` fails or is canceled, partially restored data is properly clean
 
 ## Restoring to multi-region databases
 
-<span class="version-tag">New in v21.2:</span> Restoring to a [multi-region database](multiregion-overview.html) is supported with some limitations. This section outlines details and settings that should be considered when restoring into multi-region databases.
+<span class="version-tag">New in v21.2:</span> Restoring to a [multi-region database](multiregion-overview.html) is supported with some limitations. This section outlines details and settings that should be considered when restoring into multi-region databases:
 
-* A [cluster's regions](multiregion-overview.html#cluster-regions) will be checked before a restore. Mismatched regions between [backup](backup.html) and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
+* A [cluster's regions](multiregion-overview.html#cluster-regions) will be checked before a restore. Mismatched regions between backup and restore clusters will be flagged before the restore begins, which allows for a decision between updating the [cluster localities](cockroach-start.html#locality) or restoring with the [`skip_localities_check`](#skip-localities-check) option to continue with the restore regardless.
 
 * A database that is restored with the `sql.defaults.primary_region` [cluster setting](cluster-settings.html) will have the [`PRIMARY REGION`](set-primary-region.html) from this cluster setting assigned to the target database.
 
-{{site.data.alerts.callout_info}}
-Tables with a [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables) locality cannot be restored.
-{{site.data.alerts.end}}
-
 * `RESTORE` supports restoring **non**-multi-region tables into a multi-region database and sets the table locality as [`REGIONAL BY TABLE`](multiregion-overview.html#regional-tables) to the primary region of the target database.
 
-* Restoring tables from multi-region databases with table localities set to `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported.
+* Restoring tables from multi-region databases with table localities set to [`REGIONAL BY ROW`](multiregion-overview.html#regional-by-row-tables), `REGIONAL BY TABLE`, [`REGIONAL BY TABLE IN PRIMARY REGION`](set-locality.html#regional-by-table), and [`GLOBAL`](set-locality.html#global) to another multi-region database is supported.
 
 * When restoring a `REGIONAL BY TABLE IN PRIMARY REGION` table, if the primary region is different in the source database to the target database this will be implicitly changed on restore.
+
+* Restoring a [partition](partitioning.html) of a `REGIONAL BY ROW` table is not supported.
 
 * {% include {{ page.version.version }}/known-limitations/restore-multiregion-match.md %}
 
@@ -748,7 +746,6 @@ After the restore completes, add the `users` to the existing `system.users` tabl
 
 * {% include {{ page.version.version }}/known-limitations/restore-aost.md %} [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/53044)
 * To successfully [restore a table into a multi-region database](#restoring-to-multi-region-databases), it is necessary for the order and regions to match between the source and destination database. See the [Known Limitations](known-limitations.html#using-restore-with-multi-region-table-localities) page for detail on ordering and matching regions. [Tracking GitHub Issue](https://github.com/cockroachdb/cockroach/issues/71071)
-* {% include {{ page.version.version }}/known-limitations/rbr-restore-no-support.md %}
 * {% include {{ page.version.version }}/known-limitations/restore-tables-non-multi-reg.md %}
 
 ## See also

--- a/v21.2/set-locality.md
+++ b/v21.2/set-locality.md
@@ -37,9 +37,7 @@ The user must be a member of the [`admin`](authorization.html#roles) or [owner](
 ## Examples
 
 {{site.data.alerts.callout_info}}
-[`RESTORE`](restore.html) on [`REGIONAL BY TABLE`](#regional-by-table) and [`GLOBAL`](#global) tables is supported with some limitations — see [Restoring to multi-region databases](restore.html#restoring-to-multi-region-databases) for more detail.
-
-Tables set to a [`REGIONAL BY ROW`](#regional-by-row) table locality cannot be restored. See the [Known Limitations](known-limitations.html#using-restore-with-multi-region-table-localities) page for detail.
+[`RESTORE`](restore.html) on [`REGIONAL BY TABLE`](#regional-by-table), [`REGIONAL BY ROW`](#regional-by-row), and [`GLOBAL`](#global) tables is supported with some limitations — see [Restoring to multi-region databases](restore.html#restoring-to-multi-region-databases) for more detail.
 {{site.data.alerts.end}}
 
 <a name="regional-by-table"></a>


### PR DESCRIPTION
Fixes [DOC-1872](https://cockroachlabs.atlassian.net/browse/DOC-1872), [DOC-1709](https://cockroachlabs.atlassian.net/browse/DOC-1709), [DOC-1158](https://cockroachlabs.atlassian.net/browse/DOC-1158), [DOC-723](https://cockroachlabs.atlassian.net/browse/DOC-723)

Removes limitations from 21.2: 

* backup can now backup up tables
* can now restore RBR

Also made adjustments to the Restore multi-region section to reflect these changes.