### PR TITLE
Mention OCSP-enabled setup as preferred for certificate rotation

### DIFF
--- a/v21.2/create-security-certificates-custom-ca.md
+++ b/v21.2/create-security-certificates-custom-ca.md
@@ -163,7 +163,7 @@ To enable certificate revocation:
       For production clusters, you might want to set the setting to `strict`.
 
       {{site.data.alerts.callout_info}}
-      In the `strict` mode, all certificates are presumed to be invalid if the OCSP server is not reachable. Setting the cluster setting `security.ocsp.mode` to `strict` will lock you out of your CockroachDB database if your OCSP server goes down.
+      In the `strict` mode, all certificates are presumed to be invalid if the OCSP server is not reachable. Setting the cluster setting `security.ocsp.mode` to `strict` will lock you out of your CockroachDB database if your OCSP server goes down. To avoid this behavior consider using `lax` mode: if the OCSP server didn't respond within `security.ocsp.timeout` period the certificate check will be assumed successful.
       {{site.data.alerts.end}}
 
 

--- a/v21.2/rotate-certificates.md
+++ b/v21.2/rotate-certificates.md
@@ -19,6 +19,8 @@ You may need to rotate the node, client, or CA certificates in the following sce
 - The key (for a node, client, or CA) is compromised.
 - You need to modify the contents of a certificate, for example, to add another DNS name or the IP address of a load balancer through which a node can be reached. In this case, you would need to rotate only the node certificates.
 
+{{site.data.alerts.callout_info}}Even after the certificate rotation the old certificate will be valid. To harden your security settings consider using OCSP-enabled setup to be able to revoke old certificates. Refer to <a href="create-security-certificates-custom-ca.html#certificate-revocation-with-ocsp">Certificate revocation with OCSP</a> for further details.{{site.data.alerts.end}}
+
 ### Rotate client certificates
 
 1. Create a new client certificate and key:


### PR DESCRIPTION
Hi,

This PR clears up a couple of things I bumped into while setting up mTLS-enabled setup for CockroachDB.

1. Mention OCSP on the "Rotate Certificates" page, it is not clear that rotated certificates will still be valid and without revocation, rotation doesn't really make a lot of sense.
2. Point out that "cluster locked-out" behavior with unavailable OCSP server can be changed using `lax` mode on the "Create Security Certificates using a Custom CA" page.

I hope that these additions make sense and will help other people to figure out the setup faster.
Thank you for your work!

