### PR TITLE
Fix syntax error for node-postgres connection docs

### DIFF
--- a/v21.2/connect-to-the-database.md
+++ b/v21.2/connect-to-the-database.md
@@ -54,10 +54,7 @@ For example:
 ~~~ js
 const { Client } = require('pg')
 
-const connectionString = process.env.DATABASE_URL
-const client = new Client({
-  connectionString,
-})
+const client = new Client(process.env.DATABASE_URL)
 
 client.connect()
 ~~~


### PR DESCRIPTION
Our current connection docs contain a "set literal," which is not
supported in JavaScript and causes a syntax error. A solution is
to pass the connection string directly into the client without
wrapping it in a JavaScript object.
