### PR TITLE
MInor correction for multi-region documentation

### DIFF
--- a/v21.2/cockroach-start.md
+++ b/v21.2/cockroach-start.md
@@ -309,7 +309,7 @@ $ cockroach init \
 **Scenario:**
 
 - You have a cluster that spans GCE and AWS.
-- The nodes on each cloud can reach each other on private addresses, but the private addresses aren't reachable from the other cloud.
+- The nodes on each cloud can reach each other on public addresses, but the private addresses aren't reachable from the other cloud.
 
 **Approach:**
 


### PR DESCRIPTION
The statement should say that the nodes can reach each other on public addresses across cloud providers.