### PR TITLE
DOC-1088: Highlight information about `REGION` survival plans

### DIFF
--- a/v21.1/drop-region.md
+++ b/v21.1/drop-region.md
@@ -173,6 +173,46 @@ SHOW REGIONS FROM DATABASE foo;
 (0 rows)
 ~~~
 
+You cannot drop a region from a database if the databases uses [`REGION` survival goal](multiregion-overview.html#surviving-region-failures) and there are only three regions configured on the database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo SET PRIMARY REGION "us-east1";
+~~~
+
+~~~
+ALTER DATABASE PRIMARY REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo ADD REGION "us-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo ADD REGION "europe-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo DROP REGION "us-west1";
+~~~
+
+~~~
+ERROR: at least 3 regions are required for surviving a region failure
+SQLSTATE: 22023
+HINT: you must add additional regions to the database or change the survivability goal
+~~~
+
 ## See also
 
 - [Multi-region overview](multiregion-overview.html)

--- a/v21.1/when-to-use-zone-vs-region-survival-goals.md
+++ b/v21.1/when-to-use-zone-vs-region-survival-goals.md
@@ -19,6 +19,7 @@ Set a [`REGION` survival goal](multiregion-overview.html#surviving-region-failur
 
 - The database must remain available, even if a region goes down.
 - You can accept the performance cost: write latency will be increased by at least as much as the round-trip time to the nearest region. Read performance will be unaffected.
+- The database can be or already is configured with 3 or more [database regions](multiregion-overview.html#database-regions). At least three database regions are required to survive region failures.
 
 {{site.data.alerts.callout_success}}
 For more information about how to choose a multi-region configuration, see [Choosing a multi-region configuration](choosing-a-multi-region-configuration.html).

--- a/v21.2/drop-region.md
+++ b/v21.2/drop-region.md
@@ -174,6 +174,46 @@ SHOW REGIONS FROM DATABASE foo;
 (0 rows)
 ~~~
 
+You cannot drop a region from a database if the databases uses [`REGION` survival goal](multiregion-overview.html#surviving-region-failures) and there are only three regions configured on the database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo SET PRIMARY REGION "us-east1";
+~~~
+
+~~~
+ALTER DATABASE PRIMARY REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo ADD REGION "us-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo ADD REGION "europe-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo DROP REGION "us-west1";
+~~~
+
+~~~
+ERROR: at least 3 regions are required for surviving a region failure
+SQLSTATE: 22023
+HINT: you must add additional regions to the database or change the survivability goal
+~~~
+
 ## See also
 
 - [Multi-Region Capabilities Overview](multiregion-overview.html)

--- a/v21.2/when-to-use-zone-vs-region-survival-goals.md
+++ b/v21.2/when-to-use-zone-vs-region-survival-goals.md
@@ -22,6 +22,7 @@ Set a [`REGION` survival goal](multiregion-overview.html#surviving-region-failur
 
 - The database must remain available, even if a region goes down.
 - You can accept the performance cost: write latency will be increased by at least as much as the round-trip time to the nearest region. Read performance will be unaffected.
+- The database can be or already is configured with 3 or more [database regions](multiregion-overview.html#database-regions). At least three database regions are required to survive region failures.
 
 ## See also
 

--- a/v22.1/drop-region.md
+++ b/v22.1/drop-region.md
@@ -174,6 +174,46 @@ SHOW REGIONS FROM DATABASE foo;
 (0 rows)
 ~~~
 
+You cannot drop a region from a database if the databases uses [`REGION` survival goal](multiregion-overview.html#surviving-region-failures) and there are only three regions configured on the database:
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo SET PRIMARY REGION "us-east1";
+~~~
+
+~~~
+ALTER DATABASE PRIMARY REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo ADD REGION "us-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo ADD REGION "europe-west1";
+~~~
+
+~~~
+ALTER DATABASE ADD REGION
+~~~
+
+{% include copy-clipboard.html %}
+~~~ sql
+ALTER DATABASE foo DROP REGION "us-west1";
+~~~
+
+~~~
+ERROR: at least 3 regions are required for surviving a region failure
+SQLSTATE: 22023
+HINT: you must add additional regions to the database or change the survivability goal
+~~~
+
 ## See also
 
 - [Multi-Region Capabilities Overview](multiregion-overview.html)

--- a/v22.1/when-to-use-zone-vs-region-survival-goals.md
+++ b/v22.1/when-to-use-zone-vs-region-survival-goals.md
@@ -22,6 +22,7 @@ Set a [`REGION` survival goal](multiregion-overview.html#surviving-region-failur
 
 - The database must remain available, even if a region goes down.
 - You can accept the performance cost: write latency will be increased by at least as much as the round-trip time to the nearest region. Read performance will be unaffected.
+- The database can be or already is configured with 3 or more [database regions](multiregion-overview.html#database-regions). At least three database regions are required to survive region failures.
 
 ## See also
 


### PR DESCRIPTION
Fixes DOC-1088

- `REGION` survival plans requires at least 3 regions configured on the DB