### PR TITLE
Minor updates to Snowflake changefeed tutorial

### DIFF
--- a/cockroachcloud/stream-changefeed-to-snowflake-aws.md
+++ b/cockroachcloud/stream-changefeed-to-snowflake-aws.md
@@ -21,7 +21,7 @@ Before you begin, make sure you have:
 - Write access to an [AWS S3 bucket](https://s3.console.aws.amazon.com)
 
     {{site.data.alerts.callout_info}}
-    This tutorial uses AWS S3 for cloud storage, but Snowflake also supports [Azure](https://docs.snowflake.net/manuals/user-guide/data-load-snowpipe-auto-azure.html). Snowflake does not support GCS yet.
+    This tutorial uses AWS S3 for cloud storage, but Snowflake also supports [Azure](https://docs.snowflake.net/manuals/user-guide/data-load-snowpipe-auto-azure.html) and [Google Cloud Storage](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-auto-gcs.html).
     {{site.data.alerts.end}}
 
 - [Read and write access](https://docs.snowflake.net/manuals/user-guide/security-access-control-overview.html) to a Snowflake cluster
@@ -110,10 +110,9 @@ Back in the built-in SQL shell, [create an enterprise changefeed](../{{site.vers
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > CREATE CHANGEFEED FOR TABLE order_alerts
-    INTO 's3://changefeed-example?AWS_ACCESS_KEY_ID=<KEY>&AWS_SECRET_ACCESS_KEY=<SECRET_KEY>'
+    INTO 's3://changefeed-example?AWS_ACCESS_KEY_ID={access key ID}&AWS_SECRET_ACCESS_KEY={secret access key}'
     WITH
-        updated,
-        resolved='10s';
+        updated;
 ~~~
 ~~~
         job_id
@@ -122,7 +121,7 @@ Back in the built-in SQL shell, [create an enterprise changefeed](../{{site.vers
 (1 row)
 ~~~
 
-Be sure to replace the placeholders with your AWS key ID and AWS secret key.
+Be sure to replace the placeholders with your AWS access key ID and AWS secret access key. See [Use Cloud Storage for Bulk Operations — Authentication](../{{site.versions["stable"]}}/use-cloud-storage-for-bulk-operations.html#amazon-s3) for more detail on authenticating to Amazon S3.
 
 {{site.data.alerts.callout_info}}
 If your changefeed is running but data is not displaying in your S3 bucket, you might have to [debug your changefeed](../{{site.versions["stable"]}}/monitor-and-debug-changefeeds.html#debug-a-changefeed).
@@ -175,9 +174,9 @@ If your changefeed is running but data is not displaying in your S3 bucket, you 
     > CREATE STAGE cdc_stage url='s3://changefeed-example/' credentials=(aws_key_id='<KEY>' aws_secret_key='<SECRET_KEY>') file_format = (type = json);
     ~~~
 
-    Be sure to replace the placeholders with your AWS key ID and AWS secret key.
+    Be sure to replace the placeholders with your AWS access key ID and AWS secret access key.
 
-6. In the Worksheet, create a snowpipe called `cdc-pipe`, which tells Snowflake to auto-ingest data:
+6. In the Worksheet, create a Snowpipe called `cdc-pipe`, which tells Snowflake to auto-ingest data:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
@@ -185,17 +184,17 @@ If your changefeed is running but data is not displaying in your S3 bucket, you 
     ~~~
 
     {{site.data.alerts.callout_info}}
-    Currently, auto-ingest in Snowflake only works with AWS and [Azure](https://docs.snowflake.net/manuals/user-guide/data-load-snowpipe-auto-azure.html). Snowflake does not support GCS yet.
+    Auto-ingest in Snowflake works with [AWS](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-auto-s3.html), [Azure](https://docs.snowflake.net/manuals/user-guide/data-load-snowpipe-auto-azure.html), and [Google Cloud Storage](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-auto-gcs.html).
     {{site.data.alerts.end}}
 
-7. In the Worksheet, view the snowpipe:
+7. In the Worksheet, view the Snowpipe:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
     > SHOW PIPES;
     ~~~
 
-8. Copy the **ARN** of the SQS queue for your stage (displays in the **notification_channel** column). You will use this information to [configure the S3 bucket](#step-9-configure-the-s3-bucket).
+8. Copy the **ARN** of the SQS queue for your stage (this displays in the **notification_channel** column). You will use this information to [configure the S3 bucket](#step-9-configure-the-s3-bucket).
 
 ## Step 9. Configure the S3 bucket
 
@@ -217,22 +216,21 @@ If your changefeed is running but data is not displaying in your S3 bucket, you 
     > ALTER PIPE cdc_pipe refresh;
     ~~~
 
-5. To view the data Snowflake, query the `order_alerts` table:
+5. To view the data in Snowflake, query the `order_alerts` table:
 
     {% include_cached copy-clipboard.html %}
     ~~~ sql
     > SELECT * FROM order_alerts;
     ~~~
 
-    The ingested rows will display in the **Results** panel. It may take a few minutes for the data to load into the Snowflake cluster.
+    The ingested rows will display in the **Results** panel. It may take a few minutes for the data to load into the Snowflake cluster. To check on the progress of data being written to the destination table, see [Snowflake's documentation on querying a stage](https://docs.snowflake.com/en/user-guide/querying-stage.html).
 
 Your changefeed is now streaming to Snowflake.
 
 ## Known limitations
 
 - Snowflake cannot filter streaming updates by table. Because of this, we recommend creating a changefeed that watches only one table.
-- Snowpipe is unaware of CockroachDB resolved timestamps. This means CockroachDB transactions will not be loaded atomically and partial transactions can briefly be returned from Snowflake.
-- Auto-ingest in Snowflake only works with AWS and Azure. Snowflake does not support GCS yet.
+- Snowpipe is unaware of CockroachDB [resolved timestamps](../{{site.versions["stable"]}}/create-changefeed.html#resolved-option). This means CockroachDB transactions will not be loaded atomically and partial transactions can briefly be returned from Snowflake.
 - Snowpipe works best with append-only workloads, as Snowpipe lacks native ETL capabilities to perform updates to data. You may need to pre-process data before uploading it to Snowflake.
 
 See the [Change Data Capture Overview](../{{site.versions["stable"]}}/change-data-capture-overview.html#known-limitations) for more general changefeed known limitations.

--- a/cockroachcloud/stream-changefeed-to-snowflake-aws.md
+++ b/cockroachcloud/stream-changefeed-to-snowflake-aws.md
@@ -121,7 +121,7 @@ Back in the built-in SQL shell, [create an enterprise changefeed](../{{site.vers
 (1 row)
 ~~~
 
-Be sure to replace the placeholders with your AWS access key ID and AWS secret access key. See [Use Cloud Storage for Bulk Operations — Authentication](../{{site.versions["stable"]}}/use-cloud-storage-for-bulk-operations.html#amazon-s3) for more detail on authenticating to Amazon S3.
+Be sure to replace the placeholders with your AWS access key ID and AWS secret access key. See [Use Cloud Storage for Bulk Operations — Authentication](../{{site.versions["stable"]}}/use-cloud-storage-for-bulk-operations.html#authentication) for more detail on authenticating to Amazon S3.
 
 {{site.data.alerts.callout_info}}
 If your changefeed is running but data is not displaying in your S3 bucket, you might have to [debug your changefeed](../{{site.versions["stable"]}}/monitor-and-debug-changefeeds.html#debug-a-changefeed).


### PR DESCRIPTION
Fixes [DOC-2129](https://cockroachlabs.atlassian.net/browse/DOC-2129)

Updates to tutorial:

- Relevant additions to Snowflake doc links
- GCS is now covered in auto-ingest by snowflake (updated note)
- Removed `resolved` option from the create changefeed statement to avoid creation of too many objects in the bucket.
- (the experimental was removed from the s3 URI in another PR, which is mentioned in this ticket)