### PR TITLE
Add info about generated gist.

### DIFF
--- a/_includes/releases/v22.1/v22.1.0-alpha.1.md
+++ b/_includes/releases/v22.1/v22.1.0-alpha.1.md
@@ -109,6 +109,11 @@ Release Date: January 24, 2022
                   table: abc@primary
                   spans: FULL SCAN
     ~~~
+    produces the following "gist":
+
+    `AgFuAgAHAAAAEQFuAgAHAAAAERANAAYGAA==`
+
+    The "gist" can be turned back into the plan.
     [#69293][#69293]
 
 - `T_unknown` ParameterTypeOIDs in the PostgreSQL frontend/backend protocol are now correctly handled. [#71971][#71971]


### PR DESCRIPTION
I'm documenting this feature and the release note omits the information about the gist that's generated.