### PR TITLE
Added redirect from removed changefeed file

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -405,6 +405,7 @@ layout: null
 /docs/start-a-local-cluster.html /docs/stable/start-a-local-cluster.html 301
 /docs/column-families.html /docs/stable/column-families.html 301
 /docs/performance-recipes-solutions.html /docs/stable/performance-recipes.html 301
+/docs/stable/stream-data-out-of-cockroachdb-using-changefeeds.html /docs/stable/change-data-capture-overview.html 301
 
 #CockroachDB Cloud release notes
 


### PR DESCRIPTION
Added a redirect from the now removed stream data out of cockroachdb using changefeeds page for v21.2.