### PR TITLE
node proxy on Advanced Debug Page

### DIFF
--- a/v22.1/ui-debug-pages.md
+++ b/v22.1/ui-debug-pages.md
@@ -18,7 +18,7 @@ These pages are experimental and undocumented. If you find an issue, let us know
 On the right-side of the page, the following information is displayed:
 
 - [**License type**](licensing-faqs.html): Determines if you have access to Enterprise features.
-- **Web server**: Identifies the current node when viewing the DB Console through a load balancer.
+- **Web server**: Allows you to route DB Console access through a specific node on the cluster. Afterward, identifies the current node through which DB Console access is being proxied. To cancel this behavior, click **Reset**.
 
 ## Reports
 


### PR DESCRIPTION
Fixes DOC-2821.

Document selection of a node proxy on the Advanced Debug Page.