### PR TITLE
BACKUP/RESTORE are no longer enterprise only

### DIFF
--- a/v21.2/use-a-local-file-server-for-bulk-operations.md
+++ b/v21.2/use-a-local-file-server-for-bulk-operations.md
@@ -94,8 +94,8 @@ $ ruby -run -ehttpd . -p3000 # files available at e.g., 'http://localhost:3000/d
 ## See also
 
 - [`IMPORT`][import]
-- [`BACKUP`](backup.html) (*Enterprise only*)
-- [`RESTORE`](restore.html) (*Enterprise only*)
+- [`BACKUP`](backup.html)
+- [`RESTORE`](restore.html)
 
 <!-- Reference Links -->
 


### PR DESCRIPTION
BACKUP/RESTORE are no longer enterprise only, and updating this page to reflect these changes.