### PR TITLE
Add 2nd level headings to page TOC. Fix doc area.

### DIFF
--- a/v21.2/performance-best-practices-overview.md
+++ b/v21.2/performance-best-practices-overview.md
@@ -2,7 +2,7 @@
 title: SQL Performance Best Practices
 summary: Best practices for optimizing SQL performance in CockroachDB.
 toc: true
-docs_area: manage
+docs_area: develop
 ---
 
 This page provides best practices for optimizing query performance in CockroachDB.

--- a/v21.2/performance-recipes.md
+++ b/v21.2/performance-recipes.md
@@ -2,7 +2,7 @@
 title: Performance Tuning Recipes
 summary: Identify, diagnose, and fix common performance problems
 toc: true
-toc_not_nested: true
+toc_not_nested: false
 docs_area: manage
 ---
 

--- a/v21.2/sql-tuning-with-explain.md
+++ b/v21.2/sql-tuning-with-explain.md
@@ -1,8 +1,8 @@
 ---
 title: Statement Tuning with EXPLAIN
-summary: How to use `EXPLAIN to identify and resolve SQL statement performance issues
+summary: How to use EXPLAIN to identify and resolve SQL statement performance issues
 toc: true
-docs_area: manage
+docs_area: develop
 ---
 
 This tutorial walks you through the common reasons for [slow SQL statements](query-behavior-troubleshooting.html#identify-slow-statements) and describes how to use [`EXPLAIN`](explain.html) to troubleshoot the issues in queries against the [`movr` example dataset](cockroach-demo.html#datasets).

--- a/v22.1/performance-best-practices-overview.md
+++ b/v22.1/performance-best-practices-overview.md
@@ -2,7 +2,7 @@
 title: SQL Performance Best Practices
 summary: Best practices for optimizing SQL performance in CockroachDB.
 toc: true
-docs_area: manage
+docs_area: develop
 ---
 
 This page provides best practices for optimizing query performance in CockroachDB.

--- a/v22.1/performance-recipes.md
+++ b/v22.1/performance-recipes.md
@@ -2,8 +2,8 @@
 title: Performance Tuning Recipes
 summary: Identify, diagnose, and fix common performance problems
 toc: true
-toc_not_nested: true
-docs_area: manage
+toc_not_nested: false
+docs_area: develop
 ---
 
 This page provides recipes for fixing performance issues in your applications.

--- a/v22.1/sql-tuning-with-explain.md
+++ b/v22.1/sql-tuning-with-explain.md
@@ -1,8 +1,8 @@
 ---
 title: Statement Tuning with EXPLAIN
-summary: How to use `EXPLAIN to identify and resolve SQL statement performance issues
+summary: How to use EXPLAIN to identify and resolve SQL statement performance issues
 toc: true
-docs_area: manage
+docs_area: develop
 ---
 
 This tutorial walks you through the common reasons for [slow SQL statements](query-behavior-troubleshooting.html#identify-slow-statements) and describes how to use [`EXPLAIN`](explain.html) to troubleshoot the issues in queries against the [`movr` example dataset](cockroach-demo.html#datasets).


### PR DESCRIPTION
Stephanie Bodoff (stbof) commented:

These pages were moved to Develop but still had the doc area set to manage. 
It's useful to see the 2nd level headings in recipes.

Jira Issue: DOC-3164