### PR TITLE
Update the crdb version on the "latest" cloud release notes

### DIFF
--- a/releases/cockroachcloud-01102022.md
+++ b/releases/cockroachcloud-01102022.md
@@ -13,9 +13,9 @@ Get future release notes emailed to you:
 ### General changes
 
 - New {{ site.data.products.dedicated }} clusters will now run [v21.2.3](v21.2.3.html).
-- {{ site.data.products.serverless }} clusters will now run CockroachDB [v21.2.0-beta.4](v21.2.0-beta.4.html).
+- {{ site.data.products.serverless }} clusters will now run CockroachDB [v21.2.4](v21.2.4.html).
 - The CockroachDB documentation navigation is now organized by user task instead of by product for {{ site.data.products.serverless }}, {{ site.data.products.dedicated }}, and {{ site.data.products.core }} v21.2. Topics specific to Serverless and Dedicated clusters are within the new top-level user task categories. {{ site.data.products.db }} release notes are under Reference.
 
 ### Console changes
 
-- The [**Billing**](../cockroachcloud/billing-management.html) page is now separated into two tabs, **Overview** and **Payment Details**. 
+- The [**Billing**](../cockroachcloud/billing-management.html) page is now separated into two tabs, **Overview** and **Payment Details**.

--- a/releases/cockroachcloud-01102022.md
+++ b/releases/cockroachcloud-01102022.md
@@ -12,7 +12,7 @@ Get future release notes emailed to you:
 
 ### General changes
 
-- New {{ site.data.products.dedicated }} clusters will now run [v21.2.3](v21.2.3.html).
+- New {{ site.data.products.dedicated }} clusters will now run [v21.2.4](v21.2.4.html).
 - {{ site.data.products.serverless }} clusters will now run CockroachDB [v21.2.4](v21.2.4.html).
 - The CockroachDB documentation navigation is now organized by user task instead of by product for {{ site.data.products.serverless }}, {{ site.data.products.dedicated }}, and {{ site.data.products.core }} v21.2. Topics specific to Serverless and Dedicated clusters are within the new top-level user task categories. {{ site.data.products.db }} release notes are under Reference.
 


### PR DESCRIPTION
The notes are dated based on the date on which email
communication goes out. But since cloud isn't versioned,
the date isn't meaningful beyond that. Since the
"Latest Release Notes" page is the only place where
users can find out what version of crdb the cloud offerings
are running, it makes sense to keep the versions up to date.

I know there's broader work happening around the cloud release
not process that might resolve this issue. As part of that,
we should think of a way to communicate the current crdb
version for cloud that's release note date-agnostic.