### PR TITLE
[operator]: Bump referenced version to v2.5.1

### DIFF
--- a/_config_base.yml
+++ b/_config_base.yml
@@ -26,7 +26,7 @@ include:
 keep_files:
 - _internal
 markdown: Redcarpet
-operator_version: v2.4.0
+operator_version: v2.5.1
 plugins:
 - jekyll-include-cache
 release_info:

--- a/v21.1/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v21.1/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -92,7 +92,7 @@ This article assumes you have already installed the OpenShift Container Platform
 
 	<img src="{{ 'images/v21.1/cockroachdb-operator-instance-openshift.png' | relative_url }}" alt="OpenShift OperatorHub" style="border:1px solid #eee;max-width:100%" />
 
-1. Make sure **CockroachDB Version** is set to an valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/f096daf45086136387a75092c0763689cb2a5b59/manifests/operator.yaml) on GitHub.
+1. Make sure **CockroachDB Version** is set to an valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/{{site.operator_version}}/install/operator.yaml) on GitHub.
 
 1. This will open the **Create CrdbCluster** page. By default, this deploys a 3-node secure cluster. Leave the other fields unchanged and click **Create**.
 

--- a/v21.2/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v21.2/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -89,7 +89,7 @@ This article assumes you have already installed the OpenShift Container Platform
 
 	<img src="{{ 'images/v21.2/cockroachdb-operator-instance-openshift.png' | relative_url }}" alt="OpenShift OperatorHub" style="border:1px solid #eee;max-width:100%" />
 
-1. Make sure **CockroachDB Version** is set to an valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/f096daf45086136387a75092c0763689cb2a5b59/manifests/operator.yaml) on GitHub.
+1. Make sure **CockroachDB Version** is set to an valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/{{site.operator_version}}/install/operator.yaml) on GitHub.
 
 1. This will open the **Create CrdbCluster** page. By default, this deploys a 3-node secure cluster. Leave the other fields unchanged and click **Create**.
 

--- a/v22.1/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v22.1/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -89,7 +89,7 @@ This article assumes you have already installed the OpenShift Container Platform
 
 	<img src="{{ 'images/v22.1/cockroachdb-operator-instance-openshift.png' | relative_url }}" alt="OpenShift OperatorHub" style="border:1px solid #eee;max-width:100%" />
 
-1. Make sure **CockroachDB Version** is set to an valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/f096daf45086136387a75092c0763689cb2a5b59/manifests/operator.yaml) on GitHub.
+1. Make sure **CockroachDB Version** is set to an valid CockroachDB version. For a list of compatible image names, see `spec.containers.env` in the [Operator manifest](https://github.com/cockroachdb/cockroach-operator/blob/{{site.operator_version}}/install/operator.yaml) on GitHub.
 
 1. This will open the **Create CrdbCluster** page. By default, this deploys a 3-node secure cluster. Leave the other fields unchanged and click **Create**.
 


### PR DESCRIPTION
Updating the operator version to v2.5.1 (for all the links to the
manifests, etc.).

I've also updated a dead link for the OpenShift instructions.

Fixes https://github.com/cockroachdb/cockroach-operator/issues/823