### PR TITLE
Change 22.1 alpha source download link

### DIFF
--- a/releases/v22.1.0-alpha.1.md
+++ b/releases/v22.1.0-alpha.1.md
@@ -2,7 +2,7 @@
 title: What&#39;s New in v22.1.0-alpha.1
 toc: true
 summary: Additions and changes in CockroachDB version v22.1.0-alpha.1
-docs_area: releases 
+docs_area: releases
 ---
 
 ## January 24, 2022
@@ -21,7 +21,7 @@ The new features and bug fixes noted on this page are not yet documented across 
     <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.linux-amd64.tgz"><button id="linux" class="filter-button" data-scope="linux" data-eventcategory="linux-binary-release-notes">Linux</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.darwin-10.9-amd64.tgz"><button id="mac" class="filter-button" data-scope="mac" data-eventcategory="mac-binary-release-notes">Mac</button></a>
     <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.windows-6.2-amd64.zip"><button id="windows" class="filter-button" data-scope="windows" data-eventcategory="windows-binary-release-notes">Windows</button></a>
-    <a href="https://binaries.cockroachdb.com/cockroach-v22.1.0-alpha.1.src.tgz"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
+    <a href="https://github.com/cockroachdb/cockroach/releases/tag/v22.1.0-alpha.1" target="_blank"><button id="source" class="filter-button" data-scope="source" data-eventcategory="source-release-notes">Source</button></a>
 </div>
 
 <section class="filter-content" data-scope="windows">


### PR DESCRIPTION
Link to GH tag instead of downloading a source archive.
Source archives aren't being provided as of 22.1.
