### PR TITLE
Added redirect from removed Hello World Example Apps page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -337,6 +337,8 @@ layout: null
 /docs/stable/orchetrate-cockroachdb-with-kubernetes-multi-region.html /docs/stable/orchestrate-cockroachdb-with-kubernetes-multi-cluster.md 301
 
 # Removed pages
+/docs/stable/hello-world-example-apps.html /docs/stable/example-apps.html 301
+/docs/cockroachcloud/hello-world-example-apps.html /docs/stable/example-apps.html 301
 /docs/*/contribute-to-cockroachdb.html https://wiki.crdb.io/wiki/spaces/CRDB/pages/73204033/Contributing+to+CockroachDB 301!
 /docs/*/deploy-a-test-cluster.html /docs/cockroachcloud/quickstart.html 301
 /docs/v20.1/demo-follow-the-workload.html /docs/v20.1/topology-follow-the-workload.html 301


### PR DESCRIPTION
Fixes https://cockroachlabs.atlassian.net/browse/DOC-2310. 

(*Marketing page is linking to the now-removed Hello World Example Apps overview on stable*)

Follow-up on https://github.com/cockroachdb/docs/pull/12981#issuecomment-1033778576.