### PR TITLE
Added logic to render main release note pages in PRs

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -28,9 +28,20 @@ jobs:
             if [[ $file == *.md ]] && [[ $file != _* ]]
             then
               html_file=${file%.md}.html
-              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target=\"_blank\">$file</a>"
+              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target=\"_blank\" rel=\"noopener\">$file</a>"
+              output+="$file%0A"
+            elif [[ $file == *.md ]] && [[ $file == _includes/releases/* ]]
+            then
+              OLDIFS=$IFS
+              IFS='/'
+              read -ra path <<< "$file"
+              IFS=$OLDIFS
+              major_version=${path[-2]}
+              file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/releases/${major_version}.html\" target=\"_blank\" rel=\"noopener\">releases/${major_version}.md</a>"
+              [[ " ${output[*]} " != *"releases/${major_version}.md"* ]] && output+="$file%0A"
+            else
+              output+="$file%0A"
             fi
-            output+="$file%0A"
           done;
           body="${output[@]}"
           echo ::set-output name=body::$body


### PR DESCRIPTION
When a new release note file is pushed in the _includes/releases/vXX.Y/vXX.Y.Z.md, this PR should now display the changes in the associated major version file.