### PR TITLE
Fix create dedicated cluster link in Deploy sidenav

### DIFF
--- a/_includes/v21.2/sidebar-data/deploy.json
+++ b/_includes/v21.2/sidebar-data/deploy.json
@@ -37,7 +37,7 @@
                 {
               	  "title": "Create a CockroachDB Dedicated Cluster",
               	  "urls": [
-              	    "/cockroachcloud/create-a-serverless-cluster.html"
+              	    "/cockroachcloud/create-your-cluster.html"
               	  ]
               	},
                 {


### PR DESCRIPTION
Previously, Deploy > Choose a Deployment Strategy > CockroachDB Cloud
> CockroachDB Dedicated > Create a CockroachDB Dedicated
Cluster opened the Serverless cluster creation page. Now it opens
the correct page.