### PR TITLE
Align beginning of quickstarts

### DIFF
--- a/_includes/v21.1/sidebar-data-reference.json
+++ b/_includes/v21.1/sidebar-data-reference.json
@@ -1183,7 +1183,7 @@
         ]
       },
       {
-        "title": "CLI Reference",
+        "title": "CLI",
         "urls": [
           "/${VERSION}/cockroach-commands.html"
         ],
@@ -1467,7 +1467,7 @@
         ]
       },
       {
-        "title": "Logging Reference",
+        "title": "Logging",
         "urls": [
           "/${VERSION}/logging.html"
         ],

--- a/_includes/v21.2/sidebar-data/reference.json
+++ b/_includes/v21.2/sidebar-data/reference.json
@@ -1392,7 +1392,7 @@
         ]
       },
       {
-        "title": "CLI Reference",
+        "title": "CLI",
         "items": [
           {
             "title": "Cockroach Commands",
@@ -1700,7 +1700,7 @@
         ]
       },
       {
-        "title": "Logging Reference",
+        "title": "Logging",
         "items": [
           {
             "title": "Logging Levels and Channels",

--- a/cockroachcloud/quickstart-trial-cluster.md
+++ b/cockroachcloud/quickstart-trial-cluster.md
@@ -11,16 +11,13 @@ toc: true
 
 This page shows you how to deploy a CockroachDB cluster on {{ site.data.products.dedicated }} (free for a 30-day trial for your first cluster), connect to it using a sample workload, and run your first query.
 
-To run CockroachDB on your local machine instead, see [Start a Local Cluster](../{{site.versions["stable"]}}/secure-a-cluster.html).
-
-## Before you begin
-
-If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs_quickstart_trial" rel="noopener" target="_blank">sign up for a {{ site.data.products.db }} account</a>.
+To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/secure-a-cluster.html).
 
 ## Step 1. Create a free trial cluster
 
 For this tutorial, we will create a 3-node GCP cluster in the `us-west2` region.
 
+1. If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs_quickstart_trial" rel="noopener" target="_blank">sign up for a {{ site.data.products.db }} account</a>.
 1. [Log in](https://cockroachlabs.cloud/) to your {{ site.data.products.db }} account.
 1. On the **Overview** page, click **Create Cluster**.
 1. On the **Create new cluster** page, for **Cloud provider**, select **Google Cloud**.
@@ -74,7 +71,7 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
     {% include cockroachcloud/download-the-binary.md %}
 
 1. In your terminal, run the second command from the dialog to create a new `certs` directory on your local machine and download the CA certificate to that directory.
-    
+
     {% include cockroachcloud/download-the-cert.md %}
 
 ## Step 5. Use the built-in SQL client
@@ -86,7 +83,7 @@ Once your cluster is created, you will be redirected to the **Cluster Overview**
     {{site.data.alerts.end}}
 
     {% include cockroachcloud/sql-connection-string.md %}
-    
+
 1. Enter the SQL user's password and hit enter.
 
     {% include cockroachcloud/postgresql-special-characters.md %}

--- a/cockroachcloud/quickstart.md
+++ b/cockroachcloud/quickstart.md
@@ -11,7 +11,7 @@ toc: true
 
 This page guides you through the quickest way to get started with CockroachDB. You'll start a free {{ site.data.products.serverless }} cluster, connect with the CockroachDB SQL client, insert some data, and then read the data from a sample application.
 
-For information on how to create a {{ site.data.products.db }} cluster with other options, see the [Learn more](#learn-more) section. For an intro to serverless database concepts, take the free [Intro to Serverless Databases](https://university.cockroachlabs.com/courses/intro-to-serverless/) course on Cockroach University.
+To run CockroachDB on your local machine instead, see [Start a Local Cluster](../stable/secure-a-cluster.html).
 
 {% include cockroachcloud/free-limitations.md %}
 


### PR DESCRIPTION
- Link to local cluster option from serverless quickstart
- Combine before you begin with step 1 in dedicated quickstart