### PR TITLE
DOC-2868: Add first-level references to modified includes in Changed Files bot

### DIFF
--- a/.github/workflows/changed_files.yml
+++ b/.github/workflows/changed_files.yml
@@ -39,6 +39,22 @@ jobs:
               major_version=${path[-2]}
               file="<a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/releases/${major_version}.html\" target=\"_blank\" rel=\"noopener\">releases/${major_version}.md</a>"
               [[ " ${output[*]} " != *"releases/${major_version}.md"* ]] && output+="$file%0A"
+            elif [[ $file == _includes/v* ]] || [[ $file == _includes/cockroachcloud* ]]
+            then
+              output+="${file}:<ul>"
+              OLDIFS=$IFS
+              IFS='/'
+              read -ra path <<< "$file"
+              IFS=$OLDIFS
+              major_version=${path[1]}
+              file_name=${path[-1]}
+              refs=($(grep -irl ${file_name} ${major_version}))
+              for ref in ${refs[@]}; do
+                html_file=${ref%.md}.html
+                file="<li><a href=\"https://deploy-preview-$pr_num--cockroachdb-docs.netlify.app/docs/$html_file\" target=\"_blank\" rel=\"noopener\">$ref</a></li>"
+                output+="$file%0A"
+              done
+              output+="</ul>%0A"
             else
               output+="$file%0A"
             fi


### PR DESCRIPTION
Fixes DOC-2868:

- First-level references to includes will display a link to the pages on which that modified include is referenced