### PR TITLE
DOC-2793: Add SSO note for Cloud Console login

### DIFF
--- a/_includes/cockroachcloud/prefer-sso.md
+++ b/_includes/cockroachcloud/prefer-sso.md
@@ -1,0 +1,5 @@
+{{site.data.alerts.callout_info}}
+It is best practice for {{ site.data.products.db }} Console users to login with Single Sign-On (SSO), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
+{{ site.data.products.db }} currently supports SSO with GitHub, and will be adding more SSO providers in the near future.
+Visit your CockroachDB Cloud Console's [account settings page](https://cockroachlabs.cloud/account/profile) and switch to SSO to improve the security of your cluster.
+{{site.data.alerts.end}}

--- a/_includes/cockroachcloud/prefer-sso.md
+++ b/_includes/cockroachcloud/prefer-sso.md
@@ -1,5 +1,7 @@
 {{site.data.alerts.callout_info}}
-It is best practice for {{ site.data.products.db }} Console users to login with Single Sign-On (SSO), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
+We recommend that {{ site.data.products.db }} Console users login with Single Sign-On (SSO), with two-factor authentication (2FA) enabled for the SSO provider. This prevents potential attackers from using stolen credentials to accesss or tamper with your critical data.
+
 {{ site.data.products.db }} currently supports SSO with GitHub, and will be adding more SSO providers in the near future.
-Visit your CockroachDB Cloud Console's [account settings page](https://cockroachlabs.cloud/account/profile) and switch to SSO to improve the security of your cluster.
+
+Visit your {{ site.data.products.db }} Console's [account settings page](https://cockroachlabs.cloud/account/profile) and switch to SSO to improve the security of your cluster.
 {{site.data.alerts.end}}

--- a/cockroachcloud/authentication.md
+++ b/cockroachcloud/authentication.md
@@ -7,17 +7,16 @@ docs_area: manage
 
 Users may connect with {{ site.data.products.db }} in two ways:
 
-- the [Cloud Console](https://cockroachlabs.cloud/) offers an overview of your {{ site.data.products.db }} account, and offers functionality for administrating or connecting to clusters.
+- The [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/) provides an overview of your {{ site.data.products.db }} account, and offers functionality for administrating or connecting to clusters.
 - SQL clients, including the CockroachDB CLI client and the [various supported drivers and ORMs](../{{site.versions["stable"]}}/install-client-drivers.html), connect directly to CockroachDB clusters using the [CockroachDB SQL interface](../{{site.versions["stable"]}}/sql-feature-support.html).
-
 
 ## Cloud Console authentication
 
-Users may log into the [Cloud Console](https://cockroachlabs.cloud/) with a username and password, or using SSO.
+You may login to the [{{ site.data.products.db }} Console](https://cockroachlabs.cloud/) with a username and password, or using SSO.
 
 {% include cockroachcloud/prefer-sso.md %}
 
-## SQL Authentication
+## SQL authentication
 
 ### TLS
 

--- a/cockroachcloud/authentication.md
+++ b/cockroachcloud/authentication.md
@@ -5,9 +5,25 @@ toc: true
 docs_area: manage
 ---
 
-{{ site.data.products.db }} uses TLS 1.3 for inter-node communication and TLS 1.2 or 1.3 for clinet-node communication, digital certificates for inter-node authentication, [SSL modes](#ssl-mode-settings) for node identity verification, and password authentication for client identity verification.
+Users may connect with {{ site.data.products.db }} in two ways:
 
-## Node identity verification
+- the [Cloud Console](https://cockroachlabs.cloud/) offers an overview of your {{ site.data.products.db }} account, and offers functionality for administrating or connecting to clusters.
+- SQL clients, including the CockroachDB CLI client and the [various supported drivers and ORMs](../{{site.versions["stable"]}}/install-client-drivers.html), connect directly to CockroachDB clusters using the [CockroachDB SQL interface](../{{site.versions["stable"]}}/sql-feature-support.html).
+
+
+## Cloud Console authentication
+
+Users may log into the [Cloud Console](https://cockroachlabs.cloud/) with a username and password, or using SSO.
+
+{% include cockroachcloud/prefer-sso.md %}
+
+## SQL Authentication
+
+### TLS
+
+{{ site.data.products.db }} uses TLS 1.3 for inter-node communication and TLS 1.2 or 1.3 for client-node communication, digital certificates for inter-node authentication, [SSL modes](#ssl-mode-settings) for node identity verification, and password authentication for client identity verification.
+
+### Node identity verification
 
 The [connection string](connect-to-your-cluster.html) generated to connect to your application uses the `verify-full` [SSL mode](#ssl-mode-settings) by default to verify a node’s identity. This mode encrypts the data in-flight as well as verifies the identity of the CockroachDB node, thus ensuring a secure connection to your cluster. Using this mode prevents MITM (Machine in the Middle) attacks, impersonation attacks, and eavesdropping.
 
@@ -18,13 +34,13 @@ To connect securely to your cluster using the `verify-full` mode:
 
 You can also use the `require` SSL mode, although we do not recommend using it since it can make the cluster susceptible to MITM and impersonation attacks. For more information, see the "Protection Provided in Different Modes" section in PostgreSQL's [SSL Support](https://www.postgresql.org/docs/9.4/libpq-ssl.html) document.
 
-## Client identity verification
+### Client identity verification
 
 {{ site.data.products.db }} uses password authentication for verifying a client’s identity. If no password has been set up for a user, password authentication will always fail for that user and you won’t be able to connect to the cluster.
 
 For more information about creating SQL users and passwords, see [User Authorization](user-authorization.html).
 
-## SSL mode settings
+### SSL mode settings
 
 The table below lists the `sslmode` settings you can use to [connect to your cluster](connect-to-your-cluster.html) and their associated security risks. Other settings are not recommended.
 

--- a/cockroachcloud/console-access-management.md
+++ b/cockroachcloud/console-access-management.md
@@ -7,6 +7,8 @@ docs_area: manage
 
 The **Access** page displays the name, email address, role, and invite acceptance status of the Team Members with access to your {{ site.data.products.db }} organization. To view the **Access** page, [log in](https://cockroachlabs.cloud/) and click **Access**.
 
+{% include cockroachcloud/prefer-sso.md %}
+
 ## Organization
 
 An **organization** allows you to manage your clusters under a shared [billing](billing-management.html) account and collaborate with team members. You can belong to multiple organizations.

--- a/cockroachcloud/create-a-serverless-cluster.md
+++ b/cockroachcloud/create-a-serverless-cluster.md
@@ -22,6 +22,7 @@ If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=d
 ## Step 1. Start the cluster creation process
 
 1. [Log in](https://cockroachlabs.cloud/) to your {{ site.data.products.db }} account.
+{% include cockroachcloud/prefer-sso.md %}
 1. If there are multiple [organizations](console-access-management.html#organization) in your account, select the correct organization in the top right corner.
 1. On the **Overview** page, click **Create Cluster**.
 

--- a/cockroachcloud/create-your-cluster.md
+++ b/cockroachcloud/create-your-cluster.md
@@ -19,6 +19,7 @@ To create and connect to a 30-day free {{ site.data.products.dedicated }} cluste
 ## Step 1. Start the cluster creation process
 
 1. If you haven't already, <a href="https://cockroachlabs.cloud/signup?referralId=docs_create_dedicated_cluster" rel="noopener" target="_blank">sign up for a {{ site.data.products.db }} account</a>.
+{% include cockroachcloud/prefer-sso.md %}
 1. [Log in](https://cockroachlabs.cloud/) to your {{ site.data.products.db }} account.
 1. If there are multiple [organizations](console-access-management.html#organization) in your account, select the correct organization in the top right corner.
 1. On the **Overview** page, click **Create Cluster**.


### PR DESCRIPTION
Add a note that we support GitHub SSO and will support other options soon, and that SSO is to be preferred for security.