### PR TITLE
Correction to BACKUP CHECKPOINT note on BACKUP

### DIFF
--- a/v21.1/backup.md
+++ b/v21.1/backup.md
@@ -133,7 +133,7 @@ Cancel the backup      | [`CANCEL JOB`](cancel-job.html)
 You can also visit the [**Jobs** page](ui-jobs-page.html) of the DB Console to view job details. The `BACKUP` statement will return when the backup is finished or if it encounters an error.
 
 {{site.data.alerts.callout_info}}
-The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually means the backup is not complete. This file is created when a backup is initiated, and is replaced with a `BACKUP` file once the backup is finished.
+The presence of the `BACKUP MANIFEST` file in the backup destination is an indicator that the backup job completed successfully.
 {{site.data.alerts.end}}
 
 ## Examples

--- a/v21.2/backup.md
+++ b/v21.2/backup.md
@@ -133,7 +133,7 @@ Cancel the backup      | [`CANCEL JOB`](cancel-job.html)
 You can also visit the [**Jobs** page](ui-jobs-page.html) of the DB Console to view job details. The `BACKUP` statement will return when the backup is finished or if it encounters an error.
 
 {{site.data.alerts.callout_info}}
-The presence of a `BACKUP-CHECKPOINT` file in the backup destination usually means the backup is not complete. This file is created when a backup is initiated, and is replaced with a `BACKUP` file once the backup is finished.
+The presence of the `BACKUP MANIFEST` file in the backup destination is an indicator that the backup job completed successfully.
 {{site.data.alerts.end}}
 
 ## Examples


### PR DESCRIPTION
Fixes [DOC-2386](https://cockroachlabs.atlassian.net/browse/DOC-2386)

This is a small clarification to the current note on the backup page that specifies that the presence of the `BACKUP CHECKPOINT` file in the backup destination means that the job was not successful. That is not actually the case, as this file is not necessarily cleared up. 

Adjusted this note to the `BACKUP MANIFEST` file's presence indicating that the job was successful.