### PR TITLE
Move hello worlds under Get Started

### DIFF
--- a/_includes/v21.2/misc/install-next-steps.html
+++ b/_includes/v21.2/misc/install-next-steps.html
@@ -3,7 +3,7 @@
     <ul>
       <li><a href="start-a-local-cluster.html">Start a cluster locally</a> and talk to it via the built-in SQL client</li>
       <li><a href="learn-cockroachdb-sql.html">Learn more about CockroachDB SQL</a></li>
-      <li><a href="hello-world-example-apps.html">Build a simple application</a> with CockroachDB using Postgres-compatible client drivers and ORMs</li>
+      <li><a href="example-apps.html">Build a simple application</a> with CockroachDB using Postgres-compatible client drivers and ORMs</li>
       <li><a href="demo-replication-and-rebalancing.html">Explore core CockroachDB features</a> like automatic replication, rebalancing, and fault tolerance</li>
     </ul>
   </li>

--- a/_includes/v21.2/sidebar-data/develop.json
+++ b/_includes/v21.2/sidebar-data/develop.json
@@ -321,36 +321,6 @@
           ]
         },
         {
-          "title": "Build a Hello World Application",
-          "items": [
-            {
-              "title": "Go",
-              "urls": [
-                "/${VERSION}/hello-world-go-pgx.html",
-                "/${VERSION}/hello-world-go-gorm.html"
-              ]
-            },
-            {
-              "title": "Java",
-              "urls": [
-                "/${VERSION}/hello-world-java-jdbc.html"
-              ]
-            },
-            {
-              "title": "JavaScript (Node.js)",
-              "urls": [
-                "/${VERSION}/hello-world-node-postgres.html"
-              ]
-            },
-            {
-              "title": "Python",
-              "urls": [
-                "/${VERSION}/hello-world-python-sqlalchemy.html"
-              ]
-            }
-          ]
-        },
-        {
           "title": "Build the Roach Data Application using Spring Boot",
           "items": [
             {

--- a/_includes/v21.2/sidebar-data/get-started.json
+++ b/_includes/v21.2/sidebar-data/get-started.json
@@ -19,13 +19,37 @@
       "title": "Build a Sample Application",
       "items": [
         {
-          "title": "Build a Hello World Application",
-          "urls": [
-            "/cockroachcloud/hello-world-example-apps.html"
-            ]
+          "title": "Hello World",
+          "items": [
+            {
+              "title": "Go",
+              "urls": [
+                "/${VERSION}/hello-world-go-pgx.html",
+                "/${VERSION}/hello-world-go-gorm.html"
+              ]
+            },
+            {
+              "title": "Java",
+              "urls": [
+                "/${VERSION}/hello-world-java-jdbc.html"
+              ]
+            },
+            {
+              "title": "JavaScript (Node.js)",
+              "urls": [
+                "/${VERSION}/hello-world-node-postgres.html"
+              ]
+            },
+            {
+              "title": "Python",
+              "urls": [
+                "/${VERSION}/hello-world-python-sqlalchemy.html"
+              ]
+            }
+          ]
         },
         {
-          "title": "Build a Simple CRUD Application",
+          "title": "Simple CRUD",
           "items": [
             {
               "title": "Go",

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -32,7 +32,7 @@ layout: default
           </div>
         <div class="col-lg-4 mb-3 mb-lg-0 pb-5">
           <div class="card card-link h-100 d-flex text-center">
-          <a href="{{ '/stable/hello-world-example-apps.html' | relative_url }}" class="h-100">
+          <a href="{{ '/stable/example-apps.html' | relative_url }}" class="h-100">
             <div class="card-body p-4 d-flex flex-column justify-content-center align-items-center h-100 card-header-overlap">
               <img class="m-0 mb-4 mt-3" src="{{ 'images/icon-deploy-cloud.svg' | relative_url }}" alt="icon cloud" />
               <h6 class="m-0 text-black">Sample <br>apps</h6>
@@ -72,7 +72,7 @@ layout: default
             <li><a href="{{ '/cockroachcloud/quickstart.html' | relative_url }}">Start a Free Cloud Cluster</a></li>
             <li><a href="{{ '/stable/secure-a-cluster.html' | relative_url }}">Start a Local Cluster</a></li>
             <li><a href="{{ '/stable/learn-cockroachdb-sql.html' | relative_url }}">Learn CockroachDB SQL</a></li>
-            <li><a href="{{ '/stable/hello-world-example-apps.html' | relative_url }}">Hello, World!</a></li>
+            <li><a href="{{ '/stable/hello-world-go-pgx.html' | relative_url }}">Hello, World!</a></li>
             <li><a href="{{ '/stable/demo-fault-tolerance-and-recovery.html' | relative_url }}">Explore Capabilities</a></li>
           </ul>
         </div>
@@ -82,7 +82,7 @@ layout: default
         <div class="landing-column-content">
           <ul>
             <li><a href="{{ '/stable/developer-guide-overview.html' | relative_url }}">Common Dev Tasks</a></li>
-            <li><a href="{{ '/stable/hello-world-example-apps.html' | relative_url }}">Sample Apps</a></li>
+            <li><a href="{{ '/stable/example-apps.html' | relative_url }}">Sample Apps</a></li>
             <li><a href="{{ '/stable/sql-feature-support.html' | relative_url }}">SQL Reference</a></li>
             <li><a href="{{ '/stable/performance-best-practices-overview.html' | relative_url }}">SQL Best Practices</a></li>
             <li><a href="{{ '/stable/error-handling-and-troubleshooting.html' | relative_url }}">SQL Troubleshooting</a></li>

--- a/cockroachcloud/hello-world-example-apps.md
+++ b/cockroachcloud/hello-world-example-apps.md
@@ -5,7 +5,7 @@ tags: golang, python, java
 toc: true
 ---
 
-The examples in this section show you how to build simple "Hello World" applications **using {{ site.data.products.serverless }}**. For a full list of sample applications that have been built using CockroachDB, see [Hello World Example Apps (for CockroachDB)](../{{site.versions["stable"]}}/hello-world-example-apps.html).
+The examples in this section show you how to build simple "Hello World" applications **using {{ site.data.products.serverless }}**. For a full list of sample applications that have been built using CockroachDB, see [Example Apps](../{{site.versions["stable"]}}/example-apps.html).
 
 Click the links in the table below to see simple but complete example applications for each supported language and library combination.
 

--- a/cockroachcloud/index.md
+++ b/cockroachcloud/index.md
@@ -94,7 +94,7 @@ homepage: true
       <div class="landing-column-content">
       <ul>
         <li><a href="../{{site.versions["stable"]}}/developer-guide-overview.html">Common Dev Tasks</a></li>
-        <li><a href="../{{site.versions["stable"]}}/hello-world-example-apps.html">Sample Apps</a></li>
+        <li><a href="../{{site.versions["stable"]}}/example-apps.html">Sample Apps</a></li>
         <li><a href="../{{site.versions["stable"]}}/sql-feature-support.html">SQL Reference</a></li>
         <li><a href="../{{site.versions["stable"]}}/performance-best-practices-overview.html">SQL Best Practices</a></li>
         <li><a href="../{{site.versions["stable"]}}/error-handling-and-troubleshooting.html">SQL Troubleshooting</a></li>

--- a/v21.2/architecture/storage-layer.md
+++ b/v21.2/architecture/storage-layer.md
@@ -93,4 +93,4 @@ The storage layer commits writes from the Raft log to disk, as well as returns r
 
 ## What's next?
 
-Now that you've learned about our architecture, [start a local cluster](../install-cockroachdb.html) and start [building an app with CockroachDB](../hello-world-example-apps.html).
+Now that you've learned about our architecture, [start up a CockroachDB Serverless cluster](../../cockroachcloud/quickstart.html) or [local cluster](../install-cockroachdb.html) and start [building an app with CockroachDB](../example-apps.html).

--- a/v21.2/build-a-spring-app-with-cockroachdb-jdbc.md
+++ b/v21.2/build-a-spring-app-with-cockroachdb-jdbc.md
@@ -814,5 +814,5 @@ CockroachDB documentation:
 - [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
 - [Client Connection Parameters](connection-parameters.html)
 - [CockroachDB Developer Guide](developer-guide-overview.html)
-- [Hello World Example Apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 - [Transactions](transactions.html)

--- a/v21.2/build-a-spring-app-with-cockroachdb-jpa.md
+++ b/v21.2/build-a-spring-app-with-cockroachdb-jpa.md
@@ -704,5 +704,5 @@ CockroachDB documentation:
 - [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
 - [Client Connection Parameters](connection-parameters.html)
 - [CockroachDB Developer Guide](developer-guide-overview.html)
-- [Hello World Example Apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 - [Transactions](transactions.html)

--- a/v21.2/build-a-spring-app-with-cockroachdb-mybatis.md
+++ b/v21.2/build-a-spring-app-with-cockroachdb-mybatis.md
@@ -413,5 +413,5 @@ CockroachDB documentation:
 - [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
 - [Client Connection Parameters](connection-parameters.html)
 - [CockroachDB Developer Guide](developer-guide-overview.html)
-- [Hello World Example Apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 - [Transactions](transactions.html)

--- a/v21.2/community-tooling.md
+++ b/v21.2/community-tooling.md
@@ -47,6 +47,6 @@ If you have a tested or developed a third-party tool with CockroachDB, and would
 
 ## See also
 
-- [Build an App with CockroachDB](hello-world-example-apps.html)
+- [Build an App with CockroachDB](example-apps.html)
 - [Install a Postgres Client](install-client-drivers.html)
 - [Third-Party Tools Supported by Cockroach Labs](third-party-database-tools.html)

--- a/v21.2/delete-data.md
+++ b/v21.2/delete-data.md
@@ -249,7 +249,7 @@ Other common tasks:
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Optimize Statement Performance][fast]
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/demo-serializable.md
+++ b/v21.2/demo-serializable.md
@@ -454,7 +454,7 @@ When you repeat the scenario on CockroachDB, you'll see that the anomaly is prev
     ~~~
 
     {{site.data.alerts.callout_success}}
-    For this kind of error, CockroachDB recommends a [client-side transaction retry loop](transactions.html#client-side-intervention) that would transparently observe that the one doctor cannot take time off because the other doctor already succeeded in asking for it. You can find generic transaction retry functions for various languages in our [Build an App](hello-world-example-apps.html) tutorials.
+    For this kind of error, CockroachDB recommends a [client-side transaction retry loop](transactions.html#client-side-intervention) that would transparently observe that the one doctor cannot take time off because the other doctor already succeeded in asking for it. You can find generic transaction retry functions for various languages in our [Build an App](example-apps.html) tutorials.
     {{site.data.alerts.end}}
 
 1. In the terminal for doctor 2, the application tries to commit the transaction:

--- a/v21.2/developer-guide-overview.md
+++ b/v21.2/developer-guide-overview.md
@@ -52,9 +52,10 @@ A growing number of popular third-party database tools offer full support for Co
 
 ## What's next?
 
-- [Create a {{ site.data.products.serverless }} Cluster](../cockroachcloud/create-a-serverless-cluster.html)
+- [Start a Free {{ site.data.products.serverless }} Cluster](../cockroachcloud/quickstart.html) or [Local Cluster](secure-a-cluster.html)
 - [Install a Driver or ORM Framework](install-client-drivers.html)
 - [Connect to CockroachDB](connect-to-the-database.html)
+- [Build a Sample Application](example-apps.html)
 
 You might also be interested in the following pages:
 
@@ -62,7 +63,6 @@ You might also be interested in the following pages:
 - [Transactions](transactions.html)
 - [CockroachDB Migration](migration-overview.html)
 - [PostgreSQL Compatibility](postgresql-compatibility.html)
-- [Hello World Example Apps](hello-world-example-apps.html)
 - [Build a Spring App with CockroachDB](build-a-spring-app-with-cockroachdb-jdbc.html)
 - [Develop and Deploy a Global Application](movr-flask-overview.html)
 

--- a/v21.2/error-handling-and-troubleshooting.md
+++ b/v21.2/error-handling-and-troubleshooting.md
@@ -90,7 +90,7 @@ Other common tasks:
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-statements)
 - [Optimize Statement Performance][fast]
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/example-apps.md
+++ b/v21.2/example-apps.md
@@ -3,7 +3,6 @@ title: Example Apps
 summary: Examples that show you how to build simple applications with CockroachDB
 tags: golang, python, java
 toc: true
-redirect_from: hello-world-example-apps.html
 ---
 
 The examples in this section show you how to build simple applications using CockroachDB.

--- a/v21.2/index.md
+++ b/v21.2/index.md
@@ -25,7 +25,7 @@ cta: false
       </div>
       <div class="col-lg-4 mb-3 mb-lg-0 pb-5">
         <div class="card card-link h-100 d-flex">
-        <a href="hello-world-example-apps.html" class="h-100">
+        <a href="example-apps.html" class="h-100">
           <div class="card-body p-4 d-flex flex-column h-100 card-header-overlap-text">
             <h6 class="mt-2 mt-0 text-black">Sample <br>apps</h6>
             <p class="text-black">Examples that show you how to build a simple "Hello World" application with CockroachDB</p>
@@ -71,7 +71,7 @@ cta: false
         <li><a href="install-cockroachdb.html">Install CockroachDB</a></li>
         <li><a href="secure-a-cluster.html">Start a Local Cluster</a></li>
         <li><a href="learn-cockroachdb-sql.html">Learn CockroachDB SQL</a></li>
-        <li><a href="hello-world-example-apps.html">Hello, World!</a></li>
+        <li><a href="example-apps.html">Build a Sample Application</a></li>
         <li><a href="demo-fault-tolerance-and-recovery.html">Explore Capabilities</a></li>
       </ul>
     </div>
@@ -79,7 +79,7 @@ cta: false
       <p class="landing-column-title">Develop</p>
       <ul>
         <li><a href="developer-guide-overview.html">Common Dev Tasks</a></li>
-        <li><a href="hello-world-example-apps.html">Sample Apps</a></li>
+        <li><a href="example-apps.html">Sample Apps</a></li>
         <li><a href="sql-feature-support.html">SQL Reference</a></li>
         <li><a href="performance-best-practices-overview.html">SQL Best Practices</a></li>
         <li><a href="error-handling-and-troubleshooting.html">SQL Troubleshooting</a></li>

--- a/v21.2/insert-data.md
+++ b/v21.2/insert-data.md
@@ -127,7 +127,7 @@ Other common tasks:
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Optimize Statement Performance](make-queries-fast.html)
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/learn-cockroachdb-sql.md
+++ b/v21.2/learn-cockroachdb-sql.md
@@ -351,5 +351,5 @@ When you no longer need a table, use [`DROP TABLE`](drop-table.html) followed by
 
 - Explore all [SQL Statements](sql-statements.html)
 - [Use the built-in SQL client](cockroach-sql.html) to execute statements from a shell or directly from the command line
-- [Install the client driver](install-client-drivers.html) for your preferred language and [build an app](hello-world-example-apps.html)
+- [Install the client driver](install-client-drivers.html) for your preferred language and [build an app](example-apps.html)
 - [Explore core CockroachDB features](demo-replication-and-rebalancing.html) like automatic replication, rebalancing, and fault tolerance

--- a/v21.2/make-queries-fast.md
+++ b/v21.2/make-queries-fast.md
@@ -504,7 +504,7 @@ Specific tasks:
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Identify slow queries](query-behavior-troubleshooting.html#identify-slow-statements)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/movr-flask-deployment.md
+++ b/v21.2/movr-flask-deployment.md
@@ -226,7 +226,7 @@ We do not recommend deploying insecure web applications on public networks.
 
 ### Develop your own application
 
-This tutorial demonstrates how to develop and deploy an example multi-region application. Most of the development instructions are specific to Python, Flask, and SQLAlchemy, and most of the deployment instructions are specific to Google Cloud Platform (GCP). CockroachDB supports [many more drivers and ORM's for development](hello-world-example-apps.html), and you can deploy applications using a number of cloud provider orchestration tools and networking services. We encourage you to modify the code and deployments to fit your framework and use case.
+This tutorial demonstrates how to develop and deploy an example multi-region application. Most of the development instructions are specific to Python, Flask, and SQLAlchemy, and most of the deployment instructions are specific to Google Cloud Platform (GCP). CockroachDB supports [many more drivers and ORM's for development](example-apps.html), and you can deploy applications using a number of cloud provider orchestration tools and networking services. We encourage you to modify the code and deployments to fit your framework and use case.
 
 ### Upgrade your deployment
 

--- a/v21.2/movr.md
+++ b/v21.2/movr.md
@@ -99,5 +99,5 @@ For a tutorial on developing and deploying a globally-available web application 
 ## See also
 
 - [Learn CockroachDB SQL](learn-cockroachdb-sql.html)
-- [Build an App with CockroachDB](hello-world-example-apps.html)
+- [Build an App with CockroachDB](example-apps.html)
 - [Experimental Features](experimental-features.html)

--- a/v21.2/postgresql-compatibility.md
+++ b/v21.2/postgresql-compatibility.md
@@ -6,7 +6,7 @@ toc: true
 
 CockroachDB supports the [PostgreSQL wire protocol](https://www.postgresql.org/docs/current/protocol.html) and the majority of PostgreSQL syntax. This means that existing applications built on PostgreSQL can often be migrated to CockroachDB without changing application code.
 
-CockroachDB is wire-compatible with PostgreSQL 13 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](hello-world-example-apps.html).
+CockroachDB is wire-compatible with PostgreSQL 13 and works with majority of PostgreSQL database tools such as [Dbeaver](dbeaver.html), [Intellij](intellij-idea.html), pgdump and so on. Consult this link for a full list of supported [third-party database tools](third-party-database-tools.html). CockroachDB also works with most [PostgreSQL drivers and ORMs](example-apps.html).
 
 However, CockroachDB does not support some of the PostgreSQL features or behaves differently from PostgreSQL because not all features can be easily implemented in a distributed system. This page documents the known list of differences between PostgreSQL and CockroachDB for identical input. That is, a SQL statement of the type listed here will behave differently than in PostgreSQL. Porting an existing application to CockroachDB will require changing these expressions.
 

--- a/v21.2/query-data.md
+++ b/v21.2/query-data.md
@@ -198,7 +198,7 @@ Other common tasks:
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
 - [Optimize Statement Performance][fast]
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/rollback-transaction.md
+++ b/v21.2/rollback-transaction.md
@@ -104,7 +104,7 @@ When using [advanced client-side transaction retries](advanced-client-side-trans
 > ROLLBACK TO SAVEPOINT cockroach_restart;
 ~~~
 
-For examples of retrying transactions in an application, check out the transaction code samples in our [Build an App with CockroachDB](hello-world-example-apps.html) tutorials.
+For examples of retrying transactions in an application, check out the transaction code samples in our [Build an App with CockroachDB](example-apps.html) tutorials.
 
 ## See also
 

--- a/v21.2/run-multi-statement-transactions.md
+++ b/v21.2/run-multi-statement-transactions.md
@@ -89,7 +89,7 @@ Other common tasks:
 - [Delete Data](delete-data.html)
 - [Optimize Statement Performance][fast]
 - [Error Handling and Troubleshooting](error-handling-and-troubleshooting.html)
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 

--- a/v21.2/secure-a-cluster.md
+++ b/v21.2/secure-a-cluster.md
@@ -444,4 +444,4 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 You might also be interested in the following pages:
 
 - [CockroachDB SQL client](cockroach-sql.html)
-- [Hello World Example Apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)

--- a/v21.2/simulate-a-multi-region-cluster-on-localhost.md
+++ b/v21.2/simulate-a-multi-region-cluster-on-localhost.md
@@ -23,7 +23,7 @@ toc: true
 Now that your simulated multi-region cluster is running, you are presented with a SQL prompt:
 
 ~~~
-root@127.0.0.1:26257/defaultdb> 
+root@127.0.0.1:26257/defaultdb>
 ~~~
 
 You can run some basic [CockroachDB SQL statements](learn-cockroachdb-sql.html):
@@ -93,7 +93,7 @@ When you're done with your demo cluster, you can wipe the cluster by typing the 
 
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
-- [Build an app with CockroachDB](hello-world-example-apps.html)
+- [Build an app with CockroachDB](example-apps.html)
 - Further explore CockroachDB capabilities like:
   - [Multi-region SQL performance](demo-low-latency-multi-region-deployment.html)
   - [Fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html)

--- a/v21.2/start-a-local-cluster-in-docker-linux.md
+++ b/v21.2/start-a-local-cluster-in-docker-linux.md
@@ -28,5 +28,5 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
-- [Build an app with CockroachDB](hello-world-example-apps.html)
+- [Build an app with CockroachDB](example-apps.html)
 - Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [multi-region performance](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v21.2/start-a-local-cluster-in-docker-mac.md
+++ b/v21.2/start-a-local-cluster-in-docker-mac.md
@@ -26,5 +26,5 @@ Once you've [installed the official CockroachDB Docker image](install-cockroachd
 
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
-- [Build an app with CockroachDB](hello-world-example-apps.html)
+- [Build an app with CockroachDB](example-apps.html)
 - Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [multi-region performance](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v21.2/start-a-local-cluster-in-docker-windows.md
+++ b/v21.2/start-a-local-cluster-in-docker-windows.md
@@ -234,5 +234,5 @@ PS C:\Users\username> Remove-Item cockroach-data -recurse
 
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
 - [Install the client driver](install-client-drivers.html) for your preferred language
-- [Build an app with CockroachDB](hello-world-example-apps.html)
+- [Build an app with CockroachDB](example-apps.html)
 - Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [multi-region performance](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v21.2/start-a-local-cluster.md
+++ b/v21.2/start-a-local-cluster.md
@@ -368,5 +368,5 @@ Adding capacity is as simple as starting more nodes with `cockroach start`.
 
 - [Install the client driver](install-client-drivers.html) for your preferred language
 - Learn more about [CockroachDB SQL](learn-cockroachdb-sql.html) and the [built-in SQL client](cockroach-sql.html)
-- [Build an app with CockroachDB](hello-world-example-apps.html)
+- [Build an app with CockroachDB](example-apps.html)
 - Further explore CockroachDB capabilities like [fault tolerance and automated repair](demo-fault-tolerance-and-recovery.html), [multi-region performance](demo-low-latency-multi-region-deployment.html), [serializable transactions](demo-serializable.html), and [JSON support](demo-json-support.html)

--- a/v21.2/update-data.md
+++ b/v21.2/update-data.md
@@ -425,7 +425,7 @@ Other common tasks:
 - [Run Multi-Statement Transactions](run-multi-statement-transactions.html)
 - [Error Handling and Troubleshooting][error_handling]
 - [Optimize Statement Performance](make-queries-fast.html)
-- [Hello World Example apps](hello-world-example-apps.html)
+- [Example Apps](example-apps.html)
 
 <!-- Reference Links -->
 


### PR DESCRIPTION
- Move hello worlds under Get Started and remove the sidenav reference to the outdated
hello-world-example-apps.html page.
- Update links to point to example-apps instead.