### PR TITLE
Updates to export page parquet format added

### DIFF
--- a/v22.1/export.md
+++ b/v22.1/export.md
@@ -91,9 +91,10 @@ CockroachDB types map to [Parquet types](https://github.com/apache/parquet-forma
 | [`COLLATE`](collate.html) | byte array | `STRING` |
 | [`INET`](inet.html) | byte array | `STRING` |
 | [`JSONB`](jsonb.html) | byte array | `JSON` |
-| [`INT`](int.html) `INT8` <br>(all `INT` aliases besides `INT4` `INT2`) | `INT64` | `nil` |
-| [`INT4`](int.html) `INT2` | `INT32` | `nil` |
-| [`FLOAT`](float.html) | `FLOAT64` | `nil` |
+| [`INT`](int.html) [`INT8`](int.html) | `INT64` | `nil` |
+| [`INT2`](int.html) [`INT4`](int.html) | `INT32` | `nil` |
+| [`FLOAT`](float.html) [`FLOAT8`](float.html) | `FLOAT64` | `nil` |
+| [`FLOAT4`](float.html) | `FLOAT32` | `nil` |
 | [`DECIMAL`](decimal.html) | byte array | `DECIMAL` <br>Note: scale and precision data are preserved in the Parquet file |
 | [`UUID`](uuid.html) | `fixed_len_byte_array` | `nil` |
 | [`BYTES`](bytes.html) | byte array | `nil` |
@@ -221,7 +222,7 @@ This example uses the `delimiter` option to define the ASCII character that deli
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
   WITH delimiter = '|' FROM TABLE bank.customers;
 ~~~
 
@@ -230,7 +231,7 @@ This examples uses the `nullas` option to define the string that represents `NUL
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
   WITH nullas = '' FROM TABLE bank.customers;
 ~~~
 
@@ -269,7 +270,7 @@ For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
   WITH compression = 'gzip' FROM TABLE bank.customers;
 ~~~
 
@@ -285,7 +286,7 @@ export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO PARQUET
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
   WITH compression = 'snappy' FROM TABLE bank.customers;
 ~~~
 
@@ -311,7 +312,7 @@ This example uses the `delimiter` option to define the ASCII character that deli
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
   WITH delimiter = '|' FROM TABLE bank.customers;
 ~~~
 
@@ -320,7 +321,7 @@ This examples uses the `nullas` option to define the string that represents `NUL
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
   WITH nullas = '' FROM TABLE bank.customers;
 ~~~
 
@@ -359,7 +360,7 @@ For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
   WITH compression = 'gzip' FROM TABLE bank.customers;
 ~~~
 
@@ -375,7 +376,7 @@ export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
 {% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO PARQUET
-  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
   WITH compression = 'snappy' FROM TABLE bank.customers;
 ~~~
 

--- a/v22.1/export.md
+++ b/v22.1/export.md
@@ -95,7 +95,7 @@ CockroachDB types map to [Parquet types](https://github.com/apache/parquet-forma
 | [`INT2`](int.html) [`INT4`](int.html) | `INT32` | `nil` |
 | [`FLOAT`](float.html) [`FLOAT8`](float.html) | `FLOAT64` | `nil` |
 | [`FLOAT4`](float.html) | `FLOAT32` | `nil` |
-| [`DECIMAL`](decimal.html) | byte array | `DECIMAL` <br>Note: scale and precision data are preserved in the Parquet file |
+| [`DECIMAL`](decimal.html) | byte array | `DECIMAL` <br>Note: scale and precision data are preserved in the Parquet file. |
 | [`UUID`](uuid.html) | `fixed_len_byte_array` | `nil` |
 | [`BYTES`](bytes.html) | byte array | `nil` |
 | [`BIT`](bit.html) | byte array | `nil` |
@@ -106,7 +106,7 @@ CockroachDB types map to [Parquet types](https://github.com/apache/parquet-forma
 | [`DATE`](date.html) | byte array | `STRING` |
 | [`TIME`](time.html) | `INT64` | `TIME` <br>Note: microseconds after midnight; <br>exporting to microsecond precision. |
 | [`TIMETZ`](time.html) | byte array | `STRING` <br>Note: exporting to microsecond precision. |
-| [`INTERVAL`](interval.html) | byte array | `STRING` <br>Note: specifically represented as ISO8601 |
+| [`INTERVAL`](interval.html) | byte array | `STRING` <br>Note: specifically represented as ISO8601. |
 | [`TIMESTAMP`](timestamp.html) | byte array | `STRING` <br>Note: exporting to microsecond precision. |
 | [`TIMESTAMPTZ`](timestamp.html) | byte array | `STRING` <br>Note: exporting to microsecond precision. |
 | [`ARRAY`](array.html) | Encoded as a repeated field; <br>each array value is encoded as per the preceding types. | `nil` |
@@ -173,7 +173,7 @@ For more information, see [selection queries](selection-queries.html).
 $ cockroach sql -e "SELECT * from bank.customers WHERE id>=100;" --format=csv > my.csv
 ~~~
 
-For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.html).
+For more information about the SQL client, see [`cockroach sql`](cockroach-sql.html).
 
 ### Export compressed files
 
@@ -261,7 +261,7 @@ For more information, see [selection queries](selection-queries.html).
 $ cockroach sql -e "SELECT * from bank.customers WHERE id>=100;" --format=csv > my.csv
 ~~~
 
-For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.html).
+For more information about the SQL client, see [`cockroach sql`](cockroach-sql.html).
 
 ### Export compressed files
 
@@ -351,7 +351,7 @@ For more information, see [selection queries](selection-queries.html).
 $ cockroach sql -e "SELECT * from bank.customers WHERE id>=100;" --format=csv > my.csv
 ~~~
 
-For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.html).
+For more information about the SQL client, see [`cockroach sql`](cockroach-sql.html).
 
 ### Export compressed files
 

--- a/v22.1/export.md
+++ b/v22.1/export.md
@@ -5,12 +5,17 @@ toc: true
 docs_area: reference.sql
 ---
 
-The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to CSV files.
+The `EXPORT` [statement](sql-statements.html) exports tabular data or the results of arbitrary `SELECT` statements to the following:
 
-Using the [CockroachDB distributed execution engine](architecture/sql-layer.html#distsql), `EXPORT` parallelizes CSV creation across all nodes in the cluster, making it possible to quickly get large sets of data out of CockroachDB in a format that can be ingested by downstream systems. If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
+- CSV files
+- Parquet files
+
+Using the [CockroachDB distributed execution engine](architecture/sql-layer.html#distsql), `EXPORT` parallelizes file creation across all nodes in the cluster, making it possible to quickly get large sets of data out of CockroachDB in a format that can be ingested by downstream systems.
+
+If you do not need distributed exports, you can [export tabular data in CSV format](#non-distributed-export-using-the-sql-client).
 
 {{site.data.alerts.callout_info}}
-`EXPORT` no longer requires an Enterprise license.
+`EXPORT` no longer requires an {{ site.data.products.enterprise }} license.
 {{site.data.alerts.end}}
 
 ## Cancelling export
@@ -21,7 +26,9 @@ After the export has been initiated, you can cancel it with [`CANCEL QUERY`](can
 
 <div>{% remote_include https://raw.githubusercontent.com/cockroachdb/generated-diagrams/release-22.1/grammar_svg/export.html %}</div>
 
-{{site.data.alerts.callout_info}}The <code>EXPORT</code> statement cannot be used within a <a href=transactions.html>transaction</a>.{{site.data.alerts.end}}
+{{site.data.alerts.callout_info}}
+The `EXPORT` statement cannot be used within a [transaction](transactions.html).
+{{site.data.alerts.end}}
 
 ## Required privileges
 
@@ -31,19 +38,19 @@ After the export has been initiated, you can cancel it with [`CANCEL QUERY`](can
 
  Parameter | Description
 -----------|-------------
- `file_location` | Specify the [URL of the file location](#export-file-url) where you want to store the exported CSV data.<br><br>Note: It is best practice to use a unique destination for each export, to avoid mixing files from different exports in one directory.
- `WITH kv_option` | Control your export's behavior with [these options](#export-options).
- `select_stmt` | Specify the query whose result you want to export to CSV format.
- `table_name` | Specify the name of the table you want to export to CSV format.
+ `file_location` | Specify the [URL of the file location](#export-file-url) where you want to store the exported data.<br><br>Note: It is best practice to use a unique destination for each export, to avoid mixing files from different exports in one directory.
+ `opt_with_options` | Control your export's behavior with [these options](#export-options).
+ `select_stmt` | Specify the query whose result you want to export.
+ `table_name` | Specify the name of the table you want to export.
 
 ### Export file URL
 
-You can specify the base directory where you want to store the exported .csv files. CockroachDB will create the export file(s) in the specified directory with programmatically generated names (e.g., `exportabc123-n1.1.csv`, `exportabc123-n1.2.csv`, `exportabc123-n2.1.csv`, ...). Each export should use a unique destination directory to avoid collision with other exports.
+You can specify the base directory where you want to store the exported files. CockroachDB will create the export file(s) in the specified directory with programmatically generated names (e.g., `exportabc123-n1.1.csv`, `exportabc123-n1.2.csv`, `exportabc123-n2.1.csv`, ...). Each export should use a unique destination directory to avoid collision with other exports.
 
 The `EXPORT` command [returns](#success-responses) the list of files to which the data was exported. You may wish to record these for use in subsequent imports.
 
 {{site.data.alerts.callout_info}}
-A hexadecimal hash code (`abc123...` in the file names above) uniquely identifies each export _run_; files sharing the same hash are part of the same export. If you see multiple hash codes within a single destination directory, then the directory contains multiple exports, which will likely cause confusion (duplication) on import. We recommend that you manually clean up the directory, to ensure that it contains only a single export run.
+A hexadecimal hash code (`abc123...` in the file names) uniquely identifies each export **run**; files sharing the same hash are part of the same export. If you see multiple hash codes within a single destination directory, then the directory contains multiple exports, which will likely cause confusion (duplication) on import. We recommend that you manually clean up the directory, to ensure that it contains only a single export run.
 {{site.data.alerts.end}}
 
 For more information, see the following:
@@ -57,11 +64,11 @@ You can control the [`EXPORT`](export.html) process's behavior using any of the 
 
 Key                 | <div style="width:130px">Context</div> | Value                                                                                                                             |
 --------------------+-----------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------
-`delimiter`         |    `CSV DATA`   |  The ASCII character that delimits columns in your rows. If not using comma as your column delimiter, you can specify another ASCII character as the delimiter. **Default:** `,`. <br><br>To use tab-delimited values: `WITH delimiter = e'\t'`
-`nullas`            |    `CSV DATA`, `DELIMITED DATA`          |  The string that should be used to represent _NULL_ values. To avoid collisions, it is important to pick `nullas` values that do not appear in the exported data. <br><br>To use empty columns as _NULL_: `WITH nullas = ''`
-`compression`       |    `CSV DATA`   |  This instructs export to write `gzip` compressed CSV files to the specified destination. <br><br>See the [example](#export-gzip-compressed-csv-files) below.
-`chunk_rows`        |    `CSV DATA`   |  The number of rows to be converted to CSV and written to a single CSV file. **Default:** `100000`. <br>For example, `WITH chunk_rows = '5000'` for a table with 10,000 rows would produce two CSV files. <br><br>**Note**:`EXPORT` will stop and upload the CSV file whether the configured limit for `chunk_rows` or `chunk_size` is reached first.
-`chunk_size`        |    `CSV DATA`   | A target size per CSV file that you can specify during an `EXPORT`. Once the target size is reached, the CSV file is uploaded before processing further rows. **Default:** `32MB`. <br>For example, to set the size of each CSV file uploaded during the export to 10MB: `WITH chunk_size = '10MB'`. <br><br>**Note**:`EXPORT` will stop and upload the CSV file whether the configured limit for `chunk_rows` or `chunk_size` is reached first.
+`delimiter`         |    `CSV DATA`, `PARQUET DATA`   |  The ASCII character that delimits columns in your rows. If not using comma as your column delimiter, you can specify another ASCII character as the delimiter. **Default:** `,`. <br><br>To use tab-delimited values: `WITH delimiter = e'\t'`
+`nullas`            |    `CSV DATA`, `DELIMITED DATA`, `PARQUET DATA`   |  The string that should be used to represent `NULL` values. To avoid collisions, it is important to pick `nullas` values that do not appear in the exported data. <br><br>To use empty columns as `NULL`: `WITH nullas = ''`
+`compression`       |    `CSV DATA`, `PARQUET DATA`   |  This instructs export to write `gzip` compressed files to the specified destination. <br><br>See the [example](#export-gzip-compressed-files).
+`chunk_rows`        |    `CSV DATA`, `PARQUET DATA`   |  The number of rows to be converted  and written to a single file. **Default:** `100000`. <br>For example, `WITH chunk_rows = '5000'` for a table with 10,000 rows would produce two files. <br><br>**Note**:`EXPORT` will stop and upload the file whether the configured limit for `chunk_rows` or `chunk_size` is reached first.
+`chunk_size`        |    `CSV DATA`, `PARQUET DATA`   | A target size per file that you can specify during an `EXPORT`. Once the target size is reached, the file is uploaded before processing further rows. **Default:** `32MB`. <br>For example, to set the size of each file uploaded during the export to 10MB: `WITH chunk_size = '10MB'`. <br><br>**Note**:`EXPORT` will stop and upload the file whether the configured limit for `chunk_rows` or `chunk_size` is reached first.
 
 ## Success responses
 
@@ -72,6 +79,35 @@ Successful `EXPORT` returns a table of (perhaps multiple) files to which the dat
 `filename` | The file to which the data was exported.
 `rows` | The number of rows exported to this file.
 `bytes` | The file size in bytes.
+
+## Parquet types
+
+CockroachDB types map to [Parquet types](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md) as per the following:
+
+| CockroachDB Type    | Parquet Type | Parquet Logical Type |
+--------------------|--------------|----------------------
+| [`BOOL`](bool.html) | `BOOLEAN` | `nil` |
+| [`STRING`](string.html) | byte array | `STRING` |
+| [`COLLATE`](collate.html) | byte array | `STRING` |
+| [`INET`](inet.html) | byte array | `STRING` |
+| [`JSONB`](jsonb.html) | byte array | `JSON` |
+| [`INT`](int.html) | `INT64` | `nil` |
+| [`FLOAT`](float.html) | `FLOAT64` | `nil` |
+| [`DECIMAL`](decimal.html) | byte array | `DECIMAL` <br>Note: scale and precision data are preserved in the Parquet file |
+| [`UUID`](uuid.html) | `fixed_len_byte_array` | `nil` |
+| [`BYTES`](bytes.html) | byte array | `nil` |
+| [`BIT`](bit.html) | byte array | `nil` |
+| [`ENUM`](enum.html) | byte array | `ENUM` |
+| [`Box2D`](data-types.html#data-type-conversions-and-casts) | byte array | `STRING` |
+| [`GEOGRAPHY`](data-types.html#data-type-conversions-and-casts) | byte array | `nil` |
+| [`GEOMETRY`](data-types.html#data-type-conversions-and-casts) | byte array | `nil` |
+| [`DATE`](date.html) | byte array | `STRING` |
+| [`TIME`](time.html) | `INT64` | `TIME` <br>Note: microseconds after midnight |
+| [`TIMETZ`](time.html) | byte array | `STRING` |
+| [`INTERVAL`](interval.html) | byte array | `STRING` <br>Note: specifically represented as ISO8601 |
+| [`TIMESTAMP`](timestamp.html) | byte array | `STRING` |
+| [`TIMESTAMPTZ`](timestamp.html) | byte array | `STRING` |
+| [`ARRAY`](array.html) | Encoded as a repeated field; each array value<br> is encoded as per the preceding types. | `nil` |
 
 ## Examples
 
@@ -89,18 +125,26 @@ The following provide connection examples to cloud storage providers. For more i
 
 Each of these examples use the `bank` database and the `customers` table; `customer-export-data` is the demonstration path to which we're exporting our customers' data in this example.
 
-### Export a table
+### Export a table into CSV
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
   's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
   WITH delimiter = '|' FROM TABLE bank.customers;
 ~~~
 
+### Export a table into Parquet
+
+~~~ sql
+> EXPORT INTO PARQUET
+  's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
+  FROM TABLE bank.customers;
+~~~
+
 ### Export using a `SELECT` statement
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
   's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
@@ -111,18 +155,18 @@ For more information, see [selection queries](selection-queries.html).
 
 ### Non-distributed export using the SQL client
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql -e "SELECT * from bank.customers WHERE id>=100;" --format=csv > my.csv
 ~~~
 
 For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.html).
 
-### Export gzip compressed CSV files
+### Export gzip compressed files
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> EXPORT INTO CSV
+> EXPORT INTO PARQUET
   's3://{BUCKET NAME}/{customer-export-data}?AWS_ACCESS_KEY_ID={ACCESS KEY}&AWS_SECRET_ACCESS_KEY={SECRET ACCESS KEY}'
   WITH compression = 'gzip' FROM TABLE bank.customers;
 ~~~
@@ -130,7 +174,7 @@ For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.
 ~~~
 filename                                           | rows | bytes
 ---------------------------------------------------+------+--------
-export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
+export16808a04292505c80000000000000001-n1.0.parquet.gz |   17 |   824
 (1 row)
 ~~~
 
@@ -140,18 +184,26 @@ export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
 
 Each of these examples use the `bank` database and the `customers` table; `customer-export-data` is the demonstration path to which we're exporting our customers' data in this example.
 
-### Export a table
+### Export a table into CSV
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
   'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
   WITH delimiter = '|' FROM TABLE bank.customers;
 ~~~
 
+### Export a table into Parquet
+
+~~~ sql
+> EXPORT INTO PARQUET
+  'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
+  FROM TABLE bank.customers;
+~~~
+
 ### Export using a `SELECT` statement
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
   'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
@@ -162,18 +214,18 @@ For more information, see [selection queries](selection-queries.html).
 
 ### Non-distributed export using the SQL client
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql -e "SELECT * from bank.customers WHERE id>=100;" --format=csv > my.csv
 ~~~
 
 For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.html).
 
-### Export gzip compressed CSV files
+### Export gzip compressed files
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> EXPORT INTO CSV
+> EXPORT INTO PARQUET
   'azure://{CONTAINER NAME}/{customer-export-data}?AZURE_ACCOUNT_NAME={ACCOUNT NAME}&AZURE_ACCOUNT_KEY={ENCODED KEY}'
   WITH compression = 'gzip' FROM TABLE bank.customers;
 ~~~
@@ -181,7 +233,7 @@ For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.
 ~~~
 filename                                           | rows | bytes
 ---------------------------------------------------+------+--------
-export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
+export16808a04292505c80000000000000001-n1.0.parquet.gz |   17 |   824
 (1 row)
 ~~~
 
@@ -193,18 +245,26 @@ export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
 
 Each of these examples use the `bank` database and the `customers` table; `customer-export-data` is the demonstration path to which we're exporting our customers' data in this example.
 
-### Export a table
+### Export a table into CSV
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
   'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
   WITH delimiter = '|' FROM TABLE bank.customers;
 ~~~
 
+### Export a table into Parquet
+
+~~~ sql
+> EXPORT INTO PARQUET
+  'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
+  FROM TABLE bank.customers;
+~~~
+
 ### Export using a `SELECT` statement
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > EXPORT INTO CSV
   'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
@@ -215,18 +275,18 @@ For more information, see [selection queries](selection-queries.html).
 
 ### Non-distributed export using the SQL client
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ shell
 $ cockroach sql -e "SELECT * from bank.customers WHERE id>=100;" --format=csv > my.csv
 ~~~
 
 For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.html).
 
-### Export gzip compressed CSV files
+### Export gzip compressed files
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
-> EXPORT INTO CSV
+> EXPORT INTO PARQUET
   'gs://{BUCKET NAME}/{customer-export-data}?AUTH=specified&CREDENTIALS={ENCODED KEY}'
   WITH compression = 'gzip' FROM TABLE bank.customers;
 ~~~
@@ -234,7 +294,7 @@ For more information, about the SQL client, see [`cockroach sql`](cockroach-sql.
 ~~~
 filename                                           | rows | bytes
 ---------------------------------------------------+------+--------
-export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
+export16808a04292505c80000000000000001-n1.0.parquet.gz |   17 |   824
 (1 row)
 ~~~
 
@@ -244,7 +304,7 @@ export16808a04292505c80000000000000001-n1.0.csv.gz |   17 |   824
 
 View running exports by using [`SHOW STATEMENTS`](show-statements.html):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > SHOW STATEMENTS;
 ~~~
@@ -253,7 +313,7 @@ View running exports by using [`SHOW STATEMENTS`](show-statements.html):
 
 Use [`SHOW STATEMENTS`](show-statements.html) to get a running export's `query_id`, which can be used to [cancel the export](cancel-query.html):
 
-{% include copy-clipboard.html %}
+{% include_cached copy-clipboard.html %}
 ~~~ sql
 > CANCEL QUERY '14dacc1f9a781e3d0000000000000001';
 ~~~
@@ -264,4 +324,7 @@ Use [`SHOW STATEMENTS`](show-statements.html) to get a running export's `query_i
 
 ## See also
 
+- [`IMPORT`](import.html)
+- [`IMPORT INTO`](import-into.html)
 - [Use a Local File Server for Bulk Operations](use-a-local-file-server-for-bulk-operations.html)
+- [Use Cloud Storage for Bulk Operations](use-cloud-storage-for-bulk-operations.html)


### PR DESCRIPTION
Fixes [DOC-1146](https://cockroachlabs.atlassian.net/browse/DOC-1146) [DOC-2138](https://cockroachlabs.atlassian.net/browse/DOC-2138) [DOC-2276](https://cockroachlabs.atlassian.net/browse/DOC-2276)

Parquet added as an format to the `EXPORT` sql page. Edited page to move from only CSV to more agnostically cover both formats. Format added to option table.