### PR TITLE
Remove FAQ about RUs being consumed in background

### DIFF
--- a/cockroachcloud/serverless-faqs.md
+++ b/cockroachcloud/serverless-faqs.md
@@ -75,10 +75,6 @@ To connect to a cluster, download the CA certificate, and then generate a connec
 
 Yes, your free cluster has been automatically migrated to {{ site.data.products.serverless }}. Your ability to use your cluster should not be affected, and you will now have the option to [add a spend limit](serverless-cluster-management.html#edit-your-spend-limit) for your cluster with no downtime.
 
-### My cluster doesn't have any current connections, but I'm seeing my RU usage go up while observing the cluster. Why is the cluster using RUs when there are no connections?
-
-Some pages on the Console runs background queries against your cluster, which means they consume a small number of RUs, up to 8 RUs per second. The baseline performance of 100 RUs per second includes the RUs used while observing an idle cluster.
-
 ### Why does my RU usage briefly spike when I'm running a steady workload?
 
 CockroachDB [automatically collects statistics](../{{site.versions["stable"]}}/cost-based-optimizer.html#control-statistics-refresh-rate) in a background process when certain conditions are met (for example, when more than 20% of rows in a table are modified). The statistics are used by the cost-based optimizer to tune statements for higher performance.


### PR DESCRIPTION
The CockroachDB Cloud console no longer consumes request units, so users should no longer see request units consumed if they're not using their DB.