### PR TITLE
remove version checker job callout

### DIFF
--- a/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v20.2/orchestration/start-cockroachdb-operator-secure.md
@@ -120,7 +120,3 @@ By default, the Operator will generate and sign 1 client and 1 node certificate 
 	~~~
 
     Each pod should have `READY` status soon after being created.
-
-    {{site.data.alerts.callout_info}}
-    Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `kubectl get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `kubectl delete job {cockroachdb-vcheck-job}`. Then reapply the custom resource (e.g., `kubectl apply -f example.yaml`).
-    {{site.data.alerts.end}}

--- a/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.1/orchestration/start-cockroachdb-operator-secure.md
@@ -111,7 +111,3 @@ By default, the Operator will generate and sign 1 client and 1 node certificate 
     ~~~
 
     Each pod should have `READY` status soon after being created.
-
-    {{site.data.alerts.callout_info}}
-    Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `kubectl get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `kubectl delete job {cockroachdb-vcheck-job}`. Then reapply the custom resource (e.g., `kubectl apply -f example.yaml`).
-    {{site.data.alerts.end}}

--- a/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-operator-secure.md
@@ -117,7 +117,3 @@
     ~~~
 
     Each pod should have `READY` status soon after being created.
-
-    {{site.data.alerts.callout_info}}
-    Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `kubectl get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `kubectl delete job {cockroachdb-vcheck-job}`. Then reapply the custom resource (e.g., `kubectl apply -f example.yaml`).
-    {{site.data.alerts.end}}

--- a/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
+++ b/_includes/v22.1/orchestration/start-cockroachdb-operator-secure.md
@@ -117,7 +117,3 @@
     ~~~
 
     Each pod should have `READY` status soon after being created.
-
-    {{site.data.alerts.callout_info}}
-    Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `kubectl get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `kubectl delete job {cockroachdb-vcheck-job}`. Then reapply the custom resource (e.g., `kubectl apply -f example.yaml`).
-    {{site.data.alerts.end}}

--- a/v21.1/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v21.1/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -115,10 +115,6 @@ This article assumes you have already installed the OpenShift Container Platform
 	crdb-tls-example-2                    1/1     Running   0          89s
 	~~~
 
-{{site.data.alerts.callout_info}}
-Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `oc get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `oc delete job {cockroachdb-vcheck-job}`. Then wait for the version checker job to restart and succeed.
-{{site.data.alerts.end}}
-
 ## Step 4. Create a secure client pod
 
 To use the CockroachDB SQL client, first launch a secure pod running the `cockroach` binary.

--- a/v21.2/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v21.2/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -112,10 +112,6 @@ This article assumes you have already installed the OpenShift Container Platform
 	crdb-tls-example-2                    1/1     Running   0          89s
 	~~~
 
-{{site.data.alerts.callout_info}}
-Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `oc get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `oc delete job {cockroachdb-vcheck-job}`. Then wait for the version checker job to restart and succeed.
-{{site.data.alerts.end}}
-
 ## Step 4. Create a secure client pod
 
 To use the CockroachDB SQL client, first launch a secure pod running the `cockroach` binary.

--- a/v22.1/deploy-cockroachdb-with-kubernetes-openshift.md
+++ b/v22.1/deploy-cockroachdb-with-kubernetes-openshift.md
@@ -112,10 +112,6 @@ This article assumes you have already installed the OpenShift Container Platform
 	crdb-tls-example-2                    1/1     Running   0          89s
 	~~~
 
-{{site.data.alerts.callout_info}}
-Due to a [known issue](https://github.com/cockroachdb/cockroach-operator/issues/575), in rare cases the Operator can crash while installing CockroachDB. This causes the CockroachDB pods to fail to start, while the version checker [job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) continues to run. If this happens, run `oc get jobs` to find the names of any running `cockroachdb-vcheck` jobs, and delete these jobs with `oc delete job {cockroachdb-vcheck-job}`. Then wait for the version checker job to restart and succeed.
-{{site.data.alerts.end}}
-
 ## Step 4. Create a secure client pod
 
 To use the CockroachDB SQL client, first launch a secure pod running the `cockroach` binary.


### PR DESCRIPTION
Removed a callout describing a known issue with the version checker job during CRDB installation by the Operator. The known issue has been fixed.