### PR TITLE
DOC-2531: Added note about name resolution by search path

### DIFF
--- a/v20.2/sql-name-resolution.md
+++ b/v20.2/sql-name-resolution.md
@@ -76,10 +76,9 @@ The search path is used when a name is unqualified (i.e., has no prefix). It lis
 
 - You can set the current search path with [`SET search_path`](set-vars.html) and inspected it with [`SHOW
 search_path`](show-vars.html).
-
 - You can inspect the list of valid schemas that can be listed in `search_path` with [`SHOW SCHEMAS`](show-schemas.html).
-
-- By default, the search path contains `$user`, `public`, and `pg_catalog`. For compatibility with PostgreSQL, `pg_catalog` is forced to be present in `search_path` at all times, even when not specified with `SET search_path`.
+- By default, the search path contains `$user`, `public`, `pg_catalog`, and `pg_extension`. For compatibility with PostgreSQL, `pg_catalog` is forced to be present in `search_path` at all times, even when not specified with `SET search_path`.
+- To mimic the behavior in PostgreSQL, CockroachDB will attempt a resolution to `pg_extension` prior to attempting `public`.
 
 ### Current schema
 

--- a/v21.1/sql-name-resolution.md
+++ b/v21.1/sql-name-resolution.md
@@ -76,10 +76,9 @@ The search path is used when a name is unqualified (i.e., has no prefix). It lis
 
 - You can set the current search path with [`SET search_path`](set-vars.html) and inspected it with [`SHOW
 search_path`](show-vars.html).
-
 - You can inspect the list of valid schemas that can be listed in `search_path` with [`SHOW SCHEMAS`](show-schemas.html).
-
-- By default, the search path contains `$user`, `public`, and `pg_catalog`. For compatibility with PostgreSQL, `pg_catalog` is forced to be present in `search_path` at all times, even when not specified with `SET search_path`.
+- By default, the search path contains `$user`, `public`, `pg_catalog`, and `pg_extension`. For compatibility with PostgreSQL, `pg_catalog` is forced to be present in `search_path` at all times, even when not specified with `SET search_path`.
+- To mimic the behavior in PostgreSQL, CockroachDB will attempt a resolution to `pg_extension` prior to attempting `public`.
 
 ### Current schema
 

--- a/v21.2/sql-name-resolution.md
+++ b/v21.2/sql-name-resolution.md
@@ -77,10 +77,9 @@ The search path is used when a name is unqualified (i.e., has no prefix). It lis
 
 - You can set the current search path with [`SET search_path`](set-vars.html) and inspected it with [`SHOW
 search_path`](show-vars.html).
-
 - You can inspect the list of valid schemas that can be listed in `search_path` with [`SHOW SCHEMAS`](show-schemas.html).
-
-- By default, the search path contains `$user`, `public`, and `pg_catalog`. For compatibility with PostgreSQL, `pg_catalog` is forced to be present in `search_path` at all times, even when not specified with `SET search_path`.
+- By default, the search path contains `$user`, `public`, `pg_catalog`, and `pg_extension`. For compatibility with PostgreSQL, `pg_catalog` is forced to be present in `search_path` at all times, even when not specified with `SET search_path`.
+- To mimic the behavior in PostgreSQL, CockroachDB will attempt a resolution to `pg_extension` prior to attempting `public`.
 
 ### Current schema
 


### PR DESCRIPTION
Fixes DOC-2531

- Named resolution by search path will try to resolve `pg_extension` prior to `public` schema.