### PR TITLE
Removed line from `IMPORT` page on UDT limitation

### DIFF
--- a/v21.2/import.md
+++ b/v21.2/import.md
@@ -21,7 +21,6 @@ The `IMPORT` [statement](sql-statements.html) imports the following types of dat
 
 {% include {{ page.version.version }}/import-table-deprecate.md %}
 
-- `IMPORT` cannot be used with [user-defined types](create-type.html). Use [`IMPORT INTO`](import-into.html) instead.
 - `IMPORT` is a blocking statement. To run an import job asynchronously, use the [`DETACHED`](#options-detached) option.
 - `IMPORT` cannot be used within a [rolling upgrade](upgrade-cockroach-version.html).
 - `IMPORT` cannot directly import data to `REGIONAL BY ROW` tables that are part of [multi-region databases](multiregion-overview.html). <span class="version-tag">New in v21.2:</span> Instead, use [`IMPORT INTO`](import-into.html) which supports importing into `REGIONAL BY ROW` tables.


### PR DESCRIPTION
Fixes [DOC-1870](https://cockroachlabs.atlassian.net/browse/DOC-1870)

"Release note (enterprise change): Fixed a limitation of IMPORT for tables using user-defined types whereby any change to the set of tables or views which reference the type or any changes to privileges on the type during the IMPORT would lead to failure. Now new references to the type or GRANT or REVOKE operations performed while the IMPORT is ongoing will not cause failure."