### PR TITLE
move K8s operational docs to Manage section

### DIFF
--- a/_includes/v21.2/sidebar-data/deploy.json
+++ b/_includes/v21.2/sidebar-data/deploy.json
@@ -135,53 +135,6 @@
                   ]
                 },
                 {
-                  "title": "Operate CockroachDB on Kubernetes",
-                  "items": [
-                    {
-                      "title": "Pod Scheduling",
-                      "urls": [
-                        "/${VERSION}/schedule-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Resource Management",
-                      "urls": [
-                        "/${VERSION}/configure-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Certificate Management",
-                      "urls": [
-                        "/${VERSION}/secure-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Cluster Scaling",
-                      "urls": [
-                        "/${VERSION}/scale-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Cluster Monitoring",
-                      "urls": [
-                        "/${VERSION}/monitor-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Cluster Upgrades",
-                      "urls": [
-                        "/${VERSION}/upgrade-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Optimizing Performance",
-                      "urls": [
-                        "/${VERSION}/kubernetes-performance.html"
-                      ]
-                    }
-                  ]
-                },
-                {
                   "title": "OpenShift Deployment",
                   "urls": [
                     "/${VERSION}/deploy-cockroachdb-with-kubernetes-openshift.html"

--- a/_includes/v21.2/sidebar-data/manage.json
+++ b/_includes/v21.2/sidebar-data/manage.json
@@ -32,6 +32,53 @@
       ]
     },
     {
+      "title": "Operate CockroachDB on Kubernetes",
+      "items": [
+        {
+          "title": "Pod Scheduling",
+          "urls": [
+            "/${VERSION}/schedule-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Resource Management",
+          "urls": [
+            "/${VERSION}/configure-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Certificate Management",
+          "urls": [
+            "/${VERSION}/secure-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Cluster Scaling",
+          "urls": [
+            "/${VERSION}/scale-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Cluster Monitoring",
+          "urls": [
+            "/${VERSION}/monitor-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Cluster Upgrades",
+          "urls": [
+            "/${VERSION}/upgrade-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Optimizing Performance",
+          "urls": [
+            "/${VERSION}/kubernetes-performance.html"
+          ]
+        }
+      ]
+    },
+    {
       "title": "Back Up and Restore Data",
       "items": [
         {

--- a/_includes/v22.1/sidebar-data/deploy.json
+++ b/_includes/v22.1/sidebar-data/deploy.json
@@ -135,53 +135,6 @@
                   ]
                 },
                 {
-                  "title": "Operate CockroachDB on Kubernetes",
-                  "items": [
-                    {
-                      "title": "Pod Scheduling",
-                      "urls": [
-                        "/${VERSION}/schedule-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Resource Management",
-                      "urls": [
-                        "/${VERSION}/configure-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Certificate Management",
-                      "urls": [
-                        "/${VERSION}/secure-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Cluster Scaling",
-                      "urls": [
-                        "/${VERSION}/scale-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Cluster Monitoring",
-                      "urls": [
-                        "/${VERSION}/monitor-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Cluster Upgrades",
-                      "urls": [
-                        "/${VERSION}/upgrade-cockroachdb-kubernetes.html"
-                      ]
-                    },
-                    {
-                      "title": "Optimizing Performance",
-                      "urls": [
-                        "/${VERSION}/kubernetes-performance.html"
-                      ]
-                    }
-                  ]
-                },
-                {
                   "title": "OpenShift Deployment",
                   "urls": [
                     "/${VERSION}/deploy-cockroachdb-with-kubernetes-openshift.html"

--- a/_includes/v22.1/sidebar-data/manage.json
+++ b/_includes/v22.1/sidebar-data/manage.json
@@ -32,6 +32,53 @@
       ]
     },
     {
+      "title": "Operate CockroachDB on Kubernetes",
+      "items": [
+        {
+          "title": "Pod Scheduling",
+          "urls": [
+            "/${VERSION}/schedule-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Resource Management",
+          "urls": [
+            "/${VERSION}/configure-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Certificate Management",
+          "urls": [
+            "/${VERSION}/secure-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Cluster Scaling",
+          "urls": [
+            "/${VERSION}/scale-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Cluster Monitoring",
+          "urls": [
+            "/${VERSION}/monitor-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Cluster Upgrades",
+          "urls": [
+            "/${VERSION}/upgrade-cockroachdb-kubernetes.html"
+          ]
+        },
+        {
+          "title": "Optimizing Performance",
+          "urls": [
+            "/${VERSION}/kubernetes-performance.html"
+          ]
+        }
+      ]
+    },
+    {
       "title": "Back Up and Restore Data",
       "items": [
         {

--- a/v21.2/kubernetes-overview.md
+++ b/v21.2/kubernetes-overview.md
@@ -22,21 +22,12 @@ CockroachDB can be deployed and managed on Kubernetes using the following method
 
 ## CockroachDB on Kubernetes
 
-This guide describes how to handle the following tasks when running CockroachDB on Kubernetes:
+This section describes how to:
 
-- [Deploying CockroachDB on a single Kubernetes cluster](deploy-cockroachdb-with-kubernetes.html)
-- [Scheduling CockroachDB pods onto worker nodes](schedule-cockroachdb-kubernetes.html)
-- [Managing CockroachDB resources on Kubernetes](configure-cockroachdb-kubernetes.html)
-- [Managing certificates on Kubernetes](secure-cockroachdb-kubernetes.html)
-- [Scaling CockroachDB on Kubernetes](scale-cockroachdb-kubernetes.html)
-- [Monitoring CockroachDB on Kubernetes using Prometheus and Alertmanager](monitor-cockroachdb-kubernetes.html)
-- [Upgrading CockroachDB on Kubernetes](upgrade-cockroachdb-kubernetes.html)
-- [Optimizing CockroachDB performance on Kubernetes](kubernetes-performance.html)
+- [Deploy CockroachDB on a single Kubernetes cluster](deploy-cockroachdb-with-kubernetes.html)
+- [Deploy CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html)
+- [Orchestrate CockroachDB across multiple Kubernetes clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
 
-### Additional topics
-
-- [Deploying CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html)
-- [Orchestrating CockroachDB across multiple Kubernetes clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
 
 ## Kubernetes terminology
 

--- a/v22.1/kubernetes-overview.md
+++ b/v22.1/kubernetes-overview.md
@@ -22,21 +22,11 @@ CockroachDB can be deployed and managed on Kubernetes using the following method
 
 ## CockroachDB on Kubernetes
 
-This guide describes how to handle the following tasks when running CockroachDB on Kubernetes:
+This section describes how to:
 
-- [Deploying CockroachDB on a single Kubernetes cluster](deploy-cockroachdb-with-kubernetes.html)
-- [Scheduling CockroachDB pods onto worker nodes](schedule-cockroachdb-kubernetes.html)
-- [Managing CockroachDB resources on Kubernetes](configure-cockroachdb-kubernetes.html)
-- [Managing certificates on Kubernetes](secure-cockroachdb-kubernetes.html)
-- [Scaling CockroachDB on Kubernetes](scale-cockroachdb-kubernetes.html)
-- [Monitoring CockroachDB on Kubernetes using Prometheus and Alertmanager](monitor-cockroachdb-kubernetes.html)
-- [Upgrading CockroachDB on Kubernetes](upgrade-cockroachdb-kubernetes.html)
-- [Optimizing CockroachDB performance on Kubernetes](kubernetes-performance.html)
-
-### Additional topics
-
-- [Deploying CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html)
-- [Orchestrating CockroachDB across multiple Kubernetes clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
+- [Deploy CockroachDB on a single Kubernetes cluster](deploy-cockroachdb-with-kubernetes.html)
+- [Deploy CockroachDB on Red Hat OpenShift](deploy-cockroachdb-with-kubernetes-openshift.html)
+- [Orchestrate CockroachDB across multiple Kubernetes clusters](orchestrate-cockroachdb-with-kubernetes-multi-cluster.html)
 
 ## Kubernetes terminology
 


### PR DESCRIPTION
Fixes DOC-2284.

- Relocated the K8s operational docs to the Manage section of the sidebar.
- Updated the K8s Overview doc to only refer to the deployment methods.