### PR TITLE
Removed irrelevant sentences from top of backup/restore docs

### DIFF
--- a/v21.1/take-and-restore-encrypted-backups.md
+++ b/v21.1/take-and-restore-encrypted-backups.md
@@ -4,8 +4,6 @@ summary: Learn about the advanced options you can use when you backup and restor
 toc: true
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This doc provides information about how to take and restore encrypted backups in the following ways:
 
 -  [Using AWS Key Management Service (KMS)](#use-aws-key-management-service)

--- a/v21.1/take-and-restore-locality-aware-backups.md
+++ b/v21.1/take-and-restore-locality-aware-backups.md
@@ -4,8 +4,6 @@ summary: Learn about the advanced options you can use when you backup and restor
 toc: true
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This page provides information about how to take and restore locality-aware backups.
 
 {{site.data.alerts.callout_info}}

--- a/v21.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
+++ b/v21.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
@@ -4,8 +4,6 @@ summary: Learn about the advanced options you can use when you backup and restor
 toc: true
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This doc provides information about how to take backups with revision history and restore from a point-in-time.
 
 {{site.data.alerts.callout_info}}

--- a/v21.2/take-and-restore-encrypted-backups.md
+++ b/v21.2/take-and-restore-encrypted-backups.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This doc provides information about how to take and restore encrypted backups in the following ways:
 
 -  [Using AWS Key Management Service (KMS)](#use-aws-key-management-service)

--- a/v21.2/take-and-restore-locality-aware-backups.md
+++ b/v21.2/take-and-restore-locality-aware-backups.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This page provides information about how to take and restore locality-aware backups.
 
 {{site.data.alerts.callout_info}}

--- a/v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
+++ b/v21.2/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This doc provides information about how to take backups with revision history and restore from a point-in-time.
 
 {{site.data.alerts.callout_info}}

--- a/v22.1/take-and-restore-encrypted-backups.md
+++ b/v22.1/take-and-restore-encrypted-backups.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This doc provides information about how to take and restore encrypted backups in the following ways:
 
 -  [Using AWS Key Management Service (KMS)](#use-aws-key-management-service)

--- a/v22.1/take-and-restore-locality-aware-backups.md
+++ b/v22.1/take-and-restore-locality-aware-backups.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This page provides information about how to take and restore locality-aware backups.
 
 {{site.data.alerts.callout_info}}

--- a/v22.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
+++ b/v22.1/take-backups-with-revision-history-and-restore-from-a-point-in-time.md
@@ -5,8 +5,6 @@ toc: true
 docs_area: manage
 ---
 
-The ability to [backup a full cluster](backup.html#backup-a-cluster) has been added and the syntax for [incremental backups](backup.html#create-incremental-backups) is simplified. Because of these two changes, [basic backup usage](take-full-and-incremental-backups.html) is now sufficient for most CockroachDB clusters. However, you may want to control your backup and restore options more explicitly.
-
 This doc provides information about how to take backups with revision history and restore from a point-in-time.
 
 {{site.data.alerts.callout_info}}


### PR DESCRIPTION
Fixes [DOC-3062](https://cockroachlabs.atlassian.net/browse/DOC-3062)

Fix to remove irrelevant sentences from the top of the Manage backup/restore docs that was probably applicable some versions ago.