### PR TITLE
add callout against using Helm --wait flag

### DIFF
--- a/_includes/v21.2/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v21.2/orchestration/start-cockroachdb-helm-secure.md
@@ -69,6 +69,10 @@ Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](ht
     This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands.
     {{site.data.alerts.end}}
 
+    {{site.data.alerts.callout_danger}}
+    To allow the CockroachDB pods to deploy successfully, do not set the [`--wait` flag](https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback) when using Helm comands.
+    {{site.data.alerts.end}}
+
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ helm install my-release --values {custom-values}.yaml cockroachdb/cockroachdb

--- a/_includes/v22.1/orchestration/start-cockroachdb-helm-secure.md
+++ b/_includes/v22.1/orchestration/start-cockroachdb-helm-secure.md
@@ -69,6 +69,10 @@ Secure CockroachDB deployments on Amazon EKS via Helm are [not yet supported](ht
     This tutorial uses `my-release` as the release name. If you use a different value, be sure to adjust the release name in subsequent commands.
     {{site.data.alerts.end}}
 
+    {{site.data.alerts.callout_danger}}
+    To allow the CockroachDB pods to successfully deploy, do not set the [`--wait` flag](https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback) when using Helm comands.
+    {{site.data.alerts.end}}
+
     {% include_cached copy-clipboard.html %}
     ~~~ shell
     $ helm install my-release --values {custom-values}.yaml cockroachdb/cockroachdb


### PR DESCRIPTION
Fixes DOC-2992.

Add a callout warning against using `--wait` when installing with Helm.