### PR TITLE
add --self flag to node drain

### DIFF
--- a/v21.2/cockroach-node.md
+++ b/v21.2/cockroach-node.md
@@ -129,6 +129,7 @@ The `node drain` subcommand also supports the following general flag:
 Flag | Description
 -----|------------
 `--drain-wait` | Amount of time to wait for the node to drain before returning to the client. If draining fails to complete within this duration, you must re-initiate the command to continue the drain. A very long drain may indicate an anomaly, and you should manually inspect the server to determine what blocks the drain.<br><br>**Default:** `10m`
+`--self` | Applies the operation to the node against which the command was run (e.g., via `--host`).
 
 The `node recommission` subcommand also supports the following general flag:
 

--- a/v21.2/node-shutdown.md
+++ b/v21.2/node-shutdown.md
@@ -525,7 +525,7 @@ You can use [`cockroach node drain`](cockroach-node.html) to drain a node separa
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach node drain 1 --host=localhost:{address of any live node} --drain-wait=15m --certs-dir=certs
+    cockroach node drain 1 --host={address of any live node} --drain-wait=15m --certs-dir=certs
     ~~~
 
     You will see the draining status print to `stderr`:
@@ -579,12 +579,12 @@ Run the [`cockroach node drain`](cockroach-node.html) command for each node to b
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-cockroach node drain 4 --host=localhost:{address of any live node} --certs-dir=certs
+cockroach node drain 4 --host={address of any live node} --certs-dir=certs
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-cockroach node drain 5 --host=localhost:{address of any live node} --certs-dir=certs
+cockroach node drain 5 --host={address of any live node} --certs-dir=certs
 ~~~
 
 You will see the draining status of each node print to `stderr`:

--- a/v22.1/cockroach-node.md
+++ b/v22.1/cockroach-node.md
@@ -129,6 +129,7 @@ The `node drain` subcommand also supports the following general flag:
 Flag | Description
 -----|------------
 `--drain-wait` | Amount of time to wait for the node to drain before returning to the client. If draining fails to complete within this duration, you must re-initiate the command to continue the drain. A very long drain may indicate an anomaly, and you should manually inspect the server to determine what blocks the drain.<br><br>**Default:** `10m`
+`--self` | Applies the operation to the node against which the command was run (e.g., via `--host`).
 
 The `node recommission` subcommand also supports the following general flag:
 

--- a/v22.1/node-shutdown.md
+++ b/v22.1/node-shutdown.md
@@ -528,7 +528,7 @@ You can use [`cockroach node drain`](cockroach-node.html) to drain a node separa
 
     {% include_cached copy-clipboard.html %}
     ~~~ shell
-    cockroach node drain 1 --host=localhost:{address of any live node} --drain-wait=15m --certs-dir=certs
+    cockroach node drain 1 --host={address of any live node} --drain-wait=15m --certs-dir=certs
     ~~~
 
     You will see the draining status print to `stderr`:
@@ -582,12 +582,12 @@ Run the [`cockroach node drain`](cockroach-node.html) command for each node to b
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-cockroach node drain 4 --host=localhost:{address of any live node} --certs-dir=certs
+cockroach node drain 4 --host={address of any live node} --certs-dir=certs
 ~~~
 
 {% include_cached copy-clipboard.html %}
 ~~~ shell
-cockroach node drain 5 --host=localhost:{address of any live node} --certs-dir=certs
+cockroach node drain 5 --host={address of any live node} --certs-dir=certs
 ~~~
 
 You will see the draining status of each node print to `stderr`:


### PR DESCRIPTION
Fixes DOC-2211.

Added `--self` flag to `node drain` reference (v22.1 and v21.2).