### PR TITLE
install verb shouldn't be capitalized

### DIFF
--- a/releases/index.md
+++ b/releases/index.md
@@ -6,7 +6,7 @@ docs_area: releases
 toc_not_nested: true
 ---
 
-After downloading your desired release, learn how to [Install CockroachDB](../{{site.versions["stable"]}}/install-cockroachdb.html). Also be sure to review Cockroach Labs' [Release Support Policy](release-support-policy.html).
+After downloading your desired release, learn how to [install CockroachDB](../{{site.versions["stable"]}}/install-cockroachdb.html). Also be sure to review Cockroach Labs' [Release Support Policy](release-support-policy.html).
 
 {% assign sections = site.data.releases | map: "release_type" | uniq | reverse %}
 {% comment %} Fetch the list of all release types (currently Testing, Production) {% endcomment %}


### PR DESCRIPTION
The link text should not reflect the capitalized title if it's used as a verb in a sentence.