### PR TITLE
Add (last?) correct mapping of geo* pattern to RBR

### DIFF
--- a/v21.1/migrate-to-multiregion-sql.md
+++ b/v21.1/migrate-to-multiregion-sql.md
@@ -131,7 +131,7 @@ If you applied the [geo-partitioned leaseholders][geo_leaseholders] pattern, the
     ALTER INDEX users_last_name_index PARTITION BY NOTHING;
     ~~~
 
-The latency and resiliency benefits of the geo-partitioned leaseholders pattern can be replaced by making `users` a [`REGIONAL` table](regional-tables.html) with a [`ZONE` survival goal](multiregion-overview.html#surviving-zone-failures).
+The latency and resiliency benefits of the geo-partitioned leaseholders pattern can be replaced by making `users` a [`REGIONAL BY ROW` table](regional-tables.html#regional-by-row-tables) with a [`ZONE` survival goal](multiregion-overview.html#surviving-zone-failures).
 
 ### Step 2. Add a primary region to your database
 

--- a/v21.2/migrate-to-multiregion-sql.md
+++ b/v21.2/migrate-to-multiregion-sql.md
@@ -131,7 +131,7 @@ If you applied the [geo-partitioned leaseholders][geo_leaseholders] pattern, the
     ALTER INDEX users_last_name_index PARTITION BY NOTHING;
     ~~~
 
-The latency and resiliency benefits of the geo-partitioned leaseholders pattern can be replaced by making `users` a [`REGIONAL` table](regional-tables.html) with a [`ZONE` survival goal](multiregion-overview.html#surviving-zone-failures).
+The latency and resiliency benefits of the geo-partitioned leaseholders pattern can be replaced by making `users` a [`REGIONAL BY ROW` table](regional-tables.html#regional-by-row-tables) with a [`ZONE` survival goal](multiregion-overview.html#surviving-zone-failures).
 
 ### Step 2. Add a primary region to your database
 


### PR DESCRIPTION
Fixes DOC-2357

Summary of changes:

- Fixed the (hopefully) last incorrect mapping from the old skool
  geo-partitioned leaseholder pattern to the new REGIONAL BY ROW table
  locality + ZONE survival goal on the 'Migrate to Multi-region SQL'
  page.

- Previously, we were incorrectly referring to a mapping from
  geo-partitioned leaseholders to REGIONAL BY TABLE locality + ZONE
  survival.