### PR TITLE
Release notes for v22.1.0-alpha.1

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -89,12 +89,12 @@ release_info:
     name: v21.2.4
     start_time: 2022-01-10 11:01:26.34274101 +0000 UTC
     version: v21.2.4
-  # v22.1:
-  #   build_time: 2021/11/01 11:00:26 (go1.16.6)
-  #   docker_image: cockroachdb/cockroach-unstable
-  #   name: v21.2.0
-  #   start_time: 2021-11-01 11:01:26.34274101 +0000 UTC
-  #   version: v21.2.0
+  v22.1:
+    build_time: 2022/01/24 11:00:26 (go1.16.6)
+    docker_image: cockroachdb/cockroach-unstable
+    name: v22.1.0-alpha.1
+    start_time: 2022-01-24 11:01:26.34274101 +0000 UTC
+    version: v22.1.0-alpha.1
 site_title: CockroachDB Docs
 url: https://www.cockroachlabs.com
 operator_version: v2.4.0

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -292,6 +292,8 @@
       no_windows: true
 - title: Testing releases
   releases:
+    - date: Jan 24, 2022
+      version: v22.1.0-alpha.1
     - date: Nov 1, 2021
       version: v21.2.0-rc.3
     - date: Oct 25, 2021

--- a/_includes/sidebar-releases.json
+++ b/_includes/sidebar-releases.json
@@ -59,7 +59,8 @@
         "/releases/v21.2.0-beta.4.html",
         "/releases/v21.2.0-rc.1.html",
         "/releases/v21.2.0-rc.2.html",
-        "/releases/v21.2.0-rc.3.html"
+        "/releases/v21.2.0-rc.3.html",
+        "/releases/v22.1.0-alpha.1.html"
       ]
     },
     {

--- a/releases/v22.1.0-alpha.1.md
+++ b/releases/v22.1.0-alpha.1.md
@@ -1,0 +1,607 @@
+---
+title: What&#39;s New in v22.1.0-alpha.1
+toc: true
+summary: Additions and changes in CockroachDB version v22.1.0-alpha.1
+---
+
+## January 24, 2022
+
+Get future release notes emailed to you:
+
+{% include_cached marketo.html %}
+
+{{site.data.alerts.callout_info}}
+The new features and bug fixes noted on this page are not yet documented across CockroachDB's documentation. Links on this page will direct to documentation for the [latest stable release](../releases/index.html#production-releases).
+{{site.data.alerts.end}}
+
+### Downloads
+
+<div id="os-tabs" class="filters clearfix">
+    <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
+    <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
+</div>
+
+<section class="filter-content" data-scope="windows">
+{% include_cached windows_warning.md %}
+</section>
+
+### Docker image
+
+{% include_cached copy-clipboard.html %}
+~~~shell
+$ docker pull cockroachdb/cockroach-unstable:v22.1.0-alpha.1
+~~~
+
+### Backward-incompatible changes
+
+- Using [`SESSION_USER`](../{{site.versions["dev"]}}/functions-and-operators.html#special-syntax-forms) in a projection or `WHERE` clause now returns the `SESSION_USER` instead of the `CURRENT_USER`. For backward compatibility, use [`session_user()`](../{{site.versions["dev"]}}/functions-and-operators.html#system-info-functions) for `SESSION_USER` and `current_user()` for `CURRENT_USER`. [#70444][#70444]
+- Placeholder values (e.g., `$1`) can no longer be used for [role](../{{site.versions["dev"]}}/authorization.html#roles) names in [`ALTER ROLE`](../{{site.versions["dev"]}}/alter-role.html) statements or for role names in [`CREATE ROLE`](../{{site.versions["dev"]}}/create-role.html)/[`DROP ROLE`](../{{site.versions["dev"]}}/drop-role.html) statements. [#71498][#71498]
+
+### Security updates
+
+- Authenticated HTTP requests to nodes can now contain additional cookies with the same name as the one CockroachDB uses ("session"). The HTTP spec permits duplicates and will now attempt to parse all cookies with a matching name before giving up. This can resolve issues with running other services on the same domain as your CockroachDB nodes. [#70792][#70792]
+- Added a new flag `--external-io-enable-non-admin-implicit-access` that can remove the [`admin`](../{{site.versions["dev"]}}/authorization.html#admin-role)-only restriction on interacting with arbitrary network endpoints and using `implicit` auth in operations such as [`BACKUP`](../{{site.versions["dev"]}}/backup.html), [`IMPORT`](../{{site.versions["dev"]}}/import.html), or [`EXPORT`](../{{site.versions["dev"]}}/export.html). [#71594][#71594]
+- When configuring passwords for SQL users, if the client presents the password in cleartext via `ALTER`/`CREATE USER`/`ROLE WITH PASSWORD`, CockroachDB is responsible for hashing this password before storing it. By default, this hashing uses CockroachDB's bespoke `crdb-bcrypt` algorithm, which is based on the standard [bcrypt algorithm](https://en.wikipedia.org/wiki/Bcrypt). The cost of this hashing function is now configurable via the new [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) `server.user_login.password_hashes.default_cost.crdb_bcrypt`. Its default value is `10`, which corresponds to an approximate password check latency of 50-100ms on modern hardware. This value should be increased over time to reflect improvements to CPU performance: the latency should not become so small that it becomes feasible to brute-force passwords via repeated login attempts. Future versions of CockroachDB will likely update the default accordingly. [#74582][#74582]
+
+### General changes
+
+- Non-cancelable [jobs](../{{site.versions["dev"]}}/show-jobs.html) now do not fail unless they fail with a permanent error. They retry with exponential backoff if they fail due to a transient error. Furthermore, jobs that perform reverting tasks do not fail. Instead, they are retried with exponential backoff if an error is encountered while reverting. As a result, transient errors do not impact jobs that are reverting. [#69300][#69300]
+- CockroachDB now supports exporting operation [traces](../{{site.versions["dev"]}}/show-trace.html) to [OpenTelemetry](https://opentelemetry.io/)-compatible tools using the OTLP protocol through the `trace.opentelemetry.collector` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html). [#65599][#65599]
+- CockroachDB now supports exporting traces to a [Jaeger](https://www.jaegertracing.io/) agent through the new `trace.jaeger.agent` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html). Exporting to Jaeger was previously possible by configuring the Jaeger agent to accept Zipkin traces and using the `trace.zipkin.collector ` cluster setting; this configuration is no longer required. [#65599][#65599]
+- Support for exporting to Datadog and Lightstep through other interfaces has been retired; these tools can use OpenTelemetry data. The [cluster settings](../{{site.versions["dev"]}}/cluster-settings.html) `trace.lightstep.token`, `trace.datadog.agent`, and `trace.datadog.project` have been deprecated; they no longer have any effect. [#65599][#65599]
+- Tracing transaction commits now includes details about replication. [#72738][#72738]
+
+### Enterprise edition changes
+
+- Updated retyable error warning message to begin with `"WARNING"`. [#70226][#70226]
+- Temporary tables are now [restored](../{{site.versions["dev"]}}/restore.html) to their original database instead of to `defaultdb` during a [full cluster restore](../{{site.versions["dev"]}}/restore.html#full-cluster). Furthermore, `defaultdb` and `postgres` are dropped before a full cluster restore and will only be restored if they are present in the [backup](../{{site.versions["dev"]}}/backup.html) being restored. [#71890][#71890]
+- [Changefeeds](../{{site.versions["dev"]}}/stream-data-out-of-cockroachdb-using-changefeeds.html) now support [GCP Pub/Sub](https://cloud.google.com/pubsub) as a sink. [#72056][#72056]
+
+### SQL language changes
+
+- Added new job control statements allowing an operator to manipulate all jobs of a specific type: `<Command> ALL <JobType> JOBS`. This is supported in [`CHANGEFEED`](../{{site.versions["dev"]}}/stream-data-out-of-cockroachdb-using-changefeeds.html), [`BACKUP`](../{{site.versions["dev"]}}/backup.html), [`IMPORT`](../{{site.versions["dev"]}}/import.html), and [`RESTORE`](../{{site.versions["dev"]}}/restore.html) jobs. For example: `PAUSE ALL CHANGEFEED JOBS`. [#69314][#69314]
+- [`EXPLAIN ANALYZE`](../{{site.versions["dev"]}}/explain-analyze.html) now contains more information about the [MVCC](../{{site.versions["dev"]}}/architecture/storage-layer.html#mvcc) behavior of operators that scan data from disk. [#64503][#64503]
+- Added support for SQL arrays containing JSON for in-memory processing. This does not add support for storing SQL arrays of JSON in tables. [#70041][#70041]
+- Placeholder values can now be used as the right-hand operand of the `JSONFetchVal (->)` and `JSONFetchText (->>)` [operators](../{{site.versions["dev"]}}/functions-and-operators.html#supported-operations) without ambiguity. This argument will be given the text type and the "object field lookup" variant of the operator will be used. [#70066][#70066]
+- Fixed `createdb` and `settings` columns for [`pg_catalog` tables](../{{site.versions["dev"]}}/pg-catalog.html#data-exposed-by-pg_catalog): `pg_user`, `pg_roles`, and `pg_authid`. [#69609][#69609]
+- The `information_schema._pg_truetypid`, `information_schema._pg_truetypmod`, and `information_schema._pg_char_max_length` [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) are now supported to improve compatibility with PostgreSQL. [#69913][#69913]
+- The `pg_my_temp_schema` [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) now properly returns the OID of the active session's temporary schema, if one exists. [#69909][#69909]
+- The `pg_is_other_temp_schema` [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) is now supported, which returns whether the given OID is the OID of another session's temporary schema. [#69909][#69909]
+- The `information_schema._pg_index_position` [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) is now supported, which improves compatibility with PostgreSQL. [#69911][#69911]
+- Extended index scan hints to allow [zigzag joins](../{{site.versions["dev"]}}/cost-based-optimizer.html#zigzag-joins) to be forced. [#67737][#67737]
+- `pg_authid.rolesuper`, `pg_roles.rolesuper`, and `pg_user.usesuper` are now true for users/roles that have [`admin` role](../{{site.versions["dev"]}}/authorization.html#admin-role). [#69981][#69981]
+- Added a warning that [sequences](../{{site.versions["dev"]}}/create-sequence.html) are slower than using [`UUID`](../{{site.versions["dev"]}}/uuid.html). [#68964][#68964]
+- SQL queries with [`ORDER BY x LIMIT k`](../{{site.versions["dev"]}}/order-by.html) clauses may now be transformed to use TopK sort in the query plan if the limit is a constant. Although this affects the output of [`EXPLAIN`](../{{site.versions["dev"]}}/explain.html), using TopK in the query plan does not necessarily mean that it is used during execution. [#68140][#68140]
+- The `has_tablespace_privilege`, `has_server_privilege`, and `has_foreign_data_wrapper_privilege` [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) now return [`NULL`](../{{site.versions["dev"]}}/null-handling.html) instead of `true` when provided with a non-existed OID reference. This matches the behavior of newer PostgreSQL versions. [#69939][#69939]
+- The `pg_has_role` [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) is now supported, which returns whether a given user has [privileges](../{{site.versions["dev"]}}/authorization.html#privileges) for a specified role or not. [#69939][#69939]
+- Added the `json_populate_record`, `jsonb_populate_record`, `json_populate_recordset`, and `jsonb_populate_recordset` functions, which transform JSON into row tuples based on the labels in a record type. [#70115][#70115]
+- The `enable_drop_enum_value` [session variable](../{{site.versions["dev"]}}/set-vars.html#supported-variables) has been removed, along with the corresponding [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html). The functionality of being able to drop `enum` values is now enabled automatically. Queries that refer to the session/cluster setting will still work but will have no effect. [#70369][#70369]
+- The array [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) (`array_agg`, `array_cat`, `array_position`, etc.) now operate on record types. [#70332][#70332]
+- When an invalid cast to OID is made, a `pgerror` now returns with code `22P02`. This previously threw an assertion error. [#70454][#70454]
+- Added the `new_db_name` option to the [`RESTORE DATABASE`](../{{site.versions["dev"]}}/restore.html#databases) statement, allowing the user to rename the database they intend to restore. [#70222][#70222]
+- Fixed error messaging for [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) for sequences. Example: `SELECT nextval('@#%@!324234')` correctly returns `relation "@#%@!324234" does not exist` (if the relation doesn't exist) instead of a syntax error.  `SELECT currval('')` returns `currval\(\): invalid table name:`. [#70590][#70590]
+- It is now possible to cast [JSON](../{{site.versions["dev"]}}/jsonb.html) booleans to the `BOOL` type, and to cast JSON numerics with fractions to rounded `INT` types. Error messages are now more clear when a cast from a JSON value to another type fails. [#70522][#70522]
+- Added a new SQL [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) `unordered_unique_rowid `, which generates a globally unique 64-bit integer that does not have ordering. [#70338][#70338]
+- Added a new [`serial_normalization` case](../{{site.versions["dev"]}}/set-vars.html#supported-variables) `unordered_rowid `, which generates a globally unique 64-bit integer that does not have ordering. [#70338][#70338]
+- A hint is now provided when using a [`SERIAL4` type](../{{site.versions["dev"]}}/serial.html) that gets upgraded to a `SERIAL8` due to the `serial_normalization` session variable requiring an `INT8` to succeed. [#70656][#70656]
+- Improved the error message to identify the column and data type when users try to select a named field from an anonymous record that has no labels. [#70726][#70726]
+- Implemented `pg_statistic_ext` on [`pg_catalog`](../{{site.versions["dev"]}}/pg-catalog.html#data-exposed-by-pg_catalog). [#70591][#70591]
+- Implemented `pg_shadow` at [`pg_catalog`](../{{site.versions["dev"]}}/pg-catalog.html#data-exposed-by-pg_catalog). [#68255][#68255]
+- Disallowed cross-database references for sequences by default. This can be enabled with the [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) `sql.cross_db_sequence_references.enabled`. [#70581][#70581]
+- Added the ability to comment on SQL table [constraints](../{{site.versions["dev"]}}/constraints.html) using PostgreSQL's `COMMENT ON CONSTRAINT` syntax. [#69783][#69783]
+- Added a `WITH COMMENT` clause to the [`SHOW CONSTRAINT`](../{{site.versions["dev"]}}/show-constraints.html) statement that causes constraint comments to be displayed. [#69783][#69783]
+- Added empty stubs for tables and columns. Tables: `pg_statistic`, `pg_statistic_ext_data`, `pg_stats`, `pg_stats_ext`. Columns: `pg_attribute.attmissingval`. [#70865][#70865]
+- Previously, the behavior of [casting](../{{site.versions["dev"]}}/data-types.html#data-type-conversions-and-casts) an [`INT`](../{{site.versions["dev"]}}/int.html) to `CHAR` was similar to `BPCHAR` where only the first digit of the integer was returned. Now casting `INT` to `CHAR` will be interpreted as an ASCII byte, which aligns the overall behavior more with PostgreSQL. [#70942][#70942]
+- A parameter of type `CHAR` can now be used as a parameter in a prepared statement. [#70942][#70942]
+- The `information_schema._pg_numeric_precision`, `information_schema._pg_numeric_precision_radix`, and `information_schema._pg_numeric_scale` [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) are now supported, which improves compatibility with PostgreSQL. [#70881][#70881]
+- If the time zone is set in a GMT offset, for example `+7` or `-11`, the timezone will be formatted as `<+07>-07` and `<-11>+11` respectively instead of `+7`, `-11`.  This most notably shows up when doing [`SHOW TIME ZONE`](../{{site.versions["dev"]}}/show-vars.html#supported-variables). [#70716][#70716]
+- `NULLS FIRST` and `NULLS LAST` specifiers are now supported for [`ORDER BY`](../{{site.versions["dev"]}}/order-by.html). [#71083][#71083]
+- Added `SHOW CREATE ALL SCHEMAS` to allow the user to retrieve [`CREATE` statements](../{{site.versions["dev"]}}/create-schema.html) to recreate the schemas of the current database. A flat log of the `CREATE` statements for schemas is returned. [#71138][#71138]
+- The session variable `inject_retry_errors_enabled` has been added. When this is true, any statement that is a not a [`SET`](../{{site.versions["dev"]}}/set-vars.html) statement will return a [transaction retry error](../{{site.versions["dev"]}}/transaction-retry-error-reference.html) if it is run inside of an explicit transaction. If the client retries the transaction using the special `cockroach_restart` [`SAVEPOINT`](../{{site.versions["dev"]}}/savepoint.html), then after the third error the transaction will proceed as normal. Otherwise, the errors will continue until `inject_retry_errors_enabled` is set to false. The purpose of this setting is to allow users to test their transaction retry logic. [#71357][#71357]
+- Arrays of [`ENUM`](../{{site.versions["dev"]}}/enum.html) data types can now be compared. [#71427][#71427]
+- `NULLS` can be ordered [`NULLS LAST `](../{{site.versions["dev"]}}/order-by.html#parameters) by default if the `null_ordered_last` [session variable](../{{site.versions["dev"]}}/show-vars.html#supported-variables) is set to true. [#71429][#71429]
+- Previously, comparing against [`bytea[]`](../{{site.versions["dev"]}}/bytes.html) without a cast (e.g., `SELECT * FROM t WHERE byteaarrcol = '{}'`) would result in an ambiguous error. This has now been resolved. [#71501][#71501]
+- Previously, placeholders in an [`ARRAY`](../{{site.versions["dev"]}}/array.html) (e.g., `SELECT ARRAY[$1]::int[]`) would resolve in an ambiguous error. This has now been fixed. [#71432][#71432]
+- [`EXPLAIN`](../{{site.versions["dev"]}}/explain.html) output now displays the limit hint when it is nonzero as part of the `estimated row count` field. [#71299][#71299]
+- Implicit casts performed during [`INSERT`](../{{site.versions["dev"]}}/insert.html) statements now more closely follow PostgreSQL's behavior. Several minor bugs related to these types of casts have been fixed. [#70722][#70722]
+- Newly created tables now have `<table_name>_pkey` by default as their index/constraint name. [#70604][#70604]
+- A newly created [`FOREIGN KEY`](../{{site.versions["dev"]}}/foreign-key.html) now has the same constraint name as PostgreSQL— `<table>_<cols>_fkey`. Previously, this was `fk_<cols>_ref_<target>`. [#70658][#70658]
+- `CURRENT_USER` and `SESSION_USER` can now be used as the role identifier in [`ALTER ROLE`](../{{site.versions["dev"]}}/alter-role.html) statements. [#71498][#71498]
+- Array [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html#built-in-functions) can now be used with arrays of [`ENUM`](../{{site.versions["dev"]}}/enum.html). [#71482][#71482]
+- Introduced an implicitly defined type for every table, which resolves to a `TUPLE` type that contains all of the columns in the table. [#70100][#70100]
+- The [`WITH RECURSIVE`](../{{site.versions["dev"]}}/common-table-expressions.html#recursive-common-table-expressions) variant that uses `UNION` (as opposed to `UNION ALL`) is now supported. [#71685][#71685]
+- Infinite decimal values can now be encoded when sending data to/from the client. The encoding matches the PostgreSQL encoding. [#71772][#71772]
+- Previously, certain [`ENUM`](../{{site.versions["dev"]}}/enum.html) builtins or operators required an explicit `ENUM` cast. This has been reduced in some cases. [#71653][#71653]
+- Removed the [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) `sql.defaults.interleaved_tables.enabled` as interleaved support is now fully removed. [#71537][#71537]
+- Implemented a compressed plan "gist" to record for all queries. For example, a query like this:  `SELECT * FROM abc UNION SELECT * FROM abc ORDER BY b,a`, produces the following plan according to `EXPLAIN (SHAPE)`:
+
+    ~~~
+    • distinct
+    │ distinct on: a
+    │
+    └── • union all
+        │
+        ├── • sort
+        │   │ order: +b,+a
+        │   │
+        │   └── • scan
+        │         missing stats
+        │         table: abc@primary
+        │         spans: FULL SCAN
+        │
+        └── • sort
+            │ order: +b,+a
+            │
+            └── • scan
+                  missing stats
+                  table: abc@primary
+                  spans: FULL SCAN
+    ~~~
+    [#69293][#69293]
+
+- `T_unknown` ParameterTypeOIDs in the PostgreSQL frontend/backend protocol are now correctly handled. [#71971][#71971]
+- [String literals](../{{site.versions["dev"]}}/sql-constants.html#string-literals) can now be parsed as tuples, either in a cast expression, or in other contexts like function arguments. [#71916][#71916]
+- Added the [function](../{{site.versions["dev"]}}/functions-and-operators.html) `crdb_internal.reset_index_usage_stats()` to clear index usage stats. This can be invoked from the SQL shell. [#71896][#71896]
+- Custom session options can now be used, i.e., any [session variable](../{{site.versions["dev"]}}/show-vars.html) that has `.` in the name. [#71915][#71915]
+- Added logic to process an `EXPORT PARQUET` statement. [#71868][#71868]
+- Added ability to `EXPORT PARQUET` for relations with `FLOAT`, `INT`, and `STRING` column types. [#71868][#71868]
+- This change removes support for: `IMPORT TABLE ... CREATE USING` and `IMPORT TABLE ... <non-bundle-format> DATA`.  `<non-bundle-format>` refers to CSV, Delimited, PGCOPY, AVRO. These formats do not define the table schema in the same file as the data.  The workaround following this feature removal is to use [`CREATE TABLE`](../{{site.versions["dev"]}}/create-table.html) with the same schema that was previously being passed into the [`IMPORT`](../{{site.versions["dev"]}}/import.html) statement, followed by an [`IMPORT INTO`](../{{site.versions["dev"]}}/import-into.html) the newly created table. [#71058][#71058]
+- Previously, running [`COMMENT ON CONSTRAINT`](../{{site.versions["dev"]}}/comment-on.html) on a table in a schema would succeed but the comment would not actually be created. Now the comment is successfully created. [#71985][#71985]
+- `INTERLEAVE IN PARENT` is permanently removed from CockroachDB. [#70618][#70618]
+- [`EXPLAIN ANALYZE`](../{{site.versions["dev"]}}/explain-analyze.html) now shows maximum allocated memory and maximum SQL temp disk usage for a statement. [#72113][#72113]
+- Added `SHOW CREATE ALL TYPES` to allow the user to retrieve the statements to recreate user-defined types of the current database. It returns a flat log of the `CREATE` statements for types. [#71326][#71326]
+- It is now possible to swap names (for tables, etc.) in the same transaction. For example:    
+
+    ~~~ sql
+    CREATE TABLE foo();   
+    BEGIN;   
+    ALTER TABLE foo RENAME TO bar;   
+    CREATE TABLE foo();   
+    COMMIT;
+    ~~~  
+    Previously, the user would receive a "relation ... already exists" error. [#70334][#70334]
+
+- To align with PostgreSQL, casting an OID type with a value of `0` to a `regtype`, `regproc`, `regclass`, or `regnamespace` now will convert the value to the string `-`. The reverse behavior is implemented too, so a `-` will become `0` if casted to a `reg` OID type. [#71873][#71873]
+- Implemented the `date_part` [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html) for better compatibility with PostgreSQL. [#72502][#72502]
+- `PRIMARY KEY`s have been renamed to conform to PostgreSQL (e.g., `@tbl_col1_col2_pkey`) in this release. To protect certain use cases of backward compatibility, we also allow `@primary` index hints to alias to the `PRIMARY KEY`, but only if no other index is named `primary`. [#72534][#72534]
+- Some filesystem-level properties are now exposed in `crdb_internal.kv_store_status`. Note that the particular fields and layout are not stabilized yet. [#72435][#72435]
+- Introduced a [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html) `crdb_internal.init_stream` and a [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) `stream_replication.job_liveness_timeout`. [#72330][#72330]
+- A notice is now issued when creating a [foreign key](../{{site.versions["dev"]}}/foreign-key.html) referencing a column of a different width. [#72545][#72545]
+- Newly created databases will now have the `CONNECT` [privilege](../{{site.versions["dev"]}}/authorization.html#privileges) granted by default to the `PUBLIC` [role](../{{site.versions["dev"]}}/authorization.html#roles). [#72595][#72595]
+- [SQL Stats metrics](../{{site.versions["dev"]}}/ui-statements-page.html#statement-statistics) with `*_internal` suffix in their labels are now removed. [#72667][#72667]
+- `system.table_statistics` has an additional field, `avgSize`, that is the average size in bytes of the column(s) with `columnIDs`. The new field is visible with the command `SHOW STATISTICS FOR TABLE` and can be modified with the command `INJECT STATISTICS`, as with other table statistics. This field is not yet used by the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html#table-statistics) as part of cost modeling. [#72365][#72365]
+- Added the modifier `IF NOT EXISTS` to `ALTER TABLE ... ADD CONSTRAINT IF NOT EXISTS`. [#71257][#71257]
+- Fixed [`gateway_region` builtin](../{{site.versions["dev"]}}/functions-and-operators.html) for `--multitenant` demo clusters. [#72734][#72734]
+- Prior to this change it was possible to alter a column's type in a way that was not compatible with the [`DEFAULT`](../{{site.versions["dev"]}}/default-value.html) or [`ON UPDATE`](../{{site.versions["dev"]}}/update.html) clause. This would cause parsing errors within tables. Now the `DEFAULT` or `ON UPDATE` clause is checked. [#71423][#71423]
+- Added [`CREATE SEQUENCE AS <typename>`](../{{site.versions["dev"]}}/create-sequence.html) option. [#57339][#57339]
+- Introduced new SQL syntax [`ALTER RANGE RELOCATE`](../{{site.versions["dev"]}}/configure-zone.html) to move a lease or replica between stores. This is helpful in an emergency situation to relocate data in the cluster. [#72305][#72305]
+- [`EXPORT PARQUET`](../{{site.versions["dev"]}}/export.html) can now export relations with `NULL` values to Parquet files. [#72530][#72530]
+- Previously, [`ALTER TABLE ... RENAME TO ...`](../{{site.versions["dev"]}}/alter-table.html#subcommands) would allow the user to move the table from a database to another if the table is being moved within one database's public schema to another. This is now disallowed. [#72000][#72000]
+- [`ALTER DATABASE CONVERT TO SCHEMA`](../{{site.versions["dev"]}}/alter-database.html#subcommands) is now disabled in v22.1 and later. [#72000][#72000]
+- It is now possible to specify a different path for [incremental backups](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html). [#72713][#72713]
+- If the `WITH GRANT OPTION` flag is present when granting privileges to a user, then that user is able to grant those same privileges to subsequent users; otherwise, they cannot. If the `GRANT OPTION FOR` flag is present when revoking privileges from a user, then only the ability to grant those privileges is revoked from that user, not the privileges themselves (otherwise both the privileges and the ability to grant those privileges are revoked). This behavior is consistent with PostgreSQL. [#72123][#72123]
+- Disallowed `ST_MakePolygon` making empty polygons from empty [`LINESTRING`](../{{site.versions["dev"]}}/linestring.html). This is not allowed in PostGIS. [#73489][#73489]
+- [`EXPORT PARQUET`](../{{site.versions["dev"]}}/export.html) now preserves column names and nullability. [#73382][#73382]
+- Previously, the output from [`SHOW CREATE VIEW`](../{{site.versions["dev"]}}/show-create.html#show-the-create-view-statement-for-a-view) returned on a single line. The format has now been improved to be more readable. [#73642][#73642]
+- The output of the [`EXPLAIN`](../{{site.versions["dev"]}}/explain.html) SQL statement has changed. Below the plan, index recommendations are now outputted for the SQL statement in question, if there are any. These index recommendations are indexes the user could add or indexes they could replace to make the given query faster. [#73302][#73302]
+- The [`VOID` type](../{{site.versions["dev"]}}/data-types.html) is now recognized. [#73488][#73488]
+- In the experimental [`RELOCATE`](../{{site.versions["dev"]}}/experimental-features.html#relocate-leases-and-replicas) syntax forms, the positional keyword that indicates that the statement should move non-voter replicas is now spelled `NONVOTERS`, instead of `NON_VOTERS`. [#73803][#73803]
+- The inline help for the `ALTER` statements now mentions the `RELOCATE` syntax. [#73803][#73803]
+- The experimental `ALTER RANGE...RELOCATE` syntax now accepts arbitrary [scalar expressions](../{{site.versions["dev"]}}/scalar-expressions.html) as the source and target store IDs. [#73807][#73807]
+- The output of `EXPLAIN ALTER RANGE ... RELOCATE` now includes the source and target store IDs. [#73807][#73807]
+- The experimental `ALTER RANGE...RELOCATE` syntax now accepts arbitrary [scalar expressions](../{{site.versions["dev"]}}/scalar-expressions.html) as the range ID when the `FOR` clause is not used. [#73807][#73807]
+- The output of `EXPLAIN ALTER RANGE ... RELOCATE` now includes which replicas are subject to the relocation. [#73807][#73807]
+- [`ALTER DEFAULT PRIVILEGES IN SCHEMA <schemas...>`](../{{site.versions["dev"]}}/alter-default-privileges.html) is now supported. As well as specifying default privileges globally (within a database), users can now specify default privileges in a specific schema.  When creating an object that has default privileges specified at the database (global) and at the schema level, the union of the default privileges is taken. [#73576][#73576]
+- Index recommendations can be omitted from the [`EXPLAIN`](../{{site.versions["dev"]}}/explain.html) plan if the `index_recommendations_enabled` session variable is set to false. [#73346][#73346]
+- The output of `EXPLAIN ALTER INDEX/TABLE ... RELOCATE/SPLIT` now includes the target table/index name and, for the [`SPLIT AT`](../{{site.versions["dev"]}}/split-at.html) variants, the expiry timestamp. [#73832][#73832]
+- Added the `digest` and `hmac` [built-in functions](../{{site.versions["dev"]}}/functions-and-operators.html). They match the PostgreSQL (pgcrypto) implementation. Supported hash algorithms are `md5`, `sha1`, `sha224`, `sha256`, `sha384`, and `sha512`. [#73935][#73935]
+- Users can now [`RESTORE`](../{{site.versions["dev"]}}/restore.html) (locality-aware) [incremental backups](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html) created with the `incremental_storage` parameter. [#73744][#73744]
+- Improved [cost model](../{{site.versions["dev"]}}/cost-based-optimizer.html) for TopK expressions if the input to TopK can be partially ordered by its sort columns. [#73459][#73459]
+- Added the `incremental_storage` option to [`SHOW BACKUP`](../{{site.versions["dev"]}}/show-backup.html) so users can now observe [incremental backups](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html). [#73357][#73357]
+- Previously, escape character processing (`\`) was missing from constraint span generation, which resulted in incorrect results when doing escaped lookups. This is now fixed. [#73978][#73978]
+- The shard column of a [hash-sharded index](../{{site.versions["dev"]}}/hash-sharded-indexes.html) is now a [virtual column](../{{site.versions["dev"]}}/computed-columns.html) and not a stored computed column. [#74138][#74138]
+- Clients waiting for a [schema change](../{{site.versions["dev"]}}/online-schema-changes.html) job will now receive an error if the job they are waiting for is paused. [#74157][#74157]
+- The [`GRANT`](../{{site.versions["dev"]}}/grant.html#supported-privileges) privilege is deprecated in v22.1 and will be removed in v22.2 in favor of grant options. To promote backward compatibility for users with code still using `GRANT`, we will give grant options on every privilege a user has when they are granted `GRANT` and remove all their grant options when `GRANT` is revoked, in addition to the existing grant option behavior. [#74210][#74210]
+- `system.protected_timestamp_records` table now has an additional `target` column that will store an encoded protocol buffer that represents the target a record protects. This target can either be the entire cluster, tenants, or schema objects (databases/tables). [#74281][#74281]
+- The KV tracing of SQL queries (that could be obtained with `\set auto_trace=on,kv`) has been adjusted slightly. Previously, CockroachDB would fully decode the key in each key-value pair, even if some part of the key would not be decoded while tracing was enabled. Now, CockroachDB does not perform any extra decoding, and parts of the key that are not decoded are replaced with `?`. [#74236][#74236]
+- CockroachDB now supports `default_with_oids`, which only accepts a `false` value. [#74499][#74499]
+- [`EXPORT PARQUET`](../{{site.versions["dev"]}}/export.html) can export columns of type [array](../{{site.versions["dev"]}}/data-types.html) [#73735][#73735]
+- Statements are now formatted prior to being sent to [the DB Console](../{{site.versions["dev"]}}/ui-statements-page.html). This is done using a new [built-in function](../{{site.versions["dev"]}}/functions-and-operators.html) that formats statements. [#73853][#73853]
+
+### Operational changes
+
+- [`cockroach debug zip`](../{{site.versions["dev"]}}/cockroach-debug-zip.html) now includes the raw `system.settings` table. This table makes it possible to determine whether a [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) has been explicitly set. [#70498][#70498]
+- The meaning of `sql.distsql.max_running_flows` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) has been extended so that when the value is negative, it will be multiplied by the number of CPUs on the node to get the maximum number of concurrent remote flows on the node. The default value is `-128`, meaning that a 4-CPU machine will have up to `512` concurrent remote DistSQL flows, but a 8-CPU machine will have up to `1024`. The previous default was `500`. [#71787][#71787]
+- Some existing settings related to [`BACKUP`](../{{site.versions["dev"]}}/backup.html) execution are now listed  by [`SHOW CLUSTER SETTING`](../{{site.versions["dev"]}}/show-cluster-setting.html). [#71962][#71962]
+- The [cluster settings](../{{site.versions["dev"]}}/cluster-settings.html) affecting the admission control system enablement are now set to defaults that enable [admission control](../{{site.versions["dev"]}}/architecture/admission-control.html). [#68535][#68535]
+- The default value of the `kv.rangefeed.catchup_scan_iterator_optimization.enabled` [cluster setting](../{{site.versions["dev"]}}/cluster-settings.html) is now `true`. [#73473][#73473]
+- Added a metric `addsstable.aswrites` that tracks the number of `AddSSTable` requests ingested as regular write batches. [#73910][#73910]
+- Added a metric `replica.uninitialized` that tracks the number of `Uninitialized` replicas in a store. [#73975][#73975]
+
+### Command-line changes
+
+- [`cockroach demo`](../{{site.versions["dev"]}}/cockroach-demo.html) will now begin processing scheduled jobs after 15 seconds, instead of the 2–5 minutes in a production environment. [#70242][#70242]
+- The 25 max QPS rate limit for workloads on [`cockroach demo`](../{{site.versions["dev"]}}/cockroach-demo.html) can now be configured with a `--workload-max-qps` flag. [#70642][#70642]
+- The SQL shell now supports the `\du USER` command to show information for the current user. [#70609][#70609]
+- Added support for a CLI shortcut that displays [constraint](../{{site.versions["dev"]}}/constraints.html) information similar to PostgreSQL. The shortcut is `\dd TABLE`. [#69783][#69783]
+- Added a `--read-only` flag to [`cockroach sql`](../{{site.versions["dev"]}}/cockroach-sql.html) which will set the `default_session_read_only` variable upon connecting. This is effectively equivalent to the `PGTARGETSESSIONATTRS=read-only` option added to libpq and `psql` in PostgreSQL 13. [#71003][#71003]
+- Previously, [`cockroach debug merge-logs`](../{{site.versions["dev"]}}/cockroach-debug-merge-logs.html) output was prefixed by a short machine name by default, which made it difficult to identify the originating node when looking at the merged results. CockroachDB now supports `"${fpath}"` in the `--prefix` argument. [#71254][#71254]
+- Added an option in the [`cockroach demo movr`](../{{site.versions["dev"]}}/cockroach-demo.html) command to populate the `user_promo_code` table. [#61531][#61531]
+- Allowed demoing of CockroachDB's multi-tenant features via the `--multitenant` flag to [`cockroach demo`](../{{site.versions["dev"]}}/cockroach-demo.html). [#71026][#71026]
+- [`cockroach demo`](../{{site.versions["dev"]}}/cockroach-demo.html) now runs by default in multi-tenant mode. [#71988][#71988]
+- Added buffering to log sinks. This can be configured with the new `"buffering"` field on any log sink provided via the `--log` or `--log-config-file` flags. [#70330][#70330]
+- The server identifiers (cluster ID, node ID, tenant ID, instance ID) are no longer duplicated at the start of every new [log file](../{{site.versions["dev"]}}/configure-logs.html#output-to-files) (during log file rotations). They are now only logged when known during server start-up. (The copy of the identifiers is still included in per-event envelopes for the various [`json` output logging formats](../{{site.versions["dev"]}}/log-formats.html#format-json).) [#73306][#73306]
+- The [`cockroach node drain`](../{{site.versions["dev"]}}/cockroach-node.html) command is now able to drain a node by ID, specified on the command line, from another node in the cluster. It now also supports the flag `--self` for symmetry with [`node decommission`](../{{site.versions["dev"]}}/cockroach-node.html#node-decommission). Using `node drain` without either `--self` or a node ID is now deprecated. [#73991][#73991]
+- The deprecated command [`cockroach quit`](../{{site.versions["dev"]}}/cockroach-quit.html) now accepts the flags `--self` and the ability to specify a node ID like `cockroach node drain`. Even though the command is deprecated, this change was performed to ensure symmetry in the documentation until the command is effectively removed. [#73991][#73991]
+- Not finding the right certificates in the `certs` directory, or not specifying a `certs` directory or certificate path, will now fall back on checking server CA using Go's TLS code to find the certificates in the OS trust store. If no matching certificate is found, then an `x509` error will occur announcing that the certificate is signed by an unknown authority. [#73776][#73776]
+
+### API endpoint changes
+
+- [`CREATE CHANGEFEED`](../{{site.versions["dev"]}}/create-changefeed.html) on a cloud storage sink now allows a new query parameter to specify how the file paths are partitioned. For example, `partition_format="daily"` represents the default behavior of splitting into dates `(2021-05-01/)`. While `partition_format="hourly"` will further partition them them by hour `(2021-05-01/05/)`. `partition_format="flat"` will not partition at all. [#70207][#70207]
+- [OpenID Connect (OIDC)](../{{site.versions["dev"]}}/sso.html#cluster-settings) support for DB Console is no longer marked as `experimental`. [#71183][#71183]
+- Added new API endpoint for getting a table's index statistics. [#72660][#72660]
+- Added a new batch RPC, and batch method counters are now visible in DB Console and [`_status/vars`](../{{site.versions["dev"]}}/monitoring-and-alerting.html). [#72767][#72767]
+
+### DB Console changes
+
+- Fixed drag to zoom on [custom charts](../{{site.versions["dev"]}}/ui-custom-chart-debug-page.html#use-the-custom-chart-page). [#70229][#70229]
+- Fixed drag to time range for a specific window issue. [#70326][#70326]
+- Added pre-sizing calculation for [**Metrics**](../{{site.versions["dev"]}}/ui-overview-dashboard.html) page graphs. [#70838][#70838]
+- The `/debug/pprof/goroutineui/` page has a new and improved look. [#71690][#71690]
+- The all nodes report now notifies a user if they need more privileges to view the page's information. [#71960][#71960]
+- The [**Advanced Debug**](../{{site.versions["dev"]}}/ui-debug-pages.html) page now contains an additional link under the **Metrics** header called Rules. This endpoint exposes [Prometheus-compatible alerting](../{{site.versions["dev"]}}/monitoring-and-alerting.html#events-to-alert-on) and aggregation rules for CockroachDB metrics. [#72677][#72677]
+- Added an **Index Stats** table and a button to clear index usage stats on the [Table Details](../{{site.versions["dev"]}}/ui-databases-page.html#table-details) page for each table. [#72948][#72948]
+- Added the ability to remove the dashed underline from sorted table headers for headers with no tooltips. Removed the dashed underline from the **Index Stats** table headers. [#73455][#73455]
+- Added a new **Index Details** page, which exists for each index on a table. [#73178][#73178]
+- Updated the **Reset Index Stats** button text to be more clear. [#73700][#73700]
+- The time pickers on the [**Statements**](../{{site.versions["dev"]}}/ui-statements-page.html) and [**Transactions**](../{{site.versions["dev"]}}/ui-transactions-page.html) pages now have the same style and functionality as the time picker on the [**Metrics**](../{{site.versions["dev"]}}/ui-overview-dashboard.html) page. [#73608][#73608]
+- The **clear SQL stats** links on the [**Statements**](../{{site.versions["dev"]}}/ui-statements-page.html) and [**Transactions**](../{{site.versions["dev"]}}/ui-transactions-page.html) pages were relabeled **reset SQL stats**, for consistency with the language in the SQL shell. [#73922][#73922]
+- Added the ability to create conditional statement diagnostics by adding two new fields: 1) minimum execution latency, which specifies the limit for when a statement should be tracked, and 2) expiry time, which specifies when a diagnostics request should expire. [#74112][#74112]
+- The **Terminate Session** and **Terminate Query** buttons are again available to be enabled on the [**Sessions Page**](../{{site.versions["dev"]}}/ui-sessions-page.html). [#74408][#74408]
+- Added formatting to statements on the [**Statements**](../{{site.versions["dev"]}}/ui-statements-page.html), [**Transactions**](../{{site.versions["dev"]}}/ui-transactions-page.html), and **Index Details** pages. [#73853][#73853]
+- Updated colors for **Succeeded** badges and the progress bar on the [**Jobs**](../{{site.versions["dev"]}}/ui-jobs-page.html) page. [#73924][#73924]
+
+### Bug fixes
+
+- Fixed a bug where `CURRENT_USER` and [`SESSION_USER`](../{{site.versions["dev"]}}/functions-and-operators.html#special-syntax-forms) were parsed incorrectly. [#70439][#70439]
+- Fixed a bug where [index](../{{site.versions["dev"]}}/indexes.html)/[partition](../{{site.versions["dev"]}}/partitioning.html) subzones may not have inherited the `global_reads` field correctly in some cases from their parent. [#69983][#69983]
+- Previously, [`DROP DATABASE CASCADE`](../{{site.versions["dev"]}}/drop-database.html) could fail while resolving a schema in certain scenarios with the following error: `ERROR: error resolving referenced table ID <ID>: descriptor is being dropped`. This is now fixed. [#69789][#69789]
+- [Backfills](../{{site.versions["dev"]}}/stream-data-out-of-cockroachdb-using-changefeeds.html#schema-changes-with-column-backfill) will now always respect the most up-to-date value of `changefeed.backfill.concurrent_scan_requests` even during an ongoing backfill. [#69933][#69933]
+- The [`cockroach debug merge-logs`](../{{site.versions["dev"]}}/cockroach-debug-merge-logs.html) command no longer returns an error when the log decoder attempts to parse older logs. [#68282][#68282]
+- The PostgreSQL-compatible "Access Privilege Inquiry Functions" (e.g., `has_foo_privilege`) were incorrectly returning whether all comma-separated privileges were held, instead of whether any of the provided privileges were held. This incompatibility has been resolved. [#69939][#69939]
+- Queries involving arrays of tuples will no longer spuriously fail due to an encoding error. [#63996][#63996]
+- [`cockroach sql -e`](../{{site.versions["dev"]}}/cockroach-sql.html) (and `demo -e`) can now process all client-side commands, not just `\echo`, `\set`, and a few others. [#70671][#70671]
+- [`cockroach sql --set=auto_trace=on -e 'select ...'`](../{{site.versions["dev"]}}/cockroach-sql.html) (and the similar `demo` command) now produces an execution trace properly. [#70671][#70671]
+- Previously, bulk `INSERT`/`UPDATE` in implicit transactions retried indefinitely if the statement exceeded the default leasing deadline of 5 minutes. Now, if the leasing deadline is exceeded this will be raised back up to the SQL layer to refresh the deadline before trying to commit. [#69936][#69936]
+- [`IMPORT`](../{{site.versions["dev"]}}/import.html) now respects the spatial index storage options specified in `PGDUMP` files on indexes it creates. [#66903][#66903]
+- Fixed `IMPORT` in [`tpcc`](../{{site.versions["dev"]}}/cockroach-workload.html#tpcc-workload) workload. [#71013][#71013]
+- Some query patterns that previously could cause a single node to become a [hotspot](../{{site.versions["dev"]}}/query-behavior-troubleshooting.html#single-hot-node) have been fixed so that the load is evenly distributed across the whole cluster. [#70648][#70648]
+- Fixed a bug where the 2-parameter `setval` built-in function previously caused the [sequence](../{{site.versions["dev"]}}/create-sequence.html) to increment incorrectly one extra time. For a sequence to increment, use `setval(seq, val, true)`. [#71643][#71643]
+- Previously, the effects of the `setval` and `nextval` built-in functions would be rolled back if the surrounding transaction was rolled back. This was not correct, as `setval` is not supposed to respect transaction boundaries. This is now fixed. [#71643][#71643]
+- In v21.2, jobs that fail to revert are retried unconditionally, but with exponential backoff. In the mixed-version state there is no exponential backoff, so it would not be good to retry unconditionally. The behavior has been changed such that before v21.2 is finalized, these jobs will enter the revert-failed state as in v21.1. [#71780][#71780]
+- Fixed a bug that prevented rollback of [`ALTER PRIMARY KEY`](../{{site.versions["dev"]}}/alter-primary-key.html) when the old primary key was interleaved. [#71780][#71780]
+- Previously, adding new values to a user-defined [`ENUM`](../{{site.versions["dev"]}}/enum.html) type would cause a prepared statement using that type to not work. This now works as expected. [#71632][#71632]
+- Previously, when records and [`ENUM`](../{{site.versions["dev"]}}/enum.html) types containing escape sequences were shown in the CLI, they would be incorrectly double-escaped. This is now fixed. [#71916][#71916]
+- `SCHEMA CHANGE` and `SCHEMA CHANGE GC` jobs following a `DROP ... CASCADE` now have sensible names, instead of `''` and `'GC for '`, respectively. [#70630][#70630]
+- Fixed a race condition that could have caused [core changefeeds](../{{site.versions["dev"]}}/changefeed-for.html) whose targeted table became invalid to not explain why when shutting down. [#72490][#72490]
+- [`cockroach demo`](../{{site.versions["dev"]}}/cockroach-demo.html) can now be launched with `--global` and `--multitenant=true` options. [#72750][#72750]
+- Y-axis labels on [custom charts](../{{site.versions["dev"]}}/ui-custom-chart-debug-page.html#use-the-custom-chart-page) no longer display `undefined`. [#73055][#73055]
+- Raft snapshots now detect timeouts earlier and avoid spamming the logs with [`context deadline exceeded`](../{{site.versions["dev"]}}/common-errors.html#context-deadline-exceeded) errors. [#73279][#73279]
+- Error messages produced during import are now truncated. Previously, [`IMPORT`](../{{site.versions["dev"]}}/import.html) could potentially generate large error messages that could not be persisted to the jobs table, resulting in a failed import never entering the failed state and instead retrying repeatedly. [#73303][#73303]
+- Servers no longer crash due to panics in HTTP handlers. [#72395][#72395]
+- `crdb_internal.table_indexes` now shows if an index is sharded or not. [#73380][#73380]
+- Previously, creating indexes with special characters would fail to identify indexes with the same matching name, which caused an internal error. This is now fixed. [#73367][#73367]
+- CockroachDB now prohibits mixed dimension [`LINESTRING`](../{{site.versions["dev"]}}/linestring.html) in `ST_MakePolygon`. [#73489][#73489]
+- Index `CREATE` statements in the `pg_indexes` table now shows a hash-sharding bucket count if an index is hash sharded. Column direction is removed from `gin` index in `pg_indexes`. [#73491][#73491]
+- Uninitialized replicas that are abandoned after an unsuccessful snapshot no longer perform periodic background work, so they no longer have a non-negligible cost. [#73362][#73362]
+- Fixed a bug that caused incorrect evaluation of placeholder values in `EXECUTE` statements. The bug presented when the `PREPARE` statement cast a placeholder value, e.g., `PREPARE s AS SELECT $1::INT2`. If the assigned value for `$1` exceeded the maximum width value of the cast target type, the result value of the cast could be incorrect. This bug had been present since v19.1 or earlier. [#73762][#73762]
+- Previously, during [`RESTORE`](../{{site.versions["dev"]}}/restore.html) `system.namespace` entry wouldn't be inserted for synthetic public schemas. This is now fixed. [#73875][#73875]
+- Fixed a bug that caused internal errors when altering the primary key of a table. The bug was only present if the table had a partial index with a predicate that referenced a [virtual computed column](../{{site.versions["dev"]}}/computed-columns.html). This bug was present since virtual computed columns were added in v21.1.0. [#74102][#74102]
+- [Foreign keys](../{{site.versions["dev"]}}/foreign-key.html) referencing a hash-sharded key will not fail anymore. [#74140][#74140]
+- Raft snapshots no longer risk starvation under very high concurrency. Before this fix, it was possible that many of Raft snapshots could be starved and prevented from succeeding due to timeouts, which were accompanied by errors like [`error rate limiting bulk io write: context deadline exceeded`](../{{site.versions["dev"]}}/common-errors.html#context-deadline-exceeded). [#73288][#73288]
+- Portals in the extended protocol of the PostgreSQL wire protocol can now be used from implicit transactions and can be executed multiple times if there is a row-count limit applied to the portal. Previously, trying to execute the same portal twice would result in an `unknown portal` error. [#74242][#74242]
+- Fixed a bug that incorrectly allowed creating [computed column](../{{site.versions["dev"]}}/computed-columns.html) expressions, expression indexes, and partial index predicate expressions with mutable casts between [`STRING` types](../{{site.versions["dev"]}}/data-types.html) and the types `REGCLASS`, `REGNAMESPACE`, `REGPROC`, `REGPROCEDURE`, `REGROLE`, and `REGTYPE`. Creating such computed columns, expression indexes, and partial indexes is now prohibited. Any tables with these types of expressions may be corrupt and should be dropped and recreated. [#74286][#74286]
+- Fixed a bug that, in very rare cases, could result in a node terminating with a fatal error: `unable to remove placeholder: corrupted replicasByKey map`. To avoid potential data corruption, users affected by this crash should not restart the node, but instead [decommission it](../{{site.versions["dev"]}}/remove-nodes.html) in absentia and have it rejoin the cluster under a new `nodeID`. [#73734][#73734]
+- Previously, when [foreign keys](../{{site.versions["dev"]}}/foreign-key.html) were included inside an `ADD COLUMN` statement and multiple columns were added in a single statement then the first added column would have the foreign key applied (or an error generated based on the wrong column). This is now fixed. [#74411][#74411]
+- Previously, a double-nested [`ENUM`](../{{site.versions["dev"]}}/enum.html) in a DistSQL query would not get hydrated on remote nodes resulting in panic. This is now fixed. [#74189][#74189]
+- Fixed a panic when attempting to access the hottest ranges (e.g., via the `/_status/hotranges` endpoint) before initial statistics had been gathered. [#74507][#74507]
+- Previously, setting [`sslmode=require`](../{{site.versions["dev"]}}/connection-parameters.html#additional-connection-parameters) would check for local certificates, so omitting a certs path would cause an error even though `require` does not verify server certificates. This has been fixed by bypassing certificate path checking for `sslmode=require`. This bug had been present since v21.2.0. [#73776][#73776]
+- Previously, incorrect results would be returned, or internal errors, on queries with window functions returning [`INT`](../{{site.versions["dev"]}}/data-types.html), `FLOAT`, `BYTES`, `STRING`, `UUID`, or `JSON` type when the [disk spilling](../{{site.versions["dev"]}}/vectorized-execution.html#disk-spilling-operations) occurred. The bug was introduced in v21.2.0 and is now fixed. [#74491][#74491]
+- Previously, `MIN`/`MAX` could be incorrectly calculated when used as window functions in some cases after [spilling to disk](../{{site.versions["dev"]}}/vectorized-execution.html#disk-spilling-operations). The bug was introduced in v21.2.0 and is now fixed. [#74491][#74491]
+- Previously, [`IMPORT TABLE ... PGDUMP`](../{{site.versions["dev"]}}/import.html#import-a-table-from-a-postgres-database-dump) with a `COPY FROM` statement in the dump file that has less target columns than the `CREATE TABLE` schema definition would result in a nil pointer exception. This is now fixed. [#74601][#74601]
+
+### Performance improvements
+
+- Mutation statements with a `RETURNING` clause that are not inside an explicit transaction are faster in some cases. [#70200][#70200]
+- Added collection of basic table statistics during an [import](../{{site.versions["dev"]}}/import.html), to help the optimizer until full statistics collection completes. [#67106][#67106]
+- The accuracy of histogram calculations for `BYTES` types has been improved. As a result, the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) should generate more efficient query plans in some cases. [#68740][#68740]
+- A [`SELECT`](../{{site.versions["dev"]}}/selection-queries.html) query with both `MIN(LeadingIndexColumn)` and `MAX(LeadingIndexColumn)` can now be performed with two `LIMITED SCAN`s instead of a single `FULL SCAN`. [#70496][#70496]
+- A [`SELECT`](../{{site.versions["dev"]}}/selection-queries.html) query from a single table with more than one `MIN` or `MAX` scalar aggregate expression and a `WHERE` clause can now be performed with `LIMITED SCAN`s, one per aggregate expression, instead of a single `FULL SCAN`. Note: No other aggregate function, such as `SUM`, may be present in the query block in order for it to be eligible for this transformation. This optimization should occur when each `MIN` or `MAX` expression involves a leading index column, so that a sort is not required for the limit operation, and the resulting query plan will appear cheapest to the optimizer. [#70854][#70854]
+- Queries with many ORed `WHERE` clause predicates previously took an excessive amount of time for the [optimizer](../{{site.versions["dev"]}}/cost-based-optimizer.html) to process, especially if the predicates involved index columns, and if there were more than 1000 predicates (which could happen with application-generated SQL). To fix this, the processing of SQL with many ORed predicates have been optimized to make sure a query plan can be generated in seconds instead of minutes or hours. [#71247][#71247]
+- Creating many [schema changes](../{{site.versions["dev"]}}/online-schema-changes.html) in parallel now runs faster due to improved concurrency notifying the jobs subsystem. [#71909][#71909]
+- The `sqlinstance` subsystem no longer reads from the backing SQL table for every request for SQL instance details. This will result in improved performance for supporting multi-region setup for the multi-tenant architecture. [#69976][#69976]
+- Improved efficiency of looking up old historical descriptors. [#71239][#71239]
+- Improved performance of some `GROUP BY` queries with a `LIMIT` if there is an index ordering that matches a subset of the grouping columns. In this case the total number of aggregations needed to satisfy the `LIMIT` can be emitted without scanning the entire input, enabling the execution to be more effective. [#71546][#71546]
+- [`var_pop` and `stddev_pop`](../{{site.versions["dev"]}}/functions-and-operators.html) aggregate functions are now evaluated more efficiently in a distributed setting. [#73712][#73712]
+- Improved job performance in the face of concurrent schema changes by reducing contention. [#72297][#72297]
+- [Incremental backups](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html) now use less memory to verify coverage of prior backups. [#74393][#74393]
+- CockroachDB now retrieves the password credentials of the SQL client concurrently without waiting for the password response during the authentication exchange. This can yield a small latency reduction in new SQL connections. [#74365][#74365]
+- CockroachDB now allows rangefeed streams to use separate http connection when `kv.rangefeed.use_dedicated_connection_class.enabled` setting is turned on. Using separate connection class reduces the possibility of OOMs when running rangefeeds against very large tables. The connection window size for rangefeeds can be adjusted via `COCKROACH_RANGEFEED_INITIAL_WINDOW_SIZE` environment variable, whose default is 128KB. [#74222][#74222]
+- The merging of [incremental backup](../{{site.versions["dev"]}}/take-full-and-incremental-backups.html) layers during [`RESTORE`](../{{site.versions["dev"]}}/restore.html) now uses a simpler and less memory-intensive algorithm. [#74394][#74394]
+- The default snapshot recovery/rebalance rates `kv.snapshot_rebalance.max_rate` and `kv.snapshot_recovery.max_rate` were bumped from 8MB/s to 32MB/s. Production experience has taught us that earlier values were too conservative. Users might observe higher network utilization during rebalancing/recovery in service of rebalancing/recovering faster (for the latter, possibly reducing the MTTF). If the extra utilization is undesirable, users can manually revert these rates back to their original settings of 8 MB/s. [#71814][#71814]
+
+### Build changes
+
+- Upgraded to new version of Go v1.17. [#69603][#69603]
+
+### Miscellaneous
+
+#### Docker
+
+- Env variables and init scripts in `docker-entrypoint-initdb.d` for the [`start-single-node`](../{{site.versions["dev"]}}/cockroach-start-single-node.html) command are now supported. [#70238][#70238]
+
+### Contributors
+
+This release includes 1720 merged PRs by 132 authors.
+
+We would like to thank the following contributors from the CockroachDB community:
+
+- Catherine J (first-time contributor)
+- Eudald (first-time contributor)
+- Ganeshprasad Biradar
+- Josh Soref (first-time contributor)
+- Max Neverov
+- Miguel Novelo (first-time contributor)
+- Paul Lin (first-time contributor)
+- Remy Wang (first-time contributor)
+- Rupesh Harode
+- TennyZhuang (first-time contributor)
+- Tharun
+- Ulf Adams
+- Zhou Fang (first-time contributor)
+- e-mbrown
+- lpessoa (first-time contributor)
+- mnovelodou (first-time contributor)
+- neeral
+- rharding6373
+- shralex (first-time contributor)
+- tukeJonny (first-time contributor)
+
+[#57339]: https://github.com/cockroachdb/cockroach/pull/57339
+[#61531]: https://github.com/cockroachdb/cockroach/pull/61531
+[#63996]: https://github.com/cockroachdb/cockroach/pull/63996
+[#64503]: https://github.com/cockroachdb/cockroach/pull/64503
+[#65599]: https://github.com/cockroachdb/cockroach/pull/65599
+[#66903]: https://github.com/cockroachdb/cockroach/pull/66903
+[#67106]: https://github.com/cockroachdb/cockroach/pull/67106
+[#67737]: https://github.com/cockroachdb/cockroach/pull/67737
+[#68140]: https://github.com/cockroachdb/cockroach/pull/68140
+[#68255]: https://github.com/cockroachdb/cockroach/pull/68255
+[#68282]: https://github.com/cockroachdb/cockroach/pull/68282
+[#68535]: https://github.com/cockroachdb/cockroach/pull/68535
+[#68705]: https://github.com/cockroachdb/cockroach/pull/68705
+[#68740]: https://github.com/cockroachdb/cockroach/pull/68740
+[#68964]: https://github.com/cockroachdb/cockroach/pull/68964
+[#69215]: https://github.com/cockroachdb/cockroach/pull/69215
+[#69292]: https://github.com/cockroachdb/cockroach/pull/69292
+[#69293]: https://github.com/cockroachdb/cockroach/pull/69293
+[#69300]: https://github.com/cockroachdb/cockroach/pull/69300
+[#69314]: https://github.com/cockroachdb/cockroach/pull/69314
+[#69603]: https://github.com/cockroachdb/cockroach/pull/69603
+[#69609]: https://github.com/cockroachdb/cockroach/pull/69609
+[#69783]: https://github.com/cockroachdb/cockroach/pull/69783
+[#69789]: https://github.com/cockroachdb/cockroach/pull/69789
+[#69909]: https://github.com/cockroachdb/cockroach/pull/69909
+[#69911]: https://github.com/cockroachdb/cockroach/pull/69911
+[#69913]: https://github.com/cockroachdb/cockroach/pull/69913
+[#69933]: https://github.com/cockroachdb/cockroach/pull/69933
+[#69936]: https://github.com/cockroachdb/cockroach/pull/69936
+[#69939]: https://github.com/cockroachdb/cockroach/pull/69939
+[#69976]: https://github.com/cockroachdb/cockroach/pull/69976
+[#69981]: https://github.com/cockroachdb/cockroach/pull/69981
+[#69983]: https://github.com/cockroachdb/cockroach/pull/69983
+[#70041]: https://github.com/cockroachdb/cockroach/pull/70041
+[#70066]: https://github.com/cockroachdb/cockroach/pull/70066
+[#70100]: https://github.com/cockroachdb/cockroach/pull/70100
+[#70115]: https://github.com/cockroachdb/cockroach/pull/70115
+[#70200]: https://github.com/cockroachdb/cockroach/pull/70200
+[#70207]: https://github.com/cockroachdb/cockroach/pull/70207
+[#70222]: https://github.com/cockroachdb/cockroach/pull/70222
+[#70226]: https://github.com/cockroachdb/cockroach/pull/70226
+[#70229]: https://github.com/cockroachdb/cockroach/pull/70229
+[#70238]: https://github.com/cockroachdb/cockroach/pull/70238
+[#70242]: https://github.com/cockroachdb/cockroach/pull/70242
+[#70326]: https://github.com/cockroachdb/cockroach/pull/70326
+[#70330]: https://github.com/cockroachdb/cockroach/pull/70330
+[#70332]: https://github.com/cockroachdb/cockroach/pull/70332
+[#70334]: https://github.com/cockroachdb/cockroach/pull/70334
+[#70338]: https://github.com/cockroachdb/cockroach/pull/70338
+[#70355]: https://github.com/cockroachdb/cockroach/pull/70355
+[#70369]: https://github.com/cockroachdb/cockroach/pull/70369
+[#70423]: https://github.com/cockroachdb/cockroach/pull/70423
+[#70439]: https://github.com/cockroachdb/cockroach/pull/70439
+[#70444]: https://github.com/cockroachdb/cockroach/pull/70444
+[#70454]: https://github.com/cockroachdb/cockroach/pull/70454
+[#70496]: https://github.com/cockroachdb/cockroach/pull/70496
+[#70498]: https://github.com/cockroachdb/cockroach/pull/70498
+[#70513]: https://github.com/cockroachdb/cockroach/pull/70513
+[#70522]: https://github.com/cockroachdb/cockroach/pull/70522
+[#70581]: https://github.com/cockroachdb/cockroach/pull/70581
+[#70590]: https://github.com/cockroachdb/cockroach/pull/70590
+[#70591]: https://github.com/cockroachdb/cockroach/pull/70591
+[#70604]: https://github.com/cockroachdb/cockroach/pull/70604
+[#70609]: https://github.com/cockroachdb/cockroach/pull/70609
+[#70618]: https://github.com/cockroachdb/cockroach/pull/70618
+[#70630]: https://github.com/cockroachdb/cockroach/pull/70630
+[#70642]: https://github.com/cockroachdb/cockroach/pull/70642
+[#70648]: https://github.com/cockroachdb/cockroach/pull/70648
+[#70656]: https://github.com/cockroachdb/cockroach/pull/70656
+[#70658]: https://github.com/cockroachdb/cockroach/pull/70658
+[#70671]: https://github.com/cockroachdb/cockroach/pull/70671
+[#70693]: https://github.com/cockroachdb/cockroach/pull/70693
+[#70716]: https://github.com/cockroachdb/cockroach/pull/70716
+[#70722]: https://github.com/cockroachdb/cockroach/pull/70722
+[#70726]: https://github.com/cockroachdb/cockroach/pull/70726
+[#70792]: https://github.com/cockroachdb/cockroach/pull/70792
+[#70838]: https://github.com/cockroachdb/cockroach/pull/70838
+[#70854]: https://github.com/cockroachdb/cockroach/pull/70854
+[#70865]: https://github.com/cockroachdb/cockroach/pull/70865
+[#70881]: https://github.com/cockroachdb/cockroach/pull/70881
+[#70942]: https://github.com/cockroachdb/cockroach/pull/70942
+[#71003]: https://github.com/cockroachdb/cockroach/pull/71003
+[#71013]: https://github.com/cockroachdb/cockroach/pull/71013
+[#71026]: https://github.com/cockroachdb/cockroach/pull/71026
+[#71058]: https://github.com/cockroachdb/cockroach/pull/71058
+[#71083]: https://github.com/cockroachdb/cockroach/pull/71083
+[#71138]: https://github.com/cockroachdb/cockroach/pull/71138
+[#71183]: https://github.com/cockroachdb/cockroach/pull/71183
+[#71239]: https://github.com/cockroachdb/cockroach/pull/71239
+[#71247]: https://github.com/cockroachdb/cockroach/pull/71247
+[#71254]: https://github.com/cockroachdb/cockroach/pull/71254
+[#71257]: https://github.com/cockroachdb/cockroach/pull/71257
+[#71259]: https://github.com/cockroachdb/cockroach/pull/71259
+[#71299]: https://github.com/cockroachdb/cockroach/pull/71299
+[#71326]: https://github.com/cockroachdb/cockroach/pull/71326
+[#71330]: https://github.com/cockroachdb/cockroach/pull/71330
+[#71357]: https://github.com/cockroachdb/cockroach/pull/71357
+[#71423]: https://github.com/cockroachdb/cockroach/pull/71423
+[#71427]: https://github.com/cockroachdb/cockroach/pull/71427
+[#71429]: https://github.com/cockroachdb/cockroach/pull/71429
+[#71432]: https://github.com/cockroachdb/cockroach/pull/71432
+[#71482]: https://github.com/cockroachdb/cockroach/pull/71482
+[#71498]: https://github.com/cockroachdb/cockroach/pull/71498
+[#71501]: https://github.com/cockroachdb/cockroach/pull/71501
+[#71537]: https://github.com/cockroachdb/cockroach/pull/71537
+[#71546]: https://github.com/cockroachdb/cockroach/pull/71546
+[#71594]: https://github.com/cockroachdb/cockroach/pull/71594
+[#71632]: https://github.com/cockroachdb/cockroach/pull/71632
+[#71643]: https://github.com/cockroachdb/cockroach/pull/71643
+[#71653]: https://github.com/cockroachdb/cockroach/pull/71653
+[#71685]: https://github.com/cockroachdb/cockroach/pull/71685
+[#71690]: https://github.com/cockroachdb/cockroach/pull/71690
+[#71772]: https://github.com/cockroachdb/cockroach/pull/71772
+[#71780]: https://github.com/cockroachdb/cockroach/pull/71780
+[#71787]: https://github.com/cockroachdb/cockroach/pull/71787
+[#71814]: https://github.com/cockroachdb/cockroach/pull/71814
+[#71823]: https://github.com/cockroachdb/cockroach/pull/71823
+[#71868]: https://github.com/cockroachdb/cockroach/pull/71868
+[#71871]: https://github.com/cockroachdb/cockroach/pull/71871
+[#71873]: https://github.com/cockroachdb/cockroach/pull/71873
+[#71890]: https://github.com/cockroachdb/cockroach/pull/71890
+[#71896]: https://github.com/cockroachdb/cockroach/pull/71896
+[#71909]: https://github.com/cockroachdb/cockroach/pull/71909
+[#71915]: https://github.com/cockroachdb/cockroach/pull/71915
+[#71916]: https://github.com/cockroachdb/cockroach/pull/71916
+[#71960]: https://github.com/cockroachdb/cockroach/pull/71960
+[#71962]: https://github.com/cockroachdb/cockroach/pull/71962
+[#71971]: https://github.com/cockroachdb/cockroach/pull/71971
+[#71985]: https://github.com/cockroachdb/cockroach/pull/71985
+[#71988]: https://github.com/cockroachdb/cockroach/pull/71988
+[#72000]: https://github.com/cockroachdb/cockroach/pull/72000
+[#72014]: https://github.com/cockroachdb/cockroach/pull/72014
+[#72056]: https://github.com/cockroachdb/cockroach/pull/72056
+[#72113]: https://github.com/cockroachdb/cockroach/pull/72113
+[#72123]: https://github.com/cockroachdb/cockroach/pull/72123
+[#72161]: https://github.com/cockroachdb/cockroach/pull/72161
+[#72297]: https://github.com/cockroachdb/cockroach/pull/72297
+[#72305]: https://github.com/cockroachdb/cockroach/pull/72305
+[#72330]: https://github.com/cockroachdb/cockroach/pull/72330
+[#72365]: https://github.com/cockroachdb/cockroach/pull/72365
+[#72395]: https://github.com/cockroachdb/cockroach/pull/72395
+[#72435]: https://github.com/cockroachdb/cockroach/pull/72435
+[#72490]: https://github.com/cockroachdb/cockroach/pull/72490
+[#72502]: https://github.com/cockroachdb/cockroach/pull/72502
+[#72530]: https://github.com/cockroachdb/cockroach/pull/72530
+[#72534]: https://github.com/cockroachdb/cockroach/pull/72534
+[#72545]: https://github.com/cockroachdb/cockroach/pull/72545
+[#72584]: https://github.com/cockroachdb/cockroach/pull/72584
+[#72595]: https://github.com/cockroachdb/cockroach/pull/72595
+[#72660]: https://github.com/cockroachdb/cockroach/pull/72660
+[#72667]: https://github.com/cockroachdb/cockroach/pull/72667
+[#72677]: https://github.com/cockroachdb/cockroach/pull/72677
+[#72679]: https://github.com/cockroachdb/cockroach/pull/72679
+[#72713]: https://github.com/cockroachdb/cockroach/pull/72713
+[#72734]: https://github.com/cockroachdb/cockroach/pull/72734
+[#72738]: https://github.com/cockroachdb/cockroach/pull/72738
+[#72750]: https://github.com/cockroachdb/cockroach/pull/72750
+[#72767]: https://github.com/cockroachdb/cockroach/pull/72767
+[#72908]: https://github.com/cockroachdb/cockroach/pull/72908
+[#72948]: https://github.com/cockroachdb/cockroach/pull/72948
+[#73055]: https://github.com/cockroachdb/cockroach/pull/73055
+[#73178]: https://github.com/cockroachdb/cockroach/pull/73178
+[#73260]: https://github.com/cockroachdb/cockroach/pull/73260
+[#73279]: https://github.com/cockroachdb/cockroach/pull/73279
+[#73288]: https://github.com/cockroachdb/cockroach/pull/73288
+[#73302]: https://github.com/cockroachdb/cockroach/pull/73302
+[#73303]: https://github.com/cockroachdb/cockroach/pull/73303
+[#73306]: https://github.com/cockroachdb/cockroach/pull/73306
+[#73321]: https://github.com/cockroachdb/cockroach/pull/73321
+[#73342]: https://github.com/cockroachdb/cockroach/pull/73342
+[#73346]: https://github.com/cockroachdb/cockroach/pull/73346
+[#73357]: https://github.com/cockroachdb/cockroach/pull/73357
+[#73362]: https://github.com/cockroachdb/cockroach/pull/73362
+[#73367]: https://github.com/cockroachdb/cockroach/pull/73367
+[#73380]: https://github.com/cockroachdb/cockroach/pull/73380
+[#73382]: https://github.com/cockroachdb/cockroach/pull/73382
+[#73392]: https://github.com/cockroachdb/cockroach/pull/73392
+[#73455]: https://github.com/cockroachdb/cockroach/pull/73455
+[#73459]: https://github.com/cockroachdb/cockroach/pull/73459
+[#73473]: https://github.com/cockroachdb/cockroach/pull/73473
+[#73488]: https://github.com/cockroachdb/cockroach/pull/73488
+[#73489]: https://github.com/cockroachdb/cockroach/pull/73489
+[#73491]: https://github.com/cockroachdb/cockroach/pull/73491
+[#73576]: https://github.com/cockroachdb/cockroach/pull/73576
+[#73608]: https://github.com/cockroachdb/cockroach/pull/73608
+[#73642]: https://github.com/cockroachdb/cockroach/pull/73642
+[#73648]: https://github.com/cockroachdb/cockroach/pull/73648
+[#73700]: https://github.com/cockroachdb/cockroach/pull/73700
+[#73712]: https://github.com/cockroachdb/cockroach/pull/73712
+[#73734]: https://github.com/cockroachdb/cockroach/pull/73734
+[#73735]: https://github.com/cockroachdb/cockroach/pull/73735
+[#73744]: https://github.com/cockroachdb/cockroach/pull/73744
+[#73762]: https://github.com/cockroachdb/cockroach/pull/73762
+[#73776]: https://github.com/cockroachdb/cockroach/pull/73776
+[#73802]: https://github.com/cockroachdb/cockroach/pull/73802
+[#73803]: https://github.com/cockroachdb/cockroach/pull/73803
+[#73807]: https://github.com/cockroachdb/cockroach/pull/73807
+[#73832]: https://github.com/cockroachdb/cockroach/pull/73832
+[#73853]: https://github.com/cockroachdb/cockroach/pull/73853
+[#73875]: https://github.com/cockroachdb/cockroach/pull/73875
+[#73910]: https://github.com/cockroachdb/cockroach/pull/73910
+[#73922]: https://github.com/cockroachdb/cockroach/pull/73922
+[#73924]: https://github.com/cockroachdb/cockroach/pull/73924
+[#73928]: https://github.com/cockroachdb/cockroach/pull/73928
+[#73935]: https://github.com/cockroachdb/cockroach/pull/73935
+[#73975]: https://github.com/cockroachdb/cockroach/pull/73975
+[#73978]: https://github.com/cockroachdb/cockroach/pull/73978
+[#73986]: https://github.com/cockroachdb/cockroach/pull/73986
+[#73991]: https://github.com/cockroachdb/cockroach/pull/73991
+[#74102]: https://github.com/cockroachdb/cockroach/pull/74102
+[#74112]: https://github.com/cockroachdb/cockroach/pull/74112
+[#74136]: https://github.com/cockroachdb/cockroach/pull/74136
+[#74138]: https://github.com/cockroachdb/cockroach/pull/74138
+[#74140]: https://github.com/cockroachdb/cockroach/pull/74140
+[#74156]: https://github.com/cockroachdb/cockroach/pull/74156
+[#74157]: https://github.com/cockroachdb/cockroach/pull/74157
+[#74189]: https://github.com/cockroachdb/cockroach/pull/74189
+[#74210]: https://github.com/cockroachdb/cockroach/pull/74210
+[#74222]: https://github.com/cockroachdb/cockroach/pull/74222
+[#74236]: https://github.com/cockroachdb/cockroach/pull/74236
+[#74242]: https://github.com/cockroachdb/cockroach/pull/74242
+[#74281]: https://github.com/cockroachdb/cockroach/pull/74281
+[#74286]: https://github.com/cockroachdb/cockroach/pull/74286
+[#74355]: https://github.com/cockroachdb/cockroach/pull/74355
+[#74365]: https://github.com/cockroachdb/cockroach/pull/74365
+[#74393]: https://github.com/cockroachdb/cockroach/pull/74393
+[#74394]: https://github.com/cockroachdb/cockroach/pull/74394
+[#74408]: https://github.com/cockroachdb/cockroach/pull/74408
+[#74411]: https://github.com/cockroachdb/cockroach/pull/74411
+[#74425]: https://github.com/cockroachdb/cockroach/pull/74425
+[#74491]: https://github.com/cockroachdb/cockroach/pull/74491
+[#74499]: https://github.com/cockroachdb/cockroach/pull/74499
+[#74507]: https://github.com/cockroachdb/cockroach/pull/74507
+[#74582]: https://github.com/cockroachdb/cockroach/pull/74582
+[#74592]: https://github.com/cockroachdb/cockroach/pull/74592
+[#74601]: https://github.com/cockroachdb/cockroach/pull/74601


### PR DESCRIPTION
Fixes [DOC-1904](https://cockroachlabs.atlassian.net/browse/DOC-1904)

Release notes for v22.1.0-alpha.1

Note added links with "stable" since there isn't a v22.1 doc set yet. We will want to update that when the dev version of the docs is live.